### PR TITLE
fix: restore skill import wizard functionality

### DIFF
--- a/internal/api/skills.go
+++ b/internal/api/skills.go
@@ -134,11 +134,12 @@ func (s *Server) handleSkillSourceAdd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Repo       string `json:"repo"`
-		Ref        string `json:"ref,omitempty"`
-		Path       string `json:"path,omitempty"`
-		Trust      bool   `json:"trust,omitempty"`
-		NoActivate bool   `json:"noActivate,omitempty"`
+		Repo       string   `json:"repo"`
+		Ref        string   `json:"ref,omitempty"`
+		Path       string   `json:"path,omitempty"`
+		Trust      bool     `json:"trust,omitempty"`
+		NoActivate bool     `json:"noActivate,omitempty"`
+		Selected   []string `json:"selected,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
@@ -162,6 +163,7 @@ func (s *Server) handleSkillSourceAdd(w http.ResponseWriter, r *http.Request) {
 		Path:       req.Path,
 		Trust:      req.Trust,
 		NoActivate: req.NoActivate,
+		Selected:   req.Selected,
 	})
 	if err != nil {
 		writeJSONError(w, "Import failed: "+err.Error(), http.StatusBadRequest)

--- a/pkg/skills/importer.go
+++ b/pkg/skills/importer.go
@@ -14,31 +14,32 @@ type ImportOptions struct {
 	Repo       string
 	Ref        string
 	Path       string
-	Trust      bool // Skip security scan confirmation
-	NoActivate bool // Import as draft instead of active
-	Force      bool // Overwrite existing skills
-	Rename     string // Rename the skill on import
+	Trust      bool     // Skip security scan confirmation
+	NoActivate bool     // Import as draft instead of active
+	Force      bool     // Overwrite existing skills
+	Rename     string   // Rename the skill on import
+	Selected   []string // Only import skills with these names (empty = import all)
 }
 
 // ImportResult contains the results of an import operation.
 type ImportResult struct {
-	Imported []ImportedSkill
-	Skipped  []SkippedSkill
-	Warnings []string
+	Imported []ImportedSkill `json:"imported"`
+	Skipped  []SkippedSkill  `json:"skipped"`
+	Warnings []string        `json:"warnings"`
 }
 
 // ImportedSkill records a successfully imported skill.
 type ImportedSkill struct {
-	Name      string
-	Path      string
-	Origin    *Origin
-	Findings  []SecurityFinding
+	Name     string            `json:"name"`
+	Path     string            `json:"path"`
+	Origin   *Origin           `json:"origin,omitempty"`
+	Findings []SecurityFinding `json:"findings,omitempty"`
 }
 
 // SkippedSkill records a skill that was skipped during import.
 type SkippedSkill struct {
-	Name   string
-	Reason string
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
 }
 
 // Importer orchestrates the skill import process.
@@ -86,6 +87,12 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 		return nil, fmt.Errorf("reading lock file: %w", err)
 	}
 
+	// Build selection set for O(1) lookup (empty = import all)
+	selectedSet := make(map[string]bool, len(opts.Selected))
+	for _, name := range opts.Selected {
+		selectedSet[name] = true
+	}
+
 	lockedSkills := make(map[string]LockedSkill)
 
 	for _, discovered := range result.Skills {
@@ -94,9 +101,15 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 			skillName = opts.Rename
 		}
 
-		// Check for existing skill
+		// Filter to user-selected skills when a selection is provided
+		if len(opts.Selected) > 0 && !selectedSet[skillName] {
+			continue
+		}
+
+		// Check for existing skill; treat explicitly selected skills as force-overwrite
 		if _, err := imp.store.GetSkill(skillName); err == nil {
-			if !opts.Force {
+			force := opts.Force || (len(opts.Selected) > 0 && selectedSet[skillName])
+			if !force {
 				importResult.Skipped = append(importResult.Skipped, SkippedSkill{
 					Name:   skillName,
 					Reason: fmt.Sprintf("skill %q already exists (use --force to overwrite or --rename to import with a different name)", skillName),

--- a/web/src/components/wizard/steps/SkillImportWizard.tsx
+++ b/web/src/components/wizard/steps/SkillImportWizard.tsx
@@ -78,6 +78,7 @@ export function SkillImportWizard() {
         path: path || undefined,
         trust: hasFlagged,
         noActivate: false,
+        selected: [...selected],
       });
 
       const imported = (result.imported ?? []).map((i) => i.name);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -672,6 +672,7 @@ export async function addSkillSource(source: {
   path?: string;
   trust?: boolean;
   noActivate?: boolean;
+  selected?: string[];
 }): Promise<ImportResult> {
   return mutateJSON<ImportResult>('/api/skills/sources', 'POST', source);
 }


### PR DESCRIPTION
## Description

Fixes two bugs that caused the 4-step skill import wizard to always show "Import Failed — 0 imported, 0 skipped" when importing skills from a git repository.

## Type of Change

- [x] Bug fix

## Changes Made

- Add `json:` struct tags to `ImportResult`, `ImportedSkill`, and `SkippedSkill` — Go was serializing field names as capitalized (`Imported`, `Skipped`) while the frontend expected lowercase (`imported`, `skipped`), causing all result arrays to read as `undefined`
- Add `Selected []string` to `ImportOptions` and filter the import loop to only process user-selected skills when a selection is provided
- Wire selected skill names from the wizard's Browse & Select step through the API handler and client to the importer — previously the selection was tracked in the UI but never sent to the backend
- Treat explicitly selected skills that already exist as force-overwrite — user opted in by selecting them
- No behavior change for CLI or the update flow (empty `Selected` = import all, as before)

## Testing

1. Open the skill import wizard and enter a git repo URL containing SKILL.md files
2. Browse & Select step: select one or more skills and click Install
3. Review & Install step should now show the correct imported/skipped counts
4. Verify CLI `gridctl skill add <repo>` still imports all skills as before

## Closes

Closes #451

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed