### PR TITLE
fix: secrets dropdown cannot scroll in StackForm env var section

### DIFF
--- a/web/src/__tests__/SecretsPopover.test.tsx
+++ b/web/src/__tests__/SecretsPopover.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { SecretsPopover } from '../components/wizard/SecretsPopover';
 import { useVaultStore } from '../stores/useVaultStore';
@@ -85,5 +85,46 @@ describe('SecretsPopover', () => {
     const keyInput = screen.getByPlaceholderText('SECRET_KEY');
     fireEvent.change(keyInput, { target: { value: 'my_api_key' } });
     expect(keyInput).toHaveValue('MY_API_KEY');
+  });
+
+  it('renders dropdown via portal at document.body', async () => {
+    const { container } = render(<SecretsPopover onSelect={onSelect} />);
+    fireEvent.click(screen.getByTitle('Insert vault secret'));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Filter secrets...')).toBeInTheDocument();
+    });
+
+    // Dropdown is not inside the component container — it's portalled to body
+    expect(container.querySelector('[placeholder="Filter secrets..."]')).toBeNull();
+    expect(within(document.body).getByPlaceholderText('Filter secrets...')).toBeInTheDocument();
+  });
+
+  it('renders all secrets in the list when many exist', async () => {
+    const manySecrets = Array.from({ length: 20 }, (_, i) => ({ key: `SECRET_${i}` }));
+    useVaultStore.setState({ secrets: manySecrets });
+
+    render(<SecretsPopover onSelect={onSelect} />);
+    fireEvent.click(screen.getByTitle('Insert vault secret'));
+
+    // All 20 secrets are in the DOM (accessible, not clipped)
+    for (let i = 0; i < 20; i++) {
+      expect(screen.getByText(`SECRET_${i}`)).toBeInTheDocument();
+    }
+  });
+
+  it('closes popover on outside mousedown', async () => {
+    render(<SecretsPopover onSelect={onSelect} />);
+    fireEvent.click(screen.getByTitle('Insert vault secret'));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Filter secrets...')).toBeInTheDocument();
+    });
+
+    fireEvent.mouseDown(document.body);
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Filter secrets...')).not.toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/wizard/SecretsPopover.tsx
+++ b/web/src/components/wizard/SecretsPopover.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { KeyRound, Search, Plus, Eye, EyeOff, X, Loader2, Check } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { useVaultStore } from '../../stores/useVaultStore';
@@ -9,6 +10,15 @@ interface SecretsPopoverProps {
   className?: string;
 }
 
+interface PopoverPosition {
+  top?: number;
+  bottom?: number;
+  right: number;
+}
+
+// Approximate max height of the popover (search + list + divider + button)
+const POPOVER_ESTIMATED_HEIGHT = 260;
+
 export function SecretsPopover({ onSelect, className }: SecretsPopoverProps) {
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState('');
@@ -18,9 +28,24 @@ export function SecretsPopover({ onSelect, className }: SecretsPopoverProps) {
   const [showValue, setShowValue] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<PopoverPosition | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const secrets = useVaultStore((s) => s.secrets);
   const setSecrets = useVaultStore((s) => s.setSecrets);
+
+  // Compute fixed position from trigger button rect
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    const right = window.innerWidth - rect.right;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    if (spaceBelow < POPOVER_ESTIMATED_HEIGHT + 8) {
+      setPosition({ bottom: window.innerHeight - rect.top + 6, right });
+    } else {
+      setPosition({ top: rect.bottom + 6, right });
+    }
+  }, []);
 
   // Load secrets when popover opens
   useEffect(() => {
@@ -30,11 +55,30 @@ export function SecretsPopover({ onSelect, className }: SecretsPopoverProps) {
       .catch(() => {});
   }, [open, setSecrets]);
 
-  // Close on outside click
+  // Compute position on open; reposition on scroll or resize
+  useEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return;
+    }
+    updatePosition();
+    window.addEventListener('scroll', updatePosition, true);
+    window.addEventListener('resize', updatePosition);
+    return () => {
+      window.removeEventListener('scroll', updatePosition, true);
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [open, updatePosition]);
+
+  // Close on outside click — checks both trigger and portal dropdown
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      if (
+        !triggerRef.current?.contains(target) &&
+        !dropdownRef.current?.contains(target)
+      ) {
         setOpen(false);
       }
     };
@@ -53,7 +97,6 @@ export function SecretsPopover({ onSelect, className }: SecretsPopoverProps) {
 
   const handleCreate = async () => {
     if (!newKey || !newValue) return;
-    // Validate key format
     if (!/^[A-Z][A-Z0-9_]*$/.test(newKey)) {
       setError('Key must be uppercase alphanumeric with underscores');
       return;
@@ -80,9 +123,135 @@ export function SecretsPopover({ onSelect, className }: SecretsPopoverProps) {
     s.key.toLowerCase().includes(filter.toLowerCase()),
   );
 
+  // Rendered via portal to escape ancestor overflow containers
+  const dropdown = position && (
+    <div
+      ref={dropdownRef}
+      style={{
+        position: 'fixed',
+        top: position.top,
+        bottom: position.bottom,
+        right: position.right,
+        width: '18rem',
+        zIndex: 9999,
+      }}
+      className={cn('glass-panel-elevated rounded-xl', 'animate-fade-in-scale')}
+    >
+      {/* Search */}
+      <div className="px-3 pt-3 pb-2">
+        <div className="relative">
+          <Search size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-muted" />
+          <input
+            type="text"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter secrets..."
+            autoFocus
+            className="w-full bg-background/60 border border-border/40 rounded-lg pl-7 pr-3 py-1.5 text-xs focus:outline-none focus:border-primary/50 text-text-primary placeholder:text-text-muted/50 transition-colors"
+          />
+        </div>
+      </div>
+
+      {/* Secret list — scrollable without overflow-hidden clipping */}
+      <div className="max-h-36 overflow-y-auto scrollbar-dark">
+        {filtered.length === 0 && !creating && (
+          <div className="px-3 py-4 text-center text-[10px] text-text-muted">
+            {secrets === null ? 'Loading...' : 'No secrets found'}
+          </div>
+        )}
+        {filtered.map((secret) => (
+          <button
+            key={secret.key}
+            onClick={() => handleSelect(secret.key)}
+            className="w-full flex items-center justify-between px-3 py-2 text-xs hover:bg-white/[0.04] transition-colors group"
+          >
+            <span className="font-mono text-text-primary truncate">{secret.key}</span>
+            <span className="text-[10px] text-text-muted opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1">
+              <Check size={10} />
+              Select
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* Divider */}
+      <div className="border-t border-border/30 mx-3" />
+
+      {/* Create new */}
+      {!creating ? (
+        <button
+          onClick={() => {
+            setCreating(true);
+            setError(null);
+          }}
+          className="w-full flex items-center gap-2 px-3 py-2.5 text-xs text-secondary hover:bg-white/[0.04] transition-colors"
+        >
+          <Plus size={12} />
+          Create New Secret
+        </button>
+      ) : (
+        <div className="px-3 py-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] text-text-muted uppercase tracking-wider font-medium">
+              New Secret
+            </span>
+            <button
+              onClick={() => {
+                setCreating(false);
+                setError(null);
+              }}
+              className="text-text-muted hover:text-text-secondary"
+            >
+              <X size={12} />
+            </button>
+          </div>
+          <input
+            type="text"
+            value={newKey}
+            onChange={(e) => setNewKey(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ''))}
+            placeholder="SECRET_KEY"
+            className="w-full bg-background/60 border border-border/40 rounded-lg px-3 py-1.5 text-xs font-mono focus:outline-none focus:border-primary/50 text-text-primary placeholder:text-text-muted/50 transition-colors"
+          />
+          <div className="relative">
+            <input
+              type={showValue ? 'text' : 'password'}
+              value={newValue}
+              onChange={(e) => setNewValue(e.target.value)}
+              placeholder="Secret value"
+              className="w-full bg-background/60 border border-border/40 rounded-lg px-3 py-1.5 pr-8 text-xs focus:outline-none focus:border-primary/50 text-text-primary placeholder:text-text-muted/50 transition-colors"
+            />
+            <button
+              type="button"
+              onClick={() => setShowValue(!showValue)}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-secondary"
+            >
+              {showValue ? <EyeOff size={12} /> : <Eye size={12} />}
+            </button>
+          </div>
+          {error && (
+            <p className="text-[10px] text-status-error">{error}</p>
+          )}
+          <button
+            onClick={handleCreate}
+            disabled={!newKey || !newValue || saving}
+            className={cn(
+              'w-full flex items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-all duration-200',
+              'bg-secondary/20 text-secondary hover:bg-secondary/30',
+              'disabled:opacity-40 disabled:cursor-not-allowed',
+            )}
+          >
+            {saving ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
+            Create & Insert
+          </button>
+        </div>
+      )}
+    </div>
+  );
+
   return (
-    <div className={cn('relative', className)} ref={popoverRef}>
+    <div className={cn('relative', className)}>
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setOpen(!open)}
         className={cn(
@@ -95,124 +264,7 @@ export function SecretsPopover({ onSelect, className }: SecretsPopoverProps) {
         <KeyRound size={13} />
       </button>
 
-      {open && (
-        <div
-          className={cn(
-            'absolute right-0 top-full mt-1.5 z-50 w-72',
-            'glass-panel-elevated rounded-xl overflow-hidden',
-            'animate-fade-in-scale',
-          )}
-        >
-          {/* Search */}
-          <div className="px-3 pt-3 pb-2">
-            <div className="relative">
-              <Search size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-muted" />
-              <input
-                type="text"
-                value={filter}
-                onChange={(e) => setFilter(e.target.value)}
-                placeholder="Filter secrets..."
-                autoFocus
-                className="w-full bg-background/60 border border-border/40 rounded-lg pl-7 pr-3 py-1.5 text-xs focus:outline-none focus:border-primary/50 text-text-primary placeholder:text-text-muted/50 transition-colors"
-              />
-            </div>
-          </div>
-
-          {/* Secret list */}
-          <div className="max-h-36 overflow-y-auto scrollbar-dark">
-            {filtered.length === 0 && !creating && (
-              <div className="px-3 py-4 text-center text-[10px] text-text-muted">
-                {secrets === null ? 'Loading...' : 'No secrets found'}
-              </div>
-            )}
-            {filtered.map((secret) => (
-              <button
-                key={secret.key}
-                onClick={() => handleSelect(secret.key)}
-                className="w-full flex items-center justify-between px-3 py-2 text-xs hover:bg-white/[0.04] transition-colors group"
-              >
-                <span className="font-mono text-text-primary truncate">{secret.key}</span>
-                <span className="text-[10px] text-text-muted opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1">
-                  <Check size={10} />
-                  Select
-                </span>
-              </button>
-            ))}
-          </div>
-
-          {/* Divider */}
-          <div className="border-t border-border/30 mx-3" />
-
-          {/* Create new */}
-          {!creating ? (
-            <button
-              onClick={() => {
-                setCreating(true);
-                setError(null);
-              }}
-              className="w-full flex items-center gap-2 px-3 py-2.5 text-xs text-secondary hover:bg-white/[0.04] transition-colors"
-            >
-              <Plus size={12} />
-              Create New Secret
-            </button>
-          ) : (
-            <div className="px-3 py-3 space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="text-[10px] text-text-muted uppercase tracking-wider font-medium">
-                  New Secret
-                </span>
-                <button
-                  onClick={() => {
-                    setCreating(false);
-                    setError(null);
-                  }}
-                  className="text-text-muted hover:text-text-secondary"
-                >
-                  <X size={12} />
-                </button>
-              </div>
-              <input
-                type="text"
-                value={newKey}
-                onChange={(e) => setNewKey(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ''))}
-                placeholder="SECRET_KEY"
-                className="w-full bg-background/60 border border-border/40 rounded-lg px-3 py-1.5 text-xs font-mono focus:outline-none focus:border-primary/50 text-text-primary placeholder:text-text-muted/50 transition-colors"
-              />
-              <div className="relative">
-                <input
-                  type={showValue ? 'text' : 'password'}
-                  value={newValue}
-                  onChange={(e) => setNewValue(e.target.value)}
-                  placeholder="Secret value"
-                  className="w-full bg-background/60 border border-border/40 rounded-lg px-3 py-1.5 pr-8 text-xs focus:outline-none focus:border-primary/50 text-text-primary placeholder:text-text-muted/50 transition-colors"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowValue(!showValue)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-secondary"
-                >
-                  {showValue ? <EyeOff size={12} /> : <Eye size={12} />}
-                </button>
-              </div>
-              {error && (
-                <p className="text-[10px] text-status-error">{error}</p>
-              )}
-              <button
-                onClick={handleCreate}
-                disabled={!newKey || !newValue || saving}
-                className={cn(
-                  'w-full flex items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-all duration-200',
-                  'bg-secondary/20 text-secondary hover:bg-secondary/30',
-                  'disabled:opacity-40 disabled:cursor-not-allowed',
-                )}
-              >
-                {saving ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
-                Create & Insert
-              </button>
-            </div>
-          )}
-        </div>
-      )}
+      {open && dropdown && createPortal(dropdown, document.body)}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Fixes the vault secrets dropdown in the StackForm env var section being unscrollable and clipped when opened near the bottom of the form panel. Renders the dropdown via a React Portal so it escapes the ancestor `overflow-y: auto` scroll container added in #435.

## Type of Change

- [x] Bug fix

## Changes Made

- `SecretsPopover.tsx`: Render dropdown via `createPortal` at `document.body` with `position: fixed` coordinates from `getBoundingClientRect()`
- `SecretsPopover.tsx`: Remove `overflow-hidden` from outer container (was clipping the inner `max-h-36 overflow-y-auto` scroll list)
- `SecretsPopover.tsx`: Viewport edge detection — flips dropdown upward when insufficient space below trigger
- `SecretsPopover.tsx`: Repositions portal on window scroll/resize while open
- `SecretsPopover.tsx`: Updated outside-click handler to check both trigger ref and portal dropdown ref

## Testing

Open the New MCP Server wizard → Configure step → add an env var row → click the 🔑 key icon. Dropdown should open fully visible and scroll when there are more than ~6 secrets.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #436