### PR TITLE
feat: add Save & Load action to wizard ReviewStep for stacks

### DIFF
--- a/web/src/components/wizard/steps/ReviewStep.tsx
+++ b/web/src/components/wizard/steps/ReviewStep.tsx
@@ -8,11 +8,12 @@ import {
   Rocket,
   Loader2,
   FileCode2,
+  Library,
 } from 'lucide-react';
 import { cn } from '../../../lib/cn';
 import { Button } from '../../ui/Button';
 import { showToast } from '../../ui/Toast';
-import { validateStackSpec, appendToStack } from '../../../lib/api';
+import { validateStackSpec, appendToStack, saveStack, initializeStack, StackAlreadyActiveError } from '../../../lib/api';
 import type { ValidationIssue } from '../../../types';
 
 interface ReviewStepProps {
@@ -89,6 +90,41 @@ export function ReviewStep({ yaml, resourceType, resourceName, onDeploy }: Revie
       onDeploy?.();
     } catch (err) {
       showToast('error', err instanceof Error ? err.message : 'Deploy failed');
+    } finally {
+      setDeploying(false);
+    }
+  };
+
+  /** Extract name from YAML spec (looks for a top-level `name:` field). */
+  const extractStackName = (): string => {
+    const match = yaml.match(/^name:\s*(.+)$/m);
+    if (match) return match[1].trim();
+    // Fallback: timestamp-based name
+    return `stack-${Date.now()}`;
+  };
+
+  const handleSaveAndLoad = async () => {
+    setDeploying(true);
+    const name = extractStackName();
+    try {
+      await saveStack(yaml, name);
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'Save failed');
+      setDeploying(false);
+      return;
+    }
+
+    try {
+      await initializeStack(name);
+      showToast('success', `Stack loaded — ${name} is now active`);
+      onDeploy?.();
+    } catch (err) {
+      if (err instanceof StackAlreadyActiveError) {
+        showToast('success', 'Stack saved to library');
+        onDeploy?.();
+      } else {
+        showToast('error', `Saved but could not load — restart with \`gridctl apply ~/.gridctl/stacks/${name}.yaml\``);
+      }
     } finally {
       setDeploying(false);
     }
@@ -234,16 +270,29 @@ export function ReviewStep({ yaml, resourceType, resourceName, onDeploy }: Revie
           {copied ? <CheckCircle2 size={14} /> : <Copy size={14} />}
           {copied ? 'Copied' : 'Copy'}
         </Button>
-        <Button
-          variant="primary"
-          size="sm"
-          onClick={handleDeploy}
-          disabled={hasErrors || validating || deploying}
-          className="ml-auto"
-        >
-          {deploying ? <Loader2 size={14} className="animate-spin" /> : <Rocket size={14} />}
-          {deploying ? 'Deploying...' : 'Deploy'}
-        </Button>
+        {resourceType === 'stack' ? (
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleSaveAndLoad}
+            disabled={hasErrors || validating || deploying}
+            className="ml-auto"
+          >
+            {deploying ? <Loader2 size={14} className="animate-spin" /> : <Library size={14} />}
+            {deploying ? 'Saving...' : 'Save & Load'}
+          </Button>
+        ) : (
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleDeploy}
+            disabled={hasErrors || validating || deploying}
+            className="ml-auto"
+          >
+            {deploying ? <Loader2 size={14} className="animate-spin" /> : <Rocket size={14} />}
+            {deploying ? 'Deploying...' : 'Deploy'}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -553,6 +553,57 @@ export async function appendToStack(yaml: string, resourceType: string): Promise
 }
 
 /**
+ * Save a stack spec to the library (~/.gridctl/stacks/<name>.yaml)
+ * POST /api/stacks
+ */
+export async function saveStack(yaml: string, name: string): Promise<{ success: boolean; path: string; name: string }> {
+  const response = await fetch(`${API_BASE}/api/stacks`, {
+    method: 'POST',
+    headers: buildHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ yaml, name }),
+  });
+
+  if (response.status === 401) throw new AuthError('Authentication required');
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.error || `Save failed: ${response.status}`);
+  }
+
+  return data;
+}
+
+/**
+ * Cold-load a saved stack into the running daemon.
+ * Returns 409 if a stack is already active — callers must check for this.
+ * POST /api/stack/initialize
+ */
+export class StackAlreadyActiveError extends Error {
+  constructor() {
+    super('Stack already active');
+    this.name = 'StackAlreadyActiveError';
+  }
+}
+
+export async function initializeStack(name: string): Promise<{ success: boolean; name: string }> {
+  const response = await fetch(`${API_BASE}/api/stack/initialize`, {
+    method: 'POST',
+    headers: buildHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ name }),
+  });
+
+  if (response.status === 401) throw new AuthError('Authentication required');
+  if (response.status === 409) throw new StackAlreadyActiveError();
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.error || `Initialize failed: ${response.status}`);
+  }
+
+  return data;
+}
+
+/**
  * Get spec plan diff (spec vs running state)
  * GET /api/stack/plan
  */


### PR DESCRIPTION
## Description

Adds a Save & Load flow to the wizard's ReviewStep when the resource type is `stack`. Users can save a stack spec to the library and optionally cold-load it into the running daemon in a single action.

## Type of Change

- [x] New feature

## Changes Made

- Added `saveStack` API function — POST to `/api/stacks` to persist a stack spec
- Added `initializeStack` API function — POST to `/api/stack/initialize` to cold-load a saved stack; raises `StackAlreadyActiveError` on 409
- ReviewStep now shows a **Save & Load** button (instead of Deploy) when `resourceType === 'stack'`, falling back to a save-only success toast if a stack is already active

## Testing

1. Open the wizard and build a stack spec through to the ReviewStep
2. Click **Save & Load** — expect a success toast and `onDeploy` callback
3. With a stack already active, repeat — expect "Stack saved to library" toast

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #457