### PR TITLE
fix: flush tracing spans on gateway shutdown

### DIFF
--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -66,6 +66,9 @@ type GatewayBuilder struct {
 
 	// pinStore for API server injection (schema pin management).
 	pinStore *pins.PinStore
+
+	// tracingProvider is retained so Shutdown() can be called on gateway exit.
+	tracingProvider *tracing.Provider
 }
 
 // NewGatewayBuilder creates a GatewayBuilder.
@@ -374,6 +377,7 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 	if err := tracingProvider.Init(context.Background()); err != nil {
 		slog.New(handler).Warn("tracing init failed", "error", err)
 	}
+	b.tracingProvider = tracingProvider
 	server.SetTraceBuffer(tracingProvider.Buffer)
 
 	return server, nil
@@ -538,6 +542,12 @@ func (b *GatewayBuilder) waitForShutdown(inst *GatewayInstance, handler slog.Han
 
 		if err := inst.HTTPServer.Shutdown(shutdownCtx); err != nil {
 			logger.Error("HTTP server shutdown error", "error", err)
+		}
+
+		if b.tracingProvider != nil {
+			if err := b.tracingProvider.Shutdown(shutdownCtx); err != nil {
+				logger.Error("tracing shutdown error", "error", err)
+			}
 		}
 
 		_ = state.Delete(b.stack.Name)


### PR DESCRIPTION
## Description

Stores the tracing provider on `GatewayBuilder` and calls `Shutdown()` after HTTP drain so buffered OTLP spans are flushed before the process exits.

## Type of Change

- [x] Bug fix

## Changes Made

- Added unexported `tracingProvider *tracing.Provider` field to `GatewayBuilder`
- Assigned `b.tracingProvider` in `buildAPIServer()` after `Init()`
- Added guarded `b.tracingProvider.Shutdown(shutdownCtx)` call in `waitForShutdown()` after HTTP server shutdown

## Testing

`go build ./...` and `go test ./pkg/tracing/...` — all 25 tests pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #381