### PR TITLE
feat: add Logging accordion section to StackForm

### DIFF
--- a/web/src/__tests__/StackForm.test.tsx
+++ b/web/src/__tests__/StackForm.test.tsx
@@ -27,12 +27,13 @@ describe('StackForm', () => {
     onChange = vi.fn<typeof noop>();
   });
 
-  it('renders all 7 accordion sections', () => {
+  it('renders all 8 accordion sections', () => {
     render(<StackForm data={defaultData()} onChange={onChange} />);
     expect(screen.getByText('Identity')).toBeInTheDocument();
     expect(screen.getByText('Gateway')).toBeInTheDocument();
     expect(screen.getByText('Gateway Advanced')).toBeInTheDocument();
     expect(screen.getByText('Network')).toBeInTheDocument();
+    expect(screen.getByText('Logging')).toBeInTheDocument();
     expect(screen.getByText('Secrets')).toBeInTheDocument();
     expect(screen.getByText('MCP Servers')).toBeInTheDocument();
     expect(screen.getByText('Resources')).toBeInTheDocument();
@@ -428,5 +429,82 @@ describe('YAML serialization — gateway advanced fields', () => {
     });
     expect(yaml).toContain('code_mode_timeout: 60');
     expect(yaml).toContain('maxToolResultBytes: 32768');
+  });
+});
+
+describe('StackForm Logging section', () => {
+  let onChange: typeof noop;
+  beforeEach(() => { onChange = vi.fn<typeof noop>(); });
+
+  it('renders Logging accordion collapsed by default', () => {
+    render(<StackForm data={defaultData()} onChange={onChange} />);
+    expect(screen.getByText('Logging')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('/var/log/gridctl.log')).not.toBeInTheDocument();
+  });
+
+  it('reveals all four fields when expanded', () => {
+    render(<StackForm data={defaultData()} onChange={onChange} />);
+    fireEvent.click(screen.getByText('Logging'));
+    expect(screen.getByPlaceholderText('/var/log/gridctl.log')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('100')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('7')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('3')).toBeInTheDocument();
+  });
+
+  it('shows configured badge when file is set', () => {
+    render(
+      <StackForm
+        data={defaultData({ logging: { file: '/var/log/gridctl.log' } })}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByText('configured')).toBeInTheDocument();
+  });
+
+  it('shows no badge when file is not set', () => {
+    render(<StackForm data={defaultData()} onChange={onChange} />);
+    expect(screen.queryByText('configured')).not.toBeInTheDocument();
+  });
+});
+
+describe('YAML serialization — logging fields', () => {
+  it('emits logging block when file is set', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: { name: 'my-stack', logging: { file: '/var/log/gridctl.log' } },
+    });
+    expect(yaml).toContain('logging:');
+    expect(yaml).toContain('file: /var/log/gridctl.log');
+  });
+
+  it('omits logging block when file is not set', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: { name: 'my-stack', logging: { maxSizeMB: 200 } },
+    });
+    expect(yaml).not.toContain('logging:');
+  });
+
+  it('includes rotation fields when set alongside file', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: {
+        name: 'my-stack',
+        logging: { file: '/var/log/gridctl.log', maxSizeMB: 200, maxAgeDays: 14, maxBackups: 5 },
+      },
+    });
+    expect(yaml).toContain('maxSizeMB: 200');
+    expect(yaml).toContain('maxAgeDays: 14');
+    expect(yaml).toContain('maxBackups: 5');
+  });
+
+  it('omits rotation fields when not set', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: { name: 'my-stack', logging: { file: '/var/log/gridctl.log' } },
+    });
+    expect(yaml).not.toContain('maxSizeMB');
+    expect(yaml).not.toContain('maxAgeDays');
+    expect(yaml).not.toContain('maxBackups');
   });
 });

--- a/web/src/components/wizard/steps/StackForm.tsx
+++ b/web/src/components/wizard/steps/StackForm.tsx
@@ -1002,7 +1002,74 @@ export function StackForm({ data, onChange, errors }: StackFormProps) {
         </div>
       </Section>
 
-      {/* Section 4: Secrets */}
+      {/* Section 4: Logging */}
+      <Section
+        title="Logging"
+        icon={Database}
+        expanded={expandedSections.has('logging')}
+        onToggle={() => toggleSection('logging')}
+        badge={data.logging?.file ? 'configured' : undefined}
+      >
+        <div className="space-y-3">
+          <div>
+            <label className={labelClass}>Log File Path</label>
+            <input
+              type="text"
+              value={data.logging?.file ?? ''}
+              placeholder="/var/log/gridctl.log"
+              className={cn(inputClass, 'font-mono')}
+              onChange={(e) => onChange({ logging: { ...data.logging, file: e.target.value || undefined } })}
+            />
+            <p className="text-[10px] text-text-muted mt-1">When set, logs are written to this file and the web UI ring buffer</p>
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            <div>
+              <label className={labelClass}>Max Size (MB)</label>
+              <input
+                type="number"
+                min="1"
+                value={data.logging?.maxSizeMB ?? ''}
+                placeholder="100"
+                className={inputClass}
+                onChange={(e) =>
+                  onChange({ logging: { ...data.logging, maxSizeMB: e.target.value ? Number(e.target.value) : undefined } })
+                }
+              />
+              <p className="text-[10px] text-text-muted mt-1">Default: 100</p>
+            </div>
+            <div>
+              <label className={labelClass}>Max Age (Days)</label>
+              <input
+                type="number"
+                min="1"
+                value={data.logging?.maxAgeDays ?? ''}
+                placeholder="7"
+                className={inputClass}
+                onChange={(e) =>
+                  onChange({ logging: { ...data.logging, maxAgeDays: e.target.value ? Number(e.target.value) : undefined } })
+                }
+              />
+              <p className="text-[10px] text-text-muted mt-1">Default: 7</p>
+            </div>
+            <div>
+              <label className={labelClass}>Max Backups</label>
+              <input
+                type="number"
+                min="1"
+                value={data.logging?.maxBackups ?? ''}
+                placeholder="3"
+                className={inputClass}
+                onChange={(e) =>
+                  onChange({ logging: { ...data.logging, maxBackups: e.target.value ? Number(e.target.value) : undefined } })
+                }
+              />
+              <p className="text-[10px] text-text-muted mt-1">Default: 3</p>
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      {/* Section 5: Secrets */}
       <Section
         title="Secrets"
         icon={KeyRound}

--- a/web/src/lib/yaml-builder.ts
+++ b/web/src/lib/yaml-builder.ts
@@ -105,6 +105,12 @@ export interface StackFormData {
   };
   network?: { name: string; driver: string };
   secrets?: { sets: string[] };
+  logging?: {
+    file?: string;
+    maxSizeMB?: number;
+    maxAgeDays?: number;
+    maxBackups?: number;
+  };
   mcpServers?: MCPServerFormData[];
   resources?: ResourceFormData[];
 }
@@ -349,6 +355,15 @@ function buildStack(data: StackFormData): string {
     lines.push('network:');
     lines.push(`  name: ${data.network.name}`);
     lines.push(`  driver: ${data.network.driver}`);
+  }
+
+  if (data.logging?.file) {
+    lines.push('');
+    lines.push('logging:');
+    lines.push(`  file: ${yamlValue(data.logging.file)}`);
+    if (data.logging.maxSizeMB) lines.push(`  maxSizeMB: ${data.logging.maxSizeMB}`);
+    if (data.logging.maxAgeDays) lines.push(`  maxAgeDays: ${data.logging.maxAgeDays}`);
+    if (data.logging.maxBackups) lines.push(`  maxBackups: ${data.logging.maxBackups}`);
   }
 
   if (data.mcpServers?.length) {


### PR DESCRIPTION
## Description

Adds a collapsible "Logging" accordion section to the StackForm, surfacing the backend's `LoggingConfig` fields in the wizard for the first time. Operators can now configure log file rotation without editing YAML directly.

## Type of Change

- [x] New feature (non-breaking addition)

## Changes Made

- **Logging accordion**: Collapsed by default, positioned between Network and Secrets; badge shows "configured" when a file path is entered
- **Four fields**: Log File Path (monospace, full-width), Max Size MB / Max Age Days / Max Backups in a 3-column grid with placeholder defaults and helper text
- **`yaml-builder.ts`**: Added `logging` to `StackFormData`; `buildStack()` emits a `logging:` block only when `file` is set; rotation fields only serialize when non-zero

## Testing

All 310 tests pass (`npm test`). TypeScript build passes with no errors (`npm run build`).

New test coverage:
- Logging accordion collapsed by default (fields not in DOM)
- Expanding reveals all four fields with correct placeholders
- Badge shows "configured" when file is set, absent otherwise
- YAML emits `logging:` block with `file:` when set
- Omits `logging:` block entirely when `file` is absent (even if rotation fields are set)
- Rotation fields included/excluded based on whether they are non-zero

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #432