### PR TITLE
feat: expose AgentSkill.Dir field in API responses

### DIFF
--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -48,7 +48,7 @@ type AgentSkill struct {
 
 	// --- Computed fields (not serialized to YAML) ---
 	FileCount int    `yaml:"-" json:"fileCount"` // Number of supporting files (scripts/, references/, assets/)
-	Dir       string `yaml:"-" json:"-"`          // Relative path from skills/ root (e.g., "git-workflow/branch-fork")
+	Dir       string `yaml:"-" json:"dir,omitempty"` // Relative path from skills/ root (e.g., "git-workflow/branch-fork")
 }
 
 // IsExecutable returns true if the skill has a workflow definition.


### PR DESCRIPTION
## Description

Exposes the `AgentSkill.Dir` field in JSON API responses by changing its struct tag from `json:"-"` to `json:"dir,omitempty"`. This enables the frontend to group skills by their top-level directory.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Changed `Dir` field JSON tag in `AgentSkill` struct (`pkg/registry/types.go`) from `json:"-"` to `json:"dir,omitempty"`

## Testing

`go build ./...` and `go test ./pkg/registry/...` both pass. The `Dir` field is already computed and validated by existing tests in `store_test.go`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #319