### PR TITLE
fix: wizard YAML preview indentation and Save & Load UX

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -165,7 +165,14 @@ func (sc *StackController) runStacklessDaemonMode() error {
 
 // buildAndRunStackless builds and runs the gateway in stackless mode.
 func (sc *StackController) buildAndRunStackless(ctx context.Context, verbose bool) error {
-	rt := runtime.NewOrchestrator(nil, nil)
+	// Try to create a real container runtime so Save & Load can actually bring up
+	// containers once the user loads a stack via POST /api/stack/initialize. Fall
+	// back to an empty orchestrator if detection fails — the daemon still starts;
+	// initialize will surface a clear error instead of panicking.
+	rt, err := sc.createRuntime()
+	if err != nil {
+		rt = runtime.NewOrchestrator(nil, nil)
+	}
 	stack := &config.Stack{Name: "gridctl"}
 	builder := NewGatewayBuilder(sc.config, stack, "", rt, &runtime.UpResult{})
 	builder.SetVersion(sc.version)

--- a/pkg/reload/reload.go
+++ b/pkg/reload/reload.go
@@ -166,7 +166,11 @@ func (h *Handler) Reload(ctx context.Context) (*ReloadResult, error) {
 	h.logger.Info("reload complete",
 		"added", len(result.Added),
 		"removed", len(result.Removed),
-		"modified", len(result.Modified))
+		"modified", len(result.Modified),
+		"errors", len(result.Errors))
+	for _, e := range result.Errors {
+		h.logger.Warn("reload: per-item error", "error", e)
+	}
 
 	return result, nil
 }
@@ -316,7 +320,13 @@ func (h *Handler) startMCPServer(ctx context.Context, server config.MCPServer, s
 	}
 
 	// Start container
+	if h.runtime == nil {
+		return fmt.Errorf("container runtime unavailable (Docker/Podman not detected); load the stack via 'gridctl apply' instead")
+	}
 	rt := h.runtime.Runtime()
+	if rt == nil {
+		return fmt.Errorf("container runtime unavailable (Docker/Podman not detected); load the stack via 'gridctl apply' instead")
+	}
 
 	// Pull image if needed
 	imageName := server.Image
@@ -377,7 +387,13 @@ func (h *Handler) startMCPServer(ctx context.Context, server config.MCPServer, s
 }
 
 func (h *Handler) startResource(ctx context.Context, res config.Resource, stack *config.Stack) error {
+	if h.runtime == nil {
+		return fmt.Errorf("container runtime unavailable (Docker/Podman not detected); load the stack via 'gridctl apply' instead")
+	}
 	rt := h.runtime.Runtime()
+	if rt == nil {
+		return fmt.Errorf("container runtime unavailable (Docker/Podman not detected); load the stack via 'gridctl apply' instead")
+	}
 
 	// Pull image
 	if err := rt.EnsureImage(ctx, res.Image); err != nil {

--- a/web/src/__tests__/ReviewStep.test.tsx
+++ b/web/src/__tests__/ReviewStep.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ReviewStep } from '../components/wizard/steps/ReviewStep';
+import { saveStack, initializeStack, StackAlreadyActiveError, validateStackSpec } from '../lib/api';
+import { showToast } from '../components/ui/Toast';
+
+vi.mock('../lib/api', async () => {
+  // Preserve the real StackAlreadyActiveError class so `instanceof` still works
+  // in the component code under test.
+  class StackAlreadyActiveError extends Error {
+    constructor() {
+      super('Stack already active');
+      this.name = 'StackAlreadyActiveError';
+    }
+  }
+  return {
+    saveStack: vi.fn(),
+    initializeStack: vi.fn(),
+    appendToStack: vi.fn(),
+    validateStackSpec: vi.fn(),
+    StackAlreadyActiveError,
+  };
+});
+
+vi.mock('../components/ui/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+const YAML = 'version: "1"\nname: daily\n';
+
+describe('ReviewStep handleSaveAndLoad', () => {
+  let onDeploy: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onDeploy = vi.fn<() => void>();
+    (validateStackSpec as ReturnType<typeof vi.fn>).mockResolvedValue({ issues: [] });
+  });
+
+  async function clickSaveAndLoad() {
+    render(
+      <ReviewStep
+        yaml={YAML}
+        resourceType="stack"
+        resourceName="daily"
+        onDeploy={onDeploy}
+      />,
+    );
+
+    // Wait for initial validation to finish so the button isn't disabled.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save & load/i })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /save & load/i }));
+  }
+
+  it('calls onDeploy after a fully successful save + load', async () => {
+    (saveStack as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      name: 'daily',
+      path: '/tmp/daily.yaml',
+    });
+    (initializeStack as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      name: 'daily',
+    });
+
+    await clickSaveAndLoad();
+
+    await waitFor(() => expect(onDeploy).toHaveBeenCalledTimes(1));
+    expect(showToast).toHaveBeenCalledWith(
+      'success',
+      'Stack loaded — daily is now active',
+    );
+  });
+
+  it('calls onDeploy when initialize fails with StackAlreadyActiveError (409)', async () => {
+    (saveStack as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      name: 'daily',
+      path: '/tmp/daily.yaml',
+    });
+    (initializeStack as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new StackAlreadyActiveError(),
+    );
+
+    await clickSaveAndLoad();
+
+    await waitFor(() => expect(onDeploy).toHaveBeenCalledTimes(1));
+    expect(showToast).toHaveBeenCalledWith('success', 'Stack saved to library');
+  });
+
+  it('calls onDeploy when initialize fails with a generic error (non-409 fallback)', async () => {
+    (saveStack as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      name: 'daily',
+      path: '/tmp/daily.yaml',
+    });
+    (initializeStack as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Initialize failed: 500'),
+    );
+
+    await clickSaveAndLoad();
+
+    await waitFor(() => expect(onDeploy).toHaveBeenCalledTimes(1));
+    expect(showToast).toHaveBeenCalledWith(
+      'error',
+      expect.stringContaining('gridctl apply'),
+      expect.objectContaining({ duration: expect.any(Number) }),
+    );
+  });
+
+  it('does NOT call onDeploy when saveStack itself fails', async () => {
+    (saveStack as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Save failed: 400'),
+    );
+
+    await clickSaveAndLoad();
+
+    // saveStack rejected — onDeploy must not be called (user's work is not persisted).
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith('error', 'Save failed: 400'),
+    );
+    expect(onDeploy).not.toHaveBeenCalled();
+    expect(initializeStack).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/YAMLPreview.test.tsx
+++ b/web/src/__tests__/YAMLPreview.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { YAMLPreview } from '../components/wizard/YAMLPreview';
+
+vi.mock('../lib/api', () => ({
+  validateStackSpec: vi.fn().mockResolvedValue({ issues: [] }),
+}));
+
+describe('YAMLPreview', () => {
+  it('preserves leading whitespace on rendered lines', () => {
+    const yaml = [
+      'version: "1"',
+      'name: daily',
+      'mcp-servers:',
+      '  - name: github',
+      '    image: "ghcr.io/github/github-mcp-server:latest"',
+      '    transport: stdio',
+    ].join('\n');
+
+    const { container } = render(<YAMLPreview yaml={yaml} />);
+
+    // Each rendered YAML line is a span.whitespace-pre sibling of the line-number span.
+    const contentSpans = Array.from(
+      container.querySelectorAll<HTMLSpanElement>('span.whitespace-pre'),
+    );
+    const lineTexts = contentSpans.map((s) => s.textContent ?? '');
+
+    // Line 4: `  - name: github` — two leading spaces preserved
+    expect(lineTexts).toContain('  - name: github');
+    // Line 5: `    image: "..."` — four leading spaces preserved
+    expect(lineTexts.some((t) => /^ {4}image: "/.test(t))).toBe(true);
+    // Line 6: `    transport: stdio` — four leading spaces preserved
+    expect(lineTexts).toContain('    transport: stdio');
+  });
+
+  it('applies whitespace-pre so the browser does not collapse indentation', () => {
+    const yaml = 'secrets:\n  sets:\n    - dev';
+    const { container } = render(<YAMLPreview yaml={yaml} />);
+
+    const contentSpans = container.querySelectorAll('span.whitespace-pre');
+    expect(contentSpans.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/components/wizard/YAMLPreview.tsx
+++ b/web/src/components/wizard/YAMLPreview.tsx
@@ -119,7 +119,7 @@ export function YAMLPreview({ yaml, className }: YAMLPreviewProps) {
                   {lineNum}
                 </span>
                 <span
-                  className="flex-1 px-2"
+                  className="flex-1 px-2 whitespace-pre"
                   dangerouslySetInnerHTML={{ __html: html || '&nbsp;' }}
                 />
               </div>

--- a/web/src/components/wizard/steps/ReviewStep.tsx
+++ b/web/src/components/wizard/steps/ReviewStep.tsx
@@ -123,7 +123,14 @@ export function ReviewStep({ yaml, resourceType, resourceName, onDeploy }: Revie
         showToast('success', 'Stack saved to library');
         onDeploy?.();
       } else {
-        showToast('error', `Saved but could not load — restart with \`gridctl apply ~/.gridctl/stacks/${name}.yaml\``);
+        // Save succeeded, load did not — close the modal so the user isn't trapped,
+        // and give the recovery toast enough time to be read and acted on.
+        showToast(
+          'error',
+          `Saved but could not load — restart with \`gridctl apply ~/.gridctl/stacks/${name}.yaml\``,
+          { duration: 10000 },
+        );
+        onDeploy?.();
       }
     } finally {
       setDeploying(false);


### PR DESCRIPTION
## Description

Fixes two visible defects on the stackless onboarding walkthrough path plus one hidden backend panic discovered while verifying the UX fix.

## Type of Change

- [x] Bug fix (non-breaking change)

## Changes Made

### Wizard UX
- `YAMLPreview`: add `whitespace-pre` to the rendered span so leading whitespace survives browser rendering — previously list items and nested keys appeared flush-left even though the underlying YAML string was correct.
- `ReviewStep.handleSaveAndLoad`: call `onDeploy?.()` in the non-`StackAlreadyActiveError` fallback so the wizard modal closes once the stack file has been persisted, and bump the recovery toast to 10s so the `gridctl apply …` hint is actually readable. Previously the wizard stayed open, which looked like "nothing happened".

### Stackless daemon
- `buildAndRunStackless`: detect a real container runtime at startup so `POST /api/stack/initialize` can actually bring up containers once a user saves a stack via the wizard. Falls back to an empty orchestrator if detection fails — daemon still starts; initialize returns a clear error instead of panicking.
- `reload.startMCPServer` / `startResource`: guard against a nil runtime so a future regression in wiring fails cleanly instead of panicking out of `net/http`.
- `reload.Reload`: surface per-item errors in the structured log so silent single-server registration failures are diagnosable from `~/.gridctl/logs/gridctl.log`.

### Regression tests
- `YAMLPreview.test.tsx` — asserts leading whitespace is preserved for 2/4-space indented lines.
- `ReviewStep.test.tsx` — covers all three save-and-load branches (success / 409 / generic error) and verifies `onDeploy` is not called when `saveStack` itself fails.

## Testing

- Vitest: 324/324 passing
- `tsc -b && vite build`: clean
- `go test ./pkg/reload/ ./pkg/controller/`: passing
- Manual: walkthrough stack (`daily`) saves to `~/.gridctl/stacks/daily.yaml`, wizard closes, recovery toast visible. Pre-panic stack trace in daemon logs no longer occurs.

## Known follow-up (out of scope)

After this fix, the panic is gone and the stack persists + appears in the Spec tab, but the canvas does not populate with MCP server nodes after `initialize` in stackless mode (gateway's registered-server count stays at 0 and containers end up in Docker state `Created` rather than running). Will file a separate issue with the new per-item reload error logs to diagnose.

## Checklist

- [x] Code follows project style
- [x] Self-review performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #471