### PR TITLE
chore: increase vite chunk size warning limit to 1MB

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   base: '/',
   build: {
+    chunkSizeWarningLimit: 1000,
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
## Description

Increases the Vite chunk size warning threshold from 500 kB to 1 MB. The main bundle (~696 kB) is already well-chunked with manual splits for React, graph, and chart vendors — the warning is noise at this point.

## Type of Change

- [x] chore

## Changes Made

- Set `chunkSizeWarningLimit: 1000` in `web/vite.config.ts`

## Testing

Run `make build` and confirm no chunk size warning appears.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed