### PR TITLE
feat: make GatewayNode skills row clickable to open registry

### DIFF
--- a/web/src/components/graph/GatewayNode.tsx
+++ b/web/src/components/graph/GatewayNode.tsx
@@ -3,6 +3,7 @@ import { Handle, Position } from '@xyflow/react';
 import { Activity, Server, Database, Wrench, Zap, Radio, Monitor, Code, Library } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { StatusDot } from '../ui/StatusDot';
+import { useWindowManager } from '../../hooks/useWindowManager';
 import type { GatewayNodeData } from '../../types';
 
 interface GatewayNodeProps {
@@ -11,6 +12,8 @@ interface GatewayNodeProps {
 }
 
 const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
+  const { openDetachedWindow } = useWindowManager();
+
   return (
     <div
       className={cn(
@@ -119,7 +122,11 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
 
         {/* Skills (Registry) */}
         {(data.totalSkills ?? 0) > 0 && (
-          <div className="flex items-center justify-between group">
+          <div
+            className="flex items-center justify-between group cursor-pointer hover:bg-primary/5 rounded-md transition-colors px-1 -mx-1"
+            onClick={(e) => { e.stopPropagation(); openDetachedWindow('registry'); }}
+            title="Open skills dashboard"
+          >
             <div className="flex items-center gap-2.5">
               <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
                 <Library size={12} className="text-primary" />


### PR DESCRIPTION
## Description

Makes the Skills stat row in GatewayNode interactive — clicking it opens the detached registry dashboard window at `/registry`.

## Type of Change

- [x] New feature

## Changes Made

- Added `useWindowManager` hook to `GatewayNode` to call `openDetachedWindow('registry')` on click
- Added `cursor-pointer hover:bg-primary/5 rounded-md transition-colors` to the Skills row
- Added `e.stopPropagation()` to prevent canvas drag/select interference
- Added `title="Open skills dashboard"` tooltip

## Testing

1. Start the app with skills registered
2. The Skills stat row in the gateway node shows a pointer cursor on hover with a subtle background highlight
3. Clicking the row opens the registry window (or focuses it if already open)
4. Canvas drag and node selection are unaffected

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #322