### PR TITLE
refactor: upgrade RegistrySidebar search to fuse.js

### DIFF
--- a/web/src/components/registry/RegistrySidebar.tsx
+++ b/web/src/components/registry/RegistrySidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import {
   Library,
   BookOpen,
@@ -25,6 +25,7 @@ import { useRegistryStore } from '../../stores/useRegistryStore';
 import { useStackStore } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
 import { useWindowManager } from '../../hooks/useWindowManager';
+import { useFuzzySearch } from '../../hooks/useFuzzySearch';
 import { PopoutButton } from '../ui/PopoutButton';
 import { SkillEditor } from './SkillEditor';
 import { showToast } from '../ui/Toast';
@@ -79,14 +80,7 @@ export function RegistrySidebar({ embedded = false }: { embedded?: boolean } = {
 
   const openWizard = useWizardStore((s) => s.open);
 
-  const filteredSkills = useMemo(() => {
-    const all = skills ?? [];
-    if (!searchQuery) return all;
-    const lower = searchQuery.toLowerCase();
-    return all.filter(
-      (s) => s.name.toLowerCase().includes(lower) || (s.description ?? '').toLowerCase().includes(lower),
-    );
-  }, [skills, searchQuery]);
+  const filteredSkills = useFuzzySearch(skills ?? [], searchQuery);
 
   // Delete confirmation
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);


### PR DESCRIPTION
## Description

Replaces the substring `includes()` filter in `RegistrySidebar` with the shared `useFuzzySearch` hook, matching the fuzzy search behavior already in the skills dashboard.

## Type of Change

- [x] Refactor (no functional change, code improvement)

## Changes Made

- Swapped `filteredSkills` useMemo for `useFuzzySearch(skills ?? [], searchQuery)` in `RegistrySidebar.tsx`
- Removed unused `useMemo` import

## Testing

Search "feat" in the registry sidebar — should return feature-dev, feature-scout, feature-build, etc. previously these only matched on exact substring.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #322