### PR TITLE
docs: add security policy and vulnerability disclosure process

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-f59e0b?style=flat-square" alt="License"></a>
   <a href="https://github.com/gridctl/gridctl/actions"><img src="https://img.shields.io/github/actions/workflow/status/gridctl/gridctl/gatekeeper.yaml?style=flat-square&label=build" alt="Build"></a>
   <a href="https://goreportcard.com/report/github.com/gridctl/gridctl"><img src="https://goreportcard.com/badge/github.com/gridctl/gridctl?style=flat-square" alt="Go Report"></a>
+  <a href="SECURITY.md"><img src="https://img.shields.io/badge/Security-Policy-f59e0b?style=flat-square" alt="Security Policy"></a>
 </p>
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+This document describes how to report security vulnerabilities in gridctl and how the project handles disclosure. If you have found a security issue, follow the process below. **Do not open a public GitHub issue** — not through the issue templates and not through any other public channel.
+
+## Reporting a Vulnerability
+
+Use GitHub's private vulnerability reporting feature:
+
+1. Go to the [Security tab](https://github.com/gridctl/gridctl/security) of this repository
+2. Click **"Report a vulnerability"**
+3. Fill in the report form with as much detail as possible
+
+Include in your report:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept (where possible)
+- The version of gridctl affected
+- Any relevant configuration or environment details
+
+The issue template system is for bugs and feature requests only — it is not appropriate for security reports. Do not open a public issue or pull request disclosing the vulnerability.
+
+## Response Timeline
+
+- **Initial acknowledgment**: within 14 days of submission
+- **Fix timeline**: best effort; severity and complexity determine the timeline
+
+## Disclosure Policy
+
+When a vulnerability is confirmed:
+
+1. A fix is prepared on a private branch
+2. The fix is released as a patch version
+3. A GitHub Security Advisory is published after the patch is available
+
+Coordinated disclosure is preferred. Reporters are credited in the advisory unless they request anonymity.
+
+## Security Design
+
+Gridctl is built with security as a constitutional principle. [Article XII](CONSTITUTION.md#article-xii--secure-defaults) requires that all security-sensitive configuration defaults to the most restrictive safe option. [Article XIII](CONSTITUTION.md#article-xiii--minimal-attack-surface) requires that gridctl not expose functionality beyond its stated purpose and that every network-facing endpoint has a documented purpose and ownership. These commitments apply to every release.


### PR DESCRIPTION
## Description

Adds a formal security policy (`SECURITY.md`) with private vulnerability reporting instructions, response timeline, and disclosure process. Links the policy from the README badge row.

## Type of Change

- [x] Documentation

## Changes Made

- `SECURITY.md`: private reporting link, ≤14 day response SLA, disclosure policy, references to CONSTITUTION.md Articles XII–XIII
- `README.md`: Security Policy badge added alongside existing badges

## Testing

No code changes. Verify `SECURITY.md` appears in the GitHub Security tab and the README badge links correctly.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #331