### PR TITLE
fix: prevent selection glow bleedthrough on agent badges

### DIFF
--- a/web/src/components/graph/AgentNode.tsx
+++ b/web/src/components/graph/AgentNode.tsx
@@ -55,9 +55,11 @@ const AgentNode = memo(({ data, selected }: AgentNodeProps) => {
 
       {/* A2A capability badge (top-right corner) */}
       {hasA2A && (
-        <div className="absolute -top-2 -right-2 px-2 py-0.5 rounded-full bg-secondary/20 border border-secondary/30 flex items-center gap-1">
-          <Zap size={8} className="text-secondary" />
-          <span className="text-[9px] text-secondary font-medium">
+        <div className="absolute -top-2 -right-2 px-2 py-0.5 rounded-full bg-surface border border-secondary/30 flex items-center gap-1">
+          {/* Teal overlay for glass effect */}
+          <div className="absolute inset-0 rounded-full bg-secondary/20" />
+          <Zap size={8} className="text-secondary relative" />
+          <span className="text-[9px] text-secondary font-medium relative">
             A2A
           </span>
         </div>
@@ -65,15 +67,20 @@ const AgentNode = memo(({ data, selected }: AgentNodeProps) => {
 
       {/* Variant badge (top-left corner) */}
       <div className={cn(
-        'absolute -top-2 -left-2 px-1.5 py-0.5 rounded-full border',
+        'absolute -top-2 -left-2 px-1.5 py-0.5 rounded-full border bg-surface',
         isRemote
-          ? 'bg-secondary/10 border-secondary/30'
-          : 'bg-tertiary/10 border-tertiary/30'
+          ? 'border-secondary/30'
+          : 'border-tertiary/30'
       )}>
+        {/* Color overlay for glass effect */}
+        <div className={cn(
+          'absolute inset-0 rounded-full',
+          isRemote ? 'bg-secondary/10' : 'bg-tertiary/10'
+        )} />
         {isRemote ? (
-          <Globe size={10} className="text-secondary" />
+          <Globe size={10} className="text-secondary relative" />
         ) : (
-          <Server size={10} className="text-tertiary" />
+          <Server size={10} className="text-tertiary relative" />
         )}
       </div>
 
@@ -87,8 +94,9 @@ const AgentNode = memo(({ data, selected }: AgentNodeProps) => {
         <Bot size={22} className={isRemote ? 'text-secondary' : 'text-tertiary'} />
         {/* A2A indicator on icon */}
         {hasA2A && !isRemote && (
-          <div className="absolute -bottom-1 -right-1 p-0.5 rounded-full bg-secondary/20 border border-secondary/40">
-            <Zap size={8} className="text-secondary" />
+          <div className="absolute -bottom-1 -right-1 p-0.5 rounded-full bg-surface border border-secondary/40">
+            <div className="absolute inset-0 rounded-full bg-secondary/20" />
+            <Zap size={8} className="text-secondary relative" />
           </div>
         )}
       </div>


### PR DESCRIPTION
## 📒 Description

Fixes visual artifact where the selection ring/glow bleeds through semi-transparent agent badges when an AgentNode is selected. The amber/purple selection indicator was visible through the teal A2A badge and variant badge backgrounds, reducing legibility.

Closes #77

## 🔍 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

## 🔧 Changes Made

- Added solid `bg-surface` backing to A2A badge (top-right corner)
- Added solid `bg-surface` backing to variant badge (top-left corner)
- Added solid `bg-surface` backing to A2A indicator on icon
- Overlaid translucent color layers as absolute positioned children to maintain glass aesthetic
- Added `relative` class to badge content for proper z-ordering

## 🧪 Testing

- Built frontend with `make build-web` (success)
- Visual verification: select an agent node with A2A capability and observe badges no longer show glow bleedthrough

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Tested with `make test` or relevant profile
- [x] Commits follow conventional format (`type: subject`)
- [x] No secrets or credentials committed