### PR TITLE
chore: bump vite chunk size warning limit to 650

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
   build: {
     // Suppress chunk size warning for embedded CLI tool UI.
     // React Flow library exceeds default 500 kB threshold.
-    chunkSizeWarningLimit: 600,
+    chunkSizeWarningLimit: 650,
   },
 })


### PR DESCRIPTION
## Description

Bumps Vite's `chunkSizeWarningLimit` from 600 to 650 kB. The production bundle (630 kB, 192 kB gzipped) slightly exceeds the previous threshold due to React Flow. This is a non-functional config change to suppress the build warning.

## Type of Change

- [x] Chore (non-functional configuration)

## Changes Made

- Updated `web/vite.config.ts` warning limit from 600 to 650

## Testing

`make build` completes without chunk size warning.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed