### PR TITLE
docs: sync AGENTS.md with stack library and stackless mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,8 @@ gridctl/
 │       ├── auth.go       # Gateway authentication middleware
 │       ├── registry.go   # Registry CRUD endpoints
 │       ├── vault.go      # Vault REST API endpoints
-│       └── pins.go       # Schema pins REST API endpoints
+│       ├── pins.go       # Schema pins REST API endpoints
+│       └── stack.go      # Stack library endpoints (list, save, initialize)
 ├── pkg/
 │   ├── config/           # Stack YAML parsing
 │   │   ├── types.go      # Stack, Agent, Resource structs
@@ -153,11 +154,11 @@ gridctl/
 │   │   ├── windsurf.go   # Windsurf provisioner
 │   │   └── ...           # Other client provisioners
 │   ├── reload/           # Hot reload support
-│   │   ├── reload.go     # Reload handler and result types
+│   │   ├── reload.go     # Reload handler, Initialize() for stackless cold-load, and result types
 │   │   ├── diff.go       # Stack diff computation
 │   │   └── watcher.go    # File watcher for --watch mode
 │   ├── state/            # Daemon state management
-│   │   └── state.go      # ~/.gridctl/state/ and ~/.gridctl/logs/
+│   │   └── state.go      # ~/.gridctl/state/, ~/.gridctl/logs/, StacksDir()
 │   ├── mcp/              # MCP protocol
 │   │   ├── types.go      # JSON-RPC, MCP types, AgentClient interface
 │   │   ├── client.go     # HTTP transport client
@@ -253,8 +254,15 @@ make clean-mock-servers # Stop and remove mock MCP servers
 ## CLI Usage
 
 ```bash
+# Start the web UI and API server without a stack (stackless mode)
+./gridctl serve
+./gridctl serve --port 8180 --foreground
+
 # Start a stack (runs as daemon, returns immediately)
 ./gridctl apply examples/getting-started/mcp-basic.yaml
+
+# Start in stackless mode (same as serve; stack loaded later via wizard)
+./gridctl apply
 
 # Start with options
 ./gridctl apply stack.yaml --port 8180 --no-cache
@@ -395,7 +403,14 @@ Triggers a hot reload of the stack configuration. The stack must be running with
 
 #### `gridctl serve`
 
-Starts the web UI server without managing any stack. Listens on port 8180 by default (override with `PORT` environment variable).
+Starts the API server and web UI in stackless mode — no stack file required. Stack-dependent endpoints return 503 until a stack is loaded via the wizard. Vault and wizard endpoints are always available.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--port` | `-p` | Port for the API server and web UI (default: 8180) |
+| `--foreground` | `-f` | Run in foreground (don't daemonize) |
+
+`gridctl apply` (with no arguments) is equivalent to `gridctl serve`.
 
 #### `gridctl vault <subcommand>`
 
@@ -482,6 +497,8 @@ Gridctl stores daemon state in `~/.gridctl/`:
 │   └── {name}.json     # PID, port, start time per stack
 ├── logs/               # Daemon log files
 │   └── {name}.log      # stdout/stderr from daemon
+├── stacks/             # Saved stack library (created by wizard Save & Load)
+│   └── {name}.yaml     # Saved stack specs (loaded via POST /api/stack/initialize)
 ├── vault/              # Secrets vault (0700 permissions)
 │   ├── secrets.json    # Plaintext secrets (when unlocked/unencrypted)
 │   └── secrets.enc     # Encrypted secrets (when locked)
@@ -504,6 +521,7 @@ When `gridctl apply` runs, it:
 **Endpoints:**
 - **MCP:** `POST /mcp` (JSON-RPC), `GET /sse` + `POST /message` (SSE for Claude Desktop)
 - **API:** `/api/status`, `/api/mcp-servers`, `/api/mcp-servers/{name}/restart`, `/api/tools`, `/api/logs`, `/api/clients`, `/api/reload`, `/api/metrics/tokens`, `/health`, `/ready`
+- **Stack Library:** `/api/stacks` (list/save), `/api/stack/initialize` (cold-load a saved stack into a stackless daemon)
 - **Vault:** `/api/vault`, `/api/vault/status`, `/api/vault/unlock`, `/api/vault/lock`, `/api/vault/sets`, `/api/vault/import`
 - **Pins:** `/api/pins` (list all), `/api/pins/{server}` (get), `/api/pins/{server}/approve` (POST), `/api/pins/{server}` (DELETE)
 - **Registry:** `/api/registry/status`, `/api/registry/skills[/{name}]`, `/api/registry/skills/{name}/files[/{path}]`, `/api/registry/skills/validate`, `/api/registry/skills/{name}/workflow`, `/api/registry/skills/{name}/execute`, `/api/registry/skills/{name}/validate-workflow`, `/api/registry/skills/{name}/test`
@@ -575,6 +593,15 @@ When the vault is locked, all endpoints except `status`, `unlock`, and `lock` re
   - Response: `TraceRecord[]` with fields: `trace_id`, `operation`, `start_time`, `duration_ms`, `span_count`, `is_error`, `spans`
 - `GET /api/traces/{traceId}` - Get a single trace with full span detail
   - Response: `TraceRecord` with `spans[]` — each span has `span_id`, `name`, `start_time`, `duration_ms`, `is_error`, `attrs` (OTel attributes)
+
+**Stack Library API:**
+- `GET /api/stacks` - List saved stacks from `~/.gridctl/stacks/`; returns `{stacks: [{name, path, size, modTime}]}`
+- `POST /api/stacks` - Save a stack spec to the library; body: `{name, content}` (YAML string); returns `{name, path}`
+- `POST /api/stack/initialize` - Cold-load a named saved stack into a running stackless daemon; body: `{name}`; returns 409 (`StackAlreadyActiveError`) if a stack is already running
+
+**`/ready` behavior:**
+- Returns `200 OK` when a stack is fully initialized
+- Returns `503 Service Unavailable` in stackless mode (no stack loaded yet)
 
 **Tool prefixing:** Tools are prefixed with server name to avoid collisions:
 - `server-name__tool-name` (e.g., `itential-mcp__get_workflows`)

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -599,7 +599,62 @@ Vault-specific: `fetchVaultSecrets`, `createVaultSecret`, `getVaultSecret`, `upd
 - Monospace font (`font-mono`) for secret keys and values
 - Error states use `status-error` color token
 
-## 18. Checklist for New Components
+## 18. Creation Wizard
+
+The creation wizard is a multi-step modal for adding MCP servers, resources, stacks, and skills to the running configuration.
+
+### Components (`src/components/wizard/`)
+
+- **CreationWizard**: Root wizard modal — routes to the appropriate step flow based on resource type
+- **RecipePicker**: First step — resource type selection cards (Stack, MCP Server, Resource, Agent, Skill)
+- **BrowseStep**: Registry browser for importing skills
+- **AddSourceStep**: Transport/source configuration for MCP servers
+- **MCPServerForm**: MCP server detail form
+- **ResourceForm**: Resource (non-MCP container) form
+- **StackForm**: Stack spec builder
+- **ReviewStep**: Final review and deploy step (all resource types); for stacks, shows **Save & Load** instead of Deploy
+- **SkillImportWizard**: Dedicated wizard flow for importing skills from git
+- **DraftManager**: Draft persistence for wizard in-progress state
+- **ExpertModeToggle**: Toggle between guided and expert (raw YAML) modes
+- **SecretsPopover**: Inline vault secret picker for form fields
+- **TransportAdvisor**: Guided transport selector with recommendation logic
+- **TemplateGrid**: Template browser component
+- **YAMLPreview**: Live YAML preview panel
+
+### Stackless Mode Gating
+
+When no stack is active (stackless mode), the wizard gates stack-dependent resource types:
+
+| Resource Type | Stackless Behavior |
+|---------------|-------------------|
+| **Stack** | Always enabled — the mechanism for loading a stack |
+| **MCP Server** | `opacity-40 cursor-not-allowed`; clicking is a no-op with tooltip "Requires an active stack" |
+| **Resource** | `opacity-40 cursor-not-allowed`; clicking is a no-op with tooltip "Requires an active stack" |
+| **Agent** | Always enabled |
+| **Skill** | Always enabled |
+
+### Stack Save & Load Flow
+
+When `resourceType === 'stack'`, the ReviewStep shows a **Save & Load** button instead of **Deploy**:
+
+1. Calls `POST /api/stacks` to persist the stack spec to `~/.gridctl/stacks/{name}.yaml`
+2. Calls `POST /api/stack/initialize` to cold-load it into the running daemon
+3. If a stack is already active (409 response), shows a "Stack saved to library" toast instead
+
+### Header Stack Indicator
+
+When a stack is active and the daemon is connected, the Header shows an active stack name pill:
+- **Icon:** `Layers` (Lucide)
+- **Styling:** `bg-primary/10 border border-primary/20 text-primary` pill with stack name
+- **Hidden:** When no stack is loaded (stackless mode)
+
+### Canvas Stackless Empty State
+
+The Canvas empty state conditionally renders quick-add links based on stack status:
+- **Always visible:** "Create your first stack" CTA (navigates to stack wizard)
+- **Hidden until stack active:** Quick-add "Add MCP Server" and "Add Resource" links
+
+## 19. Checklist for New Components
 
 1. Use Tailwind color tokens (no hardcoded hex values)
 2. Use `font-mono` for technical data, `font-sans` for UI


### PR DESCRIPTION
## Description

Syncs both AGENTS.md files with changes from PRs #458–#461: stackless startup mode, the stack library backend, and wizard UX gating.

## Type of Change

- [x] Documentation

## Changes Made

- `AGENTS.md`: Document `internal/api/stack.go` in directory structure
- `AGENTS.md`: Update `pkg/reload/reload.go` and `pkg/state/state.go` descriptions (Initialize, StacksDir)
- `AGENTS.md`: Add stackless CLI usage for `gridctl apply` (no args) and `gridctl serve` with flags
- `AGENTS.md`: Update `gridctl serve` command reference with `--port` and `--foreground` flags
- `AGENTS.md`: Add `~/.gridctl/stacks/` to state files directory tree
- `AGENTS.md`: Add Stack Library API endpoints (`GET/POST /api/stacks`, `POST /api/stack/initialize`)
- `AGENTS.md`: Document `/ready` 503 behavior in stackless mode
- `web/AGENTS.md`: Add Section 18 — Creation Wizard components, stackless gating rules, Save & Load flow, Header stack indicator, and Canvas empty state behavior

## Testing

Read the updated docs and verify accuracy against source.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed