### PR TITLE
chore: enforce govulncheck and npm audit in CI

### DIFF
--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -47,7 +47,6 @@ jobs:
         run: bash scripts/check-coverage.sh
 
       - name: Go vulnerability check
-        continue-on-error: true
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
@@ -159,7 +158,6 @@ jobs:
         working-directory: web
 
       - name: Security audit
-        continue-on-error: true
         run: npm audit --audit-level=high
         working-directory: web
 


### PR DESCRIPTION
## Description

Removes `continue-on-error: true` from the govulncheck and npm audit steps in the Gatekeeper workflow so that discovered vulnerabilities now fail the build instead of silently passing.

## Type of Change

- [x] Chore (maintenance, tooling, configuration)

## Changes Made

- Removed `continue-on-error: true` from the `Go vulnerability check` step (govulncheck)
- Removed `continue-on-error: true` from the `Security audit` step (npm audit)

## Testing

CI will enforce these checks on the PR itself. All dependency vulnerabilities were resolved in a prior phase, so the build is expected to pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #331