### PR TITLE
fix: add client count display to gateway node

### DIFF
--- a/web/src/components/graph/GatewayNode.tsx
+++ b/web/src/components/graph/GatewayNode.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { Handle, Position } from '@xyflow/react';
-import { Activity, Server, Wrench, Zap, Bot, Users, Radio, ListChecks } from 'lucide-react';
+import { Activity, Server, Wrench, Zap, Bot, Users, Radio, ListChecks, Monitor } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { StatusDot } from '../ui/StatusDot';
 import type { GatewayNodeData } from '../../types';
@@ -115,6 +115,21 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
             </div>
             <span className="text-sm font-bold text-text-primary tabular-nums">
               {data.sessions}
+            </span>
+          </div>
+        )}
+
+        {/* Linked Clients */}
+        {(data.clientCount ?? 0) > 0 && (
+          <div className="flex items-center justify-between group">
+            <div className="flex items-center gap-2.5">
+              <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
+                <Monitor size={12} className="text-primary" />
+              </div>
+              <span className="text-xs text-text-secondary font-medium">Clients</span>
+            </div>
+            <span className="text-sm font-bold text-text-primary tabular-nums">
+              {data.clientCount}
             </span>
           </div>
         )}


### PR DESCRIPTION
## 📒 Description

Add the missing client count display to the gateway node. This was part of the linked clients feature (#126) but the GatewayNode rendering change was not committed with the branch.

## 🔍 Type of Change

- [x] Bug fix

## 🔧 Changes Made

- Import `Monitor` icon from lucide-react
- Add "Linked Clients" section to gateway node stats, showing client count when > 0

## 🧪 Testing

- Verified gateway node renders client count when `clientCount > 0`
- Existing `SessionTaskCounts` test already includes `clientCount` in gateway test data

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Tested with `make test` or relevant profile
- [x] Commits follow conventional format (`type: subject`)
- [x] No secrets or credentials committed
- [x] PR has been labeled appropriately (`enhancement`, `bug`, `documentation`, `refactor`, `chore`)