### PR TITLE
fix: return friendly message for nodes without container logs

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -495,7 +495,21 @@ func (s *Server) handleAgentLogs(w http.ResponseWriter, r *http.Request, agentNa
 	}
 	if !exists {
 		// No container - might be an external MCP server, local process, SSH, or remote A2A agent
-		writeJSONError(w, "No container for '"+agentName+"' - logs unavailable for external/local/SSH/remote nodes", http.StatusNotFound)
+		// Return a friendly message instead of an error so the UI can display it
+		writeJSON(w, []string{
+			"═══════════════════════════════════════════════════════════════",
+			"  Container logs are not available for this node.",
+			"",
+			"  This node is configured as an external MCP server, local",
+			"  process, SSH connection, or remote A2A agent - it does not",
+			"  have a Docker container managed by AgentLab.",
+			"",
+			"  To view logs for external services, check the source directly:",
+			"    • Docker: docker logs <container-name>",
+			"    • Local process: Check stdout/stderr or log files",
+			"    • SSH: Check logs on the remote host",
+			"═══════════════════════════════════════════════════════════════",
+		})
 		return
 	}
 


### PR DESCRIPTION
## 📒 Description

Improves UX when requesting logs for nodes that don't have Docker containers (external MCP servers, local processes, SSH connections, or remote A2A agents).

## 🔍 Type of Change

- [x] Bug fix

## 🔧 Changes Made

- Replace error response with informative message array for containerless nodes
- Provide guidance on how to access logs for external services

## 🧪 Testing

Request logs for an external/SSH/local node via the UI or API and verify a friendly message is displayed instead of an error.

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format (`type: subject`)
- [x] No secrets or credentials committed