### PR TITLE
feat: add --dry-run flag to gridctl test command

### DIFF
--- a/cmd/gridctl/test.go
+++ b/cmd/gridctl/test.go
@@ -15,6 +15,7 @@ import (
 )
 
 var testStack string
+var testDryRun bool
 
 var testCmd = &cobra.Command{
 	Use:   "test <skill-name>",
@@ -34,6 +35,7 @@ Exit codes:
 
 func init() {
 	testCmd.Flags().StringVarP(&testStack, "stack", "s", "", "Stack to test against (auto-detect if only one running)")
+	testCmd.Flags().BoolVar(&testDryRun, "dry-run", false, "Show which criteria would run without executing against live tools")
 }
 
 func runTestCmd(skillName string) error {
@@ -41,6 +43,10 @@ func runTestCmd(skillName string) error {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "gateway not reachable: %v\n", err)
 		os.Exit(2)
+	}
+
+	if testDryRun {
+		return runTestDryRun(skillName, st.Port)
 	}
 
 	url := fmt.Sprintf("http://localhost:%d/api/registry/skills/%s/test", st.Port, skillName)
@@ -180,4 +186,118 @@ func printTestResult(result *registry.SkillTestResult, port int) {
 	default:
 		fmt.Println("Skill status: PASSING")
 	}
+}
+
+// runTestDryRun fetches the skill definition and reports which criteria would
+// parse without invoking any MCP tools.
+func runTestDryRun(skillName string, port int) error {
+	url := fmt.Sprintf("http://localhost:%d/api/registry/skills/%s", port, skillName)
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gateway not reachable: %v\n", err)
+		os.Exit(2)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		fmt.Fprintf(os.Stderr, "skill not found: %s\n", skillName)
+		os.Exit(2)
+	case http.StatusServiceUnavailable:
+		fmt.Fprintln(os.Stderr, "registry not available on this gateway")
+		os.Exit(2)
+	}
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "unexpected status %d\n", resp.StatusCode)
+		os.Exit(2)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading response: %v\n", err)
+		os.Exit(2)
+	}
+	var sk registry.AgentSkill
+	if err := json.Unmarshal(body, &sk); err != nil {
+		fmt.Fprintf(os.Stderr, "parsing response: %v\n", err)
+		os.Exit(2)
+	}
+
+	printDryRunResult(os.Stdout, &sk, port)
+
+	total := len(sk.AcceptanceCriteria)
+	if total == 0 {
+		os.Exit(1)
+	}
+	wouldRun := 0
+	for _, c := range sk.AcceptanceCriteria {
+		if registry.ParseCriterion(c) != nil {
+			wouldRun++
+		}
+	}
+	if wouldRun == 0 {
+		os.Exit(3)
+	}
+	if wouldRun < total {
+		os.Exit(1)
+	}
+	return nil
+}
+
+func printDryRunResult(w io.Writer, sk *registry.AgentSkill, port int) {
+	fmt.Fprintf(w, "\nDry-run: acceptance criteria parse results for skill: %s\n", sk.Name)
+	fmt.Fprintf(w, "Gateway: http://localhost:%d\n\n", port)
+
+	wouldRun := 0
+	wouldSkip := 0
+	for _, criterion := range sk.AcceptanceCriteria {
+		given, when, then := parseCriterionDisplay(criterion)
+		if when == "" {
+			fmt.Fprintf(w, "  %q\n", criterion)
+			fmt.Fprintf(w, "  → would skip: does not match GIVEN ... WHEN ... THEN\n\n")
+			wouldSkip++
+		} else {
+			fmt.Fprintf(w, "  GIVEN %s\n", given)
+			fmt.Fprintf(w, "  WHEN  %s\n", when)
+			fmt.Fprintf(w, "  THEN  %s\n", then)
+			toolName := resolveToolNameDisplay(when, sk.Name)
+			fmt.Fprintf(w, "  → would run (tool: %s)\n\n", toolName)
+			wouldRun++
+		}
+	}
+
+	total := wouldRun + wouldSkip
+	fmt.Fprintf(w, "%d of %d criteria would run", wouldRun, total)
+	if wouldSkip > 0 {
+		fmt.Fprintf(w, ", %d would be skipped", wouldSkip)
+	}
+	fmt.Fprintln(w)
+	if wouldSkip > 0 || total == 0 {
+		fmt.Fprintln(w, "Run without --dry-run to execute against live tools.")
+	}
+	fmt.Fprintln(w)
+}
+
+// resolveToolNameDisplay returns the tool name that would be called for the WHEN clause.
+// Mirrors resolveToolName() in pkg/registry/tester.go for dry-run display.
+func resolveToolNameDisplay(when, skillName string) string {
+	lower := strings.ToLower(strings.TrimSpace(when))
+	if strings.Contains(lower, "the skill is called") {
+		return skillName
+	}
+	if idx := strings.LastIndex(lower, " is called"); idx != -1 {
+		candidate := strings.TrimSpace(when[:idx])
+		if candidate != "" {
+			return candidate
+		}
+	}
+	for _, f := range strings.Fields(when) {
+		clean := strings.Trim(f, ".,;:()")
+		if strings.Contains(clean, "__") {
+			return clean
+		}
+	}
+	return skillName
 }

--- a/cmd/gridctl/test_test.go
+++ b/cmd/gridctl/test_test.go
@@ -76,6 +76,115 @@ func TestPrintTestResult_statusLine(t *testing.T) {
 	}
 }
 
+func TestResolveToolNameDisplay(t *testing.T) {
+	tests := []struct {
+		name      string
+		when      string
+		skillName string
+		want      string
+	}{
+		{
+			name:      "the skill is called",
+			when:      "the skill is called",
+			skillName: "my-skill",
+			want:      "my-skill",
+		},
+		{
+			name:      "explicit name is called",
+			when:      "other-tool is called",
+			skillName: "my-skill",
+			want:      "other-tool",
+		},
+		{
+			name:      "server__tool format",
+			when:      "github__search_repositories is called",
+			skillName: "my-skill",
+			want:      "github__search_repositories",
+		},
+		{
+			name:      "server__tool in middle of clause",
+			when:      "the server__list_files tool is invoked",
+			skillName: "my-skill",
+			want:      "server__list_files",
+		},
+		{
+			name:      "fallback to skill name",
+			when:      "something happens",
+			skillName: "my-skill",
+			want:      "my-skill",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveToolNameDisplay(tc.when, tc.skillName)
+			if got != tc.want {
+				t.Errorf("resolveToolNameDisplay(%q, %q) = %q, want %q", tc.when, tc.skillName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrintDryRunResult(t *testing.T) {
+	sk := &registry.AgentSkill{
+		Name: "my-skill",
+		AcceptanceCriteria: []string{
+			"GIVEN a valid context WHEN the skill is called THEN is not empty",
+			"GIVN a context WHEN called THEN ok",
+		},
+	}
+
+	var sb strings.Builder
+	printDryRunResult(&sb, sk, 8080)
+	out := sb.String()
+
+	if !strings.Contains(out, "Dry-run: acceptance criteria parse results for skill: my-skill") {
+		t.Error("output missing dry-run header")
+	}
+	if !strings.Contains(out, "Gateway: http://localhost:8080") {
+		t.Error("output missing gateway line")
+	}
+	if !strings.Contains(out, "GIVEN a valid context") {
+		t.Error("output missing GIVEN line for parseable criterion")
+	}
+	if !strings.Contains(out, "→ would run (tool: my-skill)") {
+		t.Error("output missing 'would run' line")
+	}
+	if !strings.Contains(out, "→ would skip: does not match GIVEN ... WHEN ... THEN") {
+		t.Error("output missing 'would skip' line for malformed criterion")
+	}
+	if !strings.Contains(out, "1 of 2 criteria would run") {
+		t.Error("output missing summary line")
+	}
+	if !strings.Contains(out, "1 would be skipped") {
+		t.Error("output missing skip count in summary")
+	}
+	if !strings.Contains(out, "Run without --dry-run") {
+		t.Error("output missing hint line when some would skip")
+	}
+}
+
+func TestPrintDryRunResult_allParseable(t *testing.T) {
+	sk := &registry.AgentSkill{
+		Name: "my-skill",
+		AcceptanceCriteria: []string{
+			"GIVEN a context WHEN the skill is called THEN is not empty",
+		},
+	}
+
+	var sb strings.Builder
+	printDryRunResult(&sb, sk, 9090)
+	out := sb.String()
+
+	if !strings.Contains(out, "1 of 1 criteria would run") {
+		t.Error("output missing all-parseable summary")
+	}
+	// No skip hint when all parse cleanly
+	if strings.Contains(out, "Run without --dry-run") {
+		t.Error("should not print hint when all criteria parse")
+	}
+}
+
 func TestPrintTestResult_summaryLine(t *testing.T) {
 	result := &registry.SkillTestResult{
 		Skill:   "my-skill",


### PR DESCRIPTION
## Description

Adds `--dry-run` to `gridctl test`. When set, fetches the skill definition from the registry and reports which criteria would parse and which would be skipped — without invoking any MCP tools. Useful for debugging acceptance criteria before a live gateway is available.

## Type of Change

- [x] New feature

## Changes Made

- Added `--dry-run` bool flag to `testCmd`
- Added `runTestDryRun()` — fetches skill via `GET /api/registry/skills/{name}`, runs `ParseCriterion()` locally, exits 0/1/3 based on parse results
- Added `printDryRunResult(io.Writer, ...)` — outputs per-criterion parse report in matching GIVEN/WHEN/THEN format
- Added `resolveToolNameDisplay()` — mirrors unexported `resolveToolName()` from `pkg/registry/tester.go` for dry-run tool annotation
- Added tests for all three new functions

## Testing

```
go test ./cmd/gridctl/...
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #375