### PR TITLE
chore: enable dependabot for go and npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Dependabot version updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Note: chore commits are excluded from CHANGELOG generation (cliff.toml).
+# This is intentional — dependency bump PRs do not appear in release notes.
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Description

Adds `.github/dependabot.yml` to enable automated weekly dependency scanning for Go modules and npm packages, with conventional commit prefixes for clean PR titles.

## Type of Change

- [x] Chore / maintenance

## Changes Made

- Add `.github/dependabot.yml` with weekly scans for `gomod` (root) and `npm` (`/web`)
- Use `chore:` commit prefix so Dependabot PRs follow the project's conventional commits format
- Note: `chore` commits are excluded from CHANGELOG generation (`cliff.toml`) — dependency bump PRs intentionally do not appear in release notes

## Testing

No runtime changes. Dependabot will begin scanning on the next scheduled run after merge.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #331