### PR TITLE
fix: remove duplicate v prefix from gateway node version display

### DIFF
--- a/web/src/components/graph/GatewayNode.tsx
+++ b/web/src/components/graph/GatewayNode.tsx
@@ -40,7 +40,7 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
         </div>
         <div>
           <h3 className="font-bold text-sm text-text-primary tracking-tight">{data.name}</h3>
-          <p className="text-[10px] text-text-muted font-mono tracking-wider">v{data.version}</p>
+          <p className="text-[10px] text-text-muted font-mono tracking-wider">{data.version}</p>
         </div>
       </div>
 


### PR DESCRIPTION
## 📒 Description

The gateway node in the UI displayed the version with a double "v" prefix (e.g., `vv0.1.0-alpha.2`) because the component added a hardcoded "v" prefix even though the version string from `git describe` already includes it.

## 🔍 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

## 🔧 Changes Made

- Removed hardcoded "v" prefix from `GatewayNode.tsx` to match the `Header.tsx` behavior

## 🧪 Testing

- Build with `make build` and deploy a topology to verify the gateway node shows the version correctly (e.g., `v0.1.0-alpha.2` instead of `vv0.1.0-alpha.2`)

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format (`type: subject`)
- [x] No secrets or credentials committed