### PR TITLE
feat: add MCP replicas schema and router (phase 1 of #470)

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -147,6 +147,15 @@ type MCPServer struct {
 	// Accepts any time.Duration string (e.g. "60s", "2m"). Empty/"0" inherits the gateway default (30s).
 	// Ignored for stdio, local process, SSH, OpenAPI, and external transports.
 	ReadyTimeout string `yaml:"ready_timeout,omitempty"`
+
+	// Replicas is the number of independent processes to spawn for this server.
+	// Defaults to 1. Values >1 load-balance JSON-RPC tool calls across replicas
+	// using ReplicaPolicy. Not supported for external URL or OpenAPI transports.
+	Replicas int `yaml:"replicas,omitempty" json:"replicas,omitempty"`
+
+	// ReplicaPolicy selects the dispatch policy when Replicas > 1.
+	// Valid values: "round-robin" (default), "least-connections".
+	ReplicaPolicy string `yaml:"replica_policy,omitempty" json:"replica_policy,omitempty"`
 }
 
 // ResolvedReadyTimeout parses ReadyTimeout; returns 0 when unset or invalid
@@ -356,6 +365,12 @@ func (s *Stack) SetDefaults() {
 			if s.MCPServers[i].Source.Type == "git" && s.MCPServers[i].Source.Ref == "" {
 				s.MCPServers[i].Source.Ref = "main"
 			}
+		}
+		if s.MCPServers[i].Replicas <= 0 {
+			s.MCPServers[i].Replicas = 1
+		}
+		if s.MCPServers[i].ReplicaPolicy == "" {
+			s.MCPServers[i].ReplicaPolicy = "round-robin"
 		}
 	}
 

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
 
 func TestStack_NeedsContainerRuntime(t *testing.T) {
 	tests := []struct {
@@ -132,6 +136,63 @@ func TestStack_ContainerWorkloads(t *testing.T) {
 	workloads := stack.ContainerWorkloads()
 	if len(workloads) != 2 {
 		t.Fatalf("expected 2 container workloads, got %d", len(workloads))
+	}
+}
+
+func TestMCPServer_ReplicasYAMLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name         string
+		yamlIn       string
+		wantReplicas int
+		wantPolicy   string
+	}{
+		{
+			name: "no replica fields",
+			yamlIn: `name: s
+image: alpine
+port: 3000
+`,
+			wantReplicas: 0,
+			wantPolicy:   "",
+		},
+		{
+			name: "explicit replicas and policy",
+			yamlIn: `name: s
+image: alpine
+port: 3000
+replicas: 3
+replica_policy: least-connections
+`,
+			wantReplicas: 3,
+			wantPolicy:   "least-connections",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var s MCPServer
+			if err := yaml.Unmarshal([]byte(tc.yamlIn), &s); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if s.Replicas != tc.wantReplicas {
+				t.Errorf("Replicas = %d, want %d", s.Replicas, tc.wantReplicas)
+			}
+			if s.ReplicaPolicy != tc.wantPolicy {
+				t.Errorf("ReplicaPolicy = %q, want %q", s.ReplicaPolicy, tc.wantPolicy)
+			}
+
+			out, err := yaml.Marshal(&s)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var got MCPServer
+			if err := yaml.Unmarshal(out, &got); err != nil {
+				t.Fatalf("re-unmarshal: %v", err)
+			}
+			if got.Replicas != s.Replicas || got.ReplicaPolicy != s.ReplicaPolicy {
+				t.Errorf("round-trip mismatch: got %+v, want %+v", got, s)
+			}
+		})
 	}
 }
 

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+// maxReplicas is the sanity cap on MCPServer.Replicas. Values above this
+// are almost certainly a config error; the cap also bounds per-server
+// fan-out costs for things like health checking and least-connections scans.
+const maxReplicas = 32
+
 // ValidationError represents a configuration validation error.
 type ValidationError struct {
 	Field   string
@@ -355,6 +360,23 @@ func Validate(s *Stack) error {
 			} else if d < 0 {
 				errs = append(errs, ValidationError{prefix + ".ready_timeout", "must be non-negative"})
 			}
+		}
+
+		// Replica validation.
+		// Zero is accepted as "unspecified" and defaulted to 1 by Stack.SetDefaults;
+		// only reject truly invalid values here.
+		if server.Replicas < 0 {
+			errs = append(errs, ValidationError{prefix + ".replicas", "must be >= 0"})
+		} else if server.Replicas > maxReplicas {
+			errs = append(errs, ValidationError{prefix + ".replicas", fmt.Sprintf("must be <= %d", maxReplicas)})
+		}
+		if server.ReplicaPolicy != "" &&
+			server.ReplicaPolicy != "round-robin" &&
+			server.ReplicaPolicy != "least-connections" {
+			errs = append(errs, ValidationError{prefix + ".replica_policy", "must be 'round-robin' or 'least-connections'"})
+		}
+		if server.Replicas > 1 && (server.IsExternal() || server.IsOpenAPI()) {
+			errs = append(errs, ValidationError{prefix + ".replicas", "not supported for external URL or OpenAPI servers (already external/stateless — scale them at the HTTP tier)"})
 		}
 
 		// In simple mode, server.Network is ignored (per design decision)

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -1219,3 +1219,128 @@ func TestValidate_SSH_NewFields(t *testing.T) {
 		})
 	}
 }
+
+func TestValidate_Replicas(t *testing.T) {
+	baseContainer := func(replicas int, policy string) *Stack {
+		return &Stack{
+			Name:    "test",
+			Network: Network{Name: "test-net"},
+			MCPServers: []MCPServer{{
+				Name:          "c",
+				Image:         "alpine",
+				Port:          3000,
+				Replicas:      replicas,
+				ReplicaPolicy: policy,
+			}},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		stack   *Stack
+		wantErr bool
+		errMsg  string
+	}{
+		{name: "replicas unspecified valid", stack: baseContainer(0, "round-robin")}, // zero = unspecified, SetDefaults handles it
+		{name: "replicas 1 valid", stack: baseContainer(1, "round-robin")},
+		{name: "replicas 3 valid", stack: baseContainer(3, "round-robin")},
+		{name: "replicas 32 valid", stack: baseContainer(32, "least-connections")},
+		{name: "replicas negative rejected", stack: baseContainer(-1, "round-robin"), wantErr: true, errMsg: "replicas"},
+		{name: "replicas 33 rejected", stack: baseContainer(33, "round-robin"), wantErr: true, errMsg: "<= 32"},
+		{name: "policy empty valid", stack: baseContainer(1, "")},
+		{name: "policy unknown rejected", stack: baseContainer(2, "random"), wantErr: true, errMsg: "replica_policy"},
+		{
+			name: "replicas > 1 on external URL rejected",
+			stack: &Stack{
+				Name:    "test",
+				Network: Network{Name: "n"},
+				MCPServers: []MCPServer{{
+					Name:     "ext",
+					URL:      "http://localhost:8080",
+					Replicas: 3,
+				}},
+			},
+			wantErr: true,
+			errMsg:  "not supported for external",
+		},
+		{
+			name: "replicas 1 on external URL valid",
+			stack: &Stack{
+				Name:    "test",
+				Network: Network{Name: "n"},
+				MCPServers: []MCPServer{{
+					Name:     "ext",
+					URL:      "http://localhost:8080",
+					Replicas: 1,
+				}},
+			},
+		},
+		{
+			name: "replicas > 1 on openapi rejected",
+			stack: &Stack{
+				Name:    "test",
+				Network: Network{Name: "n"},
+				MCPServers: []MCPServer{{
+					Name:     "api",
+					OpenAPI:  &OpenAPIConfig{Spec: "spec.yaml"},
+					Replicas: 2,
+				}},
+			},
+			wantErr: true,
+			errMsg:  "OpenAPI",
+		},
+		{
+			name: "replicas > 1 on local process valid",
+			stack: &Stack{
+				Name:    "test",
+				Network: Network{Name: "n"},
+				MCPServers: []MCPServer{{
+					Name:     "local",
+					Command:  []string{"npx", "server"},
+					Replicas: 4,
+				}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.stack)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errMsg != "" && !strings.Contains(err.Error(), tc.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tc.errMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestStack_SetDefaults_Replicas(t *testing.T) {
+	s := &Stack{
+		Name:    "test",
+		Network: Network{Name: "n"},
+		MCPServers: []MCPServer{
+			{Name: "a", Image: "alpine", Port: 3000},                               // unspecified
+			{Name: "b", Image: "alpine", Port: 3000, Replicas: 0},                  // explicit zero
+			{Name: "c", Image: "alpine", Port: 3000, Replicas: 3},                  // explicit
+			{Name: "d", Image: "alpine", Port: 3000, ReplicaPolicy: "round-robin"}, // policy only
+		},
+	}
+	s.SetDefaults()
+
+	for i, want := range []int{1, 1, 3, 1} {
+		if got := s.MCPServers[i].Replicas; got != want {
+			t.Errorf("server %s: Replicas = %d, want %d", s.MCPServers[i].Name, got, want)
+		}
+	}
+	for i, want := range []string{"round-robin", "round-robin", "round-robin", "round-robin"} {
+		if got := s.MCPServers[i].ReplicaPolicy; got != want {
+			t.Errorf("server %s: ReplicaPolicy = %q, want %q", s.MCPServers[i].Name, got, want)
+		}
+	}
+}

--- a/pkg/mcp/replica_set.go
+++ b/pkg/mcp/replica_set.go
@@ -1,0 +1,179 @@
+package mcp
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+// Dispatch policies for a ReplicaSet.
+const (
+	ReplicaPolicyRoundRobin       = "round-robin"
+	ReplicaPolicyLeastConnections = "least-connections"
+)
+
+// ErrNoHealthyReplicas is returned by ReplicaSet.Pick when every replica in
+// the set is marked unhealthy.
+var ErrNoHealthyReplicas = errors.New("no healthy replicas")
+
+// backoffState carries exponential-backoff bookkeeping for per-replica
+// restart scheduling. Fields and methods are introduced alongside the
+// restart loop in a later phase; the type is declared here so the Replica
+// layout is stable.
+type backoffState struct{}
+
+// Replica is a single member of a ReplicaSet. It wraps one AgentClient (the
+// concrete transport — ProcessClient, StdioClient, Client, etc.) and tracks
+// liveness and in-flight request count for dispatch decisions.
+type Replica struct {
+	id       int
+	client   AgentClient
+	healthy  atomic.Bool
+	inFlight atomic.Int64
+	restart  *backoffState
+}
+
+// ID returns the zero-indexed replica id within its ReplicaSet.
+func (r *Replica) ID() int { return r.id }
+
+// Client returns the underlying AgentClient.
+func (r *Replica) Client() AgentClient { return r.client }
+
+// Healthy reports whether this replica is eligible for dispatch.
+func (r *Replica) Healthy() bool { return r.healthy.Load() }
+
+// SetHealthy marks this replica healthy or unhealthy.
+func (r *Replica) SetHealthy(h bool) { r.healthy.Store(h) }
+
+// IncInFlight increments the in-flight request count.
+func (r *Replica) IncInFlight() { r.inFlight.Add(1) }
+
+// DecInFlight decrements the in-flight request count.
+func (r *Replica) DecInFlight() { r.inFlight.Add(-1) }
+
+// InFlight returns the current in-flight request count.
+func (r *Replica) InFlight() int64 { return r.inFlight.Load() }
+
+// ReplicaSet is a pool of AgentClient replicas for a single logical MCP server.
+// Dispatch is determined by the set's policy. A single-replica set behaves
+// identically to a direct AgentClient (its Pick always returns that one
+// replica when healthy).
+type ReplicaSet struct {
+	name     string
+	policy   string
+	mu       sync.RWMutex
+	replicas []*Replica
+	rrCursor atomic.Int64
+}
+
+// NewReplicaSet builds a ReplicaSet from an ordered slice of AgentClients. The
+// first client becomes replica-0, and so on. All replicas start healthy. An
+// unknown policy falls back to round-robin.
+func NewReplicaSet(name, policy string, clients []AgentClient) *ReplicaSet {
+	if policy != ReplicaPolicyRoundRobin && policy != ReplicaPolicyLeastConnections {
+		policy = ReplicaPolicyRoundRobin
+	}
+	set := &ReplicaSet{
+		name:     name,
+		policy:   policy,
+		replicas: make([]*Replica, 0, len(clients)),
+	}
+	for i, c := range clients {
+		r := &Replica{
+			id:      i,
+			client:  c,
+			restart: &backoffState{},
+		}
+		r.healthy.Store(true)
+		set.replicas = append(set.replicas, r)
+	}
+	return set
+}
+
+// Name returns the logical server name.
+func (s *ReplicaSet) Name() string { return s.name }
+
+// Policy returns the dispatch policy in effect.
+func (s *ReplicaSet) Policy() string { return s.policy }
+
+// Size returns the number of replicas in the set.
+func (s *ReplicaSet) Size() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.replicas)
+}
+
+// Replicas returns a snapshot slice of the replicas. Callers may iterate the
+// snapshot safely; the underlying *Replica values are shared.
+func (s *ReplicaSet) Replicas() []*Replica {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*Replica, len(s.replicas))
+	copy(out, s.replicas)
+	return out
+}
+
+// Pick chooses a healthy replica according to the set's policy. Returns
+// ErrNoHealthyReplicas if every replica is currently marked unhealthy.
+func (s *ReplicaSet) Pick() (*Replica, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	n := len(s.replicas)
+	if n == 0 {
+		return nil, ErrNoHealthyReplicas
+	}
+
+	switch s.policy {
+	case ReplicaPolicyLeastConnections:
+		return s.pickLeastConnectionsLocked()
+	default:
+		return s.pickRoundRobinLocked()
+	}
+}
+
+// Client is a convenience that calls Pick and returns the chosen replica's
+// AgentClient. Returns nil if no replica is pickable.
+func (s *ReplicaSet) Client() AgentClient {
+	r, err := s.Pick()
+	if err != nil || r == nil {
+		return nil
+	}
+	return r.client
+}
+
+// pickRoundRobinLocked assumes s.mu is held. It advances the cursor and scans
+// forward at most N positions to find a healthy replica.
+func (s *ReplicaSet) pickRoundRobinLocked() (*Replica, error) {
+	n := len(s.replicas)
+	// Advance once per Pick so fresh callers see a new slot.
+	start := int(s.rrCursor.Add(1) - 1)
+	for i := 0; i < n; i++ {
+		r := s.replicas[((start+i)%n+n)%n]
+		if r.Healthy() {
+			return r, nil
+		}
+	}
+	return nil, ErrNoHealthyReplicas
+}
+
+// pickLeastConnectionsLocked assumes s.mu is held. It returns the healthy
+// replica with the lowest in-flight count, breaking ties by lowest id.
+func (s *ReplicaSet) pickLeastConnectionsLocked() (*Replica, error) {
+	var chosen *Replica
+	var chosenInFlight int64
+	for _, r := range s.replicas {
+		if !r.Healthy() {
+			continue
+		}
+		inFlight := r.InFlight()
+		if chosen == nil || inFlight < chosenInFlight {
+			chosen = r
+			chosenInFlight = inFlight
+		}
+	}
+	if chosen == nil {
+		return nil, ErrNoHealthyReplicas
+	}
+	return chosen, nil
+}

--- a/pkg/mcp/replica_set_test.go
+++ b/pkg/mcp/replica_set_test.go
@@ -1,0 +1,203 @@
+package mcp
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+)
+
+func newTestReplicaSet(t *testing.T, policy string, names ...string) *ReplicaSet {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	clients := make([]AgentClient, 0, len(names))
+	for _, n := range names {
+		clients = append(clients, setupMockAgentClient(ctrl, n, nil))
+	}
+	return NewReplicaSet("svc", policy, clients)
+}
+
+func TestReplicaSet_RoundRobin_AllHealthy(t *testing.T) {
+	set := newTestReplicaSet(t, ReplicaPolicyRoundRobin, "r0", "r1", "r2")
+
+	var picks []int
+	for i := 0; i < 6; i++ {
+		r, err := set.Pick()
+		if err != nil {
+			t.Fatalf("Pick %d: %v", i, err)
+		}
+		picks = append(picks, r.ID())
+	}
+	// Cursor advances once per Pick, so across 6 picks every replica
+	// appears exactly twice (distribution is uniform, order is fixed).
+	counts := [3]int{}
+	for _, id := range picks {
+		counts[id]++
+	}
+	if counts != [3]int{2, 2, 2} {
+		t.Errorf("round-robin distribution = %v, want [2 2 2] (picks: %v)", counts, picks)
+	}
+}
+
+func TestReplicaSet_RoundRobin_SkipsUnhealthy(t *testing.T) {
+	set := newTestReplicaSet(t, ReplicaPolicyRoundRobin, "r0", "r1", "r2")
+	set.Replicas()[1].SetHealthy(false)
+
+	for i := 0; i < 10; i++ {
+		r, err := set.Pick()
+		if err != nil {
+			t.Fatalf("Pick %d: %v", i, err)
+		}
+		if r.ID() == 1 {
+			t.Fatalf("Pick %d returned unhealthy replica 1", i)
+		}
+	}
+}
+
+func TestReplicaSet_LeastConnections(t *testing.T) {
+	set := newTestReplicaSet(t, ReplicaPolicyLeastConnections, "r0", "r1", "r2")
+	reps := set.Replicas()
+	reps[0].inFlight.Store(2)
+	reps[1].inFlight.Store(1)
+	reps[2].inFlight.Store(0)
+
+	r, err := set.Pick()
+	if err != nil {
+		t.Fatalf("Pick: %v", err)
+	}
+	if r.ID() != 2 {
+		t.Errorf("least-connections picked replica %d, want 2", r.ID())
+	}
+}
+
+func TestReplicaSet_LeastConnections_TieBreakLowestID(t *testing.T) {
+	set := newTestReplicaSet(t, ReplicaPolicyLeastConnections, "r0", "r1", "r2")
+	// All replicas idle.
+	r, err := set.Pick()
+	if err != nil {
+		t.Fatalf("Pick: %v", err)
+	}
+	if r.ID() != 0 {
+		t.Errorf("tie-break picked replica %d, want 0", r.ID())
+	}
+}
+
+func TestReplicaSet_LeastConnections_SkipsUnhealthy(t *testing.T) {
+	set := newTestReplicaSet(t, ReplicaPolicyLeastConnections, "r0", "r1", "r2")
+	reps := set.Replicas()
+	reps[0].SetHealthy(false) // would be the natural tie-break winner
+	reps[1].inFlight.Store(3)
+	reps[2].inFlight.Store(1)
+
+	r, err := set.Pick()
+	if err != nil {
+		t.Fatalf("Pick: %v", err)
+	}
+	if r.ID() != 2 {
+		t.Errorf("picked replica %d, want 2 (skipping unhealthy 0, preferring lower inflight over 1)", r.ID())
+	}
+}
+
+func TestReplicaSet_NoHealthy(t *testing.T) {
+	set := newTestReplicaSet(t, ReplicaPolicyRoundRobin, "r0", "r1")
+	for _, r := range set.Replicas() {
+		r.SetHealthy(false)
+	}
+
+	if _, err := set.Pick(); !errors.Is(err, ErrNoHealthyReplicas) {
+		t.Errorf("Pick returned %v, want ErrNoHealthyReplicas", err)
+	}
+	if got := set.Client(); got != nil {
+		t.Errorf("Client returned %v, want nil", got)
+	}
+}
+
+func TestReplicaSet_Empty(t *testing.T) {
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin, nil)
+	if _, err := set.Pick(); !errors.Is(err, ErrNoHealthyReplicas) {
+		t.Errorf("Pick on empty set returned %v, want ErrNoHealthyReplicas", err)
+	}
+}
+
+func TestReplicaSet_UnknownPolicyFallsBackToRoundRobin(t *testing.T) {
+	set := newTestReplicaSet(t, "does-not-exist", "r0", "r1")
+	if set.Policy() != ReplicaPolicyRoundRobin {
+		t.Errorf("unknown policy = %q, want fallback %q", set.Policy(), ReplicaPolicyRoundRobin)
+	}
+}
+
+func TestReplicaSet_ConcurrentPick(t *testing.T) {
+	set := newTestReplicaSet(t, ReplicaPolicyRoundRobin, "r0", "r1", "r2", "r3")
+
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		counts [4]int
+	)
+	const workers = 16
+	const picksPerWorker = 250
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < picksPerWorker; i++ {
+				r, err := set.Pick()
+				if err != nil {
+					t.Errorf("concurrent Pick: %v", err)
+					return
+				}
+				mu.Lock()
+				counts[r.ID()]++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Every replica must have been chosen at least once (roughly balanced,
+	// but we don't assert exact counts under concurrency).
+	for id, c := range counts {
+		if c == 0 {
+			t.Errorf("replica %d was never picked (counts=%v)", id, counts)
+		}
+	}
+}
+
+func TestReplicaSet_ClientIdentity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	c0 := setupMockAgentClient(ctrl, "r0", nil)
+	c1 := setupMockAgentClient(ctrl, "r1", nil)
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin, []AgentClient{c0, c1})
+
+	// First Pick advances the cursor to 1, so it returns replica-0 (index
+	// (1-1)%2 = 0). This test asserts that the AgentClient pointer the
+	// caller gets back is the one we registered, not a wrapper or a copy.
+	r, err := set.Pick()
+	if err != nil {
+		t.Fatalf("Pick: %v", err)
+	}
+	if r.Client() != c0 {
+		t.Errorf("Pick returned client %p, want c0 %p", r.Client(), c0)
+	}
+}
+
+func TestReplica_InFlightCounters(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	set := NewReplicaSet("svc", ReplicaPolicyLeastConnections,
+		[]AgentClient{setupMockAgentClient(ctrl, "r0", nil)})
+	r := set.Replicas()[0]
+
+	if got := r.InFlight(); got != 0 {
+		t.Errorf("initial InFlight = %d, want 0", got)
+	}
+	r.IncInFlight()
+	r.IncInFlight()
+	if got := r.InFlight(); got != 2 {
+		t.Errorf("after 2 Inc: InFlight = %d, want 2", got)
+	}
+	r.DecInFlight()
+	if got := r.InFlight(); got != 1 {
+		t.Errorf("after Dec: InFlight = %d, want 1", got)
+	}
+}

--- a/pkg/mcp/router.go
+++ b/pkg/mcp/router.go
@@ -8,32 +8,45 @@ import (
 )
 
 // Router routes tool calls to the appropriate agent.
+//
+// Internally the Router keys on server name and stores a *ReplicaSet per name.
+// A single-client registration (via AddClient) is wrapped in a
+// single-replica round-robin set so callers outside this package observe the
+// same behavior as before replicas existed.
 type Router struct {
-	mu      sync.RWMutex
-	clients map[string]AgentClient // agentName -> client
-	tools   map[string]string      // prefixedToolName -> agentName
+	mu    sync.RWMutex
+	sets  map[string]*ReplicaSet // agentName -> replica set
+	tools map[string]string      // prefixedToolName -> agentName
 }
 
 // NewRouter creates a new tool router.
 func NewRouter() *Router {
 	return &Router{
-		clients: make(map[string]AgentClient),
-		tools:   make(map[string]string),
+		sets:  make(map[string]*ReplicaSet),
+		tools: make(map[string]string),
 	}
 }
 
-// AddClient adds an agent client to the router.
+// AddClient adds an agent client to the router as a single-replica set.
+// Preserves the pre-replicas API so existing callers keep working unchanged.
 func (r *Router) AddClient(client AgentClient) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.clients[client.Name()] = client
+	set := NewReplicaSet(client.Name(), ReplicaPolicyRoundRobin, []AgentClient{client})
+	r.AddReplicaSet(set)
 }
 
-// RemoveClient removes an agent client from the router.
+// AddReplicaSet registers a replica set under its logical server name.
+// Replaces any existing set with the same name.
+func (r *Router) AddReplicaSet(set *ReplicaSet) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sets[set.Name()] = set
+}
+
+// RemoveClient removes an agent (replica set) and its tools from the router.
 func (r *Router) RemoveClient(name string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	delete(r.clients, name)
+	delete(r.sets, name)
 
 	// Remove tools for this agent
 	for tool, agent := range r.tools {
@@ -43,23 +56,73 @@ func (r *Router) RemoveClient(name string) {
 	}
 }
 
-// GetClient returns a client by agent name.
+// GetClient returns one client for the named agent, chosen by the set's
+// dispatch policy. Returns nil if the agent is not registered or no replica
+// is currently healthy.
 func (r *Router) GetClient(name string) AgentClient {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.clients[name]
+	set, ok := r.sets[name]
+	r.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	return set.Client()
 }
 
-// Clients returns all registered clients.
+// GetReplicaSet returns the replica set for the named agent, or nil if the
+// agent is not registered. Useful for callers that need per-replica access
+// (health monitor, status reporting).
+func (r *Router) GetReplicaSet(name string) *ReplicaSet {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.sets[name]
+}
+
+// Clients returns one representative AgentClient per registered agent,
+// sorted by agent name. Each representative is chosen via the set's policy,
+// so a single-replica set returns its only client. Skips sets with no
+// currently-healthy replica.
 func (r *Router) Clients() []AgentClient {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	clients := make([]AgentClient, 0, len(r.clients))
-	for _, c := range r.clients {
-		clients = append(clients, c)
+	names := make([]string, 0, len(r.sets))
+	for n := range r.sets {
+		names = append(names, n)
 	}
-	sort.Slice(clients, func(i, j int) bool { return clients[i].Name() < clients[j].Name() })
+	sort.Strings(names)
+	clients := make([]AgentClient, 0, len(names))
+	for _, n := range names {
+		if c := r.sets[n].Client(); c != nil {
+			clients = append(clients, c)
+		}
+	}
 	return clients
+}
+
+// ReplicaSets returns all registered replica sets, sorted by agent name.
+func (r *Router) ReplicaSets() []*ReplicaSet {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.sets))
+	for n := range r.sets {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]*ReplicaSet, 0, len(names))
+	for _, n := range names {
+		out = append(out, r.sets[n])
+	}
+	return out
+}
+
+// toolsOf returns the Tools list to advertise for a set. All replicas share
+// the same tool surface, so reading from replica-0 is sufficient.
+func toolsOf(set *ReplicaSet) []Tool {
+	reps := set.Replicas()
+	if len(reps) == 0 {
+		return nil
+	}
+	return reps[0].Client().Tools()
 }
 
 // RefreshTools updates the tool registry from all agents.
@@ -70,9 +133,8 @@ func (r *Router) RefreshTools() {
 	// Clear existing tool mappings
 	r.tools = make(map[string]string)
 
-	// Register tools from each agent with prefixes
-	for name, client := range r.clients {
-		for _, tool := range client.Tools() {
+	for name, set := range r.sets {
+		for _, tool := range toolsOf(set) {
 			prefixedName := PrefixTool(name, tool.Name)
 			r.tools[prefixedName] = name
 		}
@@ -84,17 +146,15 @@ func (r *Router) AggregatedTools() []Tool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	// Collect client names and sort for deterministic output
-	names := make([]string, 0, len(r.clients))
-	for name := range r.clients {
+	names := make([]string, 0, len(r.sets))
+	for name := range r.sets {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	var tools []Tool
 	for _, name := range names {
-		client := r.clients[name]
-		for _, tool := range client.Tools() {
+		for _, tool := range toolsOf(r.sets[name]) {
 			prefixedName := PrefixTool(name, tool.Name)
 			prefixedTool := Tool{
 				Name:        prefixedName,
@@ -108,22 +168,26 @@ func (r *Router) AggregatedTools() []Tool {
 	return tools
 }
 
-// RouteToolCall routes a tool call to the appropriate agent.
+// RouteToolCall routes a tool call to the appropriate agent. The concrete
+// replica is chosen by the set's dispatch policy.
 func (r *Router) RouteToolCall(prefixedName string) (AgentClient, string, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
 	agentName, toolName, err := ParsePrefixedTool(prefixedName)
 	if err != nil {
 		return nil, "", err
 	}
 
-	client, ok := r.clients[agentName]
+	r.mu.RLock()
+	set, ok := r.sets[agentName]
+	r.mu.RUnlock()
 	if !ok {
 		return nil, "", fmt.Errorf("unknown agent: %s", agentName)
 	}
 
-	return client, toolName, nil
+	replica, err := set.Pick()
+	if err != nil {
+		return nil, "", fmt.Errorf("agent %s: %w", agentName, err)
+	}
+	return replica.Client(), toolName, nil
 }
 
 // ToolNameDelimiter is the separator between agent name and tool name in prefixed tool names.

--- a/pkg/mcp/router_test.go
+++ b/pkg/mcp/router_test.go
@@ -344,6 +344,98 @@ func TestRouter_AggregatedTools_TitleNeverLeaks(t *testing.T) {
 	}
 }
 
+func TestRouter_AddReplicaSet_RoutesAcrossReplicas(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	c0 := setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}})
+	c1 := setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}})
+	c2 := setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}})
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin, []AgentClient{c0, c1, c2})
+
+	r := NewRouter()
+	r.AddReplicaSet(set)
+	r.RefreshTools()
+
+	// Route the same prefixed tool name repeatedly; every replica should
+	// eventually return as the chosen client.
+	seen := map[AgentClient]bool{}
+	for i := 0; i < 10; i++ {
+		client, tool, err := r.RouteToolCall("svc__t")
+		if err != nil {
+			t.Fatalf("RouteToolCall: %v", err)
+		}
+		if tool != "t" {
+			t.Errorf("tool = %q, want %q", tool, "t")
+		}
+		seen[client] = true
+	}
+	if len(seen) != 3 {
+		t.Errorf("expected all 3 replicas to be routed to, got %d distinct clients", len(seen))
+	}
+}
+
+func TestRouter_ReplicaSet_TopologyHidden(t *testing.T) {
+	// Tool namespace must not leak replica ids.
+	ctrl := gomock.NewController(t)
+	c0 := setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}})
+	c1 := setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}})
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin, []AgentClient{c0, c1})
+
+	r := NewRouter()
+	r.AddReplicaSet(set)
+	r.RefreshTools()
+
+	tools := r.AggregatedTools()
+	if len(tools) != 1 {
+		t.Fatalf("replicas must not multiply advertised tools: got %d, want 1", len(tools))
+	}
+	if tools[0].Name != "svc__t" {
+		t.Errorf("leaked replica id in tool name: %q", tools[0].Name)
+	}
+}
+
+func TestRouter_RemoveClient_RemovesSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin, []AgentClient{
+		setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}}),
+		setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}}),
+	})
+
+	r := NewRouter()
+	r.AddReplicaSet(set)
+	r.RefreshTools()
+
+	if r.GetReplicaSet("svc") == nil {
+		t.Fatal("set should exist before removal")
+	}
+	r.RemoveClient("svc")
+	if r.GetReplicaSet("svc") != nil {
+		t.Error("set should be removed")
+	}
+	if len(r.AggregatedTools()) != 0 {
+		t.Error("tools should be cleared after removal")
+	}
+}
+
+func TestRouter_RouteToolCall_AllReplicasUnhealthy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin, []AgentClient{
+		setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}}),
+		setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}}),
+	})
+	for _, rep := range set.Replicas() {
+		rep.SetHealthy(false)
+	}
+
+	r := NewRouter()
+	r.AddReplicaSet(set)
+	r.RefreshTools()
+
+	_, _, err := r.RouteToolCall("svc__t")
+	if err == nil {
+		t.Fatal("expected error when all replicas unhealthy")
+	}
+}
+
 func TestRouter_AggregatedTools_DescriptionComplete(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	r := NewRouter()


### PR DESCRIPTION
## Description

Phase 1 of per-server MCP replica support (#470). Lays the foundation: config schema, validation, and a `ReplicaSet` abstraction the `Router` now keys on. No runtime registration, lifecycle, or health-monitor changes yet — those ship in phase 2.

A single-replica `ReplicaSet` is behaviorally identical to a bare `AgentClient`, so existing stacks are byte-identical.

## Type of Change

- [x] New feature (non-breaking foundation)
- [x] Refactor (internal `Router` storage)

## Changes Made

**Config schema (`pkg/config/types.go`, `pkg/config/validate.go`)**

- Add `Replicas int` and `ReplicaPolicy string` to `MCPServer`.
- `SetDefaults`: unspecified/zero `Replicas` → 1; empty `ReplicaPolicy` → `"round-robin"`.
- Validation: reject negative `Replicas`, reject `Replicas > 32` (sanity cap), reject unknown policy strings, reject `Replicas > 1` on external-URL and OpenAPI transports (those are already external / stateless — scale at the HTTP tier).

**`ReplicaSet` abstraction (new `pkg/mcp/replica_set.go`)**

- Pool of `AgentClient` replicas for a single logical server, with dispatch policies:
  - `round-robin` (default): atomic cursor, skips unhealthy.
  - `least-connections`: O(N) scan, tie-break on lowest id, skips unhealthy.
- Per-replica liveness (`atomic.Bool`) and in-flight counter (`atomic.Int64`) — no locks on hot path.
- `backoffState` placeholder declared here so the `Replica` layout is stable; fields + restart loop arrive in phase 2.
- `ErrNoHealthyReplicas` returned when every replica is unhealthy.

**`Router` refactor (`pkg/mcp/router.go`)**

- Internal storage: `name → *ReplicaSet` instead of `name → AgentClient`. Tool map (`prefixedToolName → agentName`) is unchanged — tool namespace stays `<serverName>__<toolName>` and replica ids never leak.
- Existing API (`AddClient`, `GetClient`, `RemoveClient`, `Clients`, `RouteToolCall`, `RefreshTools`, `AggregatedTools`) is preserved. `AddClient` wraps a single client in a one-replica set.
- New helpers for later phases: `AddReplicaSet`, `GetReplicaSet`, `ReplicaSets`.

**Tests**

- `pkg/config/validate_test.go`: boundary cases (0/1/32/33/-1), transport gating, policy enum, `SetDefaults` behavior.
- `pkg/config/types_test.go`: YAML round-trip with and without replica fields.
- `pkg/mcp/replica_set_test.go`: round-robin + unhealthy skip, least-connections + tie-break + unhealthy skip, no-healthy error, empty set, unknown-policy fallback, concurrent `Pick` from many goroutines, client identity, in-flight counters.
- `pkg/mcp/router_test.go`: multi-replica routing (all replicas eventually chosen), tool namespace stays single (no replica id leakage), `RemoveClient` removes the whole set, error when all replicas unhealthy.

## Testing

- `go test ./... -race` passes locally, except a pre-existing `TestHandleSkills_SourcesList_Empty` failure in `internal/api` that reproduces on `main` too and is unrelated to this change.
- `golangci-lint run` → 0 issues.
- `make build` passes.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #470