### PR TITLE
feat: complete wizard spec for SSH advanced fields, OpenAPI auth types, mTLS, and pin_schemas

### DIFF
--- a/web/src/__tests__/MCPServerForm.test.tsx
+++ b/web/src/__tests__/MCPServerForm.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MCPServerForm } from '../components/wizard/steps/MCPServerForm';
 import type { MCPServerFormData } from '../lib/yaml-builder';
+import { buildYAML } from '../lib/yaml-builder';
 
 function defaultData(overrides?: Partial<MCPServerFormData>): MCPServerFormData {
   return { name: '', serverType: 'container', ...overrides };
@@ -214,5 +215,296 @@ describe('MCPServerForm field visibility', () => {
   it('shows command builder for ssh type', () => {
     render(<MCPServerForm data={defaultData({ serverType: 'ssh' })} onChange={onChange} />);
     expect(screen.getByText('Add argument')).toBeInTheDocument();
+  });
+});
+
+describe('MCPServerForm SSH advanced fields', () => {
+  const onChange = vi.fn<typeof noop>();
+
+  it('shows knownHostsFile and jumpHost fields for ssh type', () => {
+    render(<MCPServerForm data={defaultData({ serverType: 'ssh' })} onChange={onChange} />);
+    expect(screen.getByPlaceholderText('~/.ssh/known_hosts')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('[user@]bastion.example.com[:22]')).toBeInTheDocument();
+  });
+
+  it('does not show knownHostsFile or jumpHost for non-SSH types', () => {
+    render(<MCPServerForm data={defaultData({ serverType: 'container' })} onChange={onChange} />);
+    expect(screen.queryByPlaceholderText('~/.ssh/known_hosts')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('[user@]bastion.example.com[:22]')).not.toBeInTheDocument();
+  });
+});
+
+describe('MCPServerForm OpenAPI new auth types', () => {
+  const onChange = vi.fn<typeof noop>();
+
+  it('shows query auth fields when query is selected', () => {
+    render(
+      <MCPServerForm
+        data={defaultData({
+          serverType: 'openapi',
+          openapi: { spec: 'https://api.example.com/spec.yaml', auth: { type: 'query' } },
+        })}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByText('Parameter Name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('appid')).toBeInTheDocument();
+  });
+
+  it('shows oauth2 auth fields when oauth2 is selected', () => {
+    render(
+      <MCPServerForm
+        data={defaultData({
+          serverType: 'openapi',
+          openapi: { spec: 'https://api.example.com/spec.yaml', auth: { type: 'oauth2' } },
+        })}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByPlaceholderText('OAUTH2_CLIENT_ID')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('OAUTH2_CLIENT_SECRET')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('https://auth.example.com/oauth/token')).toBeInTheDocument();
+    expect(screen.getByText('Scopes')).toBeInTheDocument();
+  });
+
+  it('shows basic auth fields when basic is selected', () => {
+    render(
+      <MCPServerForm
+        data={defaultData({
+          serverType: 'openapi',
+          openapi: { spec: 'https://api.example.com/spec.yaml', auth: { type: 'basic' } },
+        })}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByPlaceholderText('API_USERNAME')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('API_PASSWORD')).toBeInTheDocument();
+  });
+
+  it('does not show oauth2 fields when bearer is selected', () => {
+    render(
+      <MCPServerForm
+        data={defaultData({
+          serverType: 'openapi',
+          openapi: { spec: 'https://api.example.com/spec.yaml', auth: { type: 'bearer', tokenEnv: '' } },
+        })}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.queryByPlaceholderText('OAUTH2_CLIENT_ID')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('API_USERNAME')).not.toBeInTheDocument();
+  });
+});
+
+describe('MCPServerForm TLS section', () => {
+  const onChange = vi.fn<typeof noop>();
+
+  it('shows TLS / mTLS section header for OpenAPI type', () => {
+    render(<MCPServerForm data={defaultData({ serverType: 'openapi' })} onChange={onChange} />);
+    expect(screen.getByText('TLS / mTLS')).toBeInTheDocument();
+  });
+
+  it('does not show TLS section for non-OpenAPI types', () => {
+    render(<MCPServerForm data={defaultData({ serverType: 'container' })} onChange={onChange} />);
+    expect(screen.queryByText('TLS / mTLS')).not.toBeInTheDocument();
+  });
+
+  it('shows TLS fields when section is expanded', () => {
+    render(
+      <MCPServerForm
+        data={defaultData({
+          serverType: 'openapi',
+          openapi: { spec: 'https://api.example.com/spec.yaml', tls: {} },
+        })}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('TLS / mTLS'));
+    expect(screen.getByPlaceholderText('./certs/client.crt')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('./certs/client.key')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('./certs/ca.crt')).toBeInTheDocument();
+    expect(screen.getByText('Skip TLS Verification')).toBeInTheDocument();
+  });
+});
+
+describe('MCPServerForm pin_schemas select', () => {
+  const onChange = vi.fn<typeof noop>();
+
+  it('shows schema pinning select in advanced section', () => {
+    render(<MCPServerForm data={defaultData()} onChange={onChange} />);
+    // Expand the Advanced section
+    fireEvent.click(screen.getByText('Advanced'));
+    expect(screen.getByText('Schema Pinning')).toBeInTheDocument();
+  });
+});
+
+describe('YAML serialization — new fields', () => {
+  it('serializes SSH knownHostsFile and jumpHost', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'my-server',
+        serverType: 'ssh',
+        ssh: { host: '10.0.0.1', user: 'admin', knownHostsFile: '~/.ssh/known_hosts', jumpHost: 'bastion.example.com' },
+      },
+    });
+    expect(yaml).toContain('knownHostsFile: ~/.ssh/known_hosts');
+    expect(yaml).toContain('jumpHost: bastion.example.com');
+  });
+
+  it('does not serialize knownHostsFile/jumpHost when empty', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'my-server',
+        serverType: 'ssh',
+        ssh: { host: '10.0.0.1', user: 'admin' },
+      },
+    });
+    expect(yaml).not.toContain('knownHostsFile');
+    expect(yaml).not.toContain('jumpHost');
+  });
+
+  it('serializes query auth fields', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'weather',
+        serverType: 'openapi',
+        openapi: {
+          spec: 'https://api.example.com/spec.yaml',
+          auth: { type: 'query', paramName: 'appid', valueEnv: 'WEATHER_KEY' },
+        },
+      },
+    });
+    expect(yaml).toContain('type: query');
+    expect(yaml).toContain('paramName: appid');
+    expect(yaml).toContain('valueEnv: WEATHER_KEY');
+  });
+
+  it('serializes oauth2 auth fields including scopes as list', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'my-server',
+        serverType: 'openapi',
+        openapi: {
+          spec: 'https://api.example.com/spec.yaml',
+          auth: {
+            type: 'oauth2',
+            clientIdEnv: 'CLIENT_ID',
+            clientSecretEnv: 'CLIENT_SECRET',
+            tokenUrl: 'https://auth.example.com/token',
+            scopes: ['read:data', 'write:data'],
+          },
+        },
+      },
+    });
+    expect(yaml).toContain('type: oauth2');
+    expect(yaml).toContain('clientIdEnv: CLIENT_ID');
+    expect(yaml).toContain('clientSecretEnv: CLIENT_SECRET');
+    expect(yaml).toContain('tokenUrl:');
+    expect(yaml).toContain('scopes:');
+    expect(yaml).toContain('- "read:data"');
+    expect(yaml).toContain('- "write:data"');
+  });
+
+  it('serializes basic auth fields', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'my-server',
+        serverType: 'openapi',
+        openapi: {
+          spec: 'https://api.example.com/spec.yaml',
+          auth: { type: 'basic', usernameEnv: 'API_USER', passwordEnv: 'API_PASS' },
+        },
+      },
+    });
+    expect(yaml).toContain('type: basic');
+    expect(yaml).toContain('usernameEnv: API_USER');
+    expect(yaml).toContain('passwordEnv: API_PASS');
+  });
+
+  it('serializes TLS fields under tls block', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'my-server',
+        serverType: 'openapi',
+        openapi: {
+          spec: 'https://api.example.com/spec.yaml',
+          tls: { certFile: './certs/client.crt', keyFile: './certs/client.key', caFile: './certs/ca.crt' },
+        },
+      },
+    });
+    expect(yaml).toContain('tls:');
+    expect(yaml).toContain('certFile: ./certs/client.crt');
+    expect(yaml).toContain('keyFile: ./certs/client.key');
+    expect(yaml).toContain('caFile: ./certs/ca.crt');
+  });
+
+  it('serializes insecureSkipVerify: true only when set to true', () => {
+    const yamlTrue = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'my-server',
+        serverType: 'openapi',
+        openapi: {
+          spec: 'https://api.example.com/spec.yaml',
+          tls: { insecureSkipVerify: true },
+        },
+      },
+    });
+    expect(yamlTrue).toContain('insecureSkipVerify: true');
+
+    const yamlFalse = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'my-server',
+        serverType: 'openapi',
+        openapi: {
+          spec: 'https://api.example.com/spec.yaml',
+          tls: { insecureSkipVerify: false },
+        },
+      },
+    });
+    expect(yamlFalse).not.toContain('insecureSkipVerify');
+  });
+
+  it('omits tls block when no tls fields set', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'my-server',
+        serverType: 'openapi',
+        openapi: { spec: 'https://api.example.com/spec.yaml' },
+      },
+    });
+    expect(yaml).not.toContain('tls:');
+  });
+
+  it('serializes pin_schemas: true when enabled', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: { name: 'my-server', serverType: 'container', image: 'test:latest', pinSchemas: true },
+    });
+    expect(yaml).toContain('pin_schemas: true');
+  });
+
+  it('serializes pin_schemas: false when disabled', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: { name: 'my-server', serverType: 'container', image: 'test:latest', pinSchemas: false },
+    });
+    expect(yaml).toContain('pin_schemas: false');
+  });
+
+  it('omits pin_schemas when not set', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: { name: 'my-server', serverType: 'container', image: 'test:latest' },
+    });
+    expect(yaml).not.toContain('pin_schemas');
   });
 });

--- a/web/src/components/wizard/steps/MCPServerForm.tsx
+++ b/web/src/components/wizard/steps/MCPServerForm.tsx
@@ -477,7 +477,7 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
   };
 
   const envCount = data.env ? Object.keys(data.env).length : 0;
-  const advancedCount = (data.tools?.length ?? 0) + (data.outputFormat ? 1 : 0) + (data.buildArgs ? Object.keys(data.buildArgs).length : 0) + (data.network ? 1 : 0);
+  const advancedCount = (data.tools?.length ?? 0) + (data.outputFormat ? 1 : 0) + (data.buildArgs ? Object.keys(data.buildArgs).length : 0) + (data.network ? 1 : 0) + (data.pinSchemas !== undefined ? 1 : 0);
 
   return (
     <div className="space-y-3">
@@ -781,6 +781,46 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
                   />
                 </div>
               </div>
+              <div>
+                <label className={labelClass}>Known Hosts File</label>
+                <input
+                  type="text"
+                  value={data.ssh?.knownHostsFile ?? ''}
+                  onChange={(e) =>
+                    onChange({
+                      ssh: {
+                        ...data.ssh,
+                        host: data.ssh?.host ?? '',
+                        user: data.ssh?.user ?? '',
+                        knownHostsFile: e.target.value,
+                      },
+                    })
+                  }
+                  placeholder="~/.ssh/known_hosts"
+                  className={cn(inputClass, 'font-mono')}
+                />
+                <p className="text-[10px] text-text-muted mt-1">Optional — enables StrictHostKeyChecking=yes</p>
+              </div>
+              <div>
+                <label className={labelClass}>Jump Host</label>
+                <input
+                  type="text"
+                  value={data.ssh?.jumpHost ?? ''}
+                  onChange={(e) =>
+                    onChange({
+                      ssh: {
+                        ...data.ssh,
+                        host: data.ssh?.host ?? '',
+                        user: data.ssh?.user ?? '',
+                        jumpHost: e.target.value,
+                      },
+                    })
+                  }
+                  placeholder="[user@]bastion.example.com[:22]"
+                  className={cn(inputClass, 'font-mono')}
+                />
+                <p className="text-[10px] text-text-muted mt-1">Optional — bastion/jump host for multi-hop SSH</p>
+              </div>
             </div>
           )}
 
@@ -838,6 +878,9 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
                   <option value="">None</option>
                   <option value="bearer">Bearer Token</option>
                   <option value="header">Custom Header</option>
+                  <option value="query">Query Parameter</option>
+                  <option value="oauth2">OAuth2 Client Credentials</option>
+                  <option value="basic">Basic Auth</option>
                 </select>
               </div>
               {data.openapi?.auth?.type === 'bearer' && (
@@ -895,6 +938,168 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
                         })
                       }
                       placeholder="API_KEY"
+                      className={cn(inputClass, 'font-mono')}
+                    />
+                  </div>
+                </div>
+              )}
+              {data.openapi?.auth?.type === 'query' && (
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className={labelClass}>Parameter Name</label>
+                    <input
+                      type="text"
+                      value={data.openapi.auth.paramName ?? ''}
+                      onChange={(e) =>
+                        onChange({
+                          openapi: {
+                            ...data.openapi,
+                            spec: data.openapi?.spec ?? '',
+                            auth: { ...data.openapi!.auth!, paramName: e.target.value },
+                          },
+                        })
+                      }
+                      placeholder="appid"
+                      className={cn(inputClass, 'font-mono')}
+                    />
+                  </div>
+                  <div>
+                    <label className={labelClass}>Value Environment Variable</label>
+                    <input
+                      type="text"
+                      value={data.openapi.auth.valueEnv ?? ''}
+                      onChange={(e) =>
+                        onChange({
+                          openapi: {
+                            ...data.openapi,
+                            spec: data.openapi?.spec ?? '',
+                            auth: { ...data.openapi!.auth!, valueEnv: e.target.value },
+                          },
+                        })
+                      }
+                      placeholder="WEATHER_API_KEY"
+                      className={cn(inputClass, 'font-mono')}
+                    />
+                  </div>
+                </div>
+              )}
+              {data.openapi?.auth?.type === 'oauth2' && (
+                <div className="space-y-2">
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <label className={labelClass}>Client ID Env Var</label>
+                      <input
+                        type="text"
+                        value={data.openapi.auth.clientIdEnv ?? ''}
+                        onChange={(e) =>
+                          onChange({
+                            openapi: {
+                              ...data.openapi,
+                              spec: data.openapi?.spec ?? '',
+                              auth: { ...data.openapi!.auth!, clientIdEnv: e.target.value },
+                            },
+                          })
+                        }
+                        placeholder="OAUTH2_CLIENT_ID"
+                        className={cn(inputClass, 'font-mono')}
+                      />
+                    </div>
+                    <div>
+                      <label className={labelClass}>Client Secret Env Var</label>
+                      <input
+                        type="text"
+                        value={data.openapi.auth.clientSecretEnv ?? ''}
+                        onChange={(e) =>
+                          onChange({
+                            openapi: {
+                              ...data.openapi,
+                              spec: data.openapi?.spec ?? '',
+                              auth: { ...data.openapi!.auth!, clientSecretEnv: e.target.value },
+                            },
+                          })
+                        }
+                        placeholder="OAUTH2_CLIENT_SECRET"
+                        className={cn(inputClass, 'font-mono')}
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <label className={labelClass}>Token URL</label>
+                    <input
+                      type="url"
+                      value={data.openapi.auth.tokenUrl ?? ''}
+                      onChange={(e) =>
+                        onChange({
+                          openapi: {
+                            ...data.openapi,
+                            spec: data.openapi?.spec ?? '',
+                            auth: { ...data.openapi!.auth!, tokenUrl: e.target.value },
+                          },
+                        })
+                      }
+                      placeholder="https://auth.example.com/oauth/token"
+                      className={inputClass}
+                    />
+                  </div>
+                  <div>
+                    <label className={labelClass}>Scopes</label>
+                    <input
+                      type="text"
+                      value={(data.openapi.auth.scopes ?? []).join(' ')}
+                      onChange={(e) =>
+                        onChange({
+                          openapi: {
+                            ...data.openapi,
+                            spec: data.openapi?.spec ?? '',
+                            auth: {
+                              ...data.openapi!.auth!,
+                              scopes: e.target.value ? e.target.value.split(/[\s,]+/).filter(Boolean) : undefined,
+                            },
+                          },
+                        })
+                      }
+                      placeholder="read:data write:data"
+                      className={inputClass}
+                    />
+                    <p className="text-[10px] text-text-muted mt-1">Space or comma-separated</p>
+                  </div>
+                </div>
+              )}
+              {data.openapi?.auth?.type === 'basic' && (
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className={labelClass}>Username Env Var</label>
+                    <input
+                      type="text"
+                      value={data.openapi.auth.usernameEnv ?? ''}
+                      onChange={(e) =>
+                        onChange({
+                          openapi: {
+                            ...data.openapi,
+                            spec: data.openapi?.spec ?? '',
+                            auth: { ...data.openapi!.auth!, usernameEnv: e.target.value },
+                          },
+                        })
+                      }
+                      placeholder="API_USERNAME"
+                      className={cn(inputClass, 'font-mono')}
+                    />
+                  </div>
+                  <div>
+                    <label className={labelClass}>Password Env Var</label>
+                    <input
+                      type="text"
+                      value={data.openapi.auth.passwordEnv ?? ''}
+                      onChange={(e) =>
+                        onChange({
+                          openapi: {
+                            ...data.openapi,
+                            spec: data.openapi?.spec ?? '',
+                            auth: { ...data.openapi!.auth!, passwordEnv: e.target.value },
+                          },
+                        })
+                      }
+                      placeholder="API_PASSWORD"
                       className={cn(inputClass, 'font-mono')}
                     />
                   </div>
@@ -975,6 +1180,97 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
                 )}
               </div>
             </div>
+          )}
+
+          {/* TLS / mTLS section for OpenAPI */}
+          {visibility.openapi && (
+            <Section
+              title="TLS / mTLS"
+              icon={KeyRound}
+              expanded={expandedSections.has('tls')}
+              onToggle={() => toggleSection('tls')}
+            >
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <label className={labelClass}>Client Cert File</label>
+                  <input
+                    type="text"
+                    value={data.openapi?.tls?.certFile ?? ''}
+                    onChange={(e) =>
+                      onChange({
+                        openapi: {
+                          ...data.openapi,
+                          spec: data.openapi?.spec ?? '',
+                          tls: { ...data.openapi?.tls, certFile: e.target.value },
+                        },
+                      })
+                    }
+                    placeholder="./certs/client.crt"
+                    className={cn(inputClass, 'font-mono')}
+                  />
+                </div>
+                <div>
+                  <label className={labelClass}>Client Key File</label>
+                  <input
+                    type="text"
+                    value={data.openapi?.tls?.keyFile ?? ''}
+                    onChange={(e) =>
+                      onChange({
+                        openapi: {
+                          ...data.openapi,
+                          spec: data.openapi?.spec ?? '',
+                          tls: { ...data.openapi?.tls, keyFile: e.target.value },
+                        },
+                      })
+                    }
+                    placeholder="./certs/client.key"
+                    className={cn(inputClass, 'font-mono')}
+                  />
+                </div>
+              </div>
+              <div>
+                <label className={labelClass}>CA File</label>
+                <input
+                  type="text"
+                  value={data.openapi?.tls?.caFile ?? ''}
+                  onChange={(e) =>
+                    onChange({
+                      openapi: {
+                        ...data.openapi,
+                        spec: data.openapi?.spec ?? '',
+                        tls: { ...data.openapi?.tls, caFile: e.target.value },
+                      },
+                    })
+                  }
+                  placeholder="./certs/ca.crt"
+                  className={cn(inputClass, 'font-mono')}
+                />
+              </div>
+              <div className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  id="insecureSkipVerify"
+                  checked={data.openapi?.tls?.insecureSkipVerify ?? false}
+                  onChange={(e) =>
+                    onChange({
+                      openapi: {
+                        ...data.openapi,
+                        spec: data.openapi?.spec ?? '',
+                        tls: { ...data.openapi?.tls, insecureSkipVerify: e.target.checked || undefined },
+                      },
+                    })
+                  }
+                  className="mt-0.5 accent-primary"
+                />
+                <div>
+                  <label htmlFor="insecureSkipVerify" className="text-xs text-text-secondary cursor-pointer">
+                    Skip TLS Verification
+                    <span className="ml-2 text-[10px] text-status-error font-medium">Dangerous — dev only</span>
+                  </label>
+                  <p className="text-[10px] text-text-muted mt-0.5">Disables certificate validation. Never use in production.</p>
+                </div>
+              </div>
+            </Section>
           )}
 
           {/* Command (local + ssh) */}
@@ -1109,6 +1405,23 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
             />
           </div>
         )}
+
+        <div>
+          <label className={labelClass}>Schema Pinning</label>
+          <select
+            value={data.pinSchemas === undefined ? '' : String(data.pinSchemas)}
+            onChange={(e) => {
+              const v = e.target.value;
+              onChange({ pinSchemas: v === '' ? undefined : v === 'true' });
+            }}
+            className={inputClass}
+          >
+            <option value="">Inherit from gateway</option>
+            <option value="true">Enable</option>
+            <option value="false">Disable</option>
+          </select>
+          <p className="text-[10px] text-text-muted mt-1">Override the gateway-level schema pinning setting for this server</p>
+        </div>
       </Section>
     </div>
   );

--- a/web/src/lib/yaml-builder.ts
+++ b/web/src/lib/yaml-builder.ts
@@ -30,6 +30,8 @@ export interface MCPServerFormData {
     user: string;
     port?: number;
     identityFile?: string;
+    knownHostsFile?: string;
+    jumpHost?: string;
   };
   // OpenAPI
   openapi?: {
@@ -40,6 +42,19 @@ export interface MCPServerFormData {
       tokenEnv?: string;
       header?: string;
       valueEnv?: string;
+      paramName?: string;
+      clientIdEnv?: string;
+      clientSecretEnv?: string;
+      tokenUrl?: string;
+      scopes?: string[];
+      usernameEnv?: string;
+      passwordEnv?: string;
+    };
+    tls?: {
+      certFile?: string;
+      keyFile?: string;
+      caFile?: string;
+      insecureSkipVerify?: boolean;
     };
     operations?: {
       include?: string[];
@@ -52,6 +67,7 @@ export interface MCPServerFormData {
   tools?: string[];
   outputFormat?: string;
   network?: string;
+  pinSchemas?: boolean;
 }
 
 export interface ResourceFormData {
@@ -151,6 +167,8 @@ function buildMCPServer(data: MCPServerFormData, indentLevel = 2): string {
         lines.push(`${inner}  user: ${data.ssh.user}`);
         if (data.ssh.port && data.ssh.port !== 22) lines.push(`${inner}  port: ${data.ssh.port}`);
         if (data.ssh.identityFile) lines.push(`${inner}  identityFile: ${data.ssh.identityFile}`);
+        if (data.ssh.knownHostsFile) lines.push(`${inner}  knownHostsFile: ${data.ssh.knownHostsFile}`);
+        if (data.ssh.jumpHost) lines.push(`${inner}  jumpHost: ${data.ssh.jumpHost}`);
       }
       if (data.command?.length) {
         lines.push(`${inner}command:`);
@@ -163,11 +181,32 @@ function buildMCPServer(data: MCPServerFormData, indentLevel = 2): string {
         lines.push(`${inner}  spec: ${yamlValue(data.openapi.spec)}`);
         if (data.openapi.baseUrl) lines.push(`${inner}  baseUrl: ${yamlValue(data.openapi.baseUrl)}`);
         if (data.openapi.auth) {
+          const auth = data.openapi.auth;
           lines.push(`${inner}  auth:`);
-          lines.push(`${inner}    type: ${data.openapi.auth.type}`);
-          if (data.openapi.auth.tokenEnv) lines.push(`${inner}    tokenEnv: ${data.openapi.auth.tokenEnv}`);
-          if (data.openapi.auth.header) lines.push(`${inner}    header: ${data.openapi.auth.header}`);
-          if (data.openapi.auth.valueEnv) lines.push(`${inner}    valueEnv: ${data.openapi.auth.valueEnv}`);
+          lines.push(`${inner}    type: ${auth.type}`);
+          if (auth.tokenEnv) lines.push(`${inner}    tokenEnv: ${auth.tokenEnv}`);
+          if (auth.header) lines.push(`${inner}    header: ${auth.header}`);
+          if (auth.valueEnv) lines.push(`${inner}    valueEnv: ${auth.valueEnv}`);
+          if (auth.paramName) lines.push(`${inner}    paramName: ${auth.paramName}`);
+          if (auth.clientIdEnv) lines.push(`${inner}    clientIdEnv: ${auth.clientIdEnv}`);
+          if (auth.clientSecretEnv) lines.push(`${inner}    clientSecretEnv: ${auth.clientSecretEnv}`);
+          if (auth.tokenUrl) lines.push(`${inner}    tokenUrl: ${yamlValue(auth.tokenUrl)}`);
+          if (auth.scopes?.length) {
+            lines.push(`${inner}    scopes:`);
+            lines.push(serializeArray(auth.scopes, indentLevel + 6));
+          }
+          if (auth.usernameEnv) lines.push(`${inner}    usernameEnv: ${auth.usernameEnv}`);
+          if (auth.passwordEnv) lines.push(`${inner}    passwordEnv: ${auth.passwordEnv}`);
+        }
+        if (data.openapi.tls) {
+          const tls = data.openapi.tls;
+          if (tls.certFile || tls.keyFile || tls.caFile || tls.insecureSkipVerify) {
+            lines.push(`${inner}  tls:`);
+            if (tls.certFile) lines.push(`${inner}    certFile: ${tls.certFile}`);
+            if (tls.keyFile) lines.push(`${inner}    keyFile: ${tls.keyFile}`);
+            if (tls.caFile) lines.push(`${inner}    caFile: ${tls.caFile}`);
+            if (tls.insecureSkipVerify === true) lines.push(`${inner}    insecureSkipVerify: true`);
+          }
         }
       }
       break;
@@ -187,6 +226,7 @@ function buildMCPServer(data: MCPServerFormData, indentLevel = 2): string {
   }
   if (data.outputFormat) lines.push(`${inner}output_format: ${data.outputFormat}`);
   if (data.network) lines.push(`${inner}network: ${data.network}`);
+  if (data.pinSchemas !== undefined) lines.push(`${inner}pin_schemas: ${data.pinSchemas}`);
 
   return lines.join('\n');
 }


### PR DESCRIPTION
## Description

Extends the MCPServerForm wizard to cover all fields supported by the Go backend for SSH and OpenAPI server types — eliminating the gap between the wizard and what's configurable in YAML directly.

## Type of Change

- [x] New feature (non-breaking addition)

## Changes Made

- **SSH advanced fields**: `knownHostsFile` and `jumpHost` inputs added below `identityFile` in the SSH config section
- **OpenAPI auth types**: Added `Query Parameter`, `OAuth2 Client Credentials`, and `Basic Auth` options alongside existing `Bearer Token` and `Custom Header`, each with appropriate conditional field blocks
- **TLS / mTLS section**: New collapsible `Section` accordion for OpenAPI servers with `certFile`, `keyFile`, `caFile`, and `insecureSkipVerify` (with a visible danger warning)
- **Per-server schema pinning**: `pin_schemas` 3-state select added to the Advanced section for all server types (`Inherit from gateway` / `Enable` / `Disable`)
- **`yaml-builder.ts`**: Extended `MCPServerFormData` interface and `buildMCPServer()` serialization to cover all new fields; OAuth2 `scopes` serializes as a YAML list

## Testing

All 280 tests pass (`npm test`). TypeScript build passes with no errors (`npm run build`).

New test coverage:
- SSH `knownHostsFile` / `jumpHost` field visibility and serialization
- `query`, `oauth2`, `basic` auth type field visibility
- TLS section visibility and field rendering
- `pin_schemas` select in Advanced section
- YAML serialization for all new fields, including `insecureSkipVerify` omitempty behavior

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #428