### PR TITLE
test: add skills executor integration tests

### DIFF
--- a/tests/integration/skills_executor_test.go
+++ b/tests/integration/skills_executor_test.go
@@ -120,7 +120,7 @@ func TestExecutor_MultiStepDAG(t *testing.T) {
 			ID:        "step2",
 			Tool:      "test-dag__echo",
 			DependsOn: registry.StringOrSlice{"step1"},
-			Args:      map[string]any{"message": "{{ .Steps.step1.Result }}"},
+			Args:      map[string]any{"message": "{{ steps.step1.result }}"},
 		},
 	})
 	if err := store.SaveSkill(skill); err != nil {


### PR DESCRIPTION
## Description

Adds `tests/integration/skills_executor_test.go` covering the skills workflow executor with a real mock-server backend. This is the final phase of the integration test coverage expansion.

## Type of Change

- [x] Test

## Changes Made

- `TestExecutor_SingleStepSkill` — single-step skill calling the echo tool, verifies output contains expected text
- `TestExecutor_MultiStepDAG` — two-step skill with template interpolation (`{{ .Steps.step1.Result }}`), verifies DAG ordering and context propagation
- `TestExecutor_ParallelSteps` — two independent steps in the same DAG level, verifies both results appear in merged output
- `TestExecutor_DepthLimit` — mutually recursive skills (skill-a → skill-b → skill-a), verifies circular dependency is detected before max depth is reached
- `TestExecutor_ToolCallTimeout` — executor with 1ns workflow timeout, verifies expired context causes Execute to return an error

## Testing

```
go test -tags=integration -race -timeout 5m ./tests/integration/...
```

All tests skip gracefully when mock server binaries are unavailable.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #393