### PR TITLE
docs: release v0.1.0-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to gridctl will be documented in this file.
 ### Bug Fixes
 
 
+- Remove changelog generation from release workflow
 - Correct handle positions and remove translate-y hover
 - Remove translate-y hover to prevent clipping
 - Remove translate-y hover to prevent clipping


### PR DESCRIPTION
## Release v0.1.0-alpha.3

Updates CHANGELOG.md for release.

## Checklist

- [x] All checks passed (lint*, test, build)
- [x] Changelog updated
- [ ] PR reviewed and approved
- [ ] After merge, run `/release-gridctl --tag` to create the release tag

*Note: golangci-lint has a version mismatch (built with Go 1.23, project targets Go 1.24)