### PR TITLE
chore: suppress vite chunk size warning for embedded UI

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,4 +5,9 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: './',
+  build: {
+    // Suppress chunk size warning for embedded CLI tool UI.
+    // React Flow library exceeds default 500 kB threshold.
+    chunkSizeWarningLimit: 600,
+  },
 })


### PR DESCRIPTION
## 📒 Description

Suppress Vite's chunk size warning that appears during production builds. The main JS bundle is 500.84 kB, just over the default 500 kB threshold. This warning is intended for public web apps where load time matters; it's not relevant for an embedded CLI tool UI served locally.

Closes #54

## 🔍 Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Chore

## 🔧 Changes Made

- Set `chunkSizeWarningLimit: 600` in `web/vite.config.ts`

## 🧪 Testing

- Run `make build` and verify no chunk size warning appears

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Code has been commented where necessary
- [x] Tested with `make test` or relevant profile
- [x] Commits follow conventional format (`type: subject`)
- [x] No secrets or credentials committed
- [ ] Documentation has been updated accordingly
- [x] PR has been labeled appropriately (`enhancement`, `bug`, `documentation`, `refactor`, `chore`)