### PR TITLE
fix: apply log-text class to skill card name and description

### DIFF
--- a/web/src/components/registry/SkillCard.tsx
+++ b/web/src/components/registry/SkillCard.tsx
@@ -90,7 +90,7 @@ export const SkillCard = memo(({
           <div className="p-1.5 rounded-md border bg-primary/10 border-primary/20 flex-shrink-0 mt-0.5">
             <BookOpen size={14} className="text-primary/70" />
           </div>
-          <span className="font-semibold text-sm text-text-primary truncate flex-1 min-w-0 leading-tight mt-0.5">
+          <span className="font-semibold log-text text-text-primary truncate flex-1 min-w-0 leading-tight mt-0.5">
             {skill.name}
           </span>
           <StateBadge state={skill.state} />
@@ -98,7 +98,7 @@ export const SkillCard = memo(({
 
         {/* Description */}
         <p className={cn(
-          'text-xs leading-relaxed line-clamp-2',
+          'log-text leading-relaxed line-clamp-2',
           skill.description ? 'text-text-secondary' : 'text-text-muted/40 italic',
         )}>
           {skill.description || 'No description'}


### PR DESCRIPTION
## Description

Fixes the font size zoom controls on the Registry page having no effect on skill card text. The `+`/`−` controls were correctly updating state and setting the `--log-font-size` CSS variable on the container, but `SkillCard` text elements used hardcoded Tailwind size classes that never consumed the variable.

## Type of Change

- [x] Bug fix

## Changes Made

- Replace `text-sm` with `log-text` on skill card name (`SkillCard.tsx:93`)
- Replace `text-xs` with `log-text` on skill card description (`SkillCard.tsx:100`)

## Testing

1. Open the Registry page
2. Click `+` or `−` in the font size control (top-right)
3. Verify skill card name and description text scales accordingly

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #453