### PR TITLE
fix: report PASSING (N skipped) when criteria are partially skipped

### DIFF
--- a/cmd/gridctl/test.go
+++ b/cmd/gridctl/test.go
@@ -183,6 +183,8 @@ func printTestResult(result *registry.SkillTestResult, port int) {
 		fmt.Println("Skill status: FAILING")
 	case result.Skipped == total:
 		fmt.Println("Skill status: UNTESTED (no parseable criteria)")
+	case result.Skipped > 0:
+		fmt.Printf("Skill status: PASSING (%d skipped)\n", result.Skipped)
 	default:
 		fmt.Println("Skill status: PASSING")
 	}

--- a/cmd/gridctl/test_test.go
+++ b/cmd/gridctl/test_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -48,6 +49,19 @@ func TestPrintTestResult_statusLine(t *testing.T) {
 			},
 			wantStatus: "Skill status: UNTESTED (no parseable criteria)",
 		},
+		{
+			name: "partial skip — passing with skipped count",
+			result: registry.SkillTestResult{
+				Skill:   "my-skill",
+				Passed:  1,
+				Skipped: 1,
+				Results: []registry.CriterionResult{
+					{Criterion: "GIVEN a WHEN b THEN c", Passed: true},
+					{Criterion: "the skill is fast", Skipped: true, SkipReason: "does not match GIVEN ... WHEN ... THEN pattern"},
+				},
+			},
+			wantStatus: "Skill status: PASSING (1 skipped)",
+		},
 	}
 
 	for _, tc := range tests {
@@ -66,6 +80,8 @@ func TestPrintTestResult_statusLine(t *testing.T) {
 				got = "Skill status: FAILING"
 			case tc.result.Skipped == total && total > 0:
 				got = "Skill status: UNTESTED (no parseable criteria)"
+			case tc.result.Skipped > 0:
+				got = fmt.Sprintf("Skill status: PASSING (%d skipped)", tc.result.Skipped)
 			default:
 				got = "Skill status: PASSING"
 			}


### PR DESCRIPTION
## Description

When some criteria are skipped but at least one passes, the skill status was incorrectly shown as a plain PASSING. This fix surfaces the skip count so users know not all criteria were evaluated.

## Type of Change

- [x] Bug fix

## Changes Made

- Add `case result.Skipped > 0` branch in `printTestResult` to emit `PASSING (N skipped)` status
- Add test case covering the partial-skip scenario

## Testing

Run `go test ./cmd/gridctl/...` — the new `partial skip — passing with skipped count` test case covers the fix.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #375