### PR TITLE
feat: wire MCP replicas runtime and health (phase 2 of #470)

### DIFF
--- a/internal/api/stack_test.go
+++ b/internal/api/stack_test.go
@@ -673,7 +673,7 @@ mcp-servers:
 	gw := mcp.NewGateway()
 	orch := runtime.NewOrchestrator(nil, nil)
 	rh := reload.NewHandler("", &config.Stack{Name: "gridctl"}, gw, orch, 8180, 9000, nil, nil)
-	rh.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+	rh.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []reload.ReplicaRuntime, stackPath string) error {
 		return fmt.Errorf("simulated registration failure for %s", server.Name)
 	})
 

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -463,8 +463,12 @@ func (b *GatewayBuilder) setupHotReload(ctx context.Context, inst *GatewayInstan
 	// updates reloadHandler.stackPath. The handler already holds its mutex
 	// when invoking this callback, so reading h.stackPath there is safe and
 	// avoids a reentrant-lock deadlock a getter-based approach would cause.
-	reloadHandler.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
-		return registrar.RegisterOne(ctx, server, hostPort, containerID, stackPath)
+	reloadHandler.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []reload.ReplicaRuntime, stackPath string) error {
+		runtimes := make([]ReplicaRuntime, 0, len(replicas))
+		for _, rep := range replicas {
+			runtimes = append(runtimes, ReplicaRuntime{HostPort: rep.HostPort, ContainerID: rep.ContainerID})
+		}
+		return registrar.RegisterOne(ctx, server, runtimes, stackPath)
 	})
 	inst.APIServer.SetReloadHandler(reloadHandler)
 

--- a/pkg/controller/server_registrar.go
+++ b/pkg/controller/server_registrar.go
@@ -51,6 +51,8 @@ func (r *ServerRegistrar) SetRuntime(rt runtime.WorkloadRuntime) {
 }
 
 // RegisterAll registers all MCP servers from the UpResult with the gateway.
+// For each server it builds one MCPServerConfig per replica and registers
+// them as a single ReplicaSet under the server's logical name.
 func (r *ServerRegistrar) RegisterAll(ctx context.Context, result *runtime.UpResult, stack *config.Stack, stackPath string) {
 	serverConfigs := make(map[string]config.MCPServer)
 	for _, s := range stack.MCPServers {
@@ -59,21 +61,82 @@ func (r *ServerRegistrar) RegisterAll(ctx context.Context, result *runtime.UpRes
 
 	for _, server := range result.MCPServers {
 		serverCfg := serverConfigs[server.Name]
-		cfg := r.buildServerConfig(server, serverCfg, stackPath)
-		if err := r.gateway.RegisterMCPServer(ctx, cfg); err != nil {
+		cfgs := r.buildReplicaConfigs(server, serverCfg, stackPath)
+		if len(cfgs) == 0 {
+			r.logger.Warn("no replica configs built", "name", server.Name)
+			continue
+		}
+		policy := serverCfg.ReplicaPolicy
+		if policy == "" {
+			policy = mcp.ReplicaPolicyRoundRobin
+		}
+		if err := r.gateway.RegisterMCPReplicaSet(ctx, server.Name, policy, cfgs); err != nil {
 			r.logger.Warn("failed to register MCP server", "name", server.Name, "error", err)
 		}
 	}
 }
 
-// RegisterOne registers a single MCP server with the gateway.
-// Used by the reload handler to register newly added servers.
-// containerID is the runtime container ID for any container-backed server
-// (stdio or HTTP/SSE). Pass "" for External, LocalProcess, SSH, and OpenAPI —
-// the container HTTP/SSE branch uses it to wire up the readiness-failure cleanup.
-func (r *ServerRegistrar) RegisterOne(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
-	cfg := r.buildConfigFromMCPServer(server, hostPort, containerID, stackPath)
-	return r.gateway.RegisterMCPServer(ctx, cfg)
+// ReplicaRuntime carries the runtime handles for one replica that the reload
+// handler has already provisioned. For non-container replicas, ContainerID is
+// "" and HostPort may be 0.
+type ReplicaRuntime struct {
+	HostPort    int
+	ContainerID string
+}
+
+// RegisterOne registers a single MCP server (with one or more replicas) with
+// the gateway. Used by the reload handler to register newly added servers.
+// replicas carries the runtime handles the caller has already provisioned —
+// one entry per replica, in replica-id order. For External / LocalProcess /
+// SSH / OpenAPI servers that were not container-provisioned, pass a slice of
+// zero-valued ReplicaRuntime entries of the desired length (or a single-entry
+// slice for the single-replica case).
+func (r *ServerRegistrar) RegisterOne(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error {
+	if len(replicas) == 0 {
+		replicas = []ReplicaRuntime{{}}
+	}
+	cfgs := make([]mcp.MCPServerConfig, 0, len(replicas))
+	for _, rep := range replicas {
+		cfgs = append(cfgs, r.buildConfigFromMCPServer(server, rep.HostPort, rep.ContainerID, stackPath))
+	}
+	policy := server.ReplicaPolicy
+	if policy == "" {
+		policy = mcp.ReplicaPolicyRoundRobin
+	}
+	return r.gateway.RegisterMCPReplicaSet(ctx, server.Name, policy, cfgs)
+}
+
+// buildReplicaConfigs fans out an UpResult's per-replica handles into one
+// MCPServerConfig per replica, reusing the existing single-server config
+// builder for each.
+func (r *ServerRegistrar) buildReplicaConfigs(server runtime.MCPServerResult, serverCfg config.MCPServer, stackPath string) []mcp.MCPServerConfig {
+	replicas := server.Replicas
+	if len(replicas) == 0 {
+		// Defensive: treat as single-replica if the orchestrator didn't set it.
+		replicas = []runtime.MCPServerReplica{{ReplicaID: 0, WorkloadID: server.WorkloadID, Endpoint: server.Endpoint, HostPort: server.HostPort}}
+	}
+	cfgs := make([]mcp.MCPServerConfig, 0, len(replicas))
+	for _, rep := range replicas {
+		perReplica := runtime.MCPServerResult{
+			Name:            server.Name,
+			WorkloadID:      rep.WorkloadID,
+			Endpoint:        rep.Endpoint,
+			HostPort:        rep.HostPort,
+			External:        server.External,
+			LocalProcess:    server.LocalProcess,
+			SSH:             server.SSH,
+			OpenAPI:         server.OpenAPI,
+			URL:             server.URL,
+			Command:         server.Command,
+			SSHHost:         server.SSHHost,
+			SSHUser:         server.SSHUser,
+			SSHPort:         server.SSHPort,
+			SSHIdentityFile: server.SSHIdentityFile,
+			OpenAPIConfig:   server.OpenAPIConfig,
+		}
+		cfgs = append(cfgs, r.buildServerConfig(perReplica, serverCfg, stackPath))
+	}
+	return cfgs
 }
 
 // buildServerConfig constructs an MCPServerConfig from an UpResult server entry

--- a/pkg/controller/server_registrar_test.go
+++ b/pkg/controller/server_registrar_test.go
@@ -651,7 +651,7 @@ func TestServerRegistrar_RegisterOne_External(t *testing.T) {
 	cancel()
 
 	// Will fail to connect but exercises the code path
-	err := r.RegisterOne(ctx, server, 0, "", "/path/stack.yaml")
+	err := r.RegisterOne(ctx, server, []ReplicaRuntime{{}}, "/path/stack.yaml")
 	if err == nil {
 		t.Error("expected error for unreachable server")
 	}

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -124,8 +124,9 @@ type Gateway struct {
 	codeMode    *CodeMode                  // nil when code mode is off
 	codeModeStr string                           // "off", "on" — for status reporting
 
-	healthMu sync.RWMutex
-	health   map[string]*HealthStatus // name -> health status
+	healthMu      sync.RWMutex
+	health        map[string]*HealthStatus         // name -> rollup health (public API)
+	replicaHealth map[string]map[int]*HealthStatus // name -> replica_id -> health
 
 	toolCallObserver ToolCallObserver // optional observer for tool call metrics
 
@@ -155,6 +156,7 @@ func NewGateway() *Gateway {
 		},
 		serverMeta:     make(map[string]MCPServerConfig),
 		health:         make(map[string]*HealthStatus),
+		replicaHealth:  make(map[string]map[int]*HealthStatus),
 		blockedServers: make(map[string]bool),
 	}
 }
@@ -385,85 +387,188 @@ func (g *Gateway) StartHealthMonitor(ctx context.Context, interval time.Duration
 	}()
 }
 
-// checkHealth pings all registered MCP servers and updates their health status.
-// If a server is unhealthy and implements Reconnectable, it attempts reconnection.
+// checkHealth pings every replica of every registered MCP server and updates
+// per-replica health state plus a per-server rollup. Replicas that implement
+// Reconnectable are restarted on failure, gated by an exponential backoff so
+// a crashing replica does not spin.
 func (g *Gateway) checkHealth(ctx context.Context) {
-	clients := g.router.Clients()
+	for _, set := range g.router.ReplicaSets() {
+		name := set.Name()
 
-	for _, client := range clients {
-		// Only check clients that have server metadata (actual MCP servers)
+		// Only check sets that have server metadata (actual MCP servers,
+		// not the registry or other non-MCP routed clients).
 		g.mu.RLock()
-		_, isMCPServer := g.serverMeta[client.Name()]
+		_, isMCPServer := g.serverMeta[name]
 		g.mu.RUnlock()
 		if !isMCPServer {
 			continue
 		}
 
-		pingable, ok := client.(Pingable)
-		if !ok {
-			continue
+		for _, replica := range set.Replicas() {
+			g.checkReplicaHealth(ctx, name, replica)
 		}
+		g.recomputeRollup(name, set)
+	}
+}
 
-		now := time.Now()
-		err := pingable.Ping(ctx)
+// checkReplicaHealth runs one health cycle for a single replica: ping, update
+// per-replica status, and optionally trigger a backoff-gated Reconnect.
+func (g *Gateway) checkReplicaHealth(ctx context.Context, serverName string, replica *Replica) {
+	client := replica.Client()
+	pingable, ok := client.(Pingable)
+	if !ok {
+		// Not pingable (e.g. pure HTTP without ping) — treat as healthy and
+		// let tool calls surface real failures. Keep the replica in rotation.
+		return
+	}
 
-		g.healthMu.Lock()
-		prev := g.health[client.Name()]
+	now := time.Now()
+	err := pingable.Ping(ctx)
 
-		status := &HealthStatus{
-			Healthy:   err == nil,
-			LastCheck: now,
+	g.healthMu.Lock()
+	prev := g.replicaStatusLocked(serverName, replica.ID())
+	status := &HealthStatus{
+		Healthy:   err == nil,
+		LastCheck: now,
+	}
+	if err == nil {
+		status.LastHealthy = now
+		if prev != nil && !prev.Healthy {
+			g.logger.Info("MCP server recovered", "name", serverName)
 		}
-
-		if err == nil {
-			status.LastHealthy = now
-			if prev != nil && !prev.Healthy {
-				g.logger.Info("MCP server recovered", "name", client.Name())
-			}
-		} else {
-			status.Error = err.Error()
-			if prev != nil {
-				status.LastHealthy = prev.LastHealthy
-			}
-			if prev == nil || prev.Healthy {
-				g.logger.Warn("MCP server unhealthy", "name", client.Name(), "error", err)
-			}
+	} else {
+		status.Error = err.Error()
+		if prev != nil {
+			status.LastHealthy = prev.LastHealthy
 		}
-
-		g.health[client.Name()] = status
-		g.healthMu.Unlock()
-
-		// Attempt reconnection for unhealthy clients that support it
-		if err != nil {
-			if rc, ok := client.(Reconnectable); ok {
-				g.logger.Info("attempting reconnection", "name", client.Name())
-				if reconnErr := rc.Reconnect(ctx); reconnErr != nil {
-					g.logger.Warn("reconnection failed", "name", client.Name(), "error", reconnErr)
-				} else {
-					// Reconnection succeeded — update health status and refresh router
-					g.healthMu.Lock()
-					g.health[client.Name()] = &HealthStatus{
-						Healthy:     true,
-						LastCheck:   time.Now(),
-						LastHealthy: time.Now(),
-					}
-					g.healthMu.Unlock()
-					g.router.RefreshTools()
-					g.logger.Info("MCP server reconnected", "name", client.Name())
-
-					// Verify pins after reconnection; drift on reconnect is suspicious.
-					if g.pinningEnabledForServer(client.Name()) {
-						drifts, pinErr := g.schemaVerifier.VerifyOrPin(client.Name(), client.Tools())
-						if pinErr != nil {
-							g.logger.Warn("pins: verification failed after reconnect", "name", client.Name(), "error", pinErr)
-						} else {
-							g.handlePinDrift(client.Name(), drifts)
-						}
-					}
-				}
-			}
+		if prev == nil || prev.Healthy {
+			g.logger.Warn("MCP server unhealthy", "name", serverName, "error", err)
 		}
 	}
+	g.setReplicaStatusLocked(serverName, replica.ID(), status)
+	g.healthMu.Unlock()
+
+	if err == nil {
+		replica.SetHealthy(true)
+		replica.Restart().Reset()
+		return
+	}
+
+	// Unhealthy: exclude from dispatch and try to restart if eligible.
+	replica.SetHealthy(false)
+
+	rc, reconnectable := client.(Reconnectable)
+	if !reconnectable {
+		return
+	}
+	if !replica.Restart().ShouldTry(now) {
+		// Still in backoff window; wait for next check.
+		return
+	}
+
+	g.logger.Info("attempting reconnection", "name", serverName)
+	if reconnErr := rc.Reconnect(ctx); reconnErr != nil {
+		delay := replica.Restart().Advance(now)
+		g.logger.Warn("reconnection failed", "name", serverName, "error", reconnErr, "next_retry_in", delay)
+		return
+	}
+
+	// Reconnect succeeded — back in rotation.
+	replica.Restart().Reset()
+	replica.SetHealthy(true)
+
+	g.healthMu.Lock()
+	g.setReplicaStatusLocked(serverName, replica.ID(), &HealthStatus{
+		Healthy:     true,
+		LastCheck:   time.Now(),
+		LastHealthy: time.Now(),
+	})
+	g.healthMu.Unlock()
+
+	g.router.RefreshTools()
+	g.logger.Info("MCP server reconnected", "name", serverName)
+
+	// Verify pins after reconnection using replica-0's tool surface if we
+	// can get it; otherwise use this replica's tools. Drift on reconnect is
+	// suspicious but pinning stays per-server, not per-replica.
+	if g.pinningEnabledForServer(serverName) {
+		drifts, pinErr := g.schemaVerifier.VerifyOrPin(serverName, client.Tools())
+		if pinErr != nil {
+			g.logger.Warn("pins: verification failed after reconnect", "name", serverName, "error", pinErr)
+		} else {
+			g.handlePinDrift(serverName, drifts)
+		}
+	}
+}
+
+// replicaStatusLocked returns the stored replica health. Callers must hold
+// g.healthMu (read or write).
+func (g *Gateway) replicaStatusLocked(serverName string, replicaID int) *HealthStatus {
+	if g.replicaHealth == nil {
+		return nil
+	}
+	m := g.replicaHealth[serverName]
+	if m == nil {
+		return nil
+	}
+	return m[replicaID]
+}
+
+// setReplicaStatusLocked stores replica health. Callers must hold g.healthMu
+// (write).
+func (g *Gateway) setReplicaStatusLocked(serverName string, replicaID int, status *HealthStatus) {
+	m := g.replicaHealth[serverName]
+	if m == nil {
+		m = make(map[int]*HealthStatus)
+		g.replicaHealth[serverName] = m
+	}
+	m[replicaID] = status
+}
+
+// recomputeRollup updates the per-server rollup HealthStatus from the latest
+// per-replica statuses. The rollup is healthy when at least one replica is
+// healthy; error is the most recent replica error otherwise.
+func (g *Gateway) recomputeRollup(serverName string, set *ReplicaSet) {
+	g.healthMu.Lock()
+	defer g.healthMu.Unlock()
+
+	anyHealthy := false
+	sawAny := false
+	var lastCheck, lastHealthy time.Time
+	var lastErr string
+	for _, r := range set.Replicas() {
+		s := g.replicaStatusLocked(serverName, r.ID())
+		if s == nil {
+			continue
+		}
+		sawAny = true
+		if s.LastCheck.After(lastCheck) {
+			lastCheck = s.LastCheck
+		}
+		if s.LastHealthy.After(lastHealthy) {
+			lastHealthy = s.LastHealthy
+		}
+		if s.Healthy {
+			anyHealthy = true
+		} else if s.Error != "" {
+			lastErr = s.Error
+		}
+	}
+
+	// Non-pingable replicas produce no status; don't fabricate a rollup for them.
+	if !sawAny {
+		return
+	}
+
+	rollup := &HealthStatus{
+		Healthy:     anyHealthy,
+		LastCheck:   lastCheck,
+		LastHealthy: lastHealthy,
+	}
+	if !anyHealthy {
+		rollup.Error = lastErr
+	}
+	g.health[serverName] = rollup
 }
 
 // GetHealthStatus returns the health status for a named MCP server.
@@ -494,10 +599,81 @@ func (g *Gateway) ServerInfo() ServerInfo {
 	return g.serverInfo
 }
 
-// RegisterMCPServer registers and initializes an MCP server.
+// RegisterMCPServer registers and initializes a single-replica MCP server.
+// Equivalent to RegisterMCPReplicaSet with one config and round-robin policy.
 func (g *Gateway) RegisterMCPServer(ctx context.Context, cfg MCPServerConfig) error {
-	g.logger.Info("connecting to MCP server", "name", cfg.Name, "transport", cfg.Transport)
+	return g.RegisterMCPReplicaSet(ctx, cfg.Name, ReplicaPolicyRoundRobin, []MCPServerConfig{cfg})
+}
+
+// RegisterMCPReplicaSet initializes one AgentClient per config and registers
+// them as a single replica set under the given server name. All configs must
+// be for the same logical server (same Name, same transport, same tool list);
+// only the per-replica runtime handles (ContainerID / Endpoint) should differ.
+// For len(cfgs) == 1 this is byte-identical to the old single-client path.
+//
+// Partial-startup tolerance: if some replicas fail to initialize, the server
+// is still registered with the successful ones. The call only returns an
+// error when every replica failed, or when the single-replica case fails
+// (in which case the caller sees the same error shape as before).
+func (g *Gateway) RegisterMCPReplicaSet(ctx context.Context, name, policy string, cfgs []MCPServerConfig) error {
+	if len(cfgs) == 0 {
+		return fmt.Errorf("register %s: no replica configs", name)
+	}
 	start := time.Now()
+	clients := make([]AgentClient, 0, len(cfgs))
+	var firstErr error
+	for i := range cfgs {
+		client, err := g.buildAgentClient(ctx, cfgs[i])
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if len(cfgs) > 1 {
+				g.logger.Warn("replica registration failed; skipping", "name", name, "replica", i, "error", err)
+				continue
+			}
+			return err
+		}
+		clients = append(clients, client)
+	}
+	if len(clients) == 0 {
+		return fmt.Errorf("register %s: all %d replicas failed: %w", name, len(cfgs), firstErr)
+	}
+
+	// Store metadata before pin check so pinningEnabledForServer can read PinSchemas.
+	// For a replica set, we store cfgs[0] as canonical — all replicas share the
+	// same logical config modulo per-replica runtime handles.
+	canonical := cfgs[0]
+	canonical.Name = name
+	func() {
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		g.serverMeta[name] = canonical
+	}()
+
+	// Schema pinning: verify or pin on first registration. Pins are per-server
+	// (not per-replica) — all replicas should expose the same tools.
+	if g.pinningEnabledForServer(name) {
+		drifts, err := g.schemaVerifier.VerifyOrPin(name, clients[0].Tools())
+		if err != nil {
+			g.logger.Warn("pins: verification failed", "server", name, "error", err)
+		} else {
+			g.handlePinDrift(name, drifts)
+		}
+	}
+
+	g.router.AddReplicaSet(NewReplicaSet(name, policy, clients))
+	g.router.RefreshTools()
+
+	g.logger.Info("registered MCP server", "name", name, "transport", cfgs[0].Transport, "replicas", len(clients), "tools", len(clients[0].Tools()), "duration", time.Since(start))
+	return nil
+}
+
+// buildAgentClient creates, connects, and initializes an AgentClient from a
+// single MCPServerConfig. It does NOT touch serverMeta, pins, health, or the
+// router — callers compose that separately.
+func (g *Gateway) buildAgentClient(ctx context.Context, cfg MCPServerConfig) (AgentClient, error) {
+	g.logger.Info("connecting to MCP server", "name", cfg.Name, "transport", cfg.Transport)
 
 	var agentClient AgentClient
 	clientLogger := g.logger.With("server", cfg.Name)
@@ -505,11 +681,11 @@ func (g *Gateway) RegisterMCPServer(ctx context.Context, cfg MCPServerConfig) er
 	// Handle OpenAPI servers
 	if cfg.OpenAPI {
 		if cfg.OpenAPIConfig == nil {
-			return fmt.Errorf("OpenAPI config required for OpenAPI server %s", cfg.Name)
+			return nil, fmt.Errorf("OpenAPI config required for OpenAPI server %s", cfg.Name)
 		}
 		openAPIClient, err := NewOpenAPIClient(cfg.Name, cfg.OpenAPIConfig)
 		if err != nil {
-			return fmt.Errorf("creating OpenAPI client %s: %w", cfg.Name, err)
+			return nil, fmt.Errorf("creating OpenAPI client %s: %w", cfg.Name, err)
 		}
 		openAPIClient.SetLogger(clientLogger)
 		if len(cfg.Tools) > 0 {
@@ -525,7 +701,7 @@ func (g *Gateway) RegisterMCPServer(ctx context.Context, cfg MCPServerConfig) er
 			processClient.SetToolWhitelist(cfg.Tools)
 		}
 		if err := processClient.Connect(ctx); err != nil {
-			return fmt.Errorf("starting SSH process %s: %w", cfg.Name, err)
+			return nil, fmt.Errorf("starting SSH process %s: %w", cfg.Name, err)
 		}
 		agentClient = processClient
 	} else if cfg.LocalProcess {
@@ -536,14 +712,14 @@ func (g *Gateway) RegisterMCPServer(ctx context.Context, cfg MCPServerConfig) er
 			processClient.SetToolWhitelist(cfg.Tools)
 		}
 		if err := processClient.Connect(ctx); err != nil {
-			return fmt.Errorf("starting process %s: %w", cfg.Name, err)
+			return nil, fmt.Errorf("starting process %s: %w", cfg.Name, err)
 		}
 		agentClient = processClient
 	} else {
 		switch cfg.Transport {
 		case TransportStdio:
 			if g.dockerCli == nil {
-				return fmt.Errorf("docker client not set for stdio transport")
+				return nil, fmt.Errorf("docker client not set for stdio transport")
 			}
 			stdioClient := NewStdioClient(cfg.Name, cfg.ContainerID, g.dockerCli)
 			stdioClient.SetLogger(clientLogger)
@@ -551,7 +727,7 @@ func (g *Gateway) RegisterMCPServer(ctx context.Context, cfg MCPServerConfig) er
 				stdioClient.SetToolWhitelist(cfg.Tools)
 			}
 			if err := stdioClient.Connect(ctx); err != nil {
-				return fmt.Errorf("connecting to container: %w", err)
+				return nil, fmt.Errorf("connecting to container: %w", err)
 			}
 			agentClient = stdioClient
 		case TransportSSE:
@@ -564,7 +740,7 @@ func (g *Gateway) RegisterMCPServer(ctx context.Context, cfg MCPServerConfig) er
 			// Wait for MCP server to be ready with retries
 			if err := g.waitForHTTPServer(ctx, httpClient, cfg.ReadyTimeout); err != nil {
 				g.handleReadyFailure(ctx, cfg, err)
-				return fmt.Errorf("MCP server %s not ready: %w", cfg.Name, err)
+				return nil, fmt.Errorf("MCP server %s not ready: %w", cfg.Name, err)
 			}
 			agentClient = httpClient
 		case TransportHTTP, "": // Default to HTTP
@@ -576,47 +752,25 @@ func (g *Gateway) RegisterMCPServer(ctx context.Context, cfg MCPServerConfig) er
 			// Wait for MCP server to be ready with retries
 			if err := g.waitForHTTPServer(ctx, httpClient, cfg.ReadyTimeout); err != nil {
 				g.handleReadyFailure(ctx, cfg, err)
-				return fmt.Errorf("MCP server %s not ready: %w", cfg.Name, err)
+				return nil, fmt.Errorf("MCP server %s not ready: %w", cfg.Name, err)
 			}
 			agentClient = httpClient
 		default:
-			return fmt.Errorf("unknown transport: %s", cfg.Transport)
+			return nil, fmt.Errorf("unknown transport: %s", cfg.Transport)
 		}
 	}
 
 	// Initialize MCP connection
 	if err := agentClient.Initialize(ctx); err != nil {
-		return fmt.Errorf("initializing MCP server %s: %w", cfg.Name, err)
+		return nil, fmt.Errorf("initializing MCP server %s: %w", cfg.Name, err)
 	}
 
 	// Fetch tools (will be filtered by whitelist if set)
 	if err := agentClient.RefreshTools(ctx); err != nil {
-		return fmt.Errorf("fetching tools from %s: %w", cfg.Name, err)
+		return nil, fmt.Errorf("fetching tools from %s: %w", cfg.Name, err)
 	}
 
-	// Store metadata before pin check so pinningEnabledForServer can read PinSchemas.
-	func() {
-		g.mu.Lock()
-		defer g.mu.Unlock()
-		g.serverMeta[cfg.Name] = cfg
-	}()
-
-	// Schema pinning: verify or pin on first registration.
-	if g.pinningEnabledForServer(cfg.Name) {
-		drifts, err := g.schemaVerifier.VerifyOrPin(cfg.Name, agentClient.Tools())
-		if err != nil {
-			g.logger.Warn("pins: verification failed", "server", cfg.Name, "error", err)
-		} else {
-			g.handlePinDrift(cfg.Name, drifts)
-		}
-	}
-
-	// Add to router
-	g.router.AddClient(agentClient)
-	g.router.RefreshTools()
-
-	g.logger.Info("registered MCP server", "name", cfg.Name, "transport", cfg.Transport, "tools", len(agentClient.Tools()), "duration", time.Since(start))
-	return nil
+	return agentClient, nil
 }
 
 // SetServerMeta stores metadata for an MCP server without connecting to it.

--- a/pkg/mcp/gateway_test.go
+++ b/pkg/mcp/gateway_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2966,6 +2967,195 @@ func TestRegisterMCPServer_DoesNotCleanupOnInitializeError(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&cleanupCalled); got != 0 {
 		t.Errorf("cleanup must NOT fire when waitForHTTPServer succeeded and a later step failed, got %d calls", got)
+	}
+}
+
+// Phase-2 replicas: multi-replica health isolation and backoff.
+
+// installReplicaSet builds a fake multi-replica set using reconnectableClient
+// fakes so tests can drive per-replica Ping/Reconnect behavior.
+func installReplicaSet(t *testing.T, g *Gateway, name string, clients []AgentClient) *ReplicaSet {
+	t.Helper()
+	set := NewReplicaSet(name, ReplicaPolicyRoundRobin, clients)
+	g.Router().AddReplicaSet(set)
+	g.SetServerMeta(MCPServerConfig{Name: name, Transport: TransportStdio})
+	return set
+}
+
+func TestGateway_HealthMonitor_MultiReplica_IsolatesFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+
+	var pings [3]atomic.Int32
+	makeReplica := func(id int, pingFn func(context.Context) error) AgentClient {
+		mock := setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}})
+		return &reconnectableClient{
+			AgentClient: mock,
+			pingFn: func(ctx context.Context) error {
+				pings[id].Add(1)
+				return pingFn(ctx)
+			},
+			reconnectFn: func(ctx context.Context) error { return fmt.Errorf("still broken") },
+		}
+	}
+
+	clients := []AgentClient{
+		makeReplica(0, func(ctx context.Context) error { return nil }),
+		makeReplica(1, func(ctx context.Context) error { return fmt.Errorf("replica-1 down") }),
+		makeReplica(2, func(ctx context.Context) error { return nil }),
+	}
+	set := installReplicaSet(t, g, "svc", clients)
+
+	g.checkHealth(context.Background())
+
+	// Replica-1 must be marked unhealthy and excluded from dispatch.
+	if set.Replicas()[1].Healthy() {
+		t.Error("replica-1 should be unhealthy")
+	}
+	if !set.Replicas()[0].Healthy() || !set.Replicas()[2].Healthy() {
+		t.Error("replicas 0 and 2 should be healthy")
+	}
+
+	// Server-level rollup is healthy because replicas 0 and 2 are up.
+	hs := g.GetHealthStatus("svc")
+	if hs == nil || !hs.Healthy {
+		t.Errorf("rollup should be healthy when any replica is healthy: %+v", hs)
+	}
+
+	// Tool-call routing must never return replica-1 while it's unhealthy.
+	for i := 0; i < 20; i++ {
+		client, _, err := g.Router().RouteToolCall("svc__t")
+		if err != nil {
+			t.Fatalf("RouteToolCall %d: %v", i, err)
+		}
+		if client == clients[1] {
+			t.Fatal("router returned unhealthy replica-1")
+		}
+	}
+}
+
+func TestGateway_HealthMonitor_MultiReplica_RecoversReplica(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+
+	var (
+		pingMu       sync.Mutex
+		replica1Down = true
+	)
+	replica1Ping := func(ctx context.Context) error {
+		pingMu.Lock()
+		defer pingMu.Unlock()
+		if replica1Down {
+			return fmt.Errorf("replica-1 down")
+		}
+		return nil
+	}
+
+	mk := func(pingFn func(context.Context) error) AgentClient {
+		mock := setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}})
+		return &reconnectableClient{
+			AgentClient: mock,
+			pingFn:      pingFn,
+			// Reconnect fails so replica-1 stays excluded until Ping itself
+			// succeeds — this isolates the "recovery via successful Ping"
+			// path from the "recovery via successful Reconnect" path.
+			reconnectFn: func(ctx context.Context) error { return fmt.Errorf("reconnect failed") },
+		}
+	}
+
+	clients := []AgentClient{
+		mk(func(ctx context.Context) error { return nil }),
+		mk(replica1Ping),
+	}
+	set := installReplicaSet(t, g, "svc", clients)
+
+	ctx := context.Background()
+	g.checkHealth(ctx)
+	if set.Replicas()[1].Healthy() {
+		t.Fatal("replica-1 should be unhealthy after first check (ping + reconnect both fail)")
+	}
+	if attempts := set.Replicas()[1].Restart().Attempts(); attempts != 1 {
+		t.Errorf("expected backoff attempts=1 after failed reconnect, got %d", attempts)
+	}
+
+	// Simulate the replica coming back: flip Ping to succeed and bypass the
+	// backoff window by resetting it. The next health check sees a healthy
+	// replica directly (no reconnect needed) and puts it back in rotation.
+	pingMu.Lock()
+	replica1Down = false
+	pingMu.Unlock()
+	set.Replicas()[1].Restart().Reset()
+
+	g.checkHealth(ctx)
+
+	if !set.Replicas()[1].Healthy() {
+		t.Error("replica-1 should be healthy again after Ping recovers")
+	}
+	if attempts := set.Replicas()[1].Restart().Attempts(); attempts != 0 {
+		t.Errorf("backoff should remain reset after recovery, got attempts=%d", attempts)
+	}
+}
+
+func TestGateway_HealthMonitor_BackoffGatesReconnect(t *testing.T) {
+	// A replica whose ping always fails and reconnect always fails must NOT
+	// spin: within one health check the reconnect fires at most once, and the
+	// backoff has advanced afterwards.
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+
+	var reconnectCount atomic.Int32
+	mock := setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}})
+	client := &reconnectableClient{
+		AgentClient: mock,
+		pingFn:      func(ctx context.Context) error { return fmt.Errorf("dead") },
+		reconnectFn: func(ctx context.Context) error {
+			reconnectCount.Add(1)
+			return fmt.Errorf("still dead")
+		},
+	}
+	set := installReplicaSet(t, g, "svc", []AgentClient{client})
+
+	ctx := context.Background()
+	// Two consecutive health checks — backoff should gate the second attempt
+	// since the first just advanced the delay above zero.
+	g.checkHealth(ctx)
+	g.checkHealth(ctx)
+
+	got := reconnectCount.Load()
+	if got != 1 {
+		t.Errorf("expected exactly 1 reconnect attempt (backoff gates the second), got %d", got)
+	}
+	if attempts := set.Replicas()[0].Restart().Attempts(); attempts != 1 {
+		t.Errorf("expected backoff attempts=1 after first failure, got %d", attempts)
+	}
+	if !set.Replicas()[0].Restart().NextAt().After(time.Now()) {
+		t.Error("backoff NextAt should be in the future after a failed reconnect")
+	}
+}
+
+func TestGateway_HealthMonitor_SingleReplica_UnchangedBehavior(t *testing.T) {
+	// A single-replica server must produce the same public health rollup as
+	// pre-replicas gridctl: healthy rollup, no stray per-replica leakage in
+	// the GetHealthStatus API.
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+
+	mock := setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}})
+	client := &pingableClient{
+		AgentClient: mock,
+		pingFn:      func(ctx context.Context) error { return nil },
+	}
+	g.Router().AddClient(client)
+	g.SetServerMeta(MCPServerConfig{Name: "svc", Transport: TransportHTTP})
+
+	g.checkHealth(context.Background())
+
+	hs := g.GetHealthStatus("svc")
+	if hs == nil || !hs.Healthy {
+		t.Fatal("single-replica rollup should be healthy")
+	}
+	if hs.Error != "" {
+		t.Errorf("healthy rollup should have empty Error, got %q", hs.Error)
 	}
 }
 

--- a/pkg/mcp/replica_set.go
+++ b/pkg/mcp/replica_set.go
@@ -2,8 +2,17 @@ package mcp
 
 import (
 	"errors"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
+	"time"
+)
+
+// Restart-backoff constants for a failing replica.
+const (
+	restartBackoffInitial    = 1 * time.Second
+	restartBackoffCap        = 30 * time.Second
+	restartBackoffJitterFrac = 0.25 // ±25%
 )
 
 // Dispatch policies for a ReplicaSet.
@@ -16,11 +25,80 @@ const (
 // the set is marked unhealthy.
 var ErrNoHealthyReplicas = errors.New("no healthy replicas")
 
-// backoffState carries exponential-backoff bookkeeping for per-replica
-// restart scheduling. Fields and methods are introduced alongside the
-// restart loop in a later phase; the type is declared here so the Replica
-// layout is stable.
-type backoffState struct{}
+// backoffState tracks exponential-backoff bookkeeping for a failing replica.
+// Delays start at restartBackoffInitial, double on each Advance, and cap at
+// restartBackoffCap. Every delay is jittered by ±restartBackoffJitterFrac so a
+// fleet of replicas that all fail together do not resynchronize their retries.
+type backoffState struct {
+	mu       sync.Mutex
+	attempts uint32
+	nextAt   time.Time // zero value = eligible now
+}
+
+// Attempts returns the number of consecutive failures observed.
+func (b *backoffState) Attempts() uint32 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.attempts
+}
+
+// ShouldTry reports whether now is at or past the scheduled next attempt.
+// A zero nextAt (fresh state or after Reset) is always eligible.
+func (b *backoffState) ShouldTry(now time.Time) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.nextAt.IsZero() {
+		return true
+	}
+	return !now.Before(b.nextAt)
+}
+
+// Advance records a failed attempt, computes the next delay (capped, jittered),
+// and schedules the next eligible try. Returns the chosen delay so callers can
+// log the retry window. Attempts saturates at math.MaxUint32.
+func (b *backoffState) Advance(now time.Time) time.Duration {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delay := computeBackoff(b.attempts)
+	if b.attempts < ^uint32(0) {
+		b.attempts++
+	}
+	b.nextAt = now.Add(delay)
+	return delay
+}
+
+// Reset clears the backoff: next attempt is eligible immediately.
+func (b *backoffState) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.attempts = 0
+	b.nextAt = time.Time{}
+}
+
+// NextAt returns the scheduled next attempt time. Zero value means "now".
+func (b *backoffState) NextAt() time.Time {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.nextAt
+}
+
+// computeBackoff returns the jittered delay for the given attempt index.
+// attempts=0 yields the initial delay; attempts=1 yields 2× initial; etc.
+// Capped at restartBackoffCap before jitter is applied.
+func computeBackoff(attempts uint32) time.Duration {
+	base := restartBackoffInitial
+	for i := uint32(0); i < attempts && base < restartBackoffCap; i++ {
+		base *= 2
+	}
+	if base > restartBackoffCap {
+		base = restartBackoffCap
+	}
+	// Symmetric jitter: delay in [base*(1-frac), base*(1+frac)].
+	// Non-cryptographic RNG is deliberate — this is retry-timing jitter.
+	span := float64(base) * restartBackoffJitterFrac
+	offset := (rand.Float64()*2 - 1) * span //nolint:gosec // retry jitter, not security-sensitive
+	return base + time.Duration(offset)
+}
 
 // Replica is a single member of a ReplicaSet. It wraps one AgentClient (the
 // concrete transport — ProcessClient, StdioClient, Client, etc.) and tracks
@@ -53,6 +131,9 @@ func (r *Replica) DecInFlight() { r.inFlight.Add(-1) }
 
 // InFlight returns the current in-flight request count.
 func (r *Replica) InFlight() int64 { return r.inFlight.Load() }
+
+// Restart returns the replica's restart-backoff state. Never nil.
+func (r *Replica) Restart() *backoffState { return r.restart }
 
 // ReplicaSet is a pool of AgentClient replicas for a single logical MCP server.
 // Dispatch is determined by the set's policy. A single-replica set behaves

--- a/pkg/mcp/replica_set_test.go
+++ b/pkg/mcp/replica_set_test.go
@@ -4,9 +4,100 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"go.uber.org/mock/gomock"
 )
+
+func TestBackoff_ProgressionAndCap(t *testing.T) {
+	// Expected unjittered bases for attempts 0..7: 1s, 2s, 4s, 8s, 16s, 30s (cap), 30s, 30s.
+	expected := []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		30 * time.Second,
+		30 * time.Second,
+		30 * time.Second,
+	}
+
+	b := &backoffState{}
+	for i, want := range expected {
+		got := computeBackoff(b.Attempts())
+		low := time.Duration(float64(want) * (1 - restartBackoffJitterFrac))
+		high := time.Duration(float64(want) * (1 + restartBackoffJitterFrac))
+		if got < low || got > high {
+			t.Errorf("attempt %d: delay %v not in jitter envelope [%v, %v] around base %v", i, got, low, high, want)
+		}
+		b.Advance(time.Now())
+	}
+}
+
+func TestBackoff_ResetReturnsToInitial(t *testing.T) {
+	b := &backoffState{}
+	for i := 0; i < 5; i++ {
+		b.Advance(time.Now())
+	}
+	if b.Attempts() != 5 {
+		t.Fatalf("expected 5 attempts, got %d", b.Attempts())
+	}
+	b.Reset()
+	if got := b.Attempts(); got != 0 {
+		t.Errorf("after Reset: attempts = %d, want 0", got)
+	}
+	if !b.NextAt().IsZero() {
+		t.Error("after Reset: NextAt should be zero")
+	}
+	if !b.ShouldTry(time.Now()) {
+		t.Error("after Reset: ShouldTry should be true")
+	}
+}
+
+func TestBackoff_ShouldTry(t *testing.T) {
+	b := &backoffState{}
+
+	now := time.Now()
+	if !b.ShouldTry(now) {
+		t.Error("fresh backoff: ShouldTry should be true")
+	}
+
+	b.Advance(now)
+	if b.ShouldTry(now) {
+		t.Error("immediately after Advance: ShouldTry should be false")
+	}
+	// The delay at attempt 0 is 1s ± 25%, so at now+2s it must be eligible.
+	if !b.ShouldTry(now.Add(2 * time.Second)) {
+		t.Error("2s after Advance on attempt 0: ShouldTry should be true")
+	}
+}
+
+func TestBackoff_JitterEnvelope(t *testing.T) {
+	// With attempts=0 the base is 1s; jitter should keep delays in [0.75s, 1.25s].
+	for i := 0; i < 200; i++ {
+		got := computeBackoff(0)
+		if got < 750*time.Millisecond || got > 1250*time.Millisecond {
+			t.Fatalf("jitter escaped envelope: got %v", got)
+		}
+	}
+}
+
+func TestBackoff_Concurrent(t *testing.T) {
+	b := &backoffState{}
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = b.ShouldTry(time.Now())
+				b.Advance(time.Now())
+			}
+		}()
+	}
+	wg.Wait()
+	// If we get here without -race flagging, we're good.
+}
 
 func newTestReplicaSet(t *testing.T, policy string, names ...string) *ReplicaSet {
 	t.Helper()

--- a/pkg/reload/reload.go
+++ b/pkg/reload/reload.go
@@ -36,12 +36,20 @@ type Handler struct {
 	vault       config.VaultLookup
 	vaultSet    config.VaultSetLookup
 
-	// Callback for registering new MCP servers with gateway. containerID is the
-	// runtime container ID for stdio transport (empty for non-container servers).
-	// stackPath is the live active stack path; passed through to the registrar
-	// so the gateway_builder closure does not need to re-enter the Handler
-	// mutex to look it up.
-	registerServer func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error
+	// Callback for registering new MCP servers with gateway. replicas carries
+	// one entry per replica in replica-id order (ContainerID and HostPort per
+	// replica, empty for non-container replicas). stackPath is the live active
+	// stack path; passed through to the registrar so the gateway_builder closure
+	// does not need to re-enter the Handler mutex to look it up.
+	registerServer func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error
+}
+
+// ReplicaRuntime carries runtime handles for one replica that the reload
+// handler has provisioned. Container replicas populate both fields; local-
+// process, SSH, external, and OpenAPI replicas pass zero-valued entries.
+type ReplicaRuntime struct {
+	HostPort    int
+	ContainerID string
 }
 
 // NewHandler creates a reload handler.
@@ -72,7 +80,7 @@ func (h *Handler) SetNoExpand(noExpand bool) {
 }
 
 // SetRegisterServerFunc sets the callback for registering MCP servers.
-func (h *Handler) SetRegisterServerFunc(fn func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error) {
+func (h *Handler) SetRegisterServerFunc(fn func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error) {
 	h.registerServer = fn
 }
 
@@ -218,12 +226,15 @@ func (h *Handler) applyMCPServerChanges(ctx context.Context, diff MCPServerDiff,
 			h.logger.Warn("failed to reset schema pins for removed server", "name", server.Name, "error", err)
 		}
 
-		// Stop and remove container if it exists
+		// Stop and remove container(s) if the server was container-based. For
+		// multi-replica servers we iterate replica containers; single-replica
+		// preserves the pre-replicas naming (no suffix).
 		if !server.IsExternal() && !server.IsLocalProcess() && !server.IsSSH() && !server.IsOpenAPI() {
-			containerName := containerName(h.currentCfg.Name, server.Name)
-			if err := h.stopAndRemoveContainer(ctx, containerName); err != nil {
-				h.logger.Warn("failed to remove container", "name", server.Name, "error", err)
-				result.Errors = append(result.Errors, fmt.Sprintf("failed to remove container %s: %v", server.Name, err))
+			for _, name := range replicaContainerNames(h.currentCfg.Name, &server) {
+				if err := h.stopAndRemoveContainer(ctx, name); err != nil {
+					h.logger.Warn("failed to remove container", "name", name, "error", err)
+					result.Errors = append(result.Errors, fmt.Sprintf("failed to remove container %s: %v", name, err))
+				}
 			}
 		}
 
@@ -237,11 +248,12 @@ func (h *Handler) applyMCPServerChanges(ctx context.Context, diff MCPServerDiff,
 		// Unregister from gateway
 		h.gateway.UnregisterMCPServer(change.Name)
 
-		// Stop old container if it was container-based
+		// Stop old container(s) if it was container-based.
 		if !change.Old.IsExternal() && !change.Old.IsLocalProcess() && !change.Old.IsSSH() && !change.Old.IsOpenAPI() {
-			containerName := containerName(h.currentCfg.Name, change.Name)
-			if err := h.stopAndRemoveContainer(ctx, containerName); err != nil {
-				h.logger.Warn("failed to stop container", "name", change.Name, "error", err)
+			for _, name := range replicaContainerNames(h.currentCfg.Name, &change.Old) {
+				if err := h.stopAndRemoveContainer(ctx, name); err != nil {
+					h.logger.Warn("failed to stop container", "name", name, "error", err)
+				}
 			}
 		}
 
@@ -375,11 +387,13 @@ func (h *Handler) stopAndRemoveContainer(ctx context.Context, containerName stri
 }
 
 func (h *Handler) startMCPServer(ctx context.Context, server config.MCPServer, stack *config.Stack) error {
-	// Skip container creation for non-container servers
+	replicas := effectiveReplicas(&server)
+
+	// Skip container creation for non-container servers. Still produce N
+	// placeholder ReplicaRuntime entries so the registrar creates N clients.
 	if server.IsExternal() || server.IsLocalProcess() || server.IsSSH() || server.IsOpenAPI() {
-		// Just register with gateway
 		if h.registerServer != nil {
-			return h.registerServer(ctx, server, 0, "", h.stackPath)
+			return h.registerServer(ctx, server, make([]ReplicaRuntime, replicas), h.stackPath)
 		}
 		return nil
 	}
@@ -411,44 +425,59 @@ func (h *Handler) startMCPServer(ctx context.Context, server config.MCPServer, s
 		networkName = server.Network
 	}
 
-	// Allocate port - find next available port
-	hostPort := h.allocatePort(ctx)
+	// Start one container per replica. Each replica gets its own host port;
+	// for multi-replica servers the workload name gets a "-replica-<id>"
+	// suffix so container names don't collide.
+	runtimes := make([]ReplicaRuntime, 0, replicas)
+	for replicaID := 0; replicaID < replicas; replicaID++ {
+		hostPort := h.allocatePort(ctx)
+		workloadName := server.Name
+		if replicas > 1 {
+			workloadName = fmt.Sprintf("%s-replica-%d", server.Name, replicaID)
+		}
+		cfg := runtime.WorkloadConfig{
+			Name:        workloadName,
+			Stack:       stack.Name,
+			Type:        runtime.WorkloadTypeMCPServer,
+			Image:       imageName,
+			Command:     server.Command,
+			Env:         server.Env,
+			NetworkName: networkName,
+			ExposedPort: server.Port,
+			HostPort:    hostPort,
+			Transport:   server.Transport,
+			Labels: map[string]string{
+				"gridctl.managed":    "true",
+				"gridctl.stack":      stack.Name,
+				"gridctl.mcp-server": server.Name,
+			},
+		}
 
-	// Create workload config
-	cfg := runtime.WorkloadConfig{
-		Name:        server.Name,
-		Stack:       stack.Name,
-		Type:        runtime.WorkloadTypeMCPServer,
-		Image:       imageName,
-		Command:     server.Command,
-		Env:         server.Env,
-		NetworkName: networkName,
-		ExposedPort: server.Port,
-		HostPort:    hostPort,
-		Transport:   server.Transport,
-		Labels: map[string]string{
-			"gridctl.managed":    "true",
-			"gridctl.stack":      stack.Name,
-			"gridctl.mcp-server": server.Name,
-		},
+		status, err := rt.Start(ctx, cfg)
+		if err != nil {
+			return fmt.Errorf("starting container replica %d: %w", replicaID, err)
+		}
+
+		actualHostPort := status.HostPort
+		if actualHostPort == 0 {
+			actualHostPort = hostPort
+		}
+		runtimes = append(runtimes, ReplicaRuntime{HostPort: actualHostPort, ContainerID: string(status.ID)})
 	}
 
-	status, err := rt.Start(ctx, cfg)
-	if err != nil {
-		return fmt.Errorf("starting container: %w", err)
-	}
-
-	actualHostPort := status.HostPort
-	if actualHostPort == 0 {
-		actualHostPort = hostPort
-	}
-
-	// Register with gateway
 	if h.registerServer != nil {
-		return h.registerServer(ctx, server, actualHostPort, string(status.ID), h.stackPath)
+		return h.registerServer(ctx, server, runtimes, h.stackPath)
 	}
 
 	return nil
+}
+
+// effectiveReplicas returns the replica count, treating zero/negative as 1.
+func effectiveReplicas(server *config.MCPServer) int {
+	if server.Replicas <= 0 {
+		return 1
+	}
+	return server.Replicas
 }
 
 func (h *Handler) startResource(ctx context.Context, res config.Resource, stack *config.Stack) error {
@@ -512,4 +541,20 @@ func (h *Handler) allocatePort(ctx context.Context) int {
 
 func containerName(stack, name string) string {
 	return "gridctl-" + stack + "-" + name
+}
+
+// replicaContainerNames returns the container names for each replica of a
+// server. Single-replica servers keep the pre-replicas name (no suffix) so
+// backward-compatible stacks see no change.
+func replicaContainerNames(stack string, server *config.MCPServer) []string {
+	n := effectiveReplicas(server)
+	if n <= 1 {
+		return []string{containerName(stack, server.Name)}
+	}
+	names := make([]string, 0, n)
+	base := containerName(stack, server.Name)
+	for i := 0; i < n; i++ {
+		names = append(names, fmt.Sprintf("%s-replica-%d", base, i))
+	}
+	return names
 }

--- a/pkg/reload/reload_test.go
+++ b/pkg/reload/reload_test.go
@@ -131,7 +131,7 @@ func TestHandler_SettersAndGetters(t *testing.T) {
 	}
 
 	// SetRegisterServerFunc
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error {
 		return nil
 	})
 	if h.registerServer == nil {
@@ -252,7 +252,7 @@ mcp-servers:
 	h, _ := setupHandler(t, stackPath, initialCfg)
 
 	registerCalled := false
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error {
 		registerCalled = true
 		return nil
 	})
@@ -328,7 +328,7 @@ mcp-servers:
 	h, _ := setupHandler(t, stackPath, initialCfg)
 
 	registerCalled := false
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error {
 		registerCalled = true
 		return nil
 	})
@@ -408,7 +408,7 @@ mcp-servers:
 
 	h, _ := setupHandler(t, stackPath, initialCfg)
 
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error {
 		return fmt.Errorf("registration failed")
 	})
 
@@ -460,9 +460,11 @@ mcp-servers:
 
 	var capturedContainerID string
 	var capturedServerName string
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error {
 		capturedServerName = server.Name
-		capturedContainerID = containerID
+		if len(replicas) > 0 {
+			capturedContainerID = replicas[0].ContainerID
+		}
 		return nil
 	})
 
@@ -503,7 +505,7 @@ mcp-servers:
 	orch := runtime.NewOrchestrator(mockRT, &mockBuilder{})
 	gw := mcp.NewGateway()
 	h := NewHandler("", placeholder, gw, orch, 8180, 9000, nil, nil)
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error {
 		return nil
 	})
 
@@ -539,7 +541,7 @@ mcp-servers:
 	h, _ := setupHandler(t, "", &config.Stack{Name: "gridctl"})
 
 	var capturedStackPath string
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error {
 		capturedStackPath = stackPath
 		return nil
 	})
@@ -617,7 +619,7 @@ mcp-servers:
 	h, _ := setupHandler(t, stackPath, initialCfg)
 
 	registerCalls := 0
-	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, hostPort int, containerID, stackPath string) error {
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error {
 		registerCalls++
 		return nil
 	})

--- a/pkg/runtime/orchestrator.go
+++ b/pkg/runtime/orchestrator.go
@@ -62,9 +62,14 @@ type UpResult struct {
 // MCPServerResult is the runtime-agnostic result for an MCP server.
 type MCPServerResult struct {
 	Name       string     // Logical name
-	WorkloadID WorkloadID // Runtime ID (empty for external/local/SSH/OpenAPI)
-	Endpoint   string     // How to reach it (URL or host:port)
-	HostPort   int        // Host port if applicable
+	WorkloadID WorkloadID // Runtime ID (empty for external/local/SSH/OpenAPI). Mirrors Replicas[0].WorkloadID.
+	Endpoint   string     // How to reach it (URL or host:port). Mirrors Replicas[0].Endpoint.
+	HostPort   int        // Host port if applicable. Mirrors Replicas[0].HostPort.
+
+	// Replicas carries per-replica runtime handles. Always non-empty after Up()
+	// returns: a server with no replicas field (or Replicas=1) gets a single entry
+	// whose top-level fields match the mirrored fields above.
+	Replicas []MCPServerReplica
 
 	// Server type flags (exactly one should be true for non-container servers)
 	External     bool // URL-based external server
@@ -82,6 +87,16 @@ type MCPServerResult struct {
 
 	// For OpenAPI servers
 	OpenAPIConfig *config.OpenAPIConfig // OpenAPI configuration for gateway to use
+}
+
+// MCPServerReplica is one replica's runtime handle. For non-container replicas
+// (external, local process, SSH, OpenAPI) only ReplicaID is meaningful —
+// WorkloadID, Endpoint, and HostPort are empty/zero.
+type MCPServerReplica struct {
+	ReplicaID  int        // zero-indexed within the server
+	WorkloadID WorkloadID // runtime ID for container replicas
+	Endpoint   string     // host:port or URL
+	HostPort   int        // host port if applicable
 }
 
 // NewOrchestrator creates an Orchestrator with the given runtime and builder.
@@ -174,6 +189,8 @@ func (o *Orchestrator) Up(ctx context.Context, stack *config.Stack, opts UpOptio
 	result := &UpResult{}
 	containerIndex := 0 // Track container-based servers for port allocation
 	for _, server := range stack.MCPServers {
+		replicas := replicaCount(&server)
+
 		// Skip container creation for external servers
 		if server.IsExternal() {
 			o.logger.Info("registering external MCP server", "name", server.Name, "url", server.URL)
@@ -181,17 +198,19 @@ func (o *Orchestrator) Up(ctx context.Context, stack *config.Stack, opts UpOptio
 				Name:     server.Name,
 				External: true,
 				URL:      server.URL,
+				Replicas: singleReplicaPlaceholder(),
 			})
 			continue
 		}
 
 		// Skip container creation for local process servers
 		if server.IsLocalProcess() {
-			o.logger.Info("registering local process MCP server", "name", server.Name, "command", server.Command)
+			o.logger.Info("registering local process MCP server", "name", server.Name, "command", server.Command, "replicas", replicas)
 			result.MCPServers = append(result.MCPServers, MCPServerResult{
 				Name:         server.Name,
 				LocalProcess: true,
 				Command:      server.Command,
+				Replicas:     nReplicaPlaceholders(replicas),
 			})
 			continue
 		}
@@ -202,7 +221,8 @@ func (o *Orchestrator) Up(ctx context.Context, stack *config.Stack, opts UpOptio
 				"name", server.Name,
 				"host", server.SSH.Host,
 				"user", server.SSH.User,
-				"command", server.Command)
+				"command", server.Command,
+				"replicas", replicas)
 			result.MCPServers = append(result.MCPServers, MCPServerResult{
 				Name:            server.Name,
 				SSH:             true,
@@ -211,11 +231,13 @@ func (o *Orchestrator) Up(ctx context.Context, stack *config.Stack, opts UpOptio
 				SSHUser:         server.SSH.User,
 				SSHPort:         server.SSH.Port,
 				SSHIdentityFile: server.SSH.IdentityFile,
+				Replicas:        nReplicaPlaceholders(replicas),
 			})
 			continue
 		}
 
-		// Skip container creation for OpenAPI servers
+		// Skip container creation for OpenAPI servers (already validated
+		// to reject replicas > 1; singleReplicaPlaceholder is enough).
 		if server.IsOpenAPI() {
 			o.logger.Info("registering OpenAPI MCP server",
 				"name", server.Name,
@@ -224,34 +246,80 @@ func (o *Orchestrator) Up(ctx context.Context, stack *config.Stack, opts UpOptio
 				Name:          server.Name,
 				OpenAPI:       true,
 				OpenAPIConfig: server.OpenAPI,
+				Replicas:      singleReplicaPlaceholder(),
 			})
 			continue
 		}
 
-		hostPort := opts.BasePort + containerIndex
-		containerIndex++
-		info, err := o.startMCPServer(ctx, stack, &server, opts, hostPort)
-		if err != nil {
-			return nil, fmt.Errorf("starting MCP server %s: %w", server.Name, err)
+		// Container-based server: start one container per replica.
+		replicaHandles := make([]MCPServerReplica, 0, replicas)
+		for replicaID := 0; replicaID < replicas; replicaID++ {
+			hostPort := opts.BasePort + containerIndex
+			containerIndex++
+			info, err := o.startMCPServer(ctx, stack, &server, opts, hostPort, replicaID, replicas)
+			if err != nil {
+				return nil, fmt.Errorf("starting MCP server %s replica %d: %w", server.Name, replicaID, err)
+			}
+			replicaHandles = append(replicaHandles, MCPServerReplica{
+				ReplicaID:  replicaID,
+				WorkloadID: info.WorkloadID,
+				Endpoint:   info.Endpoint,
+				HostPort:   info.HostPort,
+			})
 		}
-		result.MCPServers = append(result.MCPServers, *info)
+		result.MCPServers = append(result.MCPServers, MCPServerResult{
+			Name:       server.Name,
+			WorkloadID: replicaHandles[0].WorkloadID,
+			Endpoint:   replicaHandles[0].Endpoint,
+			HostPort:   replicaHandles[0].HostPort,
+			Replicas:   replicaHandles,
+		})
 	}
 
 	o.logger.Info("all workloads started successfully")
 	return result, nil
 }
 
-func (o *Orchestrator) startMCPServer(ctx context.Context, stack *config.Stack, server *config.MCPServer, opts UpOptions, hostPort int) (*MCPServerResult, error) {
-	containerName := containerName(stack.Name, server.Name)
+// replicaCount returns the effective replica count for a server, treating any
+// value <= 0 as 1 so callers can use the result directly as a loop bound.
+func replicaCount(server *config.MCPServer) int {
+	if server.Replicas <= 0 {
+		return 1
+	}
+	return server.Replicas
+}
+
+// singleReplicaPlaceholder returns a one-element placeholder slice used by
+// non-container server results where the orchestrator has nothing runtime-
+// provisioned to carry. The registrar only reads ReplicaID from these.
+func singleReplicaPlaceholder() []MCPServerReplica {
+	return []MCPServerReplica{{ReplicaID: 0}}
+}
+
+// nReplicaPlaceholders returns n placeholders for non-container servers that
+// still want N independent replica registrations (local process, SSH).
+func nReplicaPlaceholders(n int) []MCPServerReplica {
+	if n <= 1 {
+		return singleReplicaPlaceholder()
+	}
+	out := make([]MCPServerReplica, n)
+	for i := range out {
+		out[i].ReplicaID = i
+	}
+	return out
+}
+
+func (o *Orchestrator) startMCPServer(ctx context.Context, stack *config.Stack, server *config.MCPServer, opts UpOptions, hostPort, replicaID, totalReplicas int) (*MCPServerResult, error) {
+	runtimeName := ReplicaContainerName(stack.Name, server.Name, replicaID, totalReplicas)
 
 	// Check if container already exists
-	exists, workloadID, err := o.runtime.Exists(ctx, containerName)
+	exists, workloadID, err := o.runtime.Exists(ctx, runtimeName)
 	if err != nil {
 		return nil, err
 	}
 
 	if exists {
-		o.logger.Info("MCP server already exists, starting", "name", server.Name)
+		o.logger.Info("MCP server already exists, starting", "name", server.Name, "replica", replicaID)
 		// Get actual host port
 		actualHostPort, _ := o.runtime.GetHostPort(ctx, workloadID, server.Port)
 		return &MCPServerResult{
@@ -301,10 +369,15 @@ func (o *Orchestrator) startMCPServer(ctx context.Context, stack *config.Stack, 
 		networkName = server.Network
 	}
 
-	// Create workload config
-	// Note: Name is the logical name, the runtime generates the container name
+	// Create workload config. Name drives both container name and DNS alias;
+	// for multi-replica servers we suffix it so replicas don't collide. Labels
+	// still carry the logical server name so Down/List filters by stack work.
+	workloadName := server.Name
+	if totalReplicas > 1 {
+		workloadName = fmt.Sprintf("%s-replica-%d", server.Name, replicaID)
+	}
 	cfg := WorkloadConfig{
-		Name:        server.Name,
+		Name:        workloadName,
 		Stack:       stack.Name,
 		Type:        WorkloadTypeMCPServer,
 		Image:       imageName,
@@ -328,7 +401,7 @@ func (o *Orchestrator) startMCPServer(ctx context.Context, stack *config.Stack, 
 		actualHostPort = hostPort
 	}
 
-	o.logger.Info("MCP server listening", "name", server.Name, "port", actualHostPort)
+	o.logger.Info("MCP server listening", "name", server.Name, "replica", replicaID, "port", actualHostPort)
 
 	return &MCPServerResult{
 		Name:       server.Name,
@@ -455,6 +528,19 @@ func (o *Orchestrator) Status(ctx context.Context, stack string) ([]WorkloadStat
 
 func containerName(stack, name string) string {
 	return "gridctl-" + stack + "-" + name
+}
+
+// ReplicaContainerName returns the container name for a specific replica.
+// For single-replica servers (totalReplicas <= 1) it returns the same name
+// containerName produces, so backward-compatible stacks see zero diff.
+// For totalReplicas > 1 it appends a "-replica-<id>" suffix so distinct
+// replicas of the same logical server never collide in the runtime.
+func ReplicaContainerName(stack, name string, replicaID, totalReplicas int) string {
+	base := containerName(stack, name)
+	if totalReplicas <= 1 {
+		return base
+	}
+	return fmt.Sprintf("%s-replica-%d", base, replicaID)
 }
 
 func generateTag(stack, name string) string {


### PR DESCRIPTION
## Description

Phase 2 of per-server MCP replica support (#470). Builds on PR #477. Makes `replicas > 1` actually work end-to-end: the orchestrator spawns N containers per server, the reload handler threads runtime handles per replica, the gateway registers a `ReplicaSet` instead of a single client, and the health monitor iterates per-replica with exponential-backoff-gated reconnects.

Single-replica stacks remain byte-identical to pre-replicas gridctl: same container names, same public health rollup, same log messages.

## Type of Change

- [x] New feature
- [x] Refactor (gateway registration + health monitor)

## Changes Made

**Exponential restart backoff (`pkg/mcp/replica_set.go`)**

- Populate the `backoffState` placeholder with `attempts`, `nextAt`, and a mutex.
- Delays start at 1s, double per failure, cap at 30s. Symmetric ±25% jitter to avoid synchronized retry waves across replicas. `Reset()` clears attempts on successful recovery.
- Used by the health monitor to gate reconnect attempts — a replica whose initialize keeps failing cannot spin.

**Orchestrator (`pkg/runtime/orchestrator.go`)**

- `MCPServerResult` grows a `Replicas []MCPServerReplica` slice carrying per-replica WorkloadID / Endpoint / HostPort. Top-level fields mirror `Replicas[0]` so existing readers keep working.
- For container-based servers with `Replicas > 1`, the orchestrator spawns N containers with distinct names: `gridctl-<stack>-<name>-replica-<id>`. For `Replicas == 1`, the old name is preserved (no suffix) so single-replica stacks are unchanged.
- New `ReplicaContainerName` helper makes the naming rule explicit.
- Local-process / SSH / external / OpenAPI servers still produce one result entry, but `Replicas` carries N placeholders so the registrar creates N clients for them too.

**Reload handler (`pkg/reload/reload.go`)**

- `RegisterServerFunc` signature changes from `(ctx, server, hostPort, containerID, stackPath)` to `(ctx, server, []ReplicaRuntime, stackPath)`. New exported type `ReplicaRuntime{HostPort, ContainerID}`.
- Stackless-mode `startMCPServer` provisions N containers per server with per-replica host ports and container names before invoking the registrar callback — the `723d290` fix's containerID plumbing is generalized to a list.
- Container teardown on server removal/modify now iterates replica container names.

**Gateway (`pkg/mcp/gateway.go`)**

- Extract a new `buildAgentClient(ctx, cfg)` helper from the old `RegisterMCPServer` body. It handles the transport switch, Connect, Initialize, and RefreshTools — nothing else.
- New `RegisterMCPReplicaSet(ctx, name, policy, cfgs)` calls `buildAgentClient` per replica and wires the resulting clients into the router as a single `ReplicaSet`. `RegisterMCPServer` is a thin wrapper that passes one cfg. Partial-startup tolerance: if some replicas fail, the server is still registered with the successful ones; only a total failure returns an error.
- `checkHealth` now iterates `Router.ReplicaSets()` and visits each replica. A ping failure flips `replica.SetHealthy(false)` — dispatch immediately routes around it. A reconnect attempt fires only when the replica's backoff window elapses; successful reconnect resets the backoff and clears the unhealthy flag.
- Introduce per-replica health alongside the existing per-server rollup: `replicaHealth map[string]map[int]*HealthStatus`. `GetHealthStatus(name)` still returns the rollup (healthy iff any replica is healthy), so external consumers are unchanged.

**Registrar (`pkg/controller/server_registrar.go`)**

- `RegisterAll` fans out each `MCPServerResult.Replicas` slice into N `MCPServerConfig`s per server and calls `RegisterMCPReplicaSet`.
- `RegisterOne` signature now takes `[]ReplicaRuntime`; single-replica callers pass a one-element slice.

**Wiring (`pkg/controller/gateway_builder.go`)**

- `SetRegisterServerFunc` closure adapts `[]reload.ReplicaRuntime` to `[]controller.ReplicaRuntime` and calls the new `RegisterOne`.

## Testing

- New unit tests:
  - `TestBackoff_*` (progression + cap, reset, jitter envelope, concurrent).
  - `TestGateway_HealthMonitor_MultiReplica_IsolatesFailure` — ping failure on one replica excludes it from dispatch; healthy replicas continue to serve; rollup remains healthy.
  - `TestGateway_HealthMonitor_MultiReplica_RecoversReplica` — failed replica returns to rotation after ping succeeds again.
  - `TestGateway_HealthMonitor_BackoffGatesReconnect` — a persistently-failing replica only attempts one reconnect per backoff window, not one per tick.
  - `TestGateway_HealthMonitor_SingleReplica_UnchangedBehavior` — single-replica rollup matches pre-replicas semantics.
- Existing `pkg/reload/reload_test.go` and `pkg/controller/server_registrar_test.go` updated for the new signature; no coverage regressions.
- `go test ./... -race` clean except a pre-existing `TestHandleSkills_SourcesList_Empty` failure in `internal/api` that reproduces on `main` (flagged in #477, not this PR).
- `golangci-lint run` → 0 issues.
- `make build` passes.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #470