### PR TITLE
feat: add api_key auth and Gateway Advanced accordion to StackForm

### DIFF
--- a/web/src/__tests__/StackForm.test.tsx
+++ b/web/src/__tests__/StackForm.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { StackForm } from '../components/wizard/steps/StackForm';
 import type { StackFormData } from '../lib/yaml-builder';
+import { buildYAML } from '../lib/yaml-builder';
 
 // Mock SecretsPopover to avoid vault API calls
 vi.mock('../components/wizard/SecretsPopover', () => ({
@@ -26,10 +27,11 @@ describe('StackForm', () => {
     onChange = vi.fn<typeof noop>();
   });
 
-  it('renders all 6 accordion sections', () => {
+  it('renders all 7 accordion sections', () => {
     render(<StackForm data={defaultData()} onChange={onChange} />);
     expect(screen.getByText('Identity')).toBeInTheDocument();
     expect(screen.getByText('Gateway')).toBeInTheDocument();
+    expect(screen.getByText('Gateway Advanced')).toBeInTheDocument();
     expect(screen.getByText('Network')).toBeInTheDocument();
     expect(screen.getByText('Secrets')).toBeInTheDocument();
     expect(screen.getByText('MCP Servers')).toBeInTheDocument();
@@ -182,5 +184,249 @@ describe('StackForm', () => {
     expect(onChange).toHaveBeenCalledWith({
       resources: [{ name: 'redis', image: 'redis:7-alpine' }],
     });
+  });
+});
+
+describe('StackForm gateway api_key auth', () => {
+  let onChange: typeof noop;
+  beforeEach(() => { onChange = vi.fn<typeof noop>(); });
+
+  it('shows api_key option in auth dropdown when gateway section is expanded', () => {
+    render(<StackForm data={defaultData()} onChange={onChange} />);
+    fireEvent.click(screen.getByText('Gateway'));
+    const select = screen.getByDisplayValue('');
+    expect(select.querySelector('option[value="api_key"]') ?? select).toBeTruthy();
+  });
+
+  it('shows header name field for api_key auth type', () => {
+    render(
+      <StackForm
+        data={defaultData({ gateway: { auth: { type: 'api_key', token: '' } } })}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('Gateway'));
+    expect(screen.getByPlaceholderText('X-API-Key')).toBeInTheDocument();
+    expect(screen.getByText('Header that carries the API key value')).toBeInTheDocument();
+  });
+
+  it('does not show header helper text for bearer auth type', () => {
+    render(
+      <StackForm
+        data={defaultData({ gateway: { auth: { type: 'bearer', token: '' } } })}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('Gateway'));
+    expect(screen.queryByText('Header that carries the API key value')).not.toBeInTheDocument();
+  });
+});
+
+describe('StackForm Gateway Advanced section', () => {
+  let onChange: typeof noop;
+  beforeEach(() => { onChange = vi.fn<typeof noop>(); });
+
+  it('shows Gateway Advanced section collapsed by default', () => {
+    render(<StackForm data={defaultData()} onChange={onChange} />);
+    expect(screen.getByText('Gateway Advanced')).toBeInTheDocument();
+    expect(screen.queryByText('Tracing')).not.toBeInTheDocument();
+  });
+
+  it('reveals sub-groups when expanded', () => {
+    render(<StackForm data={defaultData()} onChange={onChange} />);
+    fireEvent.click(screen.getByText('Gateway Advanced'));
+    expect(screen.getByText('Tracing')).toBeInTheDocument();
+    expect(screen.getByText('Schema Pinning')).toBeInTheDocument();
+    expect(screen.getByText('Performance')).toBeInTheDocument();
+  });
+
+  it('shows tracing fields when expanded', () => {
+    render(<StackForm data={defaultData()} onChange={onChange} />);
+    fireEvent.click(screen.getByText('Gateway Advanced'));
+    expect(screen.getByPlaceholderText('1.0')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('24h')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('65536')).toBeInTheDocument();
+  });
+
+  it('shows OTLP endpoint only when export is otlp', () => {
+    render(
+      <StackForm
+        data={defaultData({ gateway: { tracing: { export: 'otlp' } } })}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('Gateway Advanced'));
+    expect(screen.getByPlaceholderText('http://localhost:4318')).toBeInTheDocument();
+  });
+
+  it('hides OTLP endpoint when export is not set', () => {
+    render(<StackForm data={defaultData()} onChange={onChange} />);
+    fireEvent.click(screen.getByText('Gateway Advanced'));
+    expect(screen.queryByPlaceholderText('http://localhost:4318')).not.toBeInTheDocument();
+  });
+
+  it('shows schema pinning action dropdown only when schema pinning is enabled', () => {
+    render(
+      <StackForm
+        data={defaultData({ gateway: { security: { schemaPinning: { enabled: true } } } })}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('Gateway Advanced'));
+    expect(screen.getByText('Warn (log and continue)')).toBeInTheDocument();
+    expect(screen.getByText('Block (reject tool calls)')).toBeInTheDocument();
+  });
+
+  it('hides schema pinning action dropdown when schema pinning is disabled', () => {
+    render(<StackForm data={defaultData()} onChange={onChange} />);
+    fireEvent.click(screen.getByText('Gateway Advanced'));
+    expect(screen.queryByText('Warn (log and continue)')).not.toBeInTheDocument();
+  });
+
+  it('shows code_mode_timeout only when codeMode is on', () => {
+    render(
+      <StackForm
+        data={defaultData({ gateway: { codeMode: 'on' } })}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('Gateway Advanced'));
+    expect(screen.getByPlaceholderText('30')).toBeInTheDocument();
+  });
+
+  it('hides code_mode_timeout when codeMode is not on', () => {
+    render(<StackForm data={defaultData()} onChange={onChange} />);
+    fireEvent.click(screen.getByText('Gateway Advanced'));
+    expect(screen.queryByPlaceholderText('30')).not.toBeInTheDocument();
+  });
+
+  it('shows badge count when advanced fields are set', () => {
+    render(
+      <StackForm
+        data={defaultData({
+          gateway: {
+            tracing: { export: 'otlp' },
+            maxToolResultBytes: 32768,
+          },
+        })}
+        onChange={onChange}
+      />,
+    );
+    // badge shows count of non-empty advanced fields (export=1, maxToolResultBytes=1 → badge "2")
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+});
+
+describe('YAML serialization — gateway advanced fields', () => {
+  it('serializes api_key auth with header', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: {
+        name: 'my-stack',
+        gateway: { auth: { type: 'api_key', token: 'MY_TOKEN', header: 'X-API-Key' } },
+      },
+    });
+    expect(yaml).toContain('type: api_key');
+    expect(yaml).toContain('token: MY_TOKEN');
+    expect(yaml).toContain('header: X-API-Key');
+  });
+
+  it('serializes tracing block with OTLP endpoint', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: {
+        name: 'my-stack',
+        gateway: {
+          tracing: {
+            enabled: false,
+            export: 'otlp',
+            endpoint: 'http://otel-collector:4318',
+          },
+        },
+      },
+    });
+    expect(yaml).toContain('tracing:');
+    expect(yaml).toContain('enabled: false');
+    expect(yaml).toContain('export: otlp');
+    expect(yaml).toContain('endpoint:');
+  });
+
+  it('omits tracing block when no fields set', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: { name: 'my-stack', gateway: { tracing: {} } },
+    });
+    expect(yaml).not.toContain('tracing:');
+  });
+
+  it('omits sampling when set to default 1.0', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: {
+        name: 'my-stack',
+        gateway: { tracing: { sampling: 1.0 } },
+      },
+    });
+    expect(yaml).not.toContain('sampling');
+  });
+
+  it('serializes sampling when non-default', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: {
+        name: 'my-stack',
+        gateway: { tracing: { sampling: 0.5 } },
+      },
+    });
+    expect(yaml).toContain('sampling: 0.5');
+  });
+
+  it('omits retention when set to default 24h', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: {
+        name: 'my-stack',
+        gateway: { tracing: { retention: '24h' } },
+      },
+    });
+    expect(yaml).not.toContain('retention');
+  });
+
+  it('serializes schema_pinning block', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: {
+        name: 'my-stack',
+        gateway: {
+          security: {
+            schemaPinning: { enabled: true, action: 'block' },
+          },
+        },
+      },
+    });
+    expect(yaml).toContain('security:');
+    expect(yaml).toContain('schema_pinning:');
+    expect(yaml).toContain('enabled: true');
+    expect(yaml).toContain('action: block');
+  });
+
+  it('omits security block when schema pinning is not enabled', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: { name: 'my-stack', gateway: {} },
+    });
+    expect(yaml).not.toContain('security:');
+  });
+
+  it('serializes codeModeTimeout and maxToolResultBytes', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: {
+        name: 'my-stack',
+        gateway: { codeMode: 'on', codeModeTimeout: 60, maxToolResultBytes: 32768 },
+      },
+    });
+    expect(yaml).toContain('code_mode_timeout: 60');
+    expect(yaml).toContain('maxToolResultBytes: 32768');
   });
 });

--- a/web/src/components/wizard/steps/StackForm.tsx
+++ b/web/src/components/wizard/steps/StackForm.tsx
@@ -503,6 +503,17 @@ export function StackForm({ data, onChange, errors }: StackFormProps) {
     (data.gateway?.auth ? 1 : 0) +
     (data.gateway?.codeMode ? 1 : 0) +
     (data.gateway?.outputFormat ? 1 : 0);
+  const advancedGatewayCount =
+    (data.gateway?.tracing?.enabled !== undefined ? 1 : 0) +
+    (data.gateway?.tracing?.sampling !== undefined ? 1 : 0) +
+    (data.gateway?.tracing?.retention ? 1 : 0) +
+    (data.gateway?.tracing?.export ? 1 : 0) +
+    (data.gateway?.tracing?.endpoint ? 1 : 0) +
+    (data.gateway?.security?.schemaPinning?.enabled ? 1 : 0) +
+    (data.gateway?.security?.schemaPinning?.action ? 1 : 0) +
+    (data.gateway?.codeModeTimeout ? 1 : 0) +
+    (data.gateway?.maxToolResultBytes ? 1 : 0);
+  const advancedGatewayBadge = advancedGatewayCount > 0 ? `${advancedGatewayCount}` : undefined;
   const secretSetCount = data.secrets?.sets?.length ?? 0;
 
   // --- Handlers for nested arrays ---
@@ -641,6 +652,7 @@ export function StackForm({ data, onChange, errors }: StackFormProps) {
             <option value="">None</option>
             <option value="bearer">Bearer Token</option>
             <option value="header">Custom Header</option>
+            <option value="api_key">API Key</option>
           </select>
         </div>
 
@@ -685,6 +697,21 @@ export function StackForm({ data, onChange, errors }: StackFormProps) {
                 />
               </div>
             )}
+            {data.gateway.auth.type === 'api_key' && (
+              <div>
+                <label className={labelClass}>Header Name</label>
+                <input
+                  type="text"
+                  value={data.gateway.auth.header ?? ''}
+                  onChange={(e) =>
+                    onChange({ gateway: { ...data.gateway, auth: { ...data.gateway!.auth!, header: e.target.value } } })
+                  }
+                  placeholder="X-API-Key"
+                  className={cn(inputClass, 'font-mono')}
+                />
+                <p className="text-[10px] text-text-muted mt-1">Header that carries the API key value</p>
+              </div>
+            )}
           </div>
         )}
 
@@ -717,6 +744,222 @@ export function StackForm({ data, onChange, errors }: StackFormProps) {
                 <option key={f} value={f}>{f}</option>
               ))}
             </select>
+          </div>
+        </div>
+      </Section>
+
+      {/* Section 2b: Gateway Advanced */}
+      <Section
+        title="Gateway Advanced"
+        icon={Zap}
+        expanded={expandedSections.has('gateway-advanced')}
+        onToggle={() => toggleSection('gateway-advanced')}
+        badge={advancedGatewayBadge}
+      >
+        {/* Tracing sub-group */}
+        <div className="space-y-3">
+          <p className="text-[11px] font-medium text-text-muted uppercase tracking-wide">Tracing</p>
+          <div className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              id="tracing-enabled"
+              checked={data.gateway?.tracing?.enabled ?? false}
+              onChange={(e) =>
+                onChange({
+                  gateway: {
+                    ...data.gateway,
+                    tracing: { ...data.gateway?.tracing, enabled: e.target.checked || undefined },
+                  },
+                })
+              }
+              className="accent-primary"
+            />
+            <label htmlFor="tracing-enabled" className="text-xs text-text-secondary cursor-pointer">
+              Enabled
+            </label>
+            <p className="text-[10px] text-text-muted">Default: on</p>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className={labelClass}>Sampling Rate</label>
+              <input
+                type="number"
+                min="0"
+                max="1"
+                step="0.1"
+                value={data.gateway?.tracing?.sampling ?? ''}
+                placeholder="1.0"
+                className={inputClass}
+                onChange={(e) =>
+                  onChange({
+                    gateway: {
+                      ...data.gateway,
+                      tracing: {
+                        ...data.gateway?.tracing,
+                        sampling: e.target.value ? Number(e.target.value) : undefined,
+                      },
+                    },
+                  })
+                }
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Retention</label>
+              <input
+                type="text"
+                value={data.gateway?.tracing?.retention ?? ''}
+                placeholder="24h"
+                className={inputClass}
+                onChange={(e) =>
+                  onChange({
+                    gateway: {
+                      ...data.gateway,
+                      tracing: { ...data.gateway?.tracing, retention: e.target.value || undefined },
+                    },
+                  })
+                }
+              />
+              <p className="text-[10px] text-text-muted mt-1">e.g. 12h, 48h, 7d</p>
+            </div>
+          </div>
+          <div>
+            <label className={labelClass}>Export</label>
+            <select
+              value={data.gateway?.tracing?.export ?? ''}
+              onChange={(e) =>
+                onChange({
+                  gateway: {
+                    ...data.gateway,
+                    tracing: { ...data.gateway?.tracing, export: e.target.value || undefined },
+                  },
+                })
+              }
+              className={inputClass}
+            >
+              <option value="">None</option>
+              <option value="otlp">OTLP</option>
+            </select>
+          </div>
+          {data.gateway?.tracing?.export === 'otlp' && (
+            <div>
+              <label className={labelClass}>OTLP Endpoint</label>
+              <input
+                type="url"
+                value={data.gateway?.tracing?.endpoint ?? ''}
+                placeholder="http://localhost:4318"
+                className={inputClass}
+                onChange={(e) =>
+                  onChange({
+                    gateway: {
+                      ...data.gateway,
+                      tracing: { ...data.gateway?.tracing, endpoint: e.target.value || undefined },
+                    },
+                  })
+                }
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Schema Pinning sub-group */}
+        <div className="space-y-3 mt-4">
+          <p className="text-[11px] font-medium text-text-muted uppercase tracking-wide">Schema Pinning</p>
+          <div className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              id="schema-pinning-enabled"
+              checked={data.gateway?.security?.schemaPinning?.enabled ?? false}
+              onChange={(e) =>
+                onChange({
+                  gateway: {
+                    ...data.gateway,
+                    security: {
+                      ...data.gateway?.security,
+                      schemaPinning: {
+                        ...data.gateway?.security?.schemaPinning,
+                        enabled: e.target.checked || undefined,
+                      },
+                    },
+                  },
+                })
+              }
+              className="accent-primary"
+            />
+            <label htmlFor="schema-pinning-enabled" className="text-xs text-text-secondary cursor-pointer">
+              Enabled
+            </label>
+          </div>
+          {data.gateway?.security?.schemaPinning?.enabled && (
+            <div>
+              <label className={labelClass}>Action</label>
+              <select
+                value={data.gateway?.security?.schemaPinning?.action ?? ''}
+                onChange={(e) =>
+                  onChange({
+                    gateway: {
+                      ...data.gateway,
+                      security: {
+                        ...data.gateway?.security,
+                        schemaPinning: {
+                          ...data.gateway?.security?.schemaPinning,
+                          action: e.target.value || undefined,
+                        },
+                      },
+                    },
+                  })
+                }
+                className={inputClass}
+              >
+                <option value="">Default (warn)</option>
+                <option value="warn">Warn (log and continue)</option>
+                <option value="block">Block (reject tool calls)</option>
+              </select>
+            </div>
+          )}
+        </div>
+
+        {/* Performance sub-group */}
+        <div className="space-y-3 mt-4">
+          <p className="text-[11px] font-medium text-text-muted uppercase tracking-wide">Performance</p>
+          {data.gateway?.codeMode === 'on' && (
+            <div>
+              <label className={labelClass}>Code Mode Timeout</label>
+              <input
+                type="number"
+                min="1"
+                value={data.gateway?.codeModeTimeout ?? ''}
+                placeholder="30"
+                className={inputClass}
+                onChange={(e) =>
+                  onChange({
+                    gateway: {
+                      ...data.gateway,
+                      codeModeTimeout: e.target.value ? Number(e.target.value) : undefined,
+                    },
+                  })
+                }
+              />
+              <p className="text-[10px] text-text-muted mt-1">Seconds. Default: 30</p>
+            </div>
+          )}
+          <div>
+            <label className={labelClass}>Max Tool Result Bytes</label>
+            <input
+              type="number"
+              min="1"
+              value={data.gateway?.maxToolResultBytes ?? ''}
+              placeholder="65536"
+              className={inputClass}
+              onChange={(e) =>
+                onChange({
+                  gateway: {
+                    ...data.gateway,
+                    maxToolResultBytes: e.target.value ? Number(e.target.value) : undefined,
+                  },
+                })
+              }
+            />
+            <p className="text-[10px] text-text-muted mt-1">Bytes. Default: 64KB (65536)</p>
           </div>
         </div>
       </Section>

--- a/web/src/lib/yaml-builder.ts
+++ b/web/src/lib/yaml-builder.ts
@@ -86,7 +86,22 @@ export interface StackFormData {
     allowedOrigins?: string[];
     auth?: { type: string; token: string; header?: string };
     codeMode?: string;
+    codeModeTimeout?: number;
     outputFormat?: string;
+    maxToolResultBytes?: number;
+    tracing?: {
+      enabled?: boolean;
+      sampling?: number;
+      retention?: string;
+      export?: string;
+      endpoint?: string;
+    };
+    security?: {
+      schemaPinning?: {
+        enabled?: boolean;
+        action?: string;
+      };
+    };
   };
   network?: { name: string; driver: string };
   secrets?: { sets: string[] };
@@ -295,7 +310,31 @@ function buildStack(data: StackFormData): string {
       if (data.gateway.auth.header) lines.push(`    header: ${data.gateway.auth.header}`);
     }
     if (data.gateway.codeMode) lines.push(`  code_mode: ${data.gateway.codeMode}`);
+    if (data.gateway.codeModeTimeout) lines.push(`  code_mode_timeout: ${data.gateway.codeModeTimeout}`);
     if (data.gateway.outputFormat) lines.push(`  output_format: ${data.gateway.outputFormat}`);
+    if (data.gateway.maxToolResultBytes) lines.push(`  maxToolResultBytes: ${data.gateway.maxToolResultBytes}`);
+
+    const gw = data.gateway;
+    if (gw.tracing) {
+      const t = gw.tracing;
+      if (t.enabled !== undefined || t.sampling !== undefined || t.retention || t.export || t.endpoint) {
+        lines.push('  tracing:');
+        if (t.enabled !== undefined) lines.push(`    enabled: ${t.enabled}`);
+        if (t.sampling !== undefined && t.sampling !== 1.0) lines.push(`    sampling: ${t.sampling}`);
+        if (t.retention && t.retention !== '24h') lines.push(`    retention: ${t.retention}`);
+        if (t.export) lines.push(`    export: ${t.export}`);
+        if (t.endpoint) lines.push(`    endpoint: ${yamlValue(t.endpoint)}`);
+      }
+    }
+
+    if (gw.security?.schemaPinning?.enabled) {
+      lines.push('  security:');
+      lines.push('    schema_pinning:');
+      lines.push(`      enabled: ${gw.security.schemaPinning.enabled}`);
+      if (gw.security.schemaPinning.action) {
+        lines.push(`      action: ${gw.security.schemaPinning.action}`);
+      }
+    }
   }
 
   if (data.secrets?.sets?.length) {


### PR DESCRIPTION
## Description

Extends the StackForm's Gateway section with `api_key` auth type and a new collapsible \"Gateway Advanced\" accordion, completing wizard coverage for `GatewayConfig`, `TracingConfig`, `GatewaySecurityConfig`, and performance fields.

## Type of Change

- [x] New feature (non-breaking addition)

## Changes Made

- **`api_key` auth type**: Added as third option in auth dropdown; selecting it reveals a \"Header Name\" field for the custom header name
- **Gateway Advanced accordion**: Collapsed section below Gateway with three labeled sub-groups:
  - **Tracing**: enabled toggle, sampling (0–1), retention (duration string), export dropdown (none/OTLP), endpoint (conditional on OTLP)
  - **Schema Pinning**: enabled toggle, action dropdown (warn/block, conditional on enabled)
  - **Performance**: code_mode_timeout (conditional on code_mode=on), maxToolResultBytes (always visible)
- **Badge**: counts non-empty advanced fields to signal when advanced config is set
- **`yaml-builder.ts`**: Extended `StackFormData.gateway` interface; `buildStack()` serializes all new fields under correct YAML keys (`tracing:`, `security.schema_pinning:`, `code_mode_timeout`, `maxToolResultBytes`)

## Testing

All 302 tests pass (`npm test`). TypeScript build passes with no errors (`npm run build`).

New test coverage:
- `api_key` auth field visibility (header name) and serialization
- Gateway Advanced section expansion and all sub-group field visibility
- OTLP endpoint conditional on export=otlp
- Schema pinning action conditional on enabled
- `code_mode_timeout` conditional on codeMode=on
- Badge count reflects non-empty advanced fields
- YAML serialization for all new fields; default-value omit logic for sampling and retention

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #430