### PR TITLE
docs: add tokenizer fields to gateway config schema

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -58,6 +58,8 @@ gateway:
 | `code_mode_timeout` | int | No | `30` | Code mode execution timeout in seconds. Must be >= 0 *(experimental)* |
 | `output_format` | string | No | `"json"` | Default output format for tool call results: `"json"`, `"toon"`, `"csv"`, or `"text"`. Per-server `output_format` overrides this value |
 | `security` | object | No | — | Security settings (see [Security](#security)) |
+| `tokenizer` | string | No | `"embedded"` | Token counting mode: `"embedded"` (cl100k_base approximation) or `"api"` (exact counts via Anthropic `count_tokens` endpoint) |
+| `tokenizer_api_key` | string | No | — | Anthropic API key for `tokenizer: api`. Falls back to `ANTHROPIC_API_KEY` env var. Supports `${VAR}` and `${vault:KEY}` references |
 
 ### Auth
 


### PR DESCRIPTION
## Description

Documents the `tokenizer` and `tokenizer_api_key` gateway fields added in #358/#360, which were missing from the config schema reference.

## Type of Change

- [x] Documentation update

## Changes Made

- Add `tokenizer` row to gateway fields table (`"embedded"` default, `"api"` for exact counts)
- Add `tokenizer_api_key` row with fallback and variable expansion notes

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed