### PR TITLE
docs: add GitHub MCP server example topology

### DIFF
--- a/examples/github-mcp.yaml
+++ b/examples/github-mcp.yaml
@@ -1,0 +1,25 @@
+# GitHub MCP Server Example
+#
+# This topology provides access to GitHub's official MCP server, enabling
+# AI agents to interact with GitHub repositories, issues, pull requests,
+# and other GitHub resources.
+#
+# Prerequisites:
+#   - Create a GitHub Personal Access Token at https://github.com/settings/tokens
+#   - Export it: export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxxxxxxxxxxx
+#
+# Usage:
+#   agentlab up examples/github-mcp.yaml
+#
+# Reference:
+#   https://github.com/github/github-mcp-server
+
+version: "1"
+name: github-mcp
+
+mcp-servers:
+  - name: github
+    image: ghcr.io/github/github-mcp-server:latest
+    transport: stdio
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PERSONAL_ACCESS_TOKEN}"


### PR DESCRIPTION
## 📒 Description

Adds an example topology configuration for the GitHub MCP server, demonstrating how to use agentlab with GitHub's official MCP server.

## 🔍 Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Chore

## 🔧 Changes Made

- Add `examples/github-mcp.yaml` with GitHub MCP server configuration
- Include setup instructions and prerequisites in file comments

## 🧪 Testing

```bash
export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxxxxxxxxxxx
agentlab up examples/github-mcp.yaml
```

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Code has been commented where necessary
- [x] Tested with `make test` or relevant profile
- [x] Commits follow conventional format (`type: subject`)
- [x] No secrets or credentials committed
- [x] Documentation has been updated accordingly
- [x] PR has been labeled appropriately (`enhancement`, `bug`, `documentation`, `refactor`, `chore`)