### PR TITLE
feat: wizard gating and UX polish

### DIFF
--- a/web/src/components/graph/Canvas.tsx
+++ b/web/src/components/graph/Canvas.tsx
@@ -32,6 +32,8 @@ export function Canvas() {
   const selectNode = useStackStore((s) => s.selectNode);
   const selectedNodeId = useStackStore((s) => s.selectedNodeId);
   const resetLayout = useStackStore((s) => s.resetLayout);
+  const connectionStatus = useStackStore((s) => s.connectionStatus);
+  const gatewayInfo = useStackStore((s) => s.gatewayInfo);
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
   const edgeStyle = useUIStore((s) => s.edgeStyle);
   const toggleEdgeStyle = useUIStore((s) => s.toggleEdgeStyle);
@@ -164,6 +166,7 @@ export function Canvas() {
   const onConnect = useCallback((_connection: Connection) => {}, []);
 
   const isEmpty = !nodes || nodes.length === 0;
+  const hasActiveStack = connectionStatus === 'connected' && gatewayInfo !== null;
 
   return (
     <div className="absolute inset-0 canvas-wrapper">
@@ -193,28 +196,30 @@ export function Canvas() {
               <Plus size={14} />
               New Stack
             </button>
-            {/* Quick-add links */}
-            <div className="flex items-center gap-2 mt-3">
-              <span className="text-[10px] text-text-muted">or add:</span>
-              {[
-                { type: 'mcp-server' as const, icon: Server, label: 'Server', color: 'text-primary hover:text-primary/80' },
-                { type: 'resource' as const, icon: Database, label: 'Resource', color: 'text-secondary hover:text-secondary/80' },
-              ].map((item) => (
-                <button
-                  key={item.type}
-                  onClick={() => useWizardStore.getState().open(item.type)}
-                  className={cn(
-                    'inline-flex items-center gap-1 px-2 py-1 rounded-md text-[10px] font-medium',
-                    'bg-white/[0.03] border border-white/[0.06] hover:border-white/[0.12]',
-                    'transition-all duration-200',
-                    item.color,
-                  )}
-                >
-                  <item.icon size={10} />
-                  {item.label}
-                </button>
-              ))}
-            </div>
+            {/* Quick-add links — only when a stack is active */}
+            {hasActiveStack && (
+              <div className="flex items-center gap-2 mt-3">
+                <span className="text-[10px] text-text-muted">or add:</span>
+                {[
+                  { type: 'mcp-server' as const, icon: Server, label: 'Server', color: 'text-primary hover:text-primary/80' },
+                  { type: 'resource' as const, icon: Database, label: 'Resource', color: 'text-secondary hover:text-secondary/80' },
+                ].map((item) => (
+                  <button
+                    key={item.type}
+                    onClick={() => useWizardStore.getState().open(item.type)}
+                    className={cn(
+                      'inline-flex items-center gap-1 px-2 py-1 rounded-md text-[10px] font-medium',
+                      'bg-white/[0.03] border border-white/[0.06] hover:border-white/[0.12]',
+                      'transition-all duration-200',
+                      item.color,
+                    )}
+                  >
+                    <item.icon size={10} />
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw, Settings, Zap, RotateCcw, Plus, Command } from 'lucide-react';
+import { RefreshCw, Settings, Zap, RotateCcw, Plus, Command, Layers } from 'lucide-react';
 import { useState, useRef, useCallback } from 'react';
 import { cn } from '../../lib/cn';
 import { StatusDot } from '../ui/StatusDot';
@@ -134,6 +134,16 @@ export function Header({ onRefresh, isRefreshing }: HeaderProps) {
             {isConnected ? 'Connected' : 'Disconnected'}
           </span>
         </div>
+
+        {/* Active Stack Name */}
+        {isConnected && gatewayInfo?.name && (
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-surface-elevated/60 backdrop-blur-sm border border-border/50">
+            <Layers size={12} className="text-primary" />
+            <span className="text-xs font-medium text-text-secondary font-mono">
+              {gatewayInfo.name}
+            </span>
+          </div>
+        )}
 
         {/* Server Count */}
         {totalCount > 0 && (

--- a/web/src/components/wizard/CreationWizard.tsx
+++ b/web/src/components/wizard/CreationWizard.tsx
@@ -507,6 +507,8 @@ function renderStepContent(
   }
 }
 
+const STACK_GATED_TYPES: ResourceType[] = ['mcp-server', 'resource'];
+
 // Resource Type Picker — 3x2 glass-panel grid
 function TypePicker({
   selected,
@@ -517,6 +519,9 @@ function TypePicker({
   onSelect: (type: ResourceType) => void;
   counts: Record<ResourceType, number>;
 }) {
+  const connectionStatus = useStackStore((s) => s.connectionStatus);
+  const hasActiveStack = connectionStatus === 'connected';
+
   return (
     <div className="py-4">
       <div className="text-center mb-8">
@@ -532,17 +537,23 @@ function TypePicker({
           const Icon = rt.icon;
           const isSelected = selected === rt.type;
           const count = counts[rt.type];
+          const isGated = STACK_GATED_TYPES.includes(rt.type) && !hasActiveStack;
           return (
             <button
               key={rt.type}
-              onClick={() => onSelect(rt.type)}
+              onClick={() => !isGated && onSelect(rt.type)}
+              title={isGated ? 'Requires an active stack — create a Stack first' : undefined}
               className={cn(
                 'group relative flex flex-col items-center text-center p-5 rounded-xl border transition-all duration-200',
-                'bg-white/[0.03] hover:bg-white/[0.06]',
                 'animate-fade-in-up',
-                isSelected
-                  ? 'border-primary/50 shadow-[0_0_24px_rgba(245,158,11,0.1)]'
-                  : 'border-white/[0.06] hover:border-white/[0.12]',
+                isGated
+                  ? 'opacity-40 cursor-not-allowed bg-white/[0.03] border-white/[0.06]'
+                  : [
+                      'bg-white/[0.03] hover:bg-white/[0.06]',
+                      isSelected
+                        ? 'border-primary/50 shadow-[0_0_24px_rgba(245,158,11,0.1)]'
+                        : 'border-white/[0.06] hover:border-white/[0.12]',
+                    ],
               )}
               style={{ animationDelay: `${i * 50}ms`, animationFillMode: 'backwards' }}
             >
@@ -555,16 +566,22 @@ function TypePicker({
                 className={cn(
                   'w-10 h-10 rounded-xl flex items-center justify-center mb-3 transition-all duration-200',
                   'bg-surface-elevated border border-border/40',
-                  'group-hover:border-white/[0.12]',
-                  isSelected && 'border-primary/30',
+                  !isGated && 'group-hover:border-white/[0.12]',
+                  isSelected && !isGated && 'border-primary/30',
                 )}
                 style={
-                  isSelected
+                  isSelected && !isGated
                     ? { boxShadow: `0 0 20px ${rt.glowColor}` }
                     : undefined
                 }
               >
-                <Icon size={18} className={cn(rt.color, 'transition-transform duration-200 group-hover:scale-110')} />
+                <Icon
+                  size={18}
+                  className={cn(
+                    rt.color,
+                    !isGated && 'transition-transform duration-200 group-hover:scale-110',
+                  )}
+                />
               </div>
               <div className="text-sm font-medium text-text-primary mb-1">
                 {rt.label}


### PR DESCRIPTION
## Description

Gates MCP Server and Resource wizard cards on stack state, adds an active stack name indicator to the header, and hides stack-dependent quick-add links from the empty canvas state in stackless mode.

## Type of Change

- [x] New feature

## Changes Made

- `CreationWizard`: MCP Server and Resource cards render at `opacity-40` with `cursor-not-allowed` when no stack is active; clicking dimmed cards is a no-op with a tooltip explaining the requirement
- `Header`: Adds a Layers icon pill showing the active stack name when connected; hidden when no stack is loaded
- `Canvas`: Quick-add Server/Resource links in the empty state are hidden until a stack is active; the "Create your first stack" CTA remains always visible

## Testing

1. Start `gridctl serve` (stackless mode) — MCP Server and Resource cards should be dimmed in the wizard; hovering shows tooltip
2. Header should show no stack name pill
3. Canvas empty state should show only "New Stack" CTA, no quick-add links
4. Load a stack via the wizard Save & Load flow — all 5 wizard cards become enabled, header shows stack name, quick-add links appear

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #457