### PR TITLE
fix: show pending agents on canvas after wizard deploy

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -685,6 +685,24 @@ func (s *Server) getAgentStatuses() []AgentStatus {
 		}
 	}
 
+	// Include config-only agents (defined in stack file but not yet running or registered with A2A)
+	if s.stackFile != "" {
+		if stack, _, err := config.ValidateStackFile(s.stackFile); err == nil {
+			for _, cfgAgent := range stack.Agents {
+				if !seen[cfgAgent.Name] {
+					if _, hasContainer := containerAgents[cfgAgent.Name]; !hasContainer {
+						unified = append(unified, AgentStatus{
+							Name:    cfgAgent.Name,
+							Status:  "pending",
+							Variant: "local",
+							Uses:    cfgAgent.Uses,
+						})
+					}
+				}
+			}
+		}
+	}
+
 	sort.Slice(unified, func(i, j int) bool { return unified[i].Name < unified[j].Name })
 	return unified
 }

--- a/internal/api/stack_test.go
+++ b/internal/api/stack_test.go
@@ -439,3 +439,37 @@ func TestHandleStack_Routing(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentAppearsInStatusAfterAppend(t *testing.T) {
+	sf := writeTestStack(t)
+	s := &Server{stackFile: sf}
+
+	// Append a new agent to the stack
+	body, _ := json.Marshal(map[string]string{
+		"yaml":         "name: test-agent\nruntime: node\nprompt: test\n",
+		"resourceType": "agent",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/stack/append", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+	s.handleStackAppend(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Agent should now appear in getAgentStatuses with status "pending"
+	agents := s.getAgentStatuses()
+
+	var names []string
+	for _, a := range agents {
+		names = append(names, a.Name)
+	}
+	assert.Contains(t, names, "test-agent", "newly appended agent should appear in status")
+
+	var found *AgentStatus
+	for i := range agents {
+		if agents[i].Name == "test-agent" {
+			found = &agents[i]
+			break
+		}
+	}
+	assert.NotNil(t, found)
+	assert.Equal(t, "pending", found.Status)
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -217,7 +217,7 @@ export function Header({ onRefresh, isRefreshing }: HeaderProps) {
         onApply={executeReload}
         validationErrors={validationErrors}
       />
-      <CreationWizard onOpenVault={() => setShowVault(true)} />
+      <CreationWizard onOpenVault={() => setShowVault(true)} onDeploy={onRefresh} />
     </header>
   );
 }

--- a/web/src/components/wizard/CreationWizard.tsx
+++ b/web/src/components/wizard/CreationWizard.tsx
@@ -119,9 +119,10 @@ function getResourceCounts(
 
 interface CreationWizardProps {
   onOpenVault?: () => void;
+  onDeploy?: () => void;
 }
 
-export function CreationWizard({ onOpenVault }: CreationWizardProps) {
+export function CreationWizard({ onOpenVault, onDeploy }: CreationWizardProps) {
   const {
     isOpen,
     close,
@@ -231,6 +232,11 @@ export function CreationWizard({ onOpenVault }: CreationWizardProps) {
     }
     setExpertMode(enabled);
   };
+
+  const handleDeploy = useCallback(() => {
+    close();
+    onDeploy?.();
+  }, [close, onDeploy]);
 
   const canGoNext = () => {
     switch (currentStep) {
@@ -366,7 +372,7 @@ export function CreationWizard({ onOpenVault }: CreationWizardProps) {
                     yamlError,
                     generatedYaml,
                     counts,
-                    close,
+                    handleDeploy,
                   )}
                 </div>
               </Panel>
@@ -395,7 +401,7 @@ export function CreationWizard({ onOpenVault }: CreationWizardProps) {
                 yamlError,
                 generatedYaml,
                 counts,
-                close,
+                handleDeploy,
               )}
             </div>
           )}


### PR DESCRIPTION
## Description

After deploying an agent via the Creation Wizard, agents now appear on the canvas immediately with a pending status. Previously, `getAgentStatuses()` only returned agents with active Docker containers or A2A registration, so newly deployed agents were invisible to the canvas even though the YAML config had been updated.

## Type of Change

- [x] Bug fix

## Changes Made

- Extended `getAgentStatuses()` to read the stack config file and include agents defined there but not yet running, returning them with `status: "pending"` — this makes newly deployed agents visible on the canvas without requiring a container to be started
- Fixed `CreationWizard` to call a proper `onDeploy` callback after successful deploy instead of only calling `close()`, triggering an immediate poll refresh so the canvas updates without waiting for the next polling interval
- Wired `onRefresh` from `Header` into `CreationWizard.onDeploy` so deploy completion fires the same refresh path as the manual refresh button
- Added regression test `TestAgentAppearsInStatusAfterAppend` to verify the new behavior

## Testing

1. Run `go test ./internal/api/` — all tests pass including `TestAgentAppearsInStatusAfterAppend`
2. Deploy an agent via the Creation Wizard — the agent node should appear on the canvas with pending status immediately after the success toast

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #313