### PR TITLE
feat: add BookOpen toggle button for skills canvas visibility

### DIFF
--- a/web/src/components/graph/Canvas.tsx
+++ b/web/src/components/graph/Canvas.tsx
@@ -9,7 +9,7 @@ import {
   type Connection,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { RotateCcw, Spline, Minus, Plus, Maximize, Rows3, LayoutGrid, Flame, Layers, Server, Database, GitCompareArrows, Eye, Cable, KeyRound } from 'lucide-react';
+import { RotateCcw, Spline, Minus, Plus, Maximize, Rows3, LayoutGrid, Flame, Layers, Server, Database, GitCompareArrows, Eye, Cable, KeyRound, BookOpen } from 'lucide-react';
 
 import { nodeTypes } from './nodeTypes';
 import { useStackStore } from '../../stores/useStackStore';
@@ -32,6 +32,7 @@ export function Canvas() {
   const selectNode = useStackStore((s) => s.selectNode);
   const selectedNodeId = useStackStore((s) => s.selectedNodeId);
   const resetLayout = useStackStore((s) => s.resetLayout);
+  const refreshNodesAndEdges = useStackStore((s) => s.refreshNodesAndEdges);
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
   const edgeStyle = useUIStore((s) => s.edgeStyle);
   const toggleEdgeStyle = useUIStore((s) => s.toggleEdgeStyle);
@@ -47,6 +48,8 @@ export function Canvas() {
   const toggleWiringMode = useUIStore((s) => s.toggleWiringMode);
   const showSecretHeatmap = useUIStore((s) => s.showSecretHeatmap);
   const toggleSecretHeatmap = useUIStore((s) => s.toggleSecretHeatmap);
+  const showSkillsOnCanvas = useUIStore((s) => s.showSkillsOnCanvas);
+  const toggleSkillsOnCanvas = useUIStore((s) => s.toggleSkillsOnCanvas);
   const agentIsThinking = usePlaygroundStore((s) => s.agentIsThinking);
   const activeToolCallEdges = usePlaygroundStore((s) => s.activeToolCallEdges);
 
@@ -162,6 +165,11 @@ export function Canvas() {
 
   // No-op connect handler (wiring mode no longer supports agent connections)
   const onConnect = useCallback((_connection: Connection) => {}, []);
+
+  const handleSkillsToggle = useCallback(() => {
+    toggleSkillsOnCanvas();
+    refreshNodesAndEdges();
+  }, [toggleSkillsOnCanvas, refreshNodesAndEdges]);
 
   const isEmpty = !nodes || nodes.length === 0;
 
@@ -359,6 +367,16 @@ export function Canvas() {
             title={showSecretHeatmap ? 'Hide secret heatmap' : 'Show secret heatmap'}
           >
             <KeyRound className="w-4 h-4" />
+          </button>
+          <button
+            onClick={handleSkillsToggle}
+            className={cn(
+              'control-button',
+              showSkillsOnCanvas && 'ring-1 ring-tertiary/30 text-tertiary'
+            )}
+            title="Show skill groups on canvas"
+          >
+            <BookOpen className="w-4 h-4" />
           </button>
         </Panel>
       </ReactFlow>


### PR DESCRIPTION
## Description

Adds a BookOpen icon button to the canvas controls panel that toggles skill group node visibility. Clicking it calls `toggleSkillsOnCanvas()` followed by `refreshNodesAndEdges()` so the canvas updates immediately.

## Type of Change

- [x] New feature

## Changes Made

- `Canvas.tsx`: added `BookOpen` import, subscribed to `showSkillsOnCanvas`/`toggleSkillsOnCanvas` from `useUIStore` and `refreshNodesAndEdges` from `useStackStore`
- Added `handleSkillsToggle` callback (toggle then refresh)
- Added BookOpen button to controls panel — active state shows `ring-1 ring-tertiary/30 text-tertiary`, tooltip reads "Show skill groups on canvas"

## Testing

Open the canvas — no skill group nodes visible. Click the BookOpen button in the bottom-left controls panel — skill group nodes and dashed edges appear. Click again — they disappear.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #322