### PR TITLE
feat: print runtime info and rootless warning at deploy startup

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -127,6 +127,16 @@ func (sc *StackController) Deploy(ctx context.Context) error {
 	}
 	defer rt.Close()
 
+	// Print detected runtime at startup
+	if printer != nil {
+		if info := rt.RuntimeInfo(); info != nil {
+			printer.Info("Runtime detected", "runtime", info.DisplayName())
+			if info.IsRootless() {
+				printer.Warn("Rootless Podman detected — container-to-host networking may be limited")
+			}
+		}
+	}
+
 	// Set up logging for orchestrator
 	logBuffer, bufferHandler := sc.setupOrchestratorLogging(rt)
 


### PR DESCRIPTION
## Description

Prints the detected container runtime during `gridctl deploy` startup and warns when rootless Podman is detected, surfacing networking limitations early rather than requiring users to run `gridctl info`.

## Type of Change

- [x] Enhancement

## Changes Made

- Print detected runtime name after runtime creation (e.g., `runtime=docker` or `runtime=podman (experimental)`)
- Warn when rootless Podman is detected about container-to-host networking limitations
- Output respects `--quiet` mode and only fires in the parent process

## Testing

- `gridctl deploy stack.yaml` with Docker shows `Runtime detected runtime=docker`
- `gridctl deploy stack.yaml --runtime podman` with rootless Podman shows runtime info plus rootless warning
- `gridctl deploy stack.yaml --quiet` suppresses runtime output

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed