### PR TITLE
test: add MCP client SSE parsing tests

### DIFF
--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -1,0 +1,78 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestClient_ParseSSEResponse_Notifications(t *testing.T) {
+	// Simulate an SSE stream with a notification followed by a result
+	sseBody := `event: message
+data: {"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","data":{"msg":"some log"}}}
+
+event: message
+data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"success"}]}}
+`
+
+	client := &Client{}
+	resp, err := client.parseSSEResponse(strings.NewReader(sseBody))
+	if err != nil {
+		t.Fatalf("parseSSEResponse failed: %v", err)
+	}
+
+	if resp.ID == nil {
+		t.Fatal("expected response to have ID")
+	}
+
+	// Verify it picked the result, not the notification
+	var result map[string]any
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	// Check content
+	// {"content":[{"type":"text","text":"success"}]}
+	content, ok := result["content"].([]any)
+	if !ok {
+		t.Fatalf("expected content array")
+	}
+	if len(content) != 1 {
+		t.Fatalf("expected 1 content item")
+	}
+}
+
+func TestClient_ParseSSEResponse_OnlyNotification(t *testing.T) {
+	// Simulate an SSE stream with only a notification
+	sseBody := `event: message
+data: {"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info"}}
+`
+
+	client := &Client{}
+	_, err := client.parseSSEResponse(strings.NewReader(sseBody))
+	if err == nil {
+		t.Fatal("expected error when no response with ID is found")
+	}
+	if !strings.Contains(err.Error(), "no response with ID") {
+		t.Errorf("expected error message 'no response with ID', got: %v", err)
+	}
+}
+
+func TestClient_ParseSSEResponse_MalformedData(t *testing.T) {
+	// Simulate malformed data lines
+	sseBody := `event: message
+data: not-json
+
+event: message
+data: {"jsonrpc":"2.0","id":1,"result":{}}
+`
+
+	client := &Client{}
+	resp, err := client.parseSSEResponse(strings.NewReader(sseBody))
+	if err != nil {
+		t.Fatalf("parseSSEResponse failed with malformed data skipped: %v", err)
+	}
+	if resp.ID == nil {
+		t.Fatal("expected valid response despite previous malformed line")
+	}
+}


### PR DESCRIPTION
## 📒 Description

Adds unit tests for the MCP client's `parseSSEResponse` method, validating the SSE notification skipping fix from commit 28ea8e8.

## 🔍 Type of Change

- [x] Chore

## 🔧 Changes Made

- Add test for parsing SSE responses with mixed notifications and results
- Add test for error handling when only notifications exist (no response ID)
- Add test for graceful handling of malformed JSON in SSE streams

## 🧪 Testing

```bash
go test -v ./pkg/mcp/... -run TestClient_ParseSSEResponse
```

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Tested with `make test` or relevant profile
- [x] Commits follow conventional format (`type: subject`)
- [x] No secrets or credentials committed