### PR TITLE
fix: make MCP HTTP/SSE ready timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to gridctl will be documented in this file.
 ### Bug Fixes
 
 
+- Make MCP HTTP/SSE readiness timeout configurable via `ready_timeout` and remove orphan containers on timeout
 - Register logical container name as DNS alias for inter-container resolution in Podman and Docker stacks
 - Persist tool turns to history and populate FormatSavingsPct
 - Persist tool turns to history and capture streaming usage metrics

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -321,6 +321,7 @@ mcp-servers:
 | `tools` | []string | No | — | Tool whitelist. Empty exposes all tools |
 | `output_format` | string | No | — | Output format override: `"json"`, `"toon"`, `"csv"`, or `"text"`. Overrides `gateway.output_format` for this server |
 | `pin_schemas` | bool | No | — | Override schema pinning for this server. `false` disables pinning regardless of gateway setting. Omit to inherit from `gateway.security.schema_pinning.enabled` |
+| `ready_timeout` | duration | No | `30s` | Readiness wait for container-based HTTP/SSE servers. Accepts any `time.Duration` string (e.g. `"60s"`, `"2m"`). When a container does not become ready within this window, the container is stopped and removed so a retry starts clean. Ignored for stdio, external, local process, SSH, and OpenAPI servers |
 
 **Type determination rules:**
 - Must have exactly one of: `image`, `source`, `url`, `command` (alone), `ssh` + `command`, or `openapi`

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"time"
 )
 
 // Stack represents the complete gridctl configuration.
@@ -142,6 +143,23 @@ type MCPServer struct {
 	Tools        []string          `yaml:"tools,omitempty"`          // Tool whitelist (empty = all tools exposed)
 	OutputFormat string            `yaml:"output_format,omitempty"`  // Output format override: "json", "toon", "csv", "text"
 	PinSchemas   *bool             `yaml:"pin_schemas,omitempty"`    // Override gateway schema pinning for this server (nil = inherit)
+	// ReadyTimeout overrides the HTTP/SSE readiness wait for container-based servers.
+	// Accepts any time.Duration string (e.g. "60s", "2m"). Empty/"0" inherits the gateway default (30s).
+	// Ignored for stdio, local process, SSH, OpenAPI, and external transports.
+	ReadyTimeout string `yaml:"ready_timeout,omitempty"`
+}
+
+// ResolvedReadyTimeout parses ReadyTimeout; returns 0 when unset or invalid
+// so the gateway falls back to its default.
+func (s *MCPServer) ResolvedReadyTimeout() time.Duration {
+	if s.ReadyTimeout == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(s.ReadyTimeout)
+	if err != nil || d < 0 {
+		return 0
+	}
+	return d
 }
 
 // OpenAPIConfig defines an MCP server backed by an OpenAPI specification.

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
 
 // ValidationError represents a configuration validation error.
@@ -342,6 +343,18 @@ func Validate(s *Stack) error {
 		// Per-server output_format validation
 		if server.OutputFormat != "" && !validOutputFormats[server.OutputFormat] {
 			errs = append(errs, ValidationError{prefix + ".output_format", "must be one of: json, toon, csv, text"})
+		}
+
+		// ready_timeout validation: must parse as a duration and be non-negative.
+		// Only meaningful for container-based HTTP/SSE servers; accepted (but unused)
+		// on other types to avoid a cliff when templates share fields.
+		if server.ReadyTimeout != "" {
+			d, err := time.ParseDuration(server.ReadyTimeout)
+			if err != nil {
+				errs = append(errs, ValidationError{prefix + ".ready_timeout", fmt.Sprintf("invalid duration %q (expected e.g. \"60s\" or \"2m\")", server.ReadyTimeout)})
+			} else if d < 0 {
+				errs = append(errs, ValidationError{prefix + ".ready_timeout", "must be non-negative"})
+			}
 		}
 
 		// In simple mode, server.Network is ignored (per design decision)

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidate_StackLevel(t *testing.T) {
@@ -885,6 +886,29 @@ func TestValidate_MCPServer(t *testing.T) {
 			wantErr: true,
 			errMsg:  "not found in networks list",
 		},
+		{
+			name: "ready_timeout: valid duration accepted",
+			stack: base([]MCPServer{
+				{Name: "s1", Image: "alpine", Port: 3000, ReadyTimeout: "90s"},
+			}),
+			wantErr: false,
+		},
+		{
+			name: "ready_timeout: malformed value rejected",
+			stack: base([]MCPServer{
+				{Name: "s1", Image: "alpine", Port: 3000, ReadyTimeout: "90 seconds"},
+			}),
+			wantErr: true,
+			errMsg:  "invalid duration",
+		},
+		{
+			name: "ready_timeout: negative duration rejected",
+			stack: base([]MCPServer{
+				{Name: "s1", Image: "alpine", Port: 3000, ReadyTimeout: "-5s"},
+			}),
+			wantErr: true,
+			errMsg:  "must be non-negative",
+		},
 	}
 
 	for _, tc := range tests {
@@ -899,6 +923,28 @@ func TestValidate_MCPServer(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestMCPServer_ResolvedReadyTimeout(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 0},
+		{"0s", 0},
+		{"30s", 30 * time.Second},
+		{"2m", 2 * time.Minute},
+		{"garbage", 0},   // graceful fallback (pre-validated anyway)
+		{"-5s", 0},       // graceful fallback (pre-validated anyway)
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			s := &MCPServer{ReadyTimeout: tc.in}
+			if got := s.ResolvedReadyTimeout(); got != tc.want {
+				t.Errorf("ResolvedReadyTimeout(%q) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
 	}

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -235,6 +235,9 @@ func (b *GatewayBuilder) Run(ctx context.Context, inst *GatewayInstance, verbose
 	// Register MCP servers (after HTTP server is running for health checks)
 	registrar := NewServerRegistrar(gateway, b.config.NoExpand)
 	registrar.SetLogger(slog.New(bufferHandler))
+	if b.rt != nil {
+		registrar.SetRuntime(b.rt.Runtime())
+	}
 	registrar.RegisterAll(ctx, b.result, b.stack, b.stackPath)
 
 	// Start periodic health monitoring

--- a/pkg/controller/server_registrar.go
+++ b/pkg/controller/server_registrar.go
@@ -21,6 +21,10 @@ type ServerRegistrar struct {
 	gateway  *mcp.Gateway
 	noExpand bool
 	logger   *slog.Logger
+	// runtime is optional. When set, container-based HTTP/SSE registrations
+	// receive a CleanupOnReadyFailure closure that removes the workload if the
+	// gateway's readiness wait times out. nil disables cleanup (e.g. in tests).
+	runtime runtime.WorkloadRuntime
 }
 
 // NewServerRegistrar creates a ServerRegistrar.
@@ -37,6 +41,13 @@ func (r *ServerRegistrar) SetLogger(logger *slog.Logger) {
 	if logger != nil {
 		r.logger = logger
 	}
+}
+
+// SetRuntime wires the workload runtime used to clean up orphan containers
+// when an HTTP/SSE MCP server fails its readiness check. Without a runtime,
+// readiness failures still surface as errors but the container is left running.
+func (r *ServerRegistrar) SetRuntime(rt runtime.WorkloadRuntime) {
+	r.runtime = rt
 }
 
 // RegisterAll registers all MCP servers from the UpResult with the gateway.
@@ -57,8 +68,9 @@ func (r *ServerRegistrar) RegisterAll(ctx context.Context, result *runtime.UpRes
 
 // RegisterOne registers a single MCP server with the gateway.
 // Used by the reload handler to register newly added servers.
-// containerID is the runtime container ID for stdio transport; pass "" for
-// non-container servers (External, LocalProcess, SSH, OpenAPI, HTTP/SSE).
+// containerID is the runtime container ID for any container-backed server
+// (stdio or HTTP/SSE). Pass "" for External, LocalProcess, SSH, and OpenAPI —
+// the container HTTP/SSE branch uses it to wire up the readiness-failure cleanup.
 func (r *ServerRegistrar) RegisterOne(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
 	cfg := r.buildConfigFromMCPServer(server, hostPort, containerID, stackPath)
 	return r.gateway.RegisterMCPServer(ctx, cfg)
@@ -130,14 +142,7 @@ func (r *ServerRegistrar) buildServerConfig(server runtime.MCPServerResult, serv
 		}
 	}
 	// Container HTTP/SSE
-	return mcp.MCPServerConfig{
-		Name:         server.Name,
-		Transport:    transport,
-		Endpoint:     fmt.Sprintf("http://localhost:%d/mcp", server.HostPort),
-		Tools:        serverCfg.Tools,
-		OutputFormat: serverCfg.OutputFormat,
-		PinSchemas:   serverCfg.PinSchemas,
-	}
+	return r.buildContainerHTTPConfig(server.Name, transport, server.HostPort, serverCfg, server.WorkloadID)
 }
 
 // buildConfigFromMCPServer constructs an MCPServerConfig from a config.MCPServer.
@@ -204,13 +209,23 @@ func (r *ServerRegistrar) buildConfigFromMCPServer(server config.MCPServer, host
 		}
 	}
 	// Container HTTP/SSE
+	return r.buildContainerHTTPConfig(server.Name, transport, hostPort, server, runtime.WorkloadID(containerID))
+}
+
+// buildContainerHTTPConfig is the shared factory for container HTTP/SSE servers
+// used by both the bulk-apply path and the single-server reload path. Keeps
+// ReadyTimeout / CleanupOnReadyFailure propagation in one place so future fields
+// only need to be added once.
+func (r *ServerRegistrar) buildContainerHTTPConfig(name string, transport mcp.Transport, hostPort int, serverCfg config.MCPServer, id runtime.WorkloadID) mcp.MCPServerConfig {
 	return mcp.MCPServerConfig{
-		Name:         server.Name,
-		Transport:    transport,
-		Endpoint:     fmt.Sprintf("http://localhost:%d/mcp", hostPort),
-		Tools:        server.Tools,
-		OutputFormat: server.OutputFormat,
-		PinSchemas:   server.PinSchemas,
+		Name:                  name,
+		Transport:             transport,
+		Endpoint:              fmt.Sprintf("http://localhost:%d/mcp", hostPort),
+		Tools:                 serverCfg.Tools,
+		OutputFormat:          serverCfg.OutputFormat,
+		PinSchemas:            serverCfg.PinSchemas,
+		ReadyTimeout:          serverCfg.ResolvedReadyTimeout(),
+		CleanupOnReadyFailure: r.cleanupClosure(name, id),
 	}
 }
 
@@ -287,5 +302,21 @@ func resolveTransport(transport string) mcp.Transport {
 		return mcp.TransportStdio
 	default:
 		return mcp.TransportHTTP
+	}
+}
+
+// cleanupClosure returns a function the gateway can call after a readiness
+// timeout to stop and remove the container backing an HTTP/SSE MCP server.
+// Returns nil when the registrar has no runtime or no workload ID — the
+// gateway treats a nil callback as "leave the workload alone."
+func (r *ServerRegistrar) cleanupClosure(name string, id runtime.WorkloadID) func(context.Context) error {
+	if r.runtime == nil || id == "" {
+		return nil
+	}
+	return func(ctx context.Context) error {
+		if err := r.runtime.Stop(ctx, id); err != nil {
+			r.logger.Warn("stop after ready-timeout failed", "name", name, "id", id, "error", err)
+		}
+		return r.runtime.Remove(ctx, id)
 	}
 }

--- a/pkg/controller/server_registrar_test.go
+++ b/pkg/controller/server_registrar_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/gridctl/gridctl/pkg/config"
 	"github.com/gridctl/gridctl/pkg/mcp"
@@ -653,5 +654,144 @@ func TestServerRegistrar_RegisterOne_External(t *testing.T) {
 	err := r.RegisterOne(ctx, server, 0, "", "/path/stack.yaml")
 	if err == nil {
 		t.Error("expected error for unreachable server")
+	}
+}
+
+// recordingRuntime records Stop/Remove calls so tests can assert cleanup behavior
+// without spinning up a real Docker daemon.
+type recordingRuntime struct {
+	runtime.WorkloadRuntime // embed for unused methods; nil-panic signals unexpected calls
+	stopCalls   []runtime.WorkloadID
+	removeCalls []runtime.WorkloadID
+}
+
+func (r *recordingRuntime) Stop(_ context.Context, id runtime.WorkloadID) error {
+	r.stopCalls = append(r.stopCalls, id)
+	return nil
+}
+
+func (r *recordingRuntime) Remove(_ context.Context, id runtime.WorkloadID) error {
+	r.removeCalls = append(r.removeCalls, id)
+	return nil
+}
+
+func TestServerRegistrar_BuildServerConfig_ContainerHTTP_PopulatesReadyTimeoutAndCleanup(t *testing.T) {
+	rec := &recordingRuntime{}
+	r := NewServerRegistrar(mcp.NewGateway(), false)
+	r.SetRuntime(rec)
+
+	server := runtime.MCPServerResult{
+		Name:       "slow-http",
+		WorkloadID: runtime.WorkloadID("container-slow"),
+		HostPort:   9100,
+	}
+	serverCfg := config.MCPServer{
+		Name:         "slow-http",
+		Transport:    "http",
+		ReadyTimeout: "90s",
+	}
+
+	cfg := r.buildServerConfig(server, serverCfg, "/path/stack.yaml")
+
+	if cfg.ReadyTimeout != 90*time.Second {
+		t.Errorf("expected ReadyTimeout 90s, got %v", cfg.ReadyTimeout)
+	}
+	if cfg.CleanupOnReadyFailure == nil {
+		t.Fatal("expected CleanupOnReadyFailure to be populated for container HTTP")
+	}
+	if err := cfg.CleanupOnReadyFailure(context.Background()); err != nil {
+		t.Fatalf("cleanup closure returned error: %v", err)
+	}
+	if len(rec.stopCalls) != 1 || rec.stopCalls[0] != "container-slow" {
+		t.Errorf("expected one Stop(container-slow), got %v", rec.stopCalls)
+	}
+	if len(rec.removeCalls) != 1 || rec.removeCalls[0] != "container-slow" {
+		t.Errorf("expected one Remove(container-slow), got %v", rec.removeCalls)
+	}
+}
+
+func TestServerRegistrar_BuildServerConfig_ContainerStdio_NoCleanup(t *testing.T) {
+	// Stdio containers attach immediately and never call waitForHTTPServer, so
+	// populating CleanupOnReadyFailure would be dead code — verify we skip it.
+	r := NewServerRegistrar(mcp.NewGateway(), false)
+	r.SetRuntime(&recordingRuntime{})
+
+	server := runtime.MCPServerResult{
+		Name:       "stdio",
+		WorkloadID: runtime.WorkloadID("c"),
+	}
+	serverCfg := config.MCPServer{Name: "stdio", Transport: "stdio"}
+
+	cfg := r.buildServerConfig(server, serverCfg, "/path/stack.yaml")
+	if cfg.CleanupOnReadyFailure != nil {
+		t.Error("stdio transport should not carry a cleanup callback")
+	}
+	if cfg.ReadyTimeout != 0 {
+		t.Errorf("stdio transport should not carry a ready timeout, got %v", cfg.ReadyTimeout)
+	}
+}
+
+func TestServerRegistrar_BuildConfigFromMCPServer_ContainerHTTP_PopulatesCleanup(t *testing.T) {
+	rec := &recordingRuntime{}
+	r := NewServerRegistrar(mcp.NewGateway(), false)
+	r.SetRuntime(rec)
+
+	server := config.MCPServer{
+		Name:         "reload-http",
+		Image:        "example:latest",
+		Port:         3000,
+		Transport:    "http",
+		ReadyTimeout: "2m",
+	}
+
+	cfg := r.buildConfigFromMCPServer(server, 9200, "container-reload", "/path/stack.yaml")
+
+	if cfg.ReadyTimeout != 2*time.Minute {
+		t.Errorf("expected ReadyTimeout 2m, got %v", cfg.ReadyTimeout)
+	}
+	if cfg.CleanupOnReadyFailure == nil {
+		t.Fatal("expected CleanupOnReadyFailure to be populated for reload path")
+	}
+	_ = cfg.CleanupOnReadyFailure(context.Background())
+	if len(rec.removeCalls) != 1 || rec.removeCalls[0] != "container-reload" {
+		t.Errorf("expected Remove(container-reload), got %v", rec.removeCalls)
+	}
+}
+
+func TestServerRegistrar_BuildServerConfig_ContainerHTTP_NoCleanupWithoutRuntime(t *testing.T) {
+	// Tests and CI paths often construct a registrar without a runtime.
+	// The gateway treats a nil callback as "leave the container alone," so
+	// the closure must be nil when no runtime was wired.
+	r := NewServerRegistrar(mcp.NewGateway(), false)
+
+	server := runtime.MCPServerResult{
+		Name:       "http",
+		WorkloadID: runtime.WorkloadID("c1"),
+		HostPort:   9101,
+	}
+	cfg := r.buildServerConfig(server, config.MCPServer{Name: "http"}, "/path/stack.yaml")
+
+	if cfg.CleanupOnReadyFailure != nil {
+		t.Error("cleanup closure must be nil when no runtime is wired")
+	}
+}
+
+func TestServerRegistrar_BuildConfigFromMCPServer_ContainerHTTP_NoCleanupWithoutWorkloadID(t *testing.T) {
+	// The reload path passes an empty containerID for non-container transports.
+	// Ensure we don't construct a closure that would call Stop("") and panic.
+	rec := &recordingRuntime{}
+	r := NewServerRegistrar(mcp.NewGateway(), false)
+	r.SetRuntime(rec)
+
+	server := config.MCPServer{
+		Name:      "no-id",
+		Image:     "example:latest",
+		Port:      3000,
+		Transport: "http",
+	}
+
+	cfg := r.buildConfigFromMCPServer(server, 9201, "", "/path/stack.yaml")
+	if cfg.CleanupOnReadyFailure != nil {
+		t.Error("cleanup closure must be nil without a workload id")
 	}
 }

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -24,6 +25,11 @@ import (
 	"github.com/gridctl/gridctl/pkg/logging"
 	"github.com/gridctl/gridctl/pkg/token"
 )
+
+// ErrReadyTimeout indicates that an HTTP/SSE MCP server did not become reachable
+// within the configured readiness window. Callers can use errors.Is to distinguish
+// this from context cancellation or other registration errors.
+var ErrReadyTimeout = errors.New("ready timeout")
 
 // MCPServerConfig contains configuration for connecting to an MCP server.
 type MCPServerConfig struct {
@@ -48,6 +54,16 @@ type MCPServerConfig struct {
 	Tools           []string          // Tool whitelist (empty = all tools)
 	OutputFormat    string            // Output format: "json", "toon", "csv", "text"
 	PinSchemas      *bool             // Override gateway schema pinning (nil = inherit gateway default)
+
+	// ReadyTimeout overrides the HTTP/SSE readiness wait. Zero uses DefaultReadyTimeout.
+	// Applies only to HTTP and SSE transports; stdio and other paths ignore it.
+	ReadyTimeout time.Duration
+
+	// CleanupOnReadyFailure runs when waitForHTTPServer returns ErrReadyTimeout.
+	// Callers that manage the underlying container populate this with a closure
+	// that stops and removes it, so a retry starts from a clean slate. nil means
+	// "no cleanup" (e.g. external servers, tests).
+	CleanupOnReadyFailure func(ctx context.Context) error
 }
 
 // OpenAPIClientConfig contains configuration for an OpenAPI-backed MCP client.
@@ -546,7 +562,8 @@ func (g *Gateway) RegisterMCPServer(ctx context.Context, cfg MCPServerConfig) er
 				httpClient.SetToolWhitelist(cfg.Tools)
 			}
 			// Wait for MCP server to be ready with retries
-			if err := g.waitForHTTPServer(ctx, httpClient); err != nil {
+			if err := g.waitForHTTPServer(ctx, httpClient, cfg.ReadyTimeout); err != nil {
+				g.handleReadyFailure(ctx, cfg, err)
 				return fmt.Errorf("MCP server %s not ready: %w", cfg.Name, err)
 			}
 			agentClient = httpClient
@@ -557,7 +574,8 @@ func (g *Gateway) RegisterMCPServer(ctx context.Context, cfg MCPServerConfig) er
 				httpClient.SetToolWhitelist(cfg.Tools)
 			}
 			// Wait for MCP server to be ready with retries
-			if err := g.waitForHTTPServer(ctx, httpClient); err != nil {
+			if err := g.waitForHTTPServer(ctx, httpClient, cfg.ReadyTimeout); err != nil {
+				g.handleReadyFailure(ctx, cfg, err)
 				return fmt.Errorf("MCP server %s not ready: %w", cfg.Name, err)
 			}
 			agentClient = httpClient
@@ -681,20 +699,53 @@ func (g *Gateway) logToolCountHint(toolCount int) {
 	)
 }
 
+// handleReadyFailure invokes the configured cleanup callback when the readiness
+// wait failed with ErrReadyTimeout. It intentionally runs only on a true
+// ready-timeout — context cancellation and other error paths leave the workload
+// alone so the caller can decide what to do.
+func (g *Gateway) handleReadyFailure(ctx context.Context, cfg MCPServerConfig, waitErr error) {
+	if !errors.Is(waitErr, ErrReadyTimeout) || cfg.CleanupOnReadyFailure == nil {
+		return
+	}
+	g.logger.Warn("MCP server failed readiness wait; removing container",
+		"name", cfg.Name,
+		"ready_timeout", effectiveReadyTimeout(cfg.ReadyTimeout),
+	)
+	if err := cfg.CleanupOnReadyFailure(ctx); err != nil {
+		g.logger.Warn("cleanup after ready timeout failed; orphan may remain",
+			"name", cfg.Name, "error", err)
+	}
+}
+
+// effectiveReadyTimeout reports the duration waitForHTTPServer will actually use
+// for the given config value. Centralised so logs and errors stay consistent.
+func effectiveReadyTimeout(configured time.Duration) time.Duration {
+	if configured <= 0 {
+		return DefaultReadyTimeout
+	}
+	return configured
+}
+
 // waitForHTTPServer waits for an HTTP MCP server to become available.
-func (g *Gateway) waitForHTTPServer(ctx context.Context, client *Client) error {
+// timeout <= 0 falls back to DefaultReadyTimeout so callers can pass the
+// per-server override straight through without a nil check.
+// Returns an error wrapping ErrReadyTimeout on the ready-poll deadline so
+// callers can distinguish it from context cancellation.
+func (g *Gateway) waitForHTTPServer(ctx context.Context, client *Client, timeout time.Duration) error {
+	timeout = effectiveReadyTimeout(timeout)
 	start := time.Now()
 	ticker := time.NewTicker(DefaultReadyPollInterval)
 	defer ticker.Stop()
 
-	timeout := time.After(DefaultReadyTimeout)
+	timeoutCh := time.After(timeout)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-timeout:
-			return fmt.Errorf("timeout waiting for MCP server")
+		case <-timeoutCh:
+			return fmt.Errorf("%w after %s (ready_timeout=%s); set ready_timeout on the server config to wait longer",
+				ErrReadyTimeout, time.Since(start).Round(time.Millisecond), timeout)
 		case <-ticker.C:
 			if err := client.Ping(ctx); err == nil {
 				g.logger.Debug("MCP server ready", "name", client.Name(), "wait", time.Since(start))

--- a/pkg/mcp/gateway_test.go
+++ b/pkg/mcp/gateway_test.go
@@ -3,8 +3,11 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -2767,6 +2770,202 @@ func TestGateway_HandleInitialize_InstructionsFiltersNonMCP(t *testing.T) {
 	}
 	if strings.Contains(result.Instructions, "a2a-adapter") {
 		t.Errorf("Instructions must not include A2A adapter: %q", result.Instructions)
+	}
+}
+
+// slowMCPServer returns an httptest.Server whose GET handler sleeps `delay`
+// before responding 200. It deliberately ignores the request body so it works
+// for both the client's Ping (HEAD-like GET) and a full MCP initialize probe.
+func slowMCPServer(t *testing.T, delay time.Duration) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(delay):
+			w.WriteHeader(http.StatusOK)
+		case <-r.Context().Done():
+			return
+		}
+	}))
+}
+
+func TestWaitForHTTPServer_RespectsCustomTimeout(t *testing.T) {
+	// Server would respond eventually, but the per-call timeout is much shorter.
+	srv := slowMCPServer(t, 5*time.Second)
+	defer srv.Close()
+
+	g := NewGateway()
+	client := NewClient("slow", srv.URL)
+
+	start := time.Now()
+	err := g.waitForHTTPServer(context.Background(), client, 100*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, ErrReadyTimeout) {
+		t.Fatalf("expected ErrReadyTimeout, got %v", err)
+	}
+	// The poll interval is 500ms, so the timeoutCh (100ms) wins before the first poll.
+	// Allow generous slack for CI jitter.
+	if elapsed > 2*time.Second {
+		t.Fatalf("timeout fired too late: %v", elapsed)
+	}
+	if !strings.Contains(err.Error(), "ready_timeout=") {
+		t.Errorf("error text should mention ready_timeout hint, got: %v", err)
+	}
+}
+
+func TestWaitForHTTPServer_FallsBackToDefaultWhenZero(t *testing.T) {
+	// Fast server: a zero timeout should still succeed via DefaultReadyTimeout.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	g := NewGateway()
+	client := NewClient("fast", srv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := g.waitForHTTPServer(ctx, client, 0); err != nil {
+		t.Fatalf("expected success with zero timeout (falls back to default), got %v", err)
+	}
+}
+
+func TestWaitForHTTPServer_CancelNotReadyTimeout(t *testing.T) {
+	// Canceling the caller ctx must not be reported as a ready-timeout,
+	// because the gateway skips cleanup on cancel but runs it on timeout.
+	srv := slowMCPServer(t, 5*time.Second)
+	defer srv.Close()
+
+	g := NewGateway()
+	client := NewClient("cancelled", srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	err := g.waitForHTTPServer(ctx, client, time.Hour)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if errors.Is(err, ErrReadyTimeout) {
+		t.Fatalf("cancellation must not surface as ErrReadyTimeout, got %v", err)
+	}
+}
+
+func TestHandleReadyFailure_InvokesCleanupOnTimeout(t *testing.T) {
+	var called int32
+	cfg := MCPServerConfig{
+		Name:         "slow-http",
+		Transport:    TransportHTTP,
+		ReadyTimeout: 10 * time.Millisecond,
+		CleanupOnReadyFailure: func(ctx context.Context) error {
+			atomic.AddInt32(&called, 1)
+			return nil
+		},
+	}
+
+	timeoutErr := fmt.Errorf("wrapped: %w", ErrReadyTimeout)
+
+	g := NewGateway()
+	g.handleReadyFailure(context.Background(), cfg, timeoutErr)
+
+	if got := atomic.LoadInt32(&called); got != 1 {
+		t.Fatalf("expected cleanup to be invoked exactly once on ready-timeout, got %d", got)
+	}
+}
+
+func TestHandleReadyFailure_SkipsCleanupOnNonTimeout(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"context cancelled", context.Canceled},
+		{"generic error", errors.New("boom")},
+		{"nil cleanup on timeout", nil}, // ensures we do not panic on nil cleanup
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var called int32
+			cleanup := func(ctx context.Context) error {
+				atomic.AddInt32(&called, 1)
+				return nil
+			}
+			cfg := MCPServerConfig{
+				Name:                  "srv",
+				CleanupOnReadyFailure: cleanup,
+			}
+			inputErr := tc.err
+			if tc.name == "nil cleanup on timeout" {
+				cfg.CleanupOnReadyFailure = nil
+				inputErr = ErrReadyTimeout
+			}
+
+			g := NewGateway()
+			g.handleReadyFailure(context.Background(), cfg, inputErr)
+
+			if got := atomic.LoadInt32(&called); got != 0 {
+				t.Fatalf("cleanup must not fire for %s, got call count %d", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestHandleReadyFailure_SwallowsCleanupError(t *testing.T) {
+	// A cleanup error must not panic or re-bubble — the original timeout
+	// error is what the caller will report.
+	cfg := MCPServerConfig{
+		Name:         "srv",
+		ReadyTimeout: 10 * time.Millisecond,
+		CleanupOnReadyFailure: func(ctx context.Context) error {
+			return errors.New("runtime unavailable")
+		},
+	}
+	g := NewGateway()
+	g.handleReadyFailure(context.Background(), cfg, fmt.Errorf("%w: waited 10ms", ErrReadyTimeout))
+	// No assertions: if this returns cleanly, the test passes.
+}
+
+func TestRegisterMCPServer_DoesNotCleanupOnInitializeError(t *testing.T) {
+	// Stand up a fast HTTP server so waitForHTTPServer succeeds. The client
+	// will then fail Initialize (the endpoint returns 200 to Ping but does not
+	// speak MCP). That error path must NOT invoke the cleanup callback — only
+	// ready-timeouts should trigger cleanup.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var cleanupCalled int32
+	cfg := MCPServerConfig{
+		Name:         "init-fails",
+		Transport:    TransportHTTP,
+		Endpoint:     srv.URL,
+		ReadyTimeout: time.Second,
+		CleanupOnReadyFailure: func(ctx context.Context) error {
+			atomic.AddInt32(&cleanupCalled, 1)
+			return nil
+		},
+	}
+
+	g := NewGateway()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := g.RegisterMCPServer(ctx, cfg)
+	if err == nil {
+		t.Fatal("expected Initialize/RefreshTools to fail against the fake HTTP server")
+	}
+	if errors.Is(err, ErrReadyTimeout) {
+		t.Fatalf("registration error should not carry ErrReadyTimeout: %v", err)
+	}
+	if got := atomic.LoadInt32(&cleanupCalled); got != 0 {
+		t.Errorf("cleanup must NOT fire when waitForHTTPServer succeeded and a later step failed, got %d calls", got)
 	}
 }
 


### PR DESCRIPTION
## Description

HTTP/SSE container-based MCP servers currently fail registration when cold-start takes longer than a hard-coded 30 seconds, and the failing container is left running as an orphan. This PR adds a configurable `ready_timeout` per server and cleans up the container when the readiness wait fails, so slow-warming images (model downloads, DB migrations, heavy init) can register cleanly.

## Type of Change

- [x] Bug fix

## Changes Made

- Add `ready_timeout` to `mcp-servers[]` (YAML duration string; empty inherits the 30s default) with validation.
- Thread the per-server timeout through `mcp.MCPServerConfig` and `Gateway.waitForHTTPServer` so HTTP and SSE registrations honor the override.
- Introduce `ErrReadyTimeout` so callers can distinguish the ready-poll deadline from context cancellation.
- On ready-timeout, the gateway invokes a `CleanupOnReadyFailure` closure (populated by the registrar) that stops and removes the container, logging loudly first and swallowing cleanup errors so the original timeout still propagates.
- Closure is populated only for container-based HTTP/SSE; stdio, external, local-process, SSH, and OpenAPI paths are untouched.
- Improved error text includes the observed duration and a `ready_timeout=` hint.

## Testing

- `go test -race ./pkg/mcp/ ./pkg/config/ ./pkg/controller/` — all green.
- `go test -race ./...` — all previously-passing tests pass (a pre-existing `internal/api` failure on `main` is unrelated).
- `golangci-lint run ./...` — 0 issues.
- New regression coverage: custom timeout respected, zero falls back to default, cancellation is not surfaced as `ErrReadyTimeout`, cleanup invoked exactly once on timeout, cleanup skipped on non-timeout errors (including downstream Initialize/RefreshTools failures), and cleanup closure absent when no runtime or workload ID is wired.

Manual verification with a custom slow-start image is recommended before release:

1. Build an image whose entrypoint sleeps >30s before binding its MCP port.
2. Add it to a stack as `transport: http` without `ready_timeout` — expect the registration to fail with a cleanup log line and no orphan in `docker ps`.
3. Re-add with `ready_timeout: 90s` — expect success and a healthy container.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #475