### PR TITLE
docs: update README and api-reference for stackless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ gridctl test <skill>           # Run acceptance criteria for a skill (exit 0/1/2
 gridctl activate <skill>       # Promote a skill from draft to active
 ```
 
-Drift detection runs in the background: the canvas flags servers that are running but absent from your spec, and declarations in your spec that haven't been deployed — so your YAML and your environment stay in sync. Need to build a stack from scratch? The visual spec builder lets you compose `stack.yaml` through a guided wizard and export the result.
+Drift detection runs in the background: the canvas flags servers that are running but absent from your spec, and declarations in your spec that haven't been deployed — so your YAML and your environment stay in sync. Need to build a stack from scratch? Start the UI with `gridctl serve`, use the visual spec builder to compose your stack through a guided wizard, then **Save & Load** it directly into the running daemon — no YAML file required to get started.
 
 Executable skills (those with a `workflow` block) must define `acceptance_criteria` before `gridctl activate` will promote them — ensuring every deployed skill has a machine-checkable definition of done.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -40,7 +40,7 @@ OK
 
 #### `GET /ready`
 
-Readiness check. Returns `200 OK` only when all MCP servers are connected and initialized. Returns `503 Service Unavailable` if any server is not ready.
+Readiness check. Returns `200 OK` only when all MCP servers are connected and initialized. Returns `503 Service Unavailable` in two cases: any MCP server is not yet ready, or the daemon is running in stackless mode (no stack loaded yet — use `POST /api/stack/initialize` or the wizard to load one).
 
 **Auth:** No
 


### PR DESCRIPTION
## Description

Updates README and the API reference docs to reflect stackless mode behavior introduced in #458–#461.

## Type of Change

- [x] Documentation

## Changes Made

- `README.md`: Updated wizard description from "export the result" to describe the Save & Load flow and `gridctl serve` as a stackless entry point
- `docs/api-reference.md`: Updated `/ready` to document the stackless 503 case (no stack loaded) alongside the existing "server not ready" case

## Testing

Read the updated sections and verify against source behavior.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed