### PR TITLE
fix: use WithEndpointURL for scheme-aware OTLP TLS

### DIFF
--- a/pkg/tracing/provider.go
+++ b/pkg/tracing/provider.go
@@ -60,8 +60,7 @@ func (p *Provider) Init(ctx context.Context) error {
 	// Optional OTLP exporter.
 	if p.cfg.Export == "otlp" && p.cfg.Endpoint != "" {
 		exp, err := otlptracehttp.New(ctx,
-			otlptracehttp.WithEndpoint(p.cfg.Endpoint),
-			otlptracehttp.WithInsecure(),
+			otlptracehttp.WithEndpointURL(p.cfg.Endpoint),
 			otlptracehttp.WithTimeout(5*time.Second),
 		)
 		if err != nil {


### PR DESCRIPTION
## Description

Replaces `WithEndpoint() + WithInsecure()` with `WithEndpointURL()` in the OTLP exporter setup. The old approach hardcoded insecure mode, breaking all HTTPS backends (Honeycomb, Grafana Cloud, Grafana Tempo Cloud). `WithEndpointURL()` reads the URL scheme — `http://` uses plain HTTP, `https://` uses TLS — with no additional configuration required.

## Type of Change

- [x] Bug fix

## Changes Made

- `pkg/tracing/provider.go` — replace `WithEndpoint(url) + WithInsecure()` with `WithEndpointURL(url)`; remove the now-unnecessary `WithInsecure()` option

## Testing

```bash
# HTTP backend (Jaeger local)
gateway:
  tracing:
    export: otlp
    endpoint: http://localhost:4318

# HTTPS backend (Honeycomb)
gateway:
  tracing:
    export: otlp
    endpoint: https://api.honeycomb.io/v1/traces
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #381