### PR TITLE
feat: add individual MCP server restart API and UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,7 +390,7 @@ When `gridctl deploy` runs, it:
 
 **Endpoints:**
 - **MCP:** `POST /mcp` (JSON-RPC), `GET /sse` + `POST /message` (SSE for Claude Desktop)
-- **API:** `/api/status`, `/api/mcp-servers`, `/api/tools`, `/api/logs`, `/api/clients`, `/api/reload`, `/health`, `/ready`
+- **API:** `/api/status`, `/api/mcp-servers`, `/api/mcp-servers/{name}/restart`, `/api/tools`, `/api/logs`, `/api/clients`, `/api/reload`, `/health`, `/ready`
 - **Vault:** `/api/vault`, `/api/vault/status`, `/api/vault/unlock`, `/api/vault/lock`, `/api/vault/sets`, `/api/vault/import`
 - **Agents:** `/api/agents/{name}/logs`, `/api/agents/{name}/restart`, `/api/agents/{name}/stop`
 - **A2A:** `/.well-known/agent.json`, `/a2a/` (list agents), `/a2a/{agent}` (GET card, POST JSON-RPC)
@@ -412,6 +412,9 @@ When `gridctl deploy` runs, it:
 - `GET /api/agents/{name}/logs` - Returns container logs for an agent
 - `POST /api/agents/{name}/restart` - Restart an agent container
 - `POST /api/agents/{name}/stop` - Stop an agent container
+
+**MCP Server Control API:**
+- `POST /api/mcp-servers/{name}/restart` - Restart an individual MCP server connection
 
 **Registry API:**
 - `GET /api/registry/status` - Returns skill counts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to gridctl will be documented in this file.
 
 ### Features
 
-
+- Add individual MCP server restart API and UI control
 - Add OpenCode provisioner for link/unlink
 - Register OpenCode in provisioner registry
 - Add OpenCode case to simulateLink

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -301,6 +301,32 @@ curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/agents/
 
 ---
 
+### MCP Server Control
+
+#### `POST /api/mcp-servers/{name}/restart`
+
+Restarts an individual MCP server connection. For container-based servers (stdio transport), this restarts the Docker container and re-establishes the MCP session. For external servers (HTTP/SSE), this re-initializes the MCP handshake and refreshes tools. For process-based servers (local, SSH), this kills and restarts the process.
+
+**Auth:** Yes
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/mcp-servers/github/restart
+```
+
+**Response:**
+```json
+{
+  "status": "restarted",
+  "server": "github"
+}
+```
+
+**Errors:**
+- `404` — Server name not found in gateway
+- `500` — Restart failed (container error, connection timeout, etc.)
+
+---
+
 ### Vault (Secrets Management)
 
 The vault stores secrets locally with optional encryption. Secrets can be organized into variable sets for scoped injection.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -160,6 +160,7 @@ func (s *Server) Handler() http.Handler {
 
 	// API endpoints
 	mux.HandleFunc("/api/status", s.handleStatus)
+	mux.HandleFunc("/api/mcp-servers/", s.handleMCPServerAction)
 	mux.HandleFunc("/api/mcp-servers", s.handleMCPServers)
 	mux.HandleFunc("/api/tools", s.handleTools)
 	mux.HandleFunc("/api/logs", s.handleGatewayLogs)
@@ -762,6 +763,46 @@ func (s *Server) handleAgentStop(w http.ResponseWriter, r *http.Request, agentNa
 	}
 
 	writeJSON(w, map[string]string{"status": "stopped", "agent": agentName})
+}
+
+// handleMCPServerAction routes MCP server control requests.
+// URL pattern: /api/mcp-servers/{name}/{action}
+func (s *Server) handleMCPServerAction(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/mcp-servers/")
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 {
+		http.Error(w, "Invalid path: expected /api/mcp-servers/{name}/{action}", http.StatusBadRequest)
+		return
+	}
+
+	serverName := parts[0]
+	action := parts[1]
+
+	switch action {
+	case "restart":
+		s.handleMCPServerRestart(w, r, serverName)
+	default:
+		http.Error(w, "Unknown action: "+action, http.StatusBadRequest)
+	}
+}
+
+// handleMCPServerRestart restarts an individual MCP server connection.
+func (s *Server) handleMCPServerRestart(w http.ResponseWriter, r *http.Request, serverName string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := s.gateway.RestartMCPServer(r.Context(), serverName); err != nil {
+		if strings.Contains(err.Error(), "unknown MCP server") {
+			writeJSONError(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		writeJSONError(w, "Restart failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, map[string]string{"status": "restarted", "server": serverName})
 }
 
 // handleGatewayLogs returns structured logs from the gateway log buffer.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -974,6 +974,60 @@ func TestHandleAgentStop_MethodNotAllowed(t *testing.T) {
 	}
 }
 
+// --- MCP server action endpoint tests ---
+
+func TestHandleMCPServerAction_InvalidPath(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/mcp-servers/myserver", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleMCPServerAction_UnknownAction(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/mcp-servers/myserver/delete", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleMCPServerRestart_MethodNotAllowed(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp-servers/myserver/restart", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestHandleMCPServerRestart_NotFound(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/mcp-servers/nonexistent/restart", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
 // --- Docker error path tests ---
 
 func TestHandleAgentLogs_ContainerListError(t *testing.T) {

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/gridctl/gridctl/pkg/config"
 	"github.com/gridctl/gridctl/pkg/dockerclient"
 	"github.com/gridctl/gridctl/pkg/logging"
@@ -416,6 +417,59 @@ func (g *Gateway) SetServerMeta(cfg MCPServerConfig) {
 func (g *Gateway) UnregisterMCPServer(name string) {
 	g.router.RemoveClient(name)
 	g.router.RefreshTools()
+}
+
+// RestartMCPServer restarts an individual MCP server by name.
+// It tears down the existing connection, optionally restarts the container
+// (for stdio transport), and re-registers the server using its stored config.
+func (g *Gateway) RestartMCPServer(ctx context.Context, name string) error {
+	g.mu.RLock()
+	cfg, ok := g.serverMeta[name]
+	g.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("unknown MCP server: %s", name)
+	}
+
+	g.logger.Info("restarting MCP server", "name", name, "transport", cfg.Transport)
+
+	// Close the existing client connection
+	if client := g.router.GetClient(name); client != nil {
+		if closer, ok := client.(io.Closer); ok {
+			if err := closer.Close(); err != nil {
+				g.logger.Warn("error closing MCP server connection", "name", name, "error", err)
+			}
+		}
+	}
+
+	// Unregister from router (removes client + cleans tool registry)
+	g.UnregisterMCPServer(name)
+
+	// For stdio (container) transport, restart the Docker container
+	if cfg.Transport == TransportStdio && !cfg.External && !cfg.LocalProcess && !cfg.SSH && !cfg.OpenAPI {
+		if g.dockerCli != nil && cfg.ContainerID != "" {
+			timeout := 10
+			if err := g.dockerCli.ContainerRestart(ctx, cfg.ContainerID, container.StopOptions{Timeout: &timeout}); err != nil {
+				return fmt.Errorf("restarting container for %s: %w", name, err)
+			}
+		}
+	}
+
+	// Re-register using stored config (creates new client, initializes MCP, fetches tools)
+	if err := g.RegisterMCPServer(ctx, cfg); err != nil {
+		return fmt.Errorf("re-registering MCP server %s: %w", name, err)
+	}
+
+	// Update health status to healthy
+	g.healthMu.Lock()
+	g.health[name] = &HealthStatus{
+		Healthy:     true,
+		LastCheck:   time.Now(),
+		LastHealthy: time.Now(),
+	}
+	g.healthMu.Unlock()
+
+	g.logger.Info("MCP server restarted", "name", name)
+	return nil
 }
 
 // RegisterAgent registers an agent and its allowed MCP servers with optional tool filtering.

--- a/pkg/mcp/gateway_test.go
+++ b/pkg/mcp/gateway_test.go
@@ -304,6 +304,73 @@ func TestGateway_UnregisterMCPServer(t *testing.T) {
 	}
 }
 
+// closableClient wraps a MockAgentClient to implement io.Closer.
+type closableClient struct {
+	AgentClient
+	closeFn func() error
+}
+
+func (c *closableClient) Close() error {
+	return c.closeFn()
+}
+
+func TestGateway_RestartMCPServer_NotFound(t *testing.T) {
+	g := NewGateway()
+	err := g.RestartMCPServer(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unknown server")
+	}
+	if !strings.Contains(err.Error(), "unknown MCP server") {
+		t.Errorf("expected 'unknown MCP server' in error, got: %s", err)
+	}
+}
+
+func TestGateway_RestartMCPServer_ClosesExistingClient(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+
+	var closed atomic.Bool
+	mock := setupMockAgentClient(ctrl, "server1", []Tool{{Name: "tool1"}})
+	client := &closableClient{
+		AgentClient: mock,
+		closeFn:     func() error { closed.Store(true); return nil },
+	}
+	g.Router().AddClient(client)
+	g.SetServerMeta(MCPServerConfig{Name: "server1", Transport: TransportHTTP, Endpoint: "http://localhost:9999", External: true})
+
+	// Restart will fail at re-registration (no real server), but close should be called
+	_ = g.RestartMCPServer(context.Background(), "server1")
+
+	if !closed.Load() {
+		t.Error("expected existing client to be closed")
+	}
+}
+
+func TestGateway_RestartMCPServer_UnregistersBeforeReregister(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+
+	mock := setupMockAgentClient(ctrl, "server1", []Tool{{Name: "tool1"}})
+	g.Router().AddClient(mock)
+	g.Router().RefreshTools()
+	g.SetServerMeta(MCPServerConfig{Name: "server1", Transport: TransportHTTP, Endpoint: "http://localhost:9999", External: true})
+
+	// Verify tools exist before restart
+	if len(g.Router().AggregatedTools()) != 1 {
+		t.Fatal("expected 1 tool before restart")
+	}
+
+	// Restart will fail at re-registration, but unregister should have cleared the router
+	_ = g.RestartMCPServer(context.Background(), "server1")
+
+	if g.Router().GetClient("server1") != nil {
+		t.Error("expected client to be removed after failed restart")
+	}
+	if len(g.Router().AggregatedTools()) != 0 {
+		t.Error("expected 0 tools after failed restart")
+	}
+}
+
 func TestGateway_AgentToolFiltering(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	g := NewGateway()

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -438,7 +438,7 @@ export function Sidebar() {
         {/* Controls Section (not for clients - they aren't containers) */}
         {!isClient && (
           <Section title="Actions" icon={Terminal} defaultOpen>
-            <ControlBar agentName={data.name} />
+            <ControlBar name={data.name} variant={isServer ? 'mcp-server' : 'agent'} />
             <button
               onClick={handleShowLogs}
               className={cn(

--- a/web/src/components/ui/ControlBar.tsx
+++ b/web/src/components/ui/ControlBar.tsx
@@ -1,14 +1,15 @@
 import { useState } from 'react';
 import { RefreshCw, Square, AlertCircle, Zap } from 'lucide-react';
 import { Button } from './Button';
-import { restartAgent, stopAgent } from '../../lib/api';
+import { restartAgent, stopAgent, restartMCPServer } from '../../lib/api';
 
 interface ControlBarProps {
-  agentName: string;
+  name: string;
+  variant: 'agent' | 'mcp-server';
   onActionComplete?: () => void;
 }
 
-export function ControlBar({ agentName, onActionComplete }: ControlBarProps) {
+export function ControlBar({ name, variant, onActionComplete }: ControlBarProps) {
   const [isRestarting, setIsRestarting] = useState(false);
   const [isStopping, setIsStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -17,7 +18,11 @@ export function ControlBar({ agentName, onActionComplete }: ControlBarProps) {
     setIsRestarting(true);
     setError(null);
     try {
-      await restartAgent(agentName);
+      if (variant === 'mcp-server') {
+        await restartMCPServer(name);
+      } else {
+        await restartAgent(name);
+      }
       onActionComplete?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Restart failed');
@@ -30,7 +35,7 @@ export function ControlBar({ agentName, onActionComplete }: ControlBarProps) {
     setIsStopping(true);
     setError(null);
     try {
-      await stopAgent(agentName);
+      await stopAgent(name);
       onActionComplete?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Stop failed');
@@ -55,15 +60,17 @@ export function ControlBar({ agentName, onActionComplete }: ControlBarProps) {
           )}
           {isRestarting ? 'Restarting...' : 'Restart'}
         </Button>
-        <Button
-          onClick={handleStop}
-          disabled={isRestarting || isStopping}
-          variant="danger"
-          size="sm"
-        >
-          <Square size={14} />
-          {isStopping ? 'Stopping...' : 'Stop'}
-        </Button>
+        {variant === 'agent' && (
+          <Button
+            onClick={handleStop}
+            disabled={isRestarting || isStopping}
+            variant="danger"
+            size="sm"
+          >
+            <Square size={14} />
+            {isStopping ? 'Stopping...' : 'Stop'}
+          </Button>
+        )}
       </div>
 
       {error && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -169,6 +169,31 @@ export async function stopAgent(name: string): Promise<void> {
   }
 }
 
+// === MCP Server Control Functions ===
+
+/**
+ * Restart an MCP server connection
+ * POST /api/mcp-servers/{name}/restart
+ */
+export async function restartMCPServer(name: string): Promise<void> {
+  const response = await fetch(
+    `${API_BASE}/api/mcp-servers/${encodeURIComponent(name)}/restart`,
+    {
+      method: 'POST',
+      headers: buildHeaders(),
+    },
+  );
+
+  if (response.status === 401) {
+    throw new AuthError('Authentication required');
+  }
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || `Restart failed: ${response.status} ${response.statusText}`);
+  }
+}
+
 // === Structured Log Entry (from gateway) ===
 
 export interface LogEntry {


### PR DESCRIPTION
## Summary

- Add `POST /api/mcp-servers/{name}/restart` endpoint for restarting individual MCP servers by name
- Extend `ControlBar` component with `variant` prop to support both agent and MCP server restart
- Works across all transport types: stdio (container), process, SSH, HTTP/SSE, OpenAPI

Closes #221

## Changes

### Backend
- **`pkg/mcp/gateway.go`** — Add `RestartMCPServer(ctx, name) error` method with transport-aware restart (unregister → optionally restart container → re-register)
- **`internal/api/api.go`** — Add `/api/mcp-servers/{name}/restart` route with dispatcher and handler (404/405/500 error handling)

### Frontend
- **`web/src/lib/api.ts`** — Add `restartMCPServer()` API function
- **`web/src/components/ui/ControlBar.tsx`** — Add `variant` prop (`'agent' | 'mcp-server'`), dispatch to correct API, hide Stop button for MCP servers
- **`web/src/components/layout/Sidebar.tsx`** — Pass variant based on node type

### Tests
- **`pkg/mcp/gateway_test.go`** — Tests for unknown server, client close, and unregister-before-reregister
- **`internal/api/api_test.go`** — Tests for invalid path, unknown action, method not allowed, 404

### Documentation
- **`docs/api-reference.md`** — Add MCP Server Control section
- **`AGENTS.md`** — Update endpoint list
- **`CHANGELOG.md`** — Add feature entry

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go test ./pkg/mcp/...` passes (3 new restart tests)
- [x] `go test ./internal/api/...` passes (4 new handler tests)
- [x] `npm run build` in web/ compiles clean
- [x] `npx eslint` on changed files passes clean