### PR TITLE
fix: gate wizard cards on active stack in stackless mode

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -322,8 +322,13 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		},
 		MCPServers: s.getMCPServerStatuses(),
 		Resources:  s.getResourceStatuses(),
-		Sessions:   s.gateway.SessionCount(),
-		StackName:  s.stackName,
+		Sessions: s.gateway.SessionCount(),
+	}
+	// Only expose stack_name when a user-defined stack is loaded.
+	// The embedded gateway uses "gridctl" as its default name even in stackless
+	// mode, so stackFile is the authoritative indicator.
+	if s.stackFile != "" {
+		status.StackName = s.stackName
 	}
 	if cm := s.gateway.CodeModeStatus(); cm != "off" {
 		status.CodeMode = cm

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -313,6 +313,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		Registry   *registry.RegistryStatus `json:"registry,omitempty"`
 		CodeMode   string                   `json:"code_mode,omitempty"`
 		TokenUsage *metrics.TokenUsage      `json:"token_usage,omitempty"`
+		StackName  string                   `json:"stack_name,omitempty"`
 	}{
 		Gateway: ServerInfo{
 			Name:      s.gateway.ServerInfo().Name,
@@ -322,6 +323,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		MCPServers: s.getMCPServerStatuses(),
 		Resources:  s.getResourceStatuses(),
 		Sessions:   s.gateway.SessionCount(),
+		StackName:  s.stackName,
 	}
 	if cm := s.gateway.CodeModeStatus(); cm != "off" {
 		status.CodeMode = cm

--- a/web/src/components/wizard/CreationWizard.tsx
+++ b/web/src/components/wizard/CreationWizard.tsx
@@ -520,7 +520,8 @@ function TypePicker({
   counts: Record<ResourceType, number>;
 }) {
   const connectionStatus = useStackStore((s) => s.connectionStatus);
-  const hasActiveStack = connectionStatus === 'connected';
+  const gatewayInfo = useStackStore((s) => s.gatewayInfo);
+  const hasActiveStack = connectionStatus === 'connected' && gatewayInfo !== null;
 
   return (
     <div className="py-4">

--- a/web/src/components/wizard/CreationWizard.tsx
+++ b/web/src/components/wizard/CreationWizard.tsx
@@ -519,9 +519,8 @@ function TypePicker({
   onSelect: (type: ResourceType) => void;
   counts: Record<ResourceType, number>;
 }) {
-  const connectionStatus = useStackStore((s) => s.connectionStatus);
-  const gatewayInfo = useStackStore((s) => s.gatewayInfo);
-  const hasActiveStack = connectionStatus === 'connected' && gatewayInfo !== null;
+  const stackName = useStackStore((s) => s.stackName);
+  const hasActiveStack = stackName !== '';
 
   return (
     <div className="py-4">

--- a/web/src/stores/useStackStore.ts
+++ b/web/src/stores/useStackStore.ts
@@ -27,6 +27,7 @@ interface StackState {
   sessions: number;
   codeMode: string | null;  // Gateway code mode status ("on" when active)
   tokenUsage: TokenUsage | null; // Token usage metrics from status response
+  stackName: string;        // Active stack name; empty string in stackless mode
 
   // === React Flow State ===
   nodes: Node[];
@@ -67,6 +68,7 @@ export const useStackStore = create<StackState>()(
     sessions: 0,
     codeMode: null,
     tokenUsage: null,
+    stackName: '',
     nodes: [],
     edges: [],
     draggedPositions: new Map(),
@@ -85,6 +87,7 @@ export const useStackStore = create<StackState>()(
         sessions: status.sessions ?? 0,
         codeMode: status.code_mode || null,
         tokenUsage: status.token_usage ?? null,
+        stackName: status.stack_name || '',
         lastUpdated: new Date(),
         isLoading: false,
         error: null,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -100,6 +100,7 @@ export interface GatewayStatus {
   sessions?: number;       // Active MCP session count
   code_mode?: string;      // "on" when code mode is active (omitted when off)
   token_usage?: TokenUsage; // Token usage metrics (omitted if no accumulator)
+  stack_name?: string;     // Active stack name; omitted in stackless mode
 }
 
 // Tool definition matching mcp.Tool


### PR DESCRIPTION
## Description

Fixes wizard resource type card gating in stackless mode (\`gridctl serve\`). MCP Server and Resource cards were not dimmed, showed no hover tooltip, and were clickable when they should be blocked until a user-defined stack is active.

**Root cause**: The embedded gateway always runs (even without a stack file), so \`gatewayInfo\` is never null. The correct discriminator is \`stack_name\` — set when a stack is loaded via \`apply\` or Save & Load, empty in stackless mode — but it was not exposed in \`/api/status\`.

## Type of Change

- [x] Bug fix

## Changes Made

- **Backend**: Add \`stack_name\` field to \`/api/status\` response (omitted when no stack is loaded)
- **Types**: Add \`stack_name?: string\` to \`GatewayStatus\` interface
- **Store**: Add \`stackName\` state to \`useStackStore\`, populated from status polling
- **Wizard**: Gate \`TypePicker\` cards on \`stackName !== ''\` instead of \`connectionStatus === 'connected'\`

## Testing

1. \`make build && ./gridctl serve\`
2. Open \`http://localhost:8180\`, click \`+\` to open wizard
3. Verify MCP Server and Resource cards are dimmed (\`opacity-40\`)
4. Hover either disabled card — tooltip reads "Requires an active stack — create a Stack first"
5. Click either disabled card — wizard stays on type selection
6. Load a stack via Save & Load → reopen wizard → all 5 cards enabled

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #466