### PR TITLE
feat: skills registry UI polish

### DIFF
--- a/web/src/components/registry/SkillCard.tsx
+++ b/web/src/components/registry/SkillCard.tsx
@@ -20,6 +20,7 @@ export interface SkillCardProps {
   onDisable: (skill: AgentSkill) => void;
   onEdit: (skill: AgentSkill) => void;
   onDelete: (skill: AgentSkill) => void;
+  className?: string;
 }
 
 function StateBadge({ state }: { state: ItemState }) {
@@ -39,8 +40,8 @@ function StateBadge({ state }: { state: ItemState }) {
 function TestStatusBadge({ testResult }: { testResult?: SkillTestResult | null }) {
   if (!testResult || testResult.status === 'untested') {
     return (
-      <span className="flex items-center gap-1 text-[10px] font-medium text-text-muted/60">
-        <Minus size={11} />
+      <span className="flex items-center gap-1 text-[10px] font-medium text-amber-400/80 bg-amber-400/8 border border-amber-400/20 rounded px-1.5 py-0.5">
+        <Minus size={10} />
         untested
       </span>
     );
@@ -70,6 +71,7 @@ export const SkillCard = memo(({
   onDisable,
   onEdit,
   onDelete,
+  className,
 }: SkillCardProps) => {
   return (
     <div
@@ -77,7 +79,8 @@ export const SkillCard = memo(({
         'relative rounded-xl overflow-hidden flex flex-col',
         'backdrop-blur-xl border transition-all duration-200 ease-out',
         'bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.02]',
-        'border-border/40 hover:border-primary/40 hover:shadow-node-hover',
+        'border-border/60 hover:border-primary/40 hover:shadow-node-hover',
+        className,
       )}
     >
       {/* Top accent line */}

--- a/web/src/components/registry/SkillCardSkeleton.tsx
+++ b/web/src/components/registry/SkillCardSkeleton.tsx
@@ -1,0 +1,40 @@
+import { memo } from 'react';
+
+export const SkillCardSkeleton = memo(() => {
+  return (
+    <div className="relative rounded-xl overflow-hidden flex flex-col backdrop-blur-xl border border-border/60 bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.02]">
+      {/* Top accent line */}
+      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-primary/20 to-transparent" />
+
+      {/* Card body */}
+      <div className="p-3 flex flex-col gap-2 flex-1">
+        {/* Header row */}
+        <div className="flex items-start gap-2">
+          <div className="w-7 h-7 rounded-md bg-surface-elevated animate-pulse flex-shrink-0" />
+          <div className="flex-1 flex flex-col gap-1.5 mt-0.5">
+            <div className="h-4 w-24 rounded bg-surface-elevated animate-pulse" />
+          </div>
+          <div className="h-4 w-10 rounded bg-surface-elevated animate-pulse flex-shrink-0" />
+        </div>
+
+        {/* Description lines */}
+        <div className="flex flex-col gap-1.5">
+          <div className="h-3 rounded bg-surface-elevated animate-pulse" />
+          <div className="h-3 w-3/4 rounded bg-surface-elevated animate-pulse" />
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="px-3 pb-3 pt-2 border-t border-border-subtle/50 flex items-center justify-between gap-2">
+        <div className="h-4 w-16 rounded bg-surface-elevated animate-pulse" />
+        <div className="flex items-center gap-0.5">
+          <div className="w-6 h-6 rounded-lg bg-surface-elevated animate-pulse" />
+          <div className="w-6 h-6 rounded-lg bg-surface-elevated animate-pulse" />
+          <div className="w-6 h-6 rounded-lg bg-surface-elevated animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+});
+
+SkillCardSkeleton.displayName = 'SkillCardSkeleton';

--- a/web/src/components/ui/IconButton.tsx
+++ b/web/src/components/ui/IconButton.tsx
@@ -21,7 +21,7 @@ export function IconButton({
   variant = 'default',
 }: IconButtonProps) {
   const sizeClasses = {
-    sm: 'p-1.5',
+    sm: 'p-2',
     md: 'p-2',
   };
   const iconSize = size === 'sm' ? 14 : 16;

--- a/web/src/pages/DetachedRegistryPage.tsx
+++ b/web/src/pages/DetachedRegistryPage.tsx
@@ -13,6 +13,7 @@ import { IconButton } from '../components/ui/IconButton';
 import { ZoomControls } from '../components/log/ZoomControls';
 import { SkillEditor } from '../components/registry/SkillEditor';
 import { SkillCard } from '../components/registry/SkillCard';
+import { SkillCardSkeleton } from '../components/registry/SkillCardSkeleton';
 import { ToastContainer, showToast } from '../components/ui/Toast';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
 import { useLogFontSize } from '../hooks/useLogFontSize';
@@ -77,6 +78,105 @@ const TABS: { key: FilterTab; label: string }[] = [
   { key: 'draft', label: 'Draft' },
   { key: 'disabled', label: 'Disabled' },
 ];
+
+function getGroupKey(dir?: string): string {
+  if (!dir) return '';
+  return dir.split('/')[0];
+}
+
+function groupSkills(skills: AgentSkill[]): Map<string, AgentSkill[]> {
+  const groups = new Map<string, AgentSkill[]>();
+  for (const skill of skills) {
+    const key = getGroupKey(skill.dir);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(skill);
+  }
+  return groups;
+}
+
+function toTitleCase(key: string): string {
+  return key.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+interface GroupedSkillGridProps {
+  skills: AgentSkill[];
+  hasSearch: boolean;
+  onEnable: (skill: AgentSkill) => void;
+  onDisable: (skill: AgentSkill) => void;
+  onEdit: (skill: AgentSkill) => void;
+  onDelete: (skill: AgentSkill) => void;
+}
+
+function GroupedSkillGrid({ skills, hasSearch, onEnable, onDisable, onEdit, onDelete }: GroupedSkillGridProps) {
+  const groups = groupSkills(skills);
+  const showHeaders = groups.size > 1;
+
+  const gridStyle: React.CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+    gap: '12px',
+  };
+
+  return (
+    <div className="p-4" style={gridStyle}>
+      {Array.from(groups.entries()).map(([key, groupSkillList]) => (
+        <GroupSection
+          key={key || '__ungrouped__'}
+          groupKey={key}
+          skills={groupSkillList}
+          showHeader={showHeaders}
+          hasSearch={hasSearch}
+          onEnable={onEnable}
+          onDisable={onDisable}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface GroupSectionProps {
+  groupKey: string;
+  skills: AgentSkill[];
+  showHeader: boolean;
+  hasSearch: boolean;
+  onEnable: (skill: AgentSkill) => void;
+  onDisable: (skill: AgentSkill) => void;
+  onEdit: (skill: AgentSkill) => void;
+  onDelete: (skill: AgentSkill) => void;
+}
+
+function GroupSection({ groupKey, skills, showHeader, hasSearch, onEnable, onDisable, onEdit, onDelete }: GroupSectionProps) {
+  return (
+    <>
+      {showHeader && (
+        <div style={{ gridColumn: '1 / -1' }} className="flex flex-col gap-1 mt-2 first:mt-0 animate-fade-in-scale">
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] uppercase tracking-widest text-text-muted font-medium">
+              {groupKey ? toTitleCase(groupKey) : 'Other'}
+            </span>
+            <span className="text-[10px] px-1.5 rounded-full bg-surface-highlight text-text-muted">
+              {skills.length} {hasSearch ? 'matched' : 'skills'}
+            </span>
+          </div>
+          <div className="border-b border-border/30" />
+        </div>
+      )}
+      {skills.map((skill) => (
+        <SkillCard
+          key={skill.name}
+          skill={skill}
+          className={cn('animate-fade-in-scale', skill.metadata?.colspan === '2' ? 'col-span-2' : undefined)}
+          onEnable={onEnable}
+          onDisable={onDisable}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      ))}
+    </>
+  );
+}
 
 function DetachedRegistryContent() {
   const [skills, setSkills] = useState<AgentSkill[] | null>(null);
@@ -277,8 +377,17 @@ function DetachedRegistryContent() {
         style={{ '--log-font-size': `${fontSize}px` } as React.CSSProperties}
       >
         {isLoading && (
-          <div className="h-full flex items-center justify-center">
-            <div className="w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+          <div
+            className="p-4"
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+              gap: '12px',
+            }}
+          >
+            {Array.from({ length: 8 }).map((_, i) => (
+              <SkillCardSkeleton key={i} />
+            ))}
           </div>
         )}
 
@@ -315,25 +424,14 @@ function DetachedRegistryContent() {
 
         {/* Card grid */}
         {!isLoading && displayedSkills.length > 0 && (
-          <div
-            className="p-4"
-            style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
-              gap: '12px',
-            }}
-          >
-            {displayedSkills.map((skill) => (
-              <SkillCard
-                key={skill.name}
-                skill={skill}
-                onEnable={handleEnable}
-                onDisable={handleDisable}
-                onEdit={(s) => { setEditingSkill(s); setShowEditor(true); }}
-                onDelete={(s) => setConfirmDelete(s.name)}
-              />
-            ))}
-          </div>
+          <GroupedSkillGrid
+            skills={displayedSkills}
+            hasSearch={searchQuery.length > 0}
+            onEnable={handleEnable}
+            onDisable={handleDisable}
+            onEdit={(s) => { setEditingSkill(s); setShowEditor(true); }}
+            onDelete={(s) => setConfirmDelete(s.name)}
+          />
         )}
       </main>
 


### PR DESCRIPTION
## Description

Six targeted improvements to the Skills Registry UI: directory-based skill grouping, skeleton loading states, opt-in column spanning, amber untested badge, increased card border visibility, and larger icon button touch targets.

## Type of Change

- [x] New feature

## Changes Made

- `IconButton`: `sm` size padding increased from `p-1.5` to `p-2` for better touch targets
- `SkillCard`: border opacity raised to `border-border/60`, untested badge replaced with visible amber warning badge, optional `className` prop added for col-span passthrough
- `SkillCardSkeleton`: new component matching `SkillCard` dimensions for layout-shift-free loading
- `DetachedRegistryPage`: skills grouped by top-level `dir` segment with section headers (suppressed when ≤1 group), skeleton cards replace spinner on load, `col-span-2` applied when `metadata.colspan === "2"`

## Testing

Open the Skills Registry detached window. Verify: groups appear when skills are in subdirectories, flat grid renders when all skills share one group, skeleton cards show on initial load with no layout shift, untested badge is amber and visible, icon buttons have slightly larger hit area.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed