### PR TITLE
docs: add Podman graduation entries to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to gridctl will be documented in this file.
 ### Bug Fixes
 
 
+- Register logical container name as DNS alias for inter-container resolution in Podman and Docker stacks
 - Persist tool turns to history and populate FormatSavingsPct
 - Persist tool turns to history and capture streaming usage metrics
 - Persist intermediate tool turns in handlePlaygroundChat goroutine
@@ -55,6 +56,11 @@ All notable changes to gridctl will be documented in this file.
 ### Features
 
 
+- Graduate Podman runtime from experimental to stable; `gridctl info` and `--runtime` help no longer show experimental status
+- Add netavark and aardvark-dns detection for rootless Podman; `gridctl apply` warns with install instructions when either is missing
+- Add Podman 4.0+ version gate warning for rootless multi-container networking
+- Add `gridctl info` network stack display for rootless Podman (shows netavark + aardvark-dns status)
+- Add multi-container networking integration test proving rootless Podman inter-container DNS works on a shared named network
 - Add TestFlightSession, LLMClient interface, and SessionRegistry
 - Add Anthropic LLM client with streaming agentic loop
 - Add OpenAI-compatible LLM client for Ollama and hosted APIs


### PR DESCRIPTION
## Description

Adds changelog entries for the Podman runtime graduation: DNS alias fix, netavark/aardvark-dns detection, version gate, `gridctl info` network display, and multi-container integration test.

## Type of Change

- [x] Documentation update

## Changes Made

- `CHANGELOG.md`: Added bug fix entry for inter-container DNS alias registration fix
- `CHANGELOG.md`: Added five feature entries covering Podman stable graduation, netavark detection, version gate, info display, and integration test

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed