### PR TITLE
fix: register stdio container MCP servers via stackless initialize

### DIFF
--- a/internal/api/stack.go
+++ b/internal/api/stack.go
@@ -152,7 +152,15 @@ func (s *Server) handleStackInitialize(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !result.Success {
-			writeJSONError(w, "Stack initialization failed: "+result.Message, http.StatusBadRequest)
+			// Include per-item errors in the body so the wizard can surface
+			// individual server registration failures instead of a single
+			// opaque message.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error":  "Stack initialization failed: " + result.Message,
+				"errors": result.Errors,
+			})
 			return
 		}
 

--- a/internal/api/stack_test.go
+++ b/internal/api/stack_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +12,9 @@ import (
 	"testing"
 
 	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/reload"
+	"github.com/gridctl/gridctl/pkg/runtime"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
@@ -634,6 +639,61 @@ func TestHandleStackInitialize_SuccessNoReloadHandler(t *testing.T) {
 	// Verify server state was updated
 	assert.Equal(t, stackPath, s.stackFile)
 	assert.Equal(t, stackName, s.stackName)
+}
+
+// TestHandleStackInitialize_SurfacesPerServerErrors verifies that when the
+// reload handler reports per-server registration failures, the HTTP handler
+// returns HTTP 400 with an errors array in the body instead of 200 OK. This
+// guards the stackless Save & Load silent-green failure mode.
+func TestHandleStackInitialize_SurfacesPerServerErrors(t *testing.T) {
+	stacksDir := func() string {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, ".gridctl", "stacks")
+	}()
+
+	if err := os.MkdirAll(stacksDir, 0755); err != nil {
+		t.Skipf("cannot create stacks dir: %v", err)
+	}
+
+	stackName := "gridctl-test-init-partial-failure"
+	stackPath := filepath.Join(stacksDir, stackName+".yaml")
+	content := `name: ` + stackName + `
+network:
+  name: test-net
+mcp-servers:
+  - name: ext
+    url: https://example.com/mcp
+    transport: http
+`
+	if err := os.WriteFile(stackPath, []byte(content), 0644); err != nil {
+		t.Skipf("cannot write test stack: %v", err)
+	}
+	defer os.Remove(stackPath)
+
+	gw := mcp.NewGateway()
+	orch := runtime.NewOrchestrator(nil, nil)
+	rh := reload.NewHandler("", &config.Stack{Name: "gridctl"}, gw, orch, 8180, 9000, nil, nil)
+	rh.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+		return fmt.Errorf("simulated registration failure for %s", server.Name)
+	})
+
+	s := &Server{}
+	s.SetReloadHandler(rh)
+
+	body, _ := json.Marshal(map[string]string{"name": stackName})
+	req := httptest.NewRequest(http.MethodPost, "/api/stack/initialize", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+
+	s.handleStackInitialize(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Stack initialization failed")
+	assert.Contains(t, w.Body.String(), `"errors"`)
+	assert.Contains(t, w.Body.String(), "simulated registration failure for ext")
+
+	// stackFile must NOT have been persisted since the initialization failed
+	assert.Empty(t, s.stackFile, "stackFile should not be set on failure")
+	assert.Empty(t, s.stackName, "stackName should not be set on failure")
 }
 
 func TestHandleStacksList_WithFiles(t *testing.T) {

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -454,8 +454,14 @@ func (b *GatewayBuilder) setupHotReload(ctx context.Context, inst *GatewayInstan
 	reloadHandler := reload.NewHandler(b.stackPath, b.stack, inst.Gateway, b.rt, b.config.Port, b.config.BasePort, vaultLookup, vaultSetLookup)
 	reloadHandler.SetLogger(slog.New(handler))
 	reloadHandler.SetNoExpand(b.config.NoExpand)
-	reloadHandler.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int) error {
-		return registrar.RegisterOne(ctx, server, hostPort, b.stackPath)
+	// stackPath is threaded through the callback by the reload handler rather
+	// than captured from b.stackPath: in stackless mode b.stackPath starts
+	// empty and is only populated once POST /api/stack/initialize runs, which
+	// updates reloadHandler.stackPath. The handler already holds its mutex
+	// when invoking this callback, so reading h.stackPath there is safe and
+	// avoids a reentrant-lock deadlock a getter-based approach would cause.
+	reloadHandler.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+		return registrar.RegisterOne(ctx, server, hostPort, containerID, stackPath)
 	})
 	inst.APIServer.SetReloadHandler(reloadHandler)
 

--- a/pkg/controller/server_registrar.go
+++ b/pkg/controller/server_registrar.go
@@ -57,8 +57,10 @@ func (r *ServerRegistrar) RegisterAll(ctx context.Context, result *runtime.UpRes
 
 // RegisterOne registers a single MCP server with the gateway.
 // Used by the reload handler to register newly added servers.
-func (r *ServerRegistrar) RegisterOne(ctx context.Context, server config.MCPServer, hostPort int, stackPath string) error {
-	cfg := r.buildConfigFromMCPServer(server, hostPort, stackPath)
+// containerID is the runtime container ID for stdio transport; pass "" for
+// non-container servers (External, LocalProcess, SSH, OpenAPI, HTTP/SSE).
+func (r *ServerRegistrar) RegisterOne(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+	cfg := r.buildConfigFromMCPServer(server, hostPort, containerID, stackPath)
 	return r.gateway.RegisterMCPServer(ctx, cfg)
 }
 
@@ -140,7 +142,9 @@ func (r *ServerRegistrar) buildServerConfig(server runtime.MCPServerResult, serv
 
 // buildConfigFromMCPServer constructs an MCPServerConfig from a config.MCPServer.
 // This is the single-server registration path used by the reload handler.
-func (r *ServerRegistrar) buildConfigFromMCPServer(server config.MCPServer, hostPort int, stackPath string) mcp.MCPServerConfig {
+// containerID is consumed only by the stdio container branch; other branches
+// ignore it.
+func (r *ServerRegistrar) buildConfigFromMCPServer(server config.MCPServer, hostPort int, containerID, stackPath string) mcp.MCPServerConfig {
 	transport := resolveTransport(server.Transport)
 
 	if server.IsExternal() {
@@ -190,11 +194,10 @@ func (r *ServerRegistrar) buildConfigFromMCPServer(server config.MCPServer, host
 		return cfg
 	}
 	if transport == mcp.TransportStdio {
-		// Stdio containers need container ID which requires full reload
-		// Return a config that will error on registration with a clear message
 		return mcp.MCPServerConfig{
 			Name:         server.Name,
 			Transport:    transport,
+			ContainerID:  containerID,
 			Tools:        server.Tools,
 			OutputFormat: server.OutputFormat,
 			PinSchemas:   server.PinSchemas,

--- a/pkg/controller/server_registrar_test.go
+++ b/pkg/controller/server_registrar_test.go
@@ -228,7 +228,7 @@ func TestServerRegistrar_BuildConfigFromMCPServer_External(t *testing.T) {
 		Tools:     []string{"search"},
 	}
 
-	cfg := r.buildConfigFromMCPServer(server, 0, "/path/stack.yaml")
+	cfg := r.buildConfigFromMCPServer(server, 0, "", "/path/stack.yaml")
 
 	if !cfg.External {
 		t.Error("expected External to be true")
@@ -250,7 +250,7 @@ func TestServerRegistrar_BuildConfigFromMCPServer_LocalProcess(t *testing.T) {
 		Env:     map[string]string{"MODE": "dev"},
 	}
 
-	cfg := r.buildConfigFromMCPServer(server, 0, "/home/user/stacks/stack.yaml")
+	cfg := r.buildConfigFromMCPServer(server, 0, "", "/home/user/stacks/stack.yaml")
 
 	if !cfg.LocalProcess {
 		t.Error("expected LocalProcess to be true")
@@ -274,7 +274,7 @@ func TestServerRegistrar_BuildConfigFromMCPServer_SSH(t *testing.T) {
 		},
 	}
 
-	cfg := r.buildConfigFromMCPServer(server, 0, "/path/stack.yaml")
+	cfg := r.buildConfigFromMCPServer(server, 0, "", "/path/stack.yaml")
 
 	if !cfg.SSH {
 		t.Error("expected SSH to be true")
@@ -295,7 +295,7 @@ func TestServerRegistrar_BuildConfigFromMCPServer_ContainerHTTP(t *testing.T) {
 		Tools:     []string{"get", "post"},
 	}
 
-	cfg := r.buildConfigFromMCPServer(server, 9005, "/path/stack.yaml")
+	cfg := r.buildConfigFromMCPServer(server, 9005, "", "/path/stack.yaml")
 
 	if cfg.Transport != mcp.TransportHTTP {
 		t.Errorf("expected transport HTTP, got '%s'", cfg.Transport)
@@ -389,12 +389,36 @@ func TestServerRegistrar_BuildConfigFromMCPServer_Stdio(t *testing.T) {
 		Tools:     []string{"exec"},
 	}
 
-	cfg := r.buildConfigFromMCPServer(server, 0, "/path/stack.yaml")
+	cfg := r.buildConfigFromMCPServer(server, 0, "container-abc", "/path/stack.yaml")
 
 	if cfg.Transport != mcp.TransportStdio {
 		t.Errorf("expected transport stdio, got '%s'", cfg.Transport)
 	}
-	// Stdio containers don't get a container ID from this path
+	if cfg.ContainerID != "container-abc" {
+		t.Errorf("expected container ID 'container-abc', got '%s'", cfg.ContainerID)
+	}
+	if len(cfg.Tools) != 1 || cfg.Tools[0] != "exec" {
+		t.Errorf("unexpected tools: %v", cfg.Tools)
+	}
+}
+
+func TestServerRegistrar_BuildConfigFromMCPServer_StdioWithoutContainerID(t *testing.T) {
+	r := NewServerRegistrar(mcp.NewGateway(), false)
+
+	server := config.MCPServer{
+		Name:      "stdio-server",
+		Image:     "my-image:latest",
+		Transport: "stdio",
+	}
+
+	// Passing an empty container ID builds the config but the resulting
+	// registration will fail downstream in gateway.RegisterMCPServer — this is
+	// an intentional fail-fast rather than a silent success.
+	cfg := r.buildConfigFromMCPServer(server, 0, "", "/path/stack.yaml")
+
+	if cfg.Transport != mcp.TransportStdio {
+		t.Errorf("expected transport stdio, got '%s'", cfg.Transport)
+	}
 	if cfg.ContainerID != "" {
 		t.Errorf("expected empty container ID, got '%s'", cfg.ContainerID)
 	}
@@ -412,7 +436,7 @@ func TestServerRegistrar_BuildConfigFromMCPServer_OpenAPI(t *testing.T) {
 		Tools: []string{"getUser"},
 	}
 
-	cfg := r.buildConfigFromMCPServer(server, 0, "/path/stack.yaml")
+	cfg := r.buildConfigFromMCPServer(server, 0, "", "/path/stack.yaml")
 
 	if !cfg.OpenAPI {
 		t.Error("expected OpenAPI to be true")
@@ -515,7 +539,7 @@ func TestServerRegistrar_BuildConfigFromMCPServer_OutputFormat(t *testing.T) {
 		OutputFormat: "csv",
 	}
 
-	cfg := r.buildConfigFromMCPServer(server, 0, "/path/stack.yaml")
+	cfg := r.buildConfigFromMCPServer(server, 0, "", "/path/stack.yaml")
 
 	if cfg.OutputFormat != "csv" {
 		t.Errorf("expected OutputFormat 'csv', got '%s'", cfg.OutputFormat)
@@ -571,7 +595,7 @@ func TestServerRegistrar_BuildConfigFromMCPServer_SSE(t *testing.T) {
 		Transport: "sse",
 	}
 
-	cfg := r.buildConfigFromMCPServer(server, 0, "/path/stack.yaml")
+	cfg := r.buildConfigFromMCPServer(server, 0, "", "/path/stack.yaml")
 
 	if !cfg.External {
 		t.Error("expected External to be true")
@@ -626,7 +650,7 @@ func TestServerRegistrar_RegisterOne_External(t *testing.T) {
 	cancel()
 
 	// Will fail to connect but exercises the code path
-	err := r.RegisterOne(ctx, server, 0, "/path/stack.yaml")
+	err := r.RegisterOne(ctx, server, 0, "", "/path/stack.yaml")
 	if err == nil {
 		t.Error("expected error for unreachable server")
 	}

--- a/pkg/reload/reload.go
+++ b/pkg/reload/reload.go
@@ -36,8 +36,12 @@ type Handler struct {
 	vault       config.VaultLookup
 	vaultSet    config.VaultSetLookup
 
-	// Callback for registering new MCP servers with gateway
-	registerServer func(ctx context.Context, server config.MCPServer, hostPort int) error
+	// Callback for registering new MCP servers with gateway. containerID is the
+	// runtime container ID for stdio transport (empty for non-container servers).
+	// stackPath is the live active stack path; passed through to the registrar
+	// so the gateway_builder closure does not need to re-enter the Handler
+	// mutex to look it up.
+	registerServer func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error
 }
 
 // NewHandler creates a reload handler.
@@ -68,7 +72,7 @@ func (h *Handler) SetNoExpand(noExpand bool) {
 }
 
 // SetRegisterServerFunc sets the callback for registering MCP servers.
-func (h *Handler) SetRegisterServerFunc(fn func(ctx context.Context, server config.MCPServer, hostPort int) error) {
+func (h *Handler) SetRegisterServerFunc(fn func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error) {
 	h.registerServer = fn
 }
 
@@ -142,6 +146,20 @@ func (h *Handler) Reload(ctx context.Context) (*ReloadResult, error) {
 
 	result := &ReloadResult{Success: true}
 
+	// On initial load (stackless serve → /api/stack/initialize), the daemon
+	// started without running orchestrator.Up, so the stack's network(s) have
+	// never been created. Ensure them now before applyMCPServerChanges tries
+	// to start any container — otherwise Docker rejects ContainerCreate with
+	// "network X not found".
+	if isInitial && newCfg.NeedsContainerRuntime() {
+		if err := h.ensureNetworks(ctx, newCfg); err != nil {
+			return &ReloadResult{
+				Success: false,
+				Message: fmt.Sprintf("failed to ensure network: %v", err),
+			}, nil
+		}
+	}
+
 	// Apply MCP server changes
 	if err := h.applyMCPServerChanges(ctx, diff.MCPServers, newCfg, result); err != nil {
 		result.Success = false
@@ -159,7 +177,19 @@ func (h *Handler) Reload(ctx context.Context) (*ReloadResult, error) {
 	// Update current config
 	h.currentCfg = newCfg
 
-	if result.Message == "" {
+	// Per-item failures collected during applyMCPServerChanges /
+	// applyResourceChanges must flip Success so callers (HTTP handler, file
+	// watcher) see the reload as failed instead of a silent green 200.
+	if len(result.Errors) > 0 {
+		result.Success = false
+		if result.Message == "" {
+			if len(result.Errors) == 1 {
+				result.Message = result.Errors[0]
+			} else {
+				result.Message = fmt.Sprintf("%d errors during reload", len(result.Errors))
+			}
+		}
+	} else if result.Message == "" {
 		result.Message = "configuration reloaded successfully"
 	}
 
@@ -291,6 +321,41 @@ func (h *Handler) applyResourceChanges(ctx context.Context, diff ResourceDiff, n
 	return nil
 }
 
+// ensureNetworks creates the stack's network(s) if they do not already exist.
+// Mirrors the network setup in pkg/runtime/orchestrator.go Up, but is only
+// invoked during the stackless initial-load path where Up was never called.
+func (h *Handler) ensureNetworks(ctx context.Context, stack *config.Stack) error {
+	if h.runtime == nil {
+		return fmt.Errorf("container runtime unavailable (Docker/Podman not detected); load the stack via 'gridctl apply' instead")
+	}
+	rt := h.runtime.Runtime()
+	if rt == nil {
+		return fmt.Errorf("container runtime unavailable (Docker/Podman not detected); load the stack via 'gridctl apply' instead")
+	}
+
+	if len(stack.Networks) > 0 {
+		for _, net := range stack.Networks {
+			h.logger.Info("creating network", "name", net.Name)
+			if err := rt.EnsureNetwork(ctx, net.Name, runtime.NetworkOptions{
+				Driver: net.Driver,
+				Stack:  stack.Name,
+			}); err != nil {
+				return fmt.Errorf("ensuring network %s: %w", net.Name, err)
+			}
+		}
+		return nil
+	}
+
+	h.logger.Info("creating network", "name", stack.Network.Name)
+	if err := rt.EnsureNetwork(ctx, stack.Network.Name, runtime.NetworkOptions{
+		Driver: stack.Network.Driver,
+		Stack:  stack.Name,
+	}); err != nil {
+		return fmt.Errorf("ensuring network: %w", err)
+	}
+	return nil
+}
+
 func (h *Handler) stopAndRemoveContainer(ctx context.Context, containerName string) error {
 	rt := h.runtime.Runtime()
 
@@ -314,7 +379,7 @@ func (h *Handler) startMCPServer(ctx context.Context, server config.MCPServer, s
 	if server.IsExternal() || server.IsLocalProcess() || server.IsSSH() || server.IsOpenAPI() {
 		// Just register with gateway
 		if h.registerServer != nil {
-			return h.registerServer(ctx, server, 0)
+			return h.registerServer(ctx, server, 0, "", h.stackPath)
 		}
 		return nil
 	}
@@ -380,7 +445,7 @@ func (h *Handler) startMCPServer(ctx context.Context, server config.MCPServer, s
 
 	// Register with gateway
 	if h.registerServer != nil {
-		return h.registerServer(ctx, server, actualHostPort)
+		return h.registerServer(ctx, server, actualHostPort, string(status.ID), h.stackPath)
 	}
 
 	return nil

--- a/pkg/reload/reload_test.go
+++ b/pkg/reload/reload_test.go
@@ -14,8 +14,10 @@ import (
 
 // mockWorkloadRuntime implements runtime.WorkloadRuntime for testing.
 type mockWorkloadRuntime struct {
-	startFn  func(ctx context.Context, cfg runtime.WorkloadConfig) (*runtime.WorkloadStatus, error)
-	existsFn func(ctx context.Context, name string) (bool, runtime.WorkloadID, error)
+	startFn          func(ctx context.Context, cfg runtime.WorkloadConfig) (*runtime.WorkloadStatus, error)
+	existsFn         func(ctx context.Context, name string) (bool, runtime.WorkloadID, error)
+	ensureNetworkFn  func(ctx context.Context, name string, opts runtime.NetworkOptions) error
+	ensureNetworkLog []string
 }
 
 func newMockWorkloadRuntime() *mockWorkloadRuntime {
@@ -52,6 +54,10 @@ func (m *mockWorkloadRuntime) GetHostPort(ctx context.Context, id runtime.Worklo
 	return 0, nil
 }
 func (m *mockWorkloadRuntime) EnsureNetwork(ctx context.Context, name string, opts runtime.NetworkOptions) error {
+	m.ensureNetworkLog = append(m.ensureNetworkLog, name)
+	if m.ensureNetworkFn != nil {
+		return m.ensureNetworkFn(ctx, name, opts)
+	}
 	return nil
 }
 func (m *mockWorkloadRuntime) ListNetworks(ctx context.Context, stack string) ([]string, error) {
@@ -125,7 +131,7 @@ func TestHandler_SettersAndGetters(t *testing.T) {
 	}
 
 	// SetRegisterServerFunc
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
 		return nil
 	})
 	if h.registerServer == nil {
@@ -246,7 +252,7 @@ mcp-servers:
 	h, _ := setupHandler(t, stackPath, initialCfg)
 
 	registerCalled := false
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
 		registerCalled = true
 		return nil
 	})
@@ -322,7 +328,7 @@ mcp-servers:
 	h, _ := setupHandler(t, stackPath, initialCfg)
 
 	registerCalled := false
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
 		registerCalled = true
 		return nil
 	})
@@ -402,7 +408,7 @@ mcp-servers:
 
 	h, _ := setupHandler(t, stackPath, initialCfg)
 
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
 		return fmt.Errorf("registration failed")
 	})
 
@@ -412,6 +418,141 @@ mcp-servers:
 	}
 	if len(result.Errors) == 0 {
 		t.Error("expected partial failure errors")
+	}
+	if result.Success {
+		t.Error("expected Success=false when per-item errors accumulate")
+	}
+	if result.Message == "" {
+		t.Error("expected non-empty Message summarizing the failure")
+	}
+}
+
+// TestHandler_Initialize_Stdio_PassesContainerID guards the primary stackless
+// Save & Load bug: Initialize must pass the runtime container ID from rt.Start
+// through to the registerServer callback so stdio containers can be attached.
+func TestHandler_Initialize_Stdio_PassesContainerID(t *testing.T) {
+	content := `
+name: daily
+network:
+  name: daily-net
+mcp-servers:
+  - name: github
+    image: ghcr.io/github/github-mcp-server:latest
+    transport: stdio
+`
+	stackPath := writeStackFile(t, content)
+
+	// Stackless bootstrap: initial cfg is a placeholder with a different name,
+	// matching pkg/controller/controller.go buildAndRunStackless.
+	placeholder := &config.Stack{Name: "gridctl"}
+	mockRT := newMockWorkloadRuntime()
+	mockRT.startFn = func(ctx context.Context, cfg runtime.WorkloadConfig) (*runtime.WorkloadStatus, error) {
+		return &runtime.WorkloadStatus{
+			ID:       runtime.WorkloadID("real-container-id-123"),
+			Name:     cfg.Name,
+			State:    runtime.WorkloadStateRunning,
+			HostPort: cfg.HostPort,
+		}, nil
+	}
+	orch := runtime.NewOrchestrator(mockRT, &mockBuilder{})
+	gw := mcp.NewGateway()
+	h := NewHandler("", placeholder, gw, orch, 8180, 9000, nil, nil)
+
+	var capturedContainerID string
+	var capturedServerName string
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+		capturedServerName = server.Name
+		capturedContainerID = containerID
+		return nil
+	})
+
+	result, err := h.Initialize(context.Background(), stackPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("expected success, got: %s (errors=%v)", result.Message, result.Errors)
+	}
+	if capturedServerName != "github" {
+		t.Errorf("expected callback for server 'github', got %q", capturedServerName)
+	}
+	if capturedContainerID != "real-container-id-123" {
+		t.Errorf("expected callback to receive container ID from rt.Start, got %q", capturedContainerID)
+	}
+	if len(mockRT.ensureNetworkLog) != 1 || mockRT.ensureNetworkLog[0] != "daily-net" {
+		t.Errorf("expected EnsureNetwork called once for 'daily-net' before container start, got %v", mockRT.ensureNetworkLog)
+	}
+}
+
+// TestHandler_Initialize_NoNetworkEnsuredForExternalOnlyStack confirms we do
+// not incur a Docker/Podman call when the stack has no container workloads.
+func TestHandler_Initialize_NoNetworkEnsuredForExternalOnlyStack(t *testing.T) {
+	content := `
+name: ext-only
+network:
+  name: never-used-net
+mcp-servers:
+  - name: ext
+    url: https://example.com/mcp
+    transport: http
+`
+	stackPath := writeStackFile(t, content)
+
+	placeholder := &config.Stack{Name: "gridctl"}
+	mockRT := newMockWorkloadRuntime()
+	orch := runtime.NewOrchestrator(mockRT, &mockBuilder{})
+	gw := mcp.NewGateway()
+	h := NewHandler("", placeholder, gw, orch, 8180, 9000, nil, nil)
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+		return nil
+	})
+
+	result, err := h.Initialize(context.Background(), stackPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("expected success, got: %s", result.Message)
+	}
+	if len(mockRT.ensureNetworkLog) != 0 {
+		t.Errorf("expected no EnsureNetwork calls for external-only stack, got %v", mockRT.ensureNetworkLog)
+	}
+}
+
+// TestHandler_Initialize_CallbackReceivesStackPath confirms that the
+// registerServer callback receives the live post-Initialize stackPath rather
+// than the placeholder value the handler was constructed with. This is what
+// lets gateway_builder's setupHotReload closure avoid capturing b.stackPath
+// (which is "" in stackless mode at wire-up time).
+func TestHandler_Initialize_CallbackReceivesStackPath(t *testing.T) {
+	content := `
+name: ext-only
+network:
+  name: net
+mcp-servers:
+  - name: ext
+    url: https://example.com/mcp
+    transport: http
+`
+	stackPath := writeStackFile(t, content)
+
+	h, _ := setupHandler(t, "", &config.Stack{Name: "gridctl"})
+
+	var capturedStackPath string
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+		capturedStackPath = stackPath
+		return nil
+	})
+
+	result, err := h.Initialize(context.Background(), stackPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("expected success, got: %s", result.Message)
+	}
+	if capturedStackPath != stackPath {
+		t.Errorf("expected callback to receive stackPath %q, got %q", stackPath, capturedStackPath)
 	}
 }
 
@@ -476,7 +617,7 @@ mcp-servers:
 	h, _ := setupHandler(t, stackPath, initialCfg)
 
 	registerCalls := 0
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
 		registerCalls++
 		return nil
 	})


### PR DESCRIPTION
## Description

In stackless `gridctl serve`, the wizard's Save & Load (`POST /api/stack/initialize`) silently failed to register container-based MCP servers using `transport: stdio` (e.g. `github` backed by `ghcr.io/github/github-mcp-server:latest`). The HTTP call returned 200 OK while the canvas stayed empty. This PR fixes the underlying registration path so stdio containers register successfully and any failures are surfaced to the client.

Closes #473

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Threaded the runtime `ContainerID` from `rt.Start` through the reload `registerServer` callback into `ServerRegistrar.RegisterOne` so stdio containers receive a non-empty `ContainerID` (`pkg/controller/server_registrar.go`, `pkg/reload/reload.go`, `pkg/controller/gateway_builder.go`)
- Flipped `result.Success = false` in `reload.Handler.Reload` whenever per-item errors accumulate, and surfaced the `errors[]` array in the `handleStackInitialize` HTTP 400 response so the wizard can render the actual cause (`pkg/reload/reload.go`, `internal/api/stack.go`)
- Added a network-ensure step on initial load when the stack needs a container runtime, mirroring `orchestrator.Up`: stackless serve never ran `Up`, so `daily-net` did not exist and the first container start failed with `network ... not found` (`pkg/reload/reload.go`)
- Threaded the live `stackPath` through the registrar callback so the gateway-builder closure no longer captures the empty `b.stackPath` from stackless bootstrap, which also avoided a reentrant-mutex deadlock that an interim getter-based approach introduced (`pkg/controller/gateway_builder.go`, `pkg/reload/reload.go`)

## Testing

- `go test -race ./pkg/reload/... ./pkg/controller/... ./internal/api/...`
- `golangci-lint run ./...`
- Manual: `./gridctl stop && ./gridctl serve`, then run the wizard through `proto/walkthrough.md` Phase 3 with the `github` MCP server and click **Save & Load** — the canvas now populates the `github` node and the gateway card shows `MCP Servers: 1`.
- New regression tests: `TestHandler_Initialize_Stdio_PassesContainerID`, `TestHandler_Initialize_NoNetworkEnsuredForExternalOnlyStack`, `TestHandler_Initialize_CallbackReceivesStackPath`, `TestHandleStackInitialize_SurfacesPerServerErrors`, plus expanded assertions on `TestHandler_Reload_PartialFailure` and `TestServerRegistrar_BuildConfigFromMCPServer_Stdio`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed