### PR TITLE
feat: expand OpenAPI auth to support OAuth2 CC, query-param keys, mTLS, and basic auth

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -376,10 +376,28 @@ OpenAPI specification configuration for API-backed MCP servers.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `type` | string | **Yes** | — | `"bearer"` or `"header"` |
+| `type` | string | **Yes** | — | `"bearer"`, `"header"`, `"query"`, `"oauth2"`, or `"basic"` |
 | `tokenEnv` | string | Conditional | — | Env var name for bearer token (required when type is `"bearer"`) |
 | `header` | string | Conditional | — | Header name (required when type is `"header"`) |
-| `valueEnv` | string | Conditional | — | Env var name for header value (required when type is `"header"`) |
+| `valueEnv` | string | Conditional | — | Env var name for header/query value (required when type is `"header"` or `"query"`) |
+| `paramName` | string | Conditional | — | Query parameter name (required when type is `"query"`) |
+| `clientIdEnv` | string | Conditional | — | Env var name for OAuth2 client ID (required when type is `"oauth2"`) |
+| `clientSecretEnv` | string | Conditional | — | Env var name for OAuth2 client secret (required when type is `"oauth2"`) |
+| `tokenUrl` | string | Conditional | — | OAuth2 token endpoint URL (required when type is `"oauth2"`) |
+| `scopes` | []string | No | — | OAuth2 scopes to request (optional, for type `"oauth2"`) |
+| `usernameEnv` | string | Conditional | — | Env var name for username (required when type is `"basic"`) |
+| `passwordEnv` | string | Conditional | — | Env var name for password (required when type is `"basic"`) |
+
+**OpenAPI TLS (mTLS):**
+
+Transport-layer TLS configuration. Can be combined with any `auth` type.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `certFile` | string | Conditional | — | Client certificate file path (required for mTLS, must be set with `keyFile`) |
+| `keyFile` | string | Conditional | — | Client private key file path (required for mTLS, must be set with `certFile`) |
+| `caFile` | string | No | — | Custom CA certificate file path for server verification |
+| `insecureSkipVerify` | bool | No | `false` | Skip server certificate verification (not recommended for production) |
 
 **Operations Filter:**
 

--- a/examples/openapi/openapi-auth.yaml
+++ b/examples/openapi/openapi-auth.yaml
@@ -1,21 +1,19 @@
 # OpenAPI Authentication Example
 #
-# Most real APIs require authentication. Gridctl supports two auth methods
-# for OpenAPI-backed MCP servers:
+# Gridctl supports five auth methods for OpenAPI-backed MCP servers:
 #
-#   1. Bearer Token — sends "Authorization: Bearer <token>" header
+#   1. Bearer Token  — sends "Authorization: Bearer <token>" header
 #   2. Custom Header — sends any header name with a value (e.g., X-API-Key)
+#   3. Query Param   — appends an API key as a URL query parameter
+#   4. OAuth2 CC     — fetches a short-lived token via client credentials flow
+#   5. Basic Auth    — sends "Authorization: Basic <base64(user:password)>"
 #
-# Auth tokens are read from environment variables at deploy time. This keeps
-# secrets out of your stack files and works with .env files, CI/CD, and
-# secret managers.
+# All secret values are read from environment variables at deploy time.
+# This keeps secrets out of your stack files and works with .env files,
+# CI/CD pipelines, and secret managers.
 #
-# Prerequisites:
-#   Set the environment variables referenced in tokenEnv / valueEnv before
-#   deploying. For example:
-#
-#     export EXAMPLE_API_TOKEN=your-bearer-token
-#     export EXAMPLE_API_KEY=your-api-key
+# Additionally, mTLS (client certificate) can be configured as a separate
+# `tls:` block and combined with any auth type.
 #
 # Usage:
 #   gridctl apply examples/openapi/openapi-auth.yaml
@@ -25,8 +23,9 @@ name: openapi-auth-demo
 
 mcp-servers:
 
-  # Bearer token authentication
+  # 1. Bearer token authentication
   # Sends: Authorization: Bearer <value of EXAMPLE_API_TOKEN>
+  # Use for: GitHub API, OpenAI, Stripe, and most REST APIs
   - name: bearer-api
     openapi:
       spec: https://petstore3.swagger.io/api/v3/openapi.json
@@ -38,9 +37,10 @@ mcp-servers:
           - getPetById
           - findPetsByStatus
 
-  # Custom header authentication (API key style)
+  # 2. Custom header authentication
   # Sends: X-API-Key: <value of EXAMPLE_API_KEY>
-  - name: apikey-api
+  # Use for: APIs that use a custom header name instead of Authorization
+  - name: apikey-header-api
     openapi:
       spec: https://petstore3.swagger.io/api/v3/openapi.json
       auth:
@@ -50,20 +50,75 @@ mcp-servers:
       operations:
         include:
           - getPetById
-          - findPetsByStatus
 
-# Combine OpenAPI servers with container-based servers in the same stack:
+  # 3. Query parameter API key
+  # Appends: ?appid=<value of OPENWEATHER_API_KEY> to every request URL
+  # Use for: OpenWeatherMap, many geocoding and finance APIs
+  - name: query-param-api
+    openapi:
+      spec: https://petstore3.swagger.io/api/v3/openapi.json
+      auth:
+        type: query
+        paramName: appid
+        valueEnv: OPENWEATHER_API_KEY
+      operations:
+        include:
+          - getPetById
+
+  # 4. OAuth2 client credentials (machine-to-machine)
+  # Fetches a short-lived token from tokenUrl, injects Authorization: Bearer
+  # Tokens are cached and automatically refreshed on expiry
+  # Use for: Salesforce, Microsoft Graph, Workday, ServiceNow
+  - name: oauth2-api
+    openapi:
+      spec: https://petstore3.swagger.io/api/v3/openapi.json
+      auth:
+        type: oauth2
+        clientIdEnv: OAUTH_CLIENT_ID
+        clientSecretEnv: OAUTH_CLIENT_SECRET
+        tokenUrl: https://auth.example.com/oauth/token
+        scopes:
+          - read:data
+          - write:data
+      operations:
+        include:
+          - getPetById
+
+  # 5. HTTP Basic authentication
+  # Sends: Authorization: Basic <base64(username:password)>
+  # Use for: legacy APIs and internal services that use HTTP Basic
+  - name: basic-auth-api
+    openapi:
+      spec: https://petstore3.swagger.io/api/v3/openapi.json
+      auth:
+        type: basic
+        usernameEnv: API_USERNAME
+        passwordEnv: API_PASSWORD
+      operations:
+        include:
+          - getPetById
+
+  # mTLS: Bearer token + client certificate (combined)
+  # The `tls:` block is transport-layer and works with any auth type.
+  # Use for: financial services, zero-trust enterprise APIs
+  - name: mtls-api
+    openapi:
+      spec: https://secure-api.example.com/openapi.json
+      auth:
+        type: bearer
+        tokenEnv: SECURE_API_TOKEN
+      tls:
+        certFile: ~/.gridctl/certs/client.pem
+        keyFile: ~/.gridctl/certs/client-key.pem
+        caFile: ~/.gridctl/certs/ca.pem
+
+# Environment variable reference:
 #
-# mcp-servers:
-#   - name: company-api
-#     openapi:
-#       spec: https://api.example.com/openapi.json
-#       auth:
-#         type: bearer
-#         tokenEnv: COMPANY_TOKEN
-#
-#   - name: github
-#     image: ghcr.io/github/github-mcp-server:latest
-#     transport: stdio
-#     env:
-#       GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+#   export EXAMPLE_API_TOKEN=your-bearer-token
+#   export EXAMPLE_API_KEY=your-api-key
+#   export OPENWEATHER_API_KEY=your-openweather-key
+#   export OAUTH_CLIENT_ID=your-client-id
+#   export OAUTH_CLIENT_SECRET=your-client-secret
+#   export API_USERNAME=your-username
+#   export API_PASSWORD=your-password
+#   export SECURE_API_TOKEN=your-secure-token

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.51.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbR
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
 golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/config/health.go
+++ b/pkg/config/health.go
@@ -111,6 +111,32 @@ func (r *ValidationResult) addWarnings(s *Stack) {
 		}
 	}
 
+	// Warn about TLS cert/key/ca files that don't exist yet (may be created before apply)
+	for i, srv := range s.MCPServers {
+		if srv.OpenAPI == nil || srv.OpenAPI.TLS == nil {
+			continue
+		}
+		tlsPrefix := fmt.Sprintf("mcp-servers[%d].openapi.tls", i)
+		tls := srv.OpenAPI.TLS
+		for _, f := range []struct{ field, path string }{
+			{tlsPrefix + ".certFile", tls.CertFile},
+			{tlsPrefix + ".keyFile", tls.KeyFile},
+			{tlsPrefix + ".caFile", tls.CaFile},
+		} {
+			if f.path == "" {
+				continue
+			}
+			if _, err := os.Stat(f.path); err != nil {
+				r.Issues = append(r.Issues, ValidationIssue{
+					Field:    f.field,
+					Message:  fmt.Sprintf("file not found or not readable: %s", f.path),
+					Severity: SeverityWarning,
+				})
+				r.WarningCount++
+			}
+		}
+	}
+
 	// Warn about gateway without auth
 	if s.Gateway != nil && s.Gateway.Auth == nil {
 		r.Issues = append(r.Issues, ValidationIssue{

--- a/pkg/config/health_test.go
+++ b/pkg/config/health_test.go
@@ -160,6 +160,35 @@ mcp-servers:
 	assert.Equal(t, "test-net", stack.Network.Name)
 }
 
+func TestValidateWithIssues_WarningTLSFilesNotFound(t *testing.T) {
+	stack := &Stack{
+		Name:    "test",
+		Network: Network{Name: "test-net"},
+		Gateway: &GatewayConfig{Auth: &AuthConfig{Type: "bearer", Token: "secret"}},
+		MCPServers: []MCPServer{
+			{Name: "s1", OpenAPI: &OpenAPIConfig{
+				Spec: "https://example.com/spec.json",
+				TLS:  &OpenAPITLS{CertFile: "/nonexistent/cert.pem", KeyFile: "/nonexistent/key.pem", CaFile: "/nonexistent/ca.pem"},
+			}},
+		},
+	}
+
+	result := ValidateWithIssues(stack)
+	assert.True(t, result.Valid) // warnings don't make it invalid
+	assert.Equal(t, 0, result.ErrorCount)
+	assert.Equal(t, 3, result.WarningCount)
+
+	fields := make(map[string]bool)
+	for _, issue := range result.Issues {
+		if issue.Severity == SeverityWarning {
+			fields[issue.Field] = true
+		}
+	}
+	assert.True(t, fields["mcp-servers[0].openapi.tls.certFile"])
+	assert.True(t, fields["mcp-servers[0].openapi.tls.keyFile"])
+	assert.True(t, fields["mcp-servers[0].openapi.tls.caFile"])
+}
+
 func TestValidationResult_Counts(t *testing.T) {
 	result := &ValidationResult{Valid: true}
 	result.Issues = []ValidationIssue{

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -150,15 +150,38 @@ type OpenAPIConfig struct {
 	Spec       string            `yaml:"spec"`                 // URL or local file path to OpenAPI spec (JSON or YAML)
 	BaseURL    string            `yaml:"baseUrl,omitempty"`    // Override the server URL from the spec
 	Auth       *OpenAPIAuth      `yaml:"auth,omitempty"`       // Authentication configuration
+	TLS        *OpenAPITLS       `yaml:"tls,omitempty"`        // TLS/mTLS configuration (transport-layer)
 	Operations *OperationsFilter `yaml:"operations,omitempty"` // Filter which operations become tools
 }
 
 // OpenAPIAuth defines authentication for OpenAPI HTTP requests.
 type OpenAPIAuth struct {
-	Type     string `yaml:"type"`               // "bearer" or "header"
+	Type     string `yaml:"type"`               // "bearer", "header", "query", "oauth2", or "basic"
 	TokenEnv string `yaml:"tokenEnv,omitempty"` // Env var name containing bearer token (for type: bearer)
 	Header   string `yaml:"header,omitempty"`   // Header name (for type: header, e.g., "X-API-Key")
-	ValueEnv string `yaml:"valueEnv,omitempty"` // Env var name containing header value (for type: header)
+	ValueEnv string `yaml:"valueEnv,omitempty"` // Env var name containing header value (for type: header or query)
+
+	// Query param auth (type: query)
+	ParamName string `yaml:"paramName,omitempty"` // Query parameter name (for type: query)
+
+	// OAuth2 client credentials (type: oauth2)
+	ClientIdEnv     string   `yaml:"clientIdEnv,omitempty"`     // Env var name containing OAuth2 client ID
+	ClientSecretEnv string   `yaml:"clientSecretEnv,omitempty"` // Env var name containing OAuth2 client secret
+	TokenUrl        string   `yaml:"tokenUrl,omitempty"`        // OAuth2 token endpoint URL
+	Scopes          []string `yaml:"scopes,omitempty"`          // OAuth2 scopes to request
+
+	// Basic auth (type: basic)
+	UsernameEnv string `yaml:"usernameEnv,omitempty"` // Env var name containing username
+	PasswordEnv string `yaml:"passwordEnv,omitempty"` // Env var name containing password
+}
+
+// OpenAPITLS defines TLS/mTLS configuration for OpenAPI HTTP connections.
+// This is transport-layer config and can be combined with any auth type.
+type OpenAPITLS struct {
+	CertFile           string `yaml:"certFile,omitempty"`           // Client certificate file path (required for mTLS)
+	KeyFile            string `yaml:"keyFile,omitempty"`            // Client private key file path (required for mTLS)
+	CaFile             string `yaml:"caFile,omitempty"`             // Custom CA certificate file path
+	InsecureSkipVerify bool   `yaml:"insecureSkipVerify,omitempty"` // Skip server certificate verification (dangerous)
 }
 
 // OperationsFilter defines which OpenAPI operations to include or exclude.

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -238,18 +238,70 @@ func Validate(s *Stack) error {
 			// Auth validation
 			if server.OpenAPI.Auth != nil {
 				authPrefix := openapiPrefix + ".auth"
-				if server.OpenAPI.Auth.Type != "" && server.OpenAPI.Auth.Type != "bearer" && server.OpenAPI.Auth.Type != "header" {
-					errs = append(errs, ValidationError{authPrefix + ".type", "must be 'bearer' or 'header'"})
+				validAuthTypes := map[string]bool{"bearer": true, "header": true, "query": true, "oauth2": true, "basic": true}
+				if server.OpenAPI.Auth.Type != "" && !validAuthTypes[server.OpenAPI.Auth.Type] {
+					errs = append(errs, ValidationError{authPrefix + ".type", "must be 'bearer', 'header', 'query', 'oauth2', or 'basic'"})
 				}
-				if server.OpenAPI.Auth.Type == "bearer" && server.OpenAPI.Auth.TokenEnv == "" {
-					errs = append(errs, ValidationError{authPrefix + ".tokenEnv", "required when type is 'bearer'"})
-				}
-				if server.OpenAPI.Auth.Type == "header" {
+				switch server.OpenAPI.Auth.Type {
+				case "bearer":
+					if server.OpenAPI.Auth.TokenEnv == "" {
+						errs = append(errs, ValidationError{authPrefix + ".tokenEnv", "required when type is 'bearer'"})
+					}
+				case "header":
 					if server.OpenAPI.Auth.Header == "" {
 						errs = append(errs, ValidationError{authPrefix + ".header", "required when type is 'header'"})
 					}
 					if server.OpenAPI.Auth.ValueEnv == "" {
 						errs = append(errs, ValidationError{authPrefix + ".valueEnv", "required when type is 'header'"})
+					}
+				case "query":
+					if server.OpenAPI.Auth.ParamName == "" {
+						errs = append(errs, ValidationError{authPrefix + ".paramName", "required when type is 'query'"})
+					}
+					if server.OpenAPI.Auth.ValueEnv == "" {
+						errs = append(errs, ValidationError{authPrefix + ".valueEnv", "required when type is 'query'"})
+					}
+				case "oauth2":
+					if server.OpenAPI.Auth.ClientIdEnv == "" {
+						errs = append(errs, ValidationError{authPrefix + ".clientIdEnv", "required when type is 'oauth2'"})
+					}
+					if server.OpenAPI.Auth.ClientSecretEnv == "" {
+						errs = append(errs, ValidationError{authPrefix + ".clientSecretEnv", "required when type is 'oauth2'"})
+					}
+					if server.OpenAPI.Auth.TokenUrl == "" {
+						errs = append(errs, ValidationError{authPrefix + ".tokenUrl", "required when type is 'oauth2'"})
+					}
+				case "basic":
+					if server.OpenAPI.Auth.UsernameEnv == "" {
+						errs = append(errs, ValidationError{authPrefix + ".usernameEnv", "required when type is 'basic'"})
+					}
+					if server.OpenAPI.Auth.PasswordEnv == "" {
+						errs = append(errs, ValidationError{authPrefix + ".passwordEnv", "required when type is 'basic'"})
+					}
+				}
+			}
+			// TLS validation
+			if server.OpenAPI.TLS != nil {
+				tlsPrefix := openapiPrefix + ".tls"
+				if server.OpenAPI.TLS.CertFile != "" && server.OpenAPI.TLS.KeyFile == "" {
+					errs = append(errs, ValidationError{tlsPrefix + ".keyFile", "required when certFile is set"})
+				}
+				if server.OpenAPI.TLS.KeyFile != "" && server.OpenAPI.TLS.CertFile == "" {
+					errs = append(errs, ValidationError{tlsPrefix + ".certFile", "required when keyFile is set"})
+				}
+				if server.OpenAPI.TLS.CertFile != "" {
+					if _, err := os.Stat(server.OpenAPI.TLS.CertFile); err != nil {
+						errs = append(errs, ValidationError{tlsPrefix + ".certFile", fmt.Sprintf("file not found or not readable: %s", server.OpenAPI.TLS.CertFile)})
+					}
+				}
+				if server.OpenAPI.TLS.KeyFile != "" {
+					if _, err := os.Stat(server.OpenAPI.TLS.KeyFile); err != nil {
+						errs = append(errs, ValidationError{tlsPrefix + ".keyFile", fmt.Sprintf("file not found or not readable: %s", server.OpenAPI.TLS.KeyFile)})
+					}
+				}
+				if server.OpenAPI.TLS.CaFile != "" {
+					if _, err := os.Stat(server.OpenAPI.TLS.CaFile); err != nil {
+						errs = append(errs, ValidationError{tlsPrefix + ".caFile", fmt.Sprintf("file not found or not readable: %s", server.OpenAPI.TLS.CaFile)})
 					}
 				}
 			}

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -289,22 +289,7 @@ func Validate(s *Stack) error {
 				if server.OpenAPI.TLS.KeyFile != "" && server.OpenAPI.TLS.CertFile == "" {
 					errs = append(errs, ValidationError{tlsPrefix + ".certFile", "required when keyFile is set"})
 				}
-				if server.OpenAPI.TLS.CertFile != "" {
-					if _, err := os.Stat(server.OpenAPI.TLS.CertFile); err != nil {
-						errs = append(errs, ValidationError{tlsPrefix + ".certFile", fmt.Sprintf("file not found or not readable: %s", server.OpenAPI.TLS.CertFile)})
-					}
 				}
-				if server.OpenAPI.TLS.KeyFile != "" {
-					if _, err := os.Stat(server.OpenAPI.TLS.KeyFile); err != nil {
-						errs = append(errs, ValidationError{tlsPrefix + ".keyFile", fmt.Sprintf("file not found or not readable: %s", server.OpenAPI.TLS.KeyFile)})
-					}
-				}
-				if server.OpenAPI.TLS.CaFile != "" {
-					if _, err := os.Stat(server.OpenAPI.TLS.CaFile); err != nil {
-						errs = append(errs, ValidationError{tlsPrefix + ".caFile", fmt.Sprintf("file not found or not readable: %s", server.OpenAPI.TLS.CaFile)})
-					}
-				}
-			}
 			// Operations filter validation
 			if server.OpenAPI.Operations != nil {
 				if len(server.OpenAPI.Operations.Include) > 0 && len(server.OpenAPI.Operations.Exclude) > 0 {

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -699,6 +699,147 @@ func TestValidate_MCPServer(t *testing.T) {
 				{Name: "s1", OpenAPI: &OpenAPIConfig{Spec: "https://example.com/spec.json"}},
 			}),
 		},
+		// OpenAPI query auth
+		{
+			name: "OpenAPI query auth missing paramName",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					Auth: &OpenAPIAuth{Type: "query", ValueEnv: "API_KEY"},
+				}},
+			}),
+			wantErr: true,
+			errMsg:  "openapi.auth.paramName",
+		},
+		{
+			name: "OpenAPI query auth missing valueEnv",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					Auth: &OpenAPIAuth{Type: "query", ParamName: "api_key"},
+				}},
+			}),
+			wantErr: true,
+			errMsg:  "openapi.auth.valueEnv",
+		},
+		{
+			name: "valid OpenAPI query auth",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					Auth: &OpenAPIAuth{Type: "query", ParamName: "api_key", ValueEnv: "API_KEY"},
+				}},
+			}),
+		},
+		// OpenAPI oauth2 auth
+		{
+			name: "OpenAPI oauth2 missing clientIdEnv",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					Auth: &OpenAPIAuth{Type: "oauth2", ClientSecretEnv: "SEC", TokenUrl: "https://auth.example.com/token"},
+				}},
+			}),
+			wantErr: true,
+			errMsg:  "openapi.auth.clientIdEnv",
+		},
+		{
+			name: "OpenAPI oauth2 missing clientSecretEnv",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					Auth: &OpenAPIAuth{Type: "oauth2", ClientIdEnv: "ID", TokenUrl: "https://auth.example.com/token"},
+				}},
+			}),
+			wantErr: true,
+			errMsg:  "openapi.auth.clientSecretEnv",
+		},
+		{
+			name: "OpenAPI oauth2 missing tokenUrl",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					Auth: &OpenAPIAuth{Type: "oauth2", ClientIdEnv: "ID", ClientSecretEnv: "SEC"},
+				}},
+			}),
+			wantErr: true,
+			errMsg:  "openapi.auth.tokenUrl",
+		},
+		{
+			name: "valid OpenAPI oauth2 auth",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					Auth: &OpenAPIAuth{Type: "oauth2", ClientIdEnv: "ID", ClientSecretEnv: "SEC", TokenUrl: "https://auth.example.com/token"},
+				}},
+			}),
+		},
+		// OpenAPI basic auth
+		{
+			name: "OpenAPI basic auth missing usernameEnv",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					Auth: &OpenAPIAuth{Type: "basic", PasswordEnv: "PASS"},
+				}},
+			}),
+			wantErr: true,
+			errMsg:  "openapi.auth.usernameEnv",
+		},
+		{
+			name: "OpenAPI basic auth missing passwordEnv",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					Auth: &OpenAPIAuth{Type: "basic", UsernameEnv: "USER"},
+				}},
+			}),
+			wantErr: true,
+			errMsg:  "openapi.auth.passwordEnv",
+		},
+		{
+			name: "valid OpenAPI basic auth",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					Auth: &OpenAPIAuth{Type: "basic", UsernameEnv: "USER", PasswordEnv: "PASS"},
+				}},
+			}),
+		},
+		// OpenAPI TLS validation
+		{
+			name: "OpenAPI TLS certFile without keyFile",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					TLS:  &OpenAPITLS{CertFile: "/nonexistent/cert.pem"},
+				}},
+			}),
+			wantErr: true,
+			errMsg:  "openapi.tls.keyFile",
+		},
+		{
+			name: "OpenAPI TLS keyFile without certFile",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					TLS:  &OpenAPITLS{KeyFile: "/nonexistent/key.pem"},
+				}},
+			}),
+			wantErr: true,
+			errMsg:  "openapi.tls.certFile",
+		},
+		{
+			name: "OpenAPI TLS certFile not found",
+			stack: base([]MCPServer{
+				{Name: "s1", OpenAPI: &OpenAPIConfig{
+					Spec: "https://example.com/spec.json",
+					TLS:  &OpenAPITLS{CertFile: "/nonexistent/cert.pem", KeyFile: "/nonexistent/key.pem"},
+				}},
+			}),
+			wantErr: true,
+			errMsg:  "openapi.tls.certFile",
+		},
 		// Container server validation
 		{
 			name: "container invalid transport",

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -829,17 +829,6 @@ func TestValidate_MCPServer(t *testing.T) {
 			wantErr: true,
 			errMsg:  "openapi.tls.certFile",
 		},
-		{
-			name: "OpenAPI TLS certFile not found",
-			stack: base([]MCPServer{
-				{Name: "s1", OpenAPI: &OpenAPIConfig{
-					Spec: "https://example.com/spec.json",
-					TLS:  &OpenAPITLS{CertFile: "/nonexistent/cert.pem", KeyFile: "/nonexistent/key.pem"},
-				}},
-			}),
-			wantErr: true,
-			errMsg:  "openapi.tls.certFile",
-		},
 		// Container server validation
 		{
 			name: "container invalid transport",

--- a/pkg/controller/server_registrar.go
+++ b/pkg/controller/server_registrar.go
@@ -226,14 +226,45 @@ func (r *ServerRegistrar) buildOpenAPIConfig(name string, openAPICfg *config.Ope
 
 	if openAPICfg.Auth != nil {
 		cfg.OpenAPIConfig.AuthType = openAPICfg.Auth.Type
-		if openAPICfg.Auth.Type == "bearer" && openAPICfg.Auth.TokenEnv != "" {
-			cfg.OpenAPIConfig.AuthToken = os.Getenv(openAPICfg.Auth.TokenEnv)
-		} else if openAPICfg.Auth.Type == "header" {
+		switch openAPICfg.Auth.Type {
+		case "bearer":
+			if openAPICfg.Auth.TokenEnv != "" {
+				cfg.OpenAPIConfig.AuthToken = os.Getenv(openAPICfg.Auth.TokenEnv)
+			}
+		case "header":
 			cfg.OpenAPIConfig.AuthHeader = openAPICfg.Auth.Header
 			if openAPICfg.Auth.ValueEnv != "" {
 				cfg.OpenAPIConfig.AuthValue = os.Getenv(openAPICfg.Auth.ValueEnv)
 			}
+		case "query":
+			cfg.OpenAPIConfig.AuthQueryParam = openAPICfg.Auth.ParamName
+			if openAPICfg.Auth.ValueEnv != "" {
+				cfg.OpenAPIConfig.AuthQueryValue = os.Getenv(openAPICfg.Auth.ValueEnv)
+			}
+		case "oauth2":
+			if openAPICfg.Auth.ClientIdEnv != "" {
+				cfg.OpenAPIConfig.OAuth2ClientID = os.Getenv(openAPICfg.Auth.ClientIdEnv)
+			}
+			if openAPICfg.Auth.ClientSecretEnv != "" {
+				cfg.OpenAPIConfig.OAuth2ClientSecret = os.Getenv(openAPICfg.Auth.ClientSecretEnv)
+			}
+			cfg.OpenAPIConfig.OAuth2TokenURL = openAPICfg.Auth.TokenUrl
+			cfg.OpenAPIConfig.OAuth2Scopes = openAPICfg.Auth.Scopes
+		case "basic":
+			if openAPICfg.Auth.UsernameEnv != "" {
+				cfg.OpenAPIConfig.BasicUsername = os.Getenv(openAPICfg.Auth.UsernameEnv)
+			}
+			if openAPICfg.Auth.PasswordEnv != "" {
+				cfg.OpenAPIConfig.BasicPassword = os.Getenv(openAPICfg.Auth.PasswordEnv)
+			}
 		}
+	}
+
+	if openAPICfg.TLS != nil {
+		cfg.OpenAPIConfig.TLSCertFile = openAPICfg.TLS.CertFile
+		cfg.OpenAPIConfig.TLSKeyFile = openAPICfg.TLS.KeyFile
+		cfg.OpenAPIConfig.TLSCAFile = openAPICfg.TLS.CaFile
+		cfg.OpenAPIConfig.TLSInsecureSkipVerify = openAPICfg.TLS.InsecureSkipVerify
 	}
 
 	if openAPICfg.Operations != nil {

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -54,13 +54,33 @@ type MCPServerConfig struct {
 type OpenAPIClientConfig struct {
 	Spec       string   // URL or local file path to OpenAPI spec
 	BaseURL    string   // Override server URL from spec
-	AuthType   string   // "bearer" or "header"
+	AuthType   string   // "bearer", "header", "query", "oauth2", or "basic"
 	AuthToken  string   // Resolved bearer token (from env)
 	AuthHeader string   // Header name for header-based auth
 	AuthValue  string   // Resolved header value (from env)
 	Include    []string // Operation IDs to include
 	Exclude    []string // Operation IDs to exclude
 	NoExpand   bool     // If true, skip environment variable expansion in spec file
+
+	// Query param auth fields
+	AuthQueryParam string // Query parameter name for type: query
+	AuthQueryValue string // Resolved query parameter value (from env)
+
+	// OAuth2 client credentials fields
+	OAuth2ClientID     string   // Resolved OAuth2 client ID (from env)
+	OAuth2ClientSecret string   // Resolved OAuth2 client secret (from env)
+	OAuth2TokenURL     string   // OAuth2 token endpoint URL
+	OAuth2Scopes       []string // OAuth2 scopes to request
+
+	// Basic auth fields
+	BasicUsername string // Resolved username (from env)
+	BasicPassword string // Resolved password (from env)
+
+	// TLS/mTLS fields
+	TLSCertFile           string // Client certificate file path
+	TLSKeyFile            string // Client private key file path
+	TLSCAFile             string // Custom CA certificate file path
+	TLSInsecureSkipVerify bool   // Skip server certificate verification
 }
 
 // HealthStatus tracks the health state of a downstream MCP server.

--- a/pkg/mcp/openapi_client.go
+++ b/pkg/mcp/openapi_client.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +18,8 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gridctl/gridctl/pkg/logging"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 // Default HTTP timeout for OpenAPI requests
@@ -42,6 +46,17 @@ type OpenAPIClient struct {
 	logger     *slog.Logger
 	noExpand   bool // If true, skip environment variable expansion in spec file
 
+	// Query param auth
+	authQueryParam string
+	authQueryValue string
+
+	// Basic auth
+	basicUsername string
+	basicPassword string
+
+	// OAuth2 client credentials — non-nil when authType == "oauth2"
+	tokenSource oauth2.TokenSource
+
 	operations map[string]*OpenAPIOperation // toolName -> operation (protected by ClientBase.mu)
 	cachedDoc  *openapi3.T                  // Cached OpenAPI document (protected by ClientBase.mu)
 }
@@ -59,17 +74,20 @@ type OpenAPIOperation struct {
 // NewOpenAPIClient creates an OpenAPI-based MCP client.
 func NewOpenAPIClient(name string, cfg *OpenAPIClientConfig) (*OpenAPIClient, error) {
 	c := &OpenAPIClient{
-		name:       name,
-		spec:       cfg.Spec,
-		baseURL:    cfg.BaseURL,
-		authType:   cfg.AuthType,
-		authToken:  cfg.AuthToken,
-		authHeader: cfg.AuthHeader,
-		authValue:  cfg.AuthValue,
-		httpClient: &http.Client{Timeout: defaultOpenAPITimeout},
-		logger:     logging.NewDiscardLogger(),
-		operations: make(map[string]*OpenAPIOperation),
-		noExpand:   cfg.NoExpand,
+		name:           name,
+		spec:           cfg.Spec,
+		baseURL:        cfg.BaseURL,
+		authType:       cfg.AuthType,
+		authToken:      cfg.AuthToken,
+		authHeader:     cfg.AuthHeader,
+		authValue:      cfg.AuthValue,
+		authQueryParam: cfg.AuthQueryParam,
+		authQueryValue: cfg.AuthQueryValue,
+		basicUsername:  cfg.BasicUsername,
+		basicPassword:  cfg.BasicPassword,
+		logger:         logging.NewDiscardLogger(),
+		operations:     make(map[string]*OpenAPIOperation),
+		noExpand:       cfg.NoExpand,
 	}
 
 	if len(cfg.Include) > 0 {
@@ -83,6 +101,47 @@ func NewOpenAPIClient(name string, cfg *OpenAPIClientConfig) (*OpenAPIClient, er
 		for _, op := range cfg.Exclude {
 			c.excludeOps[op] = true
 		}
+	}
+
+	// Build HTTP transport — clone default to avoid mutating shared state
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	// Configure TLS if cert files are provided
+	if cfg.TLSCertFile != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.TLSCertFile, cfg.TLSKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("loading TLS client certificate: %w", err)
+		}
+		tlsCfg := &tls.Config{
+			Certificates:       []tls.Certificate{cert},
+			InsecureSkipVerify: cfg.TLSInsecureSkipVerify, //nolint:gosec // user-controlled config
+		}
+		if cfg.TLSCAFile != "" {
+			caCert, err := os.ReadFile(cfg.TLSCAFile)
+			if err != nil {
+				return nil, fmt.Errorf("reading TLS CA file: %w", err)
+			}
+			caPool := x509.NewCertPool()
+			if !caPool.AppendCertsFromPEM(caCert) {
+				return nil, fmt.Errorf("parsing TLS CA certificate: no valid certificates found in %s", cfg.TLSCAFile)
+			}
+			tlsCfg.RootCAs = caPool
+		}
+		transport.TLSClientConfig = tlsCfg
+	}
+
+	c.httpClient = &http.Client{Timeout: defaultOpenAPITimeout, Transport: transport}
+
+	// Build OAuth2 token source for client credentials flow
+	if cfg.AuthType == "oauth2" {
+		ccCfg := &clientcredentials.Config{
+			ClientID:     cfg.OAuth2ClientID,
+			ClientSecret: cfg.OAuth2ClientSecret,
+			TokenURL:     cfg.OAuth2TokenURL,
+			Scopes:       cfg.OAuth2Scopes,
+		}
+		// Use background context so the token source outlives individual requests
+		c.tokenSource = ccCfg.TokenSource(context.Background())
 	}
 
 	return c, nil
@@ -277,7 +336,9 @@ func (c *OpenAPIClient) Ping(ctx context.Context) error {
 		return fmt.Errorf("creating request: %w", err)
 	}
 
-	c.applyAuth(req)
+	if err := c.applyAuth(req); err != nil {
+		return err
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -632,7 +693,9 @@ func (c *OpenAPIClient) executeOperation(ctx context.Context, op *OpenAPIOperati
 	}
 
 	// Apply authentication
-	c.applyAuth(req)
+	if err := c.applyAuth(req); err != nil {
+		return "", 0, err
+	}
 
 	// Execute request
 	resp, err := c.httpClient.Do(req)
@@ -651,8 +714,8 @@ func (c *OpenAPIClient) executeOperation(ctx context.Context, op *OpenAPIOperati
 	return string(respBody), resp.StatusCode, nil
 }
 
-// applyAuth applies authentication headers to the request.
-func (c *OpenAPIClient) applyAuth(req *http.Request) {
+// applyAuth applies authentication to the request.
+func (c *OpenAPIClient) applyAuth(req *http.Request) error {
 	switch c.authType {
 	case "bearer":
 		if c.authToken != "" {
@@ -662,7 +725,22 @@ func (c *OpenAPIClient) applyAuth(req *http.Request) {
 		if c.authHeader != "" && c.authValue != "" {
 			req.Header.Set(c.authHeader, c.authValue)
 		}
+	case "query":
+		if c.authQueryParam != "" {
+			q := req.URL.Query()
+			q.Set(c.authQueryParam, c.authQueryValue)
+			req.URL.RawQuery = q.Encode()
+		}
+	case "basic":
+		req.SetBasicAuth(c.basicUsername, c.basicPassword)
+	case "oauth2":
+		tok, err := c.tokenSource.Token()
+		if err != nil {
+			return fmt.Errorf("fetching OAuth2 token: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
 	}
+	return nil
 }
 
 // sanitizeOpenAPIToolName ensures the tool name is valid for MCP.

--- a/pkg/mcp/openapi_client_test.go
+++ b/pkg/mcp/openapi_client_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -651,5 +652,88 @@ func TestRefreshTools(t *testing.T) {
 	tools := client.Tools()
 	if len(tools) != 1 {
 		t.Errorf("expected 1 tool after refresh, got %d", len(tools))
+	}
+}
+
+func TestPing_NoBaseURL(t *testing.T) {
+	c, _ := NewOpenAPIClient("test", &OpenAPIClientConfig{
+		Spec: "http://example.com/spec.json",
+	})
+	err := c.Ping(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "no base URL") {
+		t.Errorf("expected 'no base URL' error, got %v", err)
+	}
+}
+
+func TestPing_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, _ := NewOpenAPIClient("test", &OpenAPIClientConfig{
+		Spec:    srv.URL + "/spec.json",
+		BaseURL: srv.URL,
+	})
+	if err := c.Ping(context.Background()); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPing_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c, _ := NewOpenAPIClient("test", &OpenAPIClientConfig{
+		Spec:    srv.URL + "/spec.json",
+		BaseURL: srv.URL,
+	})
+	if err := c.Ping(context.Background()); err == nil {
+		t.Error("expected error for 500 response")
+	}
+}
+
+func TestPing_WithBearerAuth(t *testing.T) {
+	const token = "ping-test-token"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, _ := NewOpenAPIClient("test", &OpenAPIClientConfig{
+		Spec:      srv.URL + "/spec.json",
+		BaseURL:   srv.URL,
+		AuthType:  "bearer",
+		AuthToken: token,
+	})
+	if err := c.Ping(context.Background()); err != nil {
+		t.Errorf("unexpected error with valid bearer token: %v", err)
+	}
+}
+
+func TestNewOpenAPIClient_TLSInvalidCert(t *testing.T) {
+	dir := t.TempDir()
+	certFile := dir + "/cert.pem"
+	keyFile := dir + "/key.pem"
+	if err := os.WriteFile(certFile, []byte("not a cert"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("not a key"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := NewOpenAPIClient("test", &OpenAPIClientConfig{
+		Spec:        "http://example.com/spec.json",
+		TLSCertFile: certFile,
+		TLSKeyFile:  keyFile,
+	})
+	if err == nil || !strings.Contains(err.Error(), "loading TLS client certificate") {
+		t.Errorf("expected TLS cert error, got %v", err)
 	}
 }

--- a/pkg/mcp/openapi_client_test.go
+++ b/pkg/mcp/openapi_client_test.go
@@ -477,7 +477,9 @@ func TestApplyAuth_Bearer(t *testing.T) {
 	})
 
 	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
-	c.applyAuth(req)
+	if err := c.applyAuth(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if req.Header.Get("Authorization") != "Bearer my-token" {
 		t.Errorf("expected 'Bearer my-token', got %q", req.Header.Get("Authorization"))
@@ -494,7 +496,9 @@ func TestApplyAuth_Header(t *testing.T) {
 	})
 
 	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
-	c.applyAuth(req)
+	if err := c.applyAuth(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if req.Header.Get("X-API-Key") != "secret123" {
 		t.Errorf("expected 'secret123', got %q", req.Header.Get("X-API-Key"))
@@ -508,10 +512,102 @@ func TestApplyAuth_NoAuth(t *testing.T) {
 	})
 
 	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
-	c.applyAuth(req)
+	if err := c.applyAuth(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if req.Header.Get("Authorization") != "" {
 		t.Error("expected no Authorization header")
+	}
+}
+
+func TestApplyAuth_Query(t *testing.T) {
+	c, _ := NewOpenAPIClient("test", &OpenAPIClientConfig{
+		Spec:           "http://example.com/spec.json",
+		BaseURL:        "http://example.com",
+		AuthType:       "query",
+		AuthQueryParam: "api_key",
+		AuthQueryValue: "myapikey",
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com/test?existing=1", nil)
+	if err := c.applyAuth(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	q := req.URL.Query()
+	if q.Get("api_key") != "myapikey" {
+		t.Errorf("expected api_key=myapikey, got %q", q.Get("api_key"))
+	}
+	// Existing query params must be preserved
+	if q.Get("existing") != "1" {
+		t.Errorf("existing query param lost; got %q", q.Get("existing"))
+	}
+}
+
+func TestApplyAuth_Basic(t *testing.T) {
+	c, _ := NewOpenAPIClient("test", &OpenAPIClientConfig{
+		Spec:          "http://example.com/spec.json",
+		BaseURL:       "http://example.com",
+		AuthType:      "basic",
+		BasicUsername: "alice",
+		BasicPassword: "s3cr3t",
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+	if err := c.applyAuth(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	user, pass, ok := req.BasicAuth()
+	if !ok {
+		t.Fatal("expected Basic auth header")
+	}
+	if user != "alice" || pass != "s3cr3t" {
+		t.Errorf("expected alice/s3cr3t, got %q/%q", user, pass)
+	}
+}
+
+func TestApplyAuth_OAuth2(t *testing.T) {
+	// Mock token endpoint
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if r.Form.Get("grant_type") != "client_credentials" {
+			http.Error(w, "invalid grant_type", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"test-oauth-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	c, err := NewOpenAPIClient("test", &OpenAPIClientConfig{
+		Spec:               "http://example.com/spec.json",
+		BaseURL:            "http://example.com",
+		AuthType:           "oauth2",
+		OAuth2ClientID:     "client-id",
+		OAuth2ClientSecret: "client-secret",
+		OAuth2TokenURL:     tokenServer.URL + "/token",
+	})
+	if err != nil {
+		t.Fatalf("NewOpenAPIClient failed: %v", err)
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+	if err := c.applyAuth(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if req.Header.Get("Authorization") != "Bearer test-oauth-token" {
+		t.Errorf("expected 'Bearer test-oauth-token', got %q", req.Header.Get("Authorization"))
 	}
 }
 

--- a/tests/integration/openapi_test.go
+++ b/tests/integration/openapi_test.go
@@ -2,12 +2,21 @@ package integration
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gridctl/gridctl/pkg/mcp"
 )
@@ -1045,4 +1054,388 @@ func TestOpenAPIClient_EnvVarExpansion(t *testing.T) {
 			t.Error("Expected initialization to fail with unexpanded variable, but it succeeded")
 		}
 	})
+}
+
+// createTestServerWithQueryAuth creates a test server requiring an API key query parameter.
+func createTestServerWithQueryAuth(t *testing.T, paramName, expectedKey string) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	authMiddleware := func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/openapi.json" {
+				next(w, r)
+				return
+			}
+			if r.URL.Query().Get(paramName) != expectedKey {
+				http.Error(w, `{"error": "unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+			next(w, r)
+		}
+	}
+
+	mux.HandleFunc("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testOpenAPISpec))
+	})
+
+	mux.HandleFunc("GET /items", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mockItems)
+	}))
+
+	return httptest.NewServer(mux)
+}
+
+func TestOpenAPIClient_WithQueryAuth(t *testing.T) {
+	server := createTestServerWithQueryAuth(t, "api_key", "secret-key-123")
+	defer server.Close()
+
+	spec := strings.ReplaceAll(testOpenAPISpec, "SERVER_URL_PLACEHOLDER", server.URL)
+	_ = spec
+
+	cfg := &mcp.OpenAPIClientConfig{
+		Spec:           server.URL + "/openapi.json",
+		BaseURL:        server.URL,
+		AuthType:       "query",
+		AuthQueryParam: "api_key",
+		AuthQueryValue: "secret-key-123",
+	}
+
+	client, err := mcp.NewOpenAPIClient("test-api", cfg)
+	if err != nil {
+		t.Fatalf("NewOpenAPIClient failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := client.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+	if err := client.RefreshTools(ctx); err != nil {
+		t.Fatalf("RefreshTools failed: %v", err)
+	}
+
+	result, err := client.CallTool(ctx, "listItems", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("expected successful result, got error: %v", result.Content)
+	}
+}
+
+func TestOpenAPIClient_WithQueryAuth_MissingKey(t *testing.T) {
+	server := createTestServerWithQueryAuth(t, "api_key", "secret-key-123")
+	defer server.Close()
+
+	cfg := &mcp.OpenAPIClientConfig{
+		Spec:           server.URL + "/openapi.json",
+		BaseURL:        server.URL,
+		AuthType:       "query",
+		AuthQueryParam: "api_key",
+		AuthQueryValue: "wrong-key",
+	}
+
+	client, err := mcp.NewOpenAPIClient("test-api", cfg)
+	if err != nil {
+		t.Fatalf("NewOpenAPIClient failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := client.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+	if err := client.RefreshTools(ctx); err != nil {
+		t.Fatalf("RefreshTools failed: %v", err)
+	}
+
+	result, err := client.CallTool(ctx, "listItems", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected isError=true for 401 response")
+	}
+}
+
+func TestOpenAPIClient_WithOAuth2(t *testing.T) {
+	const testToken = "oauth2-access-token-xyz"
+
+	// Mock OAuth2 token endpoint
+	tokenCalled := 0
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenCalled++
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		if err := r.ParseForm(); err != nil || r.Form.Get("grant_type") != "client_credentials" {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + testToken + `","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	// API server that requires the OAuth2 token
+	apiServer := createTestServerWithAuth(t, testToken)
+	defer apiServer.Close()
+
+	cfg := &mcp.OpenAPIClientConfig{
+		Spec:               apiServer.URL + "/openapi.json",
+		BaseURL:            apiServer.URL,
+		AuthType:           "oauth2",
+		OAuth2ClientID:     "my-client-id",
+		OAuth2ClientSecret: "my-client-secret",
+		OAuth2TokenURL:     tokenServer.URL + "/token",
+	}
+
+	client, err := mcp.NewOpenAPIClient("test-api", cfg)
+	if err != nil {
+		t.Fatalf("NewOpenAPIClient failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := client.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+	if err := client.RefreshTools(ctx); err != nil {
+		t.Fatalf("RefreshTools failed: %v", err)
+	}
+
+	result, err := client.CallTool(ctx, "listItems", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("expected successful result with OAuth2, got error: %v", result.Content)
+	}
+	if tokenCalled == 0 {
+		t.Error("expected token endpoint to be called")
+	}
+}
+
+// generateTestCerts generates a self-signed CA and client cert/key for mTLS testing.
+// Returns (caCertPEM, clientCertPEM, clientKeyPEM).
+func generateTestCerts(t *testing.T) ([]byte, []byte, []byte) {
+	t.Helper()
+
+	// Generate CA key and cert
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("creating CA cert: %v", err)
+	}
+	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	// Generate client key and cert signed by CA
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating client key: %v", err)
+	}
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parsing CA cert: %v", err)
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caCert, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("creating client cert: %v", err)
+	}
+	clientCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+
+	clientKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+	if err != nil {
+		t.Fatalf("marshaling client key: %v", err)
+	}
+	clientKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: clientKeyDER})
+
+	return caCertPEM, clientCertPEM, clientKeyPEM
+}
+
+func TestOpenAPIClient_WithMTLS(t *testing.T) {
+	caCertPEM, clientCertPEM, clientKeyPEM := generateTestCerts(t)
+
+	// Write cert files to temp dir
+	dir := t.TempDir()
+	caFile := dir + "/ca.pem"
+	certFile := dir + "/client.pem"
+	keyFile := dir + "/client-key.pem"
+	if err := os.WriteFile(caFile, caCertPEM, 0600); err != nil {
+		t.Fatalf("writing CA: %v", err)
+	}
+	if err := os.WriteFile(certFile, clientCertPEM, 0600); err != nil {
+		t.Fatalf("writing client cert: %v", err)
+	}
+	if err := os.WriteFile(keyFile, clientKeyPEM, 0600); err != nil {
+		t.Fatalf("writing client key: %v", err)
+	}
+
+	// Build mTLS server that requires client cert
+	caCert, err := x509.ParseCertificate(func() []byte {
+		block, _ := pem.Decode(caCertPEM)
+		return block.Bytes
+	}())
+	if err != nil {
+		t.Fatalf("parsing CA cert: %v", err)
+	}
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert)
+
+	clientCertReceived := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testOpenAPISpec))
+	})
+	mux.HandleFunc("GET /items", func(w http.ResponseWriter, r *http.Request) {
+		if len(r.TLS.PeerCertificates) > 0 {
+			clientCertReceived = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mockItems)
+	})
+
+	tlsServer := httptest.NewUnstartedServer(mux)
+	tlsServer.TLS = &tls.Config{
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  caPool,
+	}
+	tlsServer.StartTLS()
+	defer tlsServer.Close()
+
+	// The test TLS server uses a self-signed cert; skip server verification
+	cfg := &mcp.OpenAPIClientConfig{
+		Spec:                  tlsServer.URL + "/openapi.json",
+		BaseURL:               tlsServer.URL,
+		TLSCertFile:           certFile,
+		TLSKeyFile:            keyFile,
+		TLSInsecureSkipVerify: true, // test server has self-signed cert
+	}
+
+	client, err := mcp.NewOpenAPIClient("test-api", cfg)
+	if err != nil {
+		t.Fatalf("NewOpenAPIClient failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := client.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+	if err := client.RefreshTools(ctx); err != nil {
+		t.Fatalf("RefreshTools failed: %v", err)
+	}
+
+	result, err := client.CallTool(ctx, "listItems", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("expected successful result with mTLS, got error: %v", result.Content)
+	}
+	if !clientCertReceived {
+		t.Error("server did not receive client certificate")
+	}
+}
+
+func TestOpenAPIClient_WithMTLSAndBearer(t *testing.T) {
+	const expectedToken = "bearer-plus-mtls"
+	caCertPEM, clientCertPEM, clientKeyPEM := generateTestCerts(t)
+
+	dir := t.TempDir()
+	certFile := dir + "/client.pem"
+	keyFile := dir + "/client-key.pem"
+	if err := os.WriteFile(certFile, clientCertPEM, 0600); err != nil {
+		t.Fatalf("writing client cert: %v", err)
+	}
+	if err := os.WriteFile(keyFile, clientKeyPEM, 0600); err != nil {
+		t.Fatalf("writing client key: %v", err)
+	}
+
+	// Parse CA for server
+	block, _ := pem.Decode(caCertPEM)
+	caCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parsing CA cert: %v", err)
+	}
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert)
+
+	bothPresent := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testOpenAPISpec))
+	})
+	mux.HandleFunc("GET /items", func(w http.ResponseWriter, r *http.Request) {
+		hasClientCert := r.TLS != nil && len(r.TLS.PeerCertificates) > 0
+		hasBearer := r.Header.Get("Authorization") == "Bearer "+expectedToken
+		if hasClientCert && hasBearer {
+			bothPresent = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mockItems)
+	})
+
+	tlsServer := httptest.NewUnstartedServer(mux)
+	tlsServer.TLS = &tls.Config{
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  caPool,
+	}
+	tlsServer.StartTLS()
+	defer tlsServer.Close()
+
+	cfg := &mcp.OpenAPIClientConfig{
+		Spec:                  tlsServer.URL + "/openapi.json",
+		BaseURL:               tlsServer.URL,
+		AuthType:              "bearer",
+		AuthToken:             expectedToken,
+		TLSCertFile:           certFile,
+		TLSKeyFile:            keyFile,
+		TLSInsecureSkipVerify: true,
+	}
+
+	client, err := mcp.NewOpenAPIClient("test-api", cfg)
+	if err != nil {
+		t.Fatalf("NewOpenAPIClient failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := client.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+	if err := client.RefreshTools(ctx); err != nil {
+		t.Fatalf("RefreshTools failed: %v", err)
+	}
+
+	result, err := client.CallTool(ctx, "listItems", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("expected successful result, got error: %v", result.Content)
+	}
+	if !bothPresent {
+		t.Error("expected both mTLS client cert and Bearer header to be present")
+	}
 }


### PR DESCRIPTION
## Description

Expands the OpenAPI gateway's authentication support from two types (bearer, header) to five, unblocking the majority of real-world API auth patterns that were previously unsupported.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **`type: query`** — API key injected as a URL query parameter (e.g., OpenWeatherMap `?appid=`)
- **`type: oauth2`** — OAuth2 client credentials flow: fetches token from `tokenUrl`, caches it, re-fetches on expiry; uses `golang.org/x/oauth2/clientcredentials` (goroutine-safe)
- **`type: basic`** — HTTP Basic Auth from `usernameEnv`/`passwordEnv`
- **`tls:` block** — mTLS client certificate config (transport-layer, combinable with any auth type); uses stdlib `crypto/tls`, no new deps
- `applyAuth()` signature changed from `void` to `error` to propagate OAuth2 token fetch failures
- Config validation extended for all new types and TLS cert file existence
- Unit and integration tests added for all new auth types (including mock OAuth2 token endpoint and mTLS server)

## Testing

All new auth types are covered by unit tests (`TestApplyAuth_Query`, `TestApplyAuth_Basic`, `TestApplyAuth_OAuth2`) and integration tests (`TestOpenAPIClient_WithQueryAuth`, `TestOpenAPIClient_WithOAuth2`, `TestOpenAPIClient_WithMTLS`, `TestOpenAPIClient_WithMTLSAndBearer`).

```
go test -race ./pkg/mcp/... ./pkg/config/... ./pkg/controller/... ./tests/integration/...
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #426