### PR TITLE
fix: improve metrics graph axis label contrast

### DIFF
--- a/web/src/components/chart/AreaChart.tsx
+++ b/web/src/components/chart/AreaChart.tsx
@@ -389,7 +389,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
             ticks={startEndOnly ? [data[0][index], data[data.length - 1][index]] : undefined}
             fill=""
             stroke=""
-            className="text-xs fill-text-muted"
+            className="text-xs fill-text-secondary"
             tickLine={false}
             axisLine={false}
             minTickGap={tickGap}
@@ -410,7 +410,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
             tick={{ transform: "translate(-3, 0)" }}
             fill=""
             stroke=""
-            className="text-xs fill-text-muted"
+            className="text-xs fill-text-secondary"
             tickFormatter={type === "percent" ? valueToPercent : valueFormatter}
             allowDecimals={allowDecimals}
           >


### PR DESCRIPTION
## Description

Axis tick labels on the metrics graph were using `fill-text-muted` (`#78716c`), which has very low contrast against the dark theme background. This changes both `XAxis` and `YAxis` to `fill-text-secondary` (`#a8a29e`) for readable labels that still blend with the dark theme.

Closes #285

## Type of Change

- [x] Bug fix

## Changes Made

- `web/src/components/chart/AreaChart.tsx`: update `XAxis` and `YAxis` className from `fill-text-muted` to `fill-text-secondary`

## Testing

1. Run `gridctl portal` and open any MCP server
2. Navigate to the **Metrics** tab
3. Verify axis tick labels (values and timestamps) are clearly readable on the dark background
4. Pop out the metrics window and confirm the same improvement

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed