### PR TITLE
feat: replicas observability, status, and API (phase 3 of #470)

### DIFF
--- a/cmd/gridctl/status.go
+++ b/cmd/gridctl/status.go
@@ -18,7 +18,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var statusStack string
+var (
+	statusStack          string
+	statusShowReplicas   bool
+)
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
@@ -26,17 +29,19 @@ var statusCmd = &cobra.Command{
 	Long: `Displays the current status of gridctl-managed gateways and containers.
 
 Shows running gateways with their ports, and container states.
-Use --stack to filter by a specific stack.`,
+Use --stack to filter by a specific stack.
+Use --replicas to expand multi-replica servers to one row per replica.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runStatus(statusStack)
+		return runStatus(statusStack, statusShowReplicas)
 	},
 }
 
 func init() {
 	statusCmd.Flags().StringVarP(&statusStack, "stack", "s", "", "Only show containers from this stack")
+	statusCmd.Flags().BoolVar(&statusShowReplicas, "replicas", false, "Expand to one row per replica instead of rolled-up per-server state")
 }
 
-func runStatus(stack string) error {
+func runStatus(stack string, showReplicas bool) error {
 	printer := output.New()
 
 	// Show gateway status from state files
@@ -128,6 +133,23 @@ func runStatus(stack string) error {
 	printer.Gateways(gateways)
 	printer.Containers(containers)
 
+	// MCP server tables: query each running gateway for replica info. If
+	// --replicas is set, render one row per replica instead of a rollup.
+	for _, s := range filteredStates {
+		if !state.IsRunning(&s) {
+			continue
+		}
+		servers := queryMCPServers(s.Port)
+		if len(servers) == 0 {
+			continue
+		}
+		if showReplicas {
+			printer.Replicas(buildReplicaDetails(servers))
+		} else {
+			printer.MCPServers(buildMCPRollup(servers))
+		}
+	}
+
 	// Show trace activity summary for each running gateway.
 	for _, s := range filteredStates {
 		if state.IsRunning(&s) {
@@ -154,6 +176,192 @@ func queryTraceCount(port int) int {
 		return len(traces)
 	}
 	return -1
+}
+
+// mcpServerAPI mirrors the subset of internal/api.MCPServerStatus the CLI needs
+// to render rolled-up and per-replica views. Defined locally so the CLI does
+// not pull in the internal/api package.
+type mcpServerAPI struct {
+	Name         string            `json:"name"`
+	Transport    string            `json:"transport"`
+	External     bool              `json:"external"`
+	LocalProcess bool              `json:"localProcess"`
+	SSH          bool              `json:"ssh"`
+	OpenAPI      bool              `json:"openapi"`
+	Replicas     []mcpReplicaAPI   `json:"replicas,omitempty"`
+}
+
+// mcpReplicaAPI is the per-replica slice of mcpServerAPI.
+type mcpReplicaAPI struct {
+	ReplicaID       int        `json:"replicaId"`
+	State           string     `json:"state"`
+	Healthy         bool       `json:"healthy"`
+	InFlight        int64      `json:"inFlight"`
+	StartedAt       time.Time  `json:"startedAt,omitempty"`
+	RestartAttempts uint32     `json:"restartAttempts,omitempty"`
+	NextRetryAt     *time.Time `json:"nextRetryAt,omitempty"`
+	PID             int        `json:"pid,omitempty"`
+	ContainerID     string     `json:"containerId,omitempty"`
+}
+
+// queryMCPServers fetches the /api/mcp-servers payload from a running
+// gateway. Returns nil if the gateway is unreachable or the response is
+// malformed — the CLI renders whatever it can.
+func queryMCPServers(port int) []mcpServerAPI {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/api/mcp-servers", port))
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var servers []mcpServerAPI
+	if err := json.NewDecoder(resp.Body).Decode(&servers); err != nil {
+		return nil
+	}
+	return servers
+}
+
+// buildMCPRollup converts API statuses into the rolled-up table rows shown
+// by `gridctl status`.
+func buildMCPRollup(servers []mcpServerAPI) []output.MCPServerRollup {
+	rows := make([]output.MCPServerRollup, 0, len(servers))
+	now := time.Now()
+	for _, srv := range servers {
+		row := output.MCPServerRollup{
+			Name:     srv.Name,
+			Type:     mcpServerType(srv),
+			Replicas: "—",
+			State:    "healthy",
+		}
+		n := len(srv.Replicas)
+		if n == 0 {
+			// No replica info (e.g. pre-phase-3 daemon, or external transport).
+			row.State = "unknown"
+			rows = append(rows, row)
+			continue
+		}
+		healthy := 0
+		var firstRestarting *mcpReplicaAPI
+		for i := range srv.Replicas {
+			r := &srv.Replicas[i]
+			if r.Healthy {
+				healthy++
+			} else if firstRestarting == nil && r.State == "restarting" {
+				firstRestarting = r
+			}
+		}
+		if n > 1 {
+			row.Replicas = fmt.Sprintf("%d/%d", healthy, n)
+		}
+		switch healthy {
+		case n:
+			row.State = "healthy"
+		case 0:
+			row.State = "unhealthy"
+		default:
+			row.State = formatDegradedState(firstRestarting, now)
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// buildReplicaDetails converts API statuses into the per-replica rows for
+// `gridctl status --replicas`. Servers with no replica data are skipped.
+func buildReplicaDetails(servers []mcpServerAPI) []output.ReplicaDetail {
+	var rows []output.ReplicaDetail
+	now := time.Now()
+	for _, srv := range servers {
+		for _, r := range srv.Replicas {
+			row := output.ReplicaDetail{
+				Server:   srv.Name,
+				Replica:  r.ReplicaID,
+				Handle:   replicaHandle(r),
+				State:    r.State,
+				InFlight: r.InFlight,
+			}
+			if r.Healthy && !r.StartedAt.IsZero() {
+				row.Uptime = formatUptime(now.Sub(r.StartedAt))
+			} else {
+				row.Uptime = "—"
+			}
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+// mcpServerType returns the transport label shown in the rollup view.
+func mcpServerType(srv mcpServerAPI) string {
+	switch {
+	case srv.External:
+		return "external"
+	case srv.OpenAPI:
+		return "openapi"
+	case srv.LocalProcess:
+		return "local-process"
+	case srv.SSH:
+		return "ssh"
+	case srv.Transport != "":
+		return srv.Transport
+	default:
+		return "container"
+	}
+}
+
+// replicaHandle returns a short handle for the replica row's PID/container
+// column. Prefers PID for local-process replicas, a truncated container id
+// otherwise, or "—" when neither is known.
+func replicaHandle(r mcpReplicaAPI) string {
+	if r.PID > 0 {
+		return fmt.Sprintf("%d", r.PID)
+	}
+	if r.ContainerID != "" {
+		if len(r.ContainerID) > 12 {
+			return r.ContainerID[:12]
+		}
+		return r.ContainerID
+	}
+	return "—"
+}
+
+// formatDegradedState composes the "degraded" annotation including next-retry
+// info for the first restarting replica, matching the UX spec.
+func formatDegradedState(r *mcpReplicaAPI, now time.Time) string {
+	if r == nil {
+		return "degraded"
+	}
+	if r.NextRetryAt != nil && !r.NextRetryAt.IsZero() {
+		d := r.NextRetryAt.Sub(now)
+		if d > 0 {
+			return fmt.Sprintf("degraded (replica-%d restarting, next in %s)", r.ReplicaID, formatRetry(d))
+		}
+	}
+	return fmt.Sprintf("degraded (replica-%d restarting)", r.ReplicaID)
+}
+
+// formatRetry formats a retry delay compactly ("4s" / "1m20s").
+func formatRetry(d time.Duration) string {
+	d = d.Round(time.Second)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	return d.String()
+}
+
+// formatUptime formats a duration as human-readable uptime ("12m", "3h", "2d").
+func formatUptime(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
 }
 
 // queryCodeMode queries a running gateway's API for code mode status.

--- a/cmd/gridctl/status_test.go
+++ b/cmd/gridctl/status_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildMCPRollup_HealthyServers(t *testing.T) {
+	now := time.Now()
+	servers := []mcpServerAPI{
+		{
+			Name:         "junos",
+			LocalProcess: true,
+			Replicas: []mcpReplicaAPI{
+				{ReplicaID: 0, Healthy: true, State: "healthy", StartedAt: now.Add(-12 * time.Minute)},
+				{ReplicaID: 1, Healthy: true, State: "healthy", StartedAt: now.Add(-12 * time.Minute)},
+				{ReplicaID: 2, Healthy: true, State: "healthy", StartedAt: now.Add(-12 * time.Minute)},
+			},
+		},
+		{
+			Name:     "github",
+			External: true,
+			// external transport shows a single-replica set in phase 2;
+			// rollup should render "—" in the replicas column.
+			Replicas: []mcpReplicaAPI{
+				{ReplicaID: 0, Healthy: true, State: "healthy", StartedAt: now.Add(-20 * time.Minute)},
+			},
+		},
+	}
+
+	rows := buildMCPRollup(servers)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if rows[0].Name != "junos" || rows[0].Replicas != "3/3" || rows[0].State != "healthy" {
+		t.Errorf("junos row wrong: %+v", rows[0])
+	}
+	if rows[0].Type != "local-process" {
+		t.Errorf("expected local-process type for junos, got %q", rows[0].Type)
+	}
+	if rows[1].Name != "github" || rows[1].Replicas != "—" || rows[1].State != "healthy" {
+		t.Errorf("github row wrong: %+v", rows[1])
+	}
+	if rows[1].Type != "external" {
+		t.Errorf("expected external type for github, got %q", rows[1].Type)
+	}
+}
+
+func TestBuildMCPRollup_DegradedWithNextRetry(t *testing.T) {
+	now := time.Now()
+	next := now.Add(4 * time.Second)
+	servers := []mcpServerAPI{
+		{
+			Name:      "docker",
+			Transport: "stdio",
+			Replicas: []mcpReplicaAPI{
+				{ReplicaID: 0, Healthy: true, State: "healthy"},
+				{ReplicaID: 1, Healthy: false, State: "restarting", NextRetryAt: &next, RestartAttempts: 1},
+				{ReplicaID: 2, Healthy: true, State: "healthy"},
+			},
+		},
+	}
+	rows := buildMCPRollup(servers)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].Replicas != "2/3" {
+		t.Errorf("replicas column = %q, want 2/3", rows[0].Replicas)
+	}
+	if !strings.HasPrefix(rows[0].State, "degraded (replica-1 restarting") {
+		t.Errorf("state should start with degraded; got %q", rows[0].State)
+	}
+	if !strings.Contains(rows[0].State, "next in ") {
+		t.Errorf("state should include retry window; got %q", rows[0].State)
+	}
+}
+
+func TestBuildMCPRollup_AllUnhealthy(t *testing.T) {
+	servers := []mcpServerAPI{
+		{
+			Name: "broken",
+			Replicas: []mcpReplicaAPI{
+				{ReplicaID: 0, Healthy: false, State: "unhealthy"},
+				{ReplicaID: 1, Healthy: false, State: "unhealthy"},
+			},
+		},
+	}
+	rows := buildMCPRollup(servers)
+	if rows[0].State != "unhealthy" {
+		t.Errorf("all-down server should render unhealthy; got %q", rows[0].State)
+	}
+	if rows[0].Replicas != "0/2" {
+		t.Errorf("replicas column = %q, want 0/2", rows[0].Replicas)
+	}
+}
+
+func TestBuildReplicaDetails(t *testing.T) {
+	now := time.Now()
+	servers := []mcpServerAPI{
+		{
+			Name: "junos",
+			Replicas: []mcpReplicaAPI{
+				{ReplicaID: 0, Healthy: true, State: "healthy", StartedAt: now.Add(-12 * time.Minute), PID: 82341, InFlight: 2},
+				{ReplicaID: 1, Healthy: true, State: "healthy", StartedAt: now.Add(-12 * time.Minute), PID: 82342, InFlight: 0},
+			},
+		},
+		{
+			Name: "db",
+			Replicas: []mcpReplicaAPI{
+				{ReplicaID: 0, Healthy: true, State: "healthy", ContainerID: "abc123def456789", StartedAt: now.Add(-1 * time.Hour)},
+			},
+		},
+	}
+	rows := buildReplicaDetails(servers)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(rows))
+	}
+	if rows[0].Handle != "82341" {
+		t.Errorf("expected PID as handle, got %q", rows[0].Handle)
+	}
+	if rows[0].Uptime != "12m" {
+		t.Errorf("uptime = %q, want 12m", rows[0].Uptime)
+	}
+	if rows[2].Handle != "abc123def456" {
+		t.Errorf("container id should be truncated to 12 chars; got %q", rows[2].Handle)
+	}
+}
+
+func TestBuildReplicaDetails_UnhealthyShowsDash(t *testing.T) {
+	servers := []mcpServerAPI{
+		{
+			Name: "x",
+			Replicas: []mcpReplicaAPI{
+				{ReplicaID: 0, Healthy: false, State: "restarting"},
+			},
+		},
+	}
+	rows := buildReplicaDetails(servers)
+	if rows[0].Uptime != "—" {
+		t.Errorf("unhealthy replica uptime = %q, want —", rows[0].Uptime)
+	}
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -408,6 +408,8 @@ type MCPServerStatus struct {
 	Healthy      *bool    `json:"healthy,omitempty"`
 	LastCheck    *string  `json:"lastCheck,omitempty"`
 	HealthError  string   `json:"healthError,omitempty"`
+
+	Replicas []mcp.ReplicaStatus `json:"replicas,omitempty"`
 }
 
 func (s *Server) getMCPServerStatuses() []MCPServerStatus {
@@ -430,6 +432,7 @@ func (s *Server) getMCPServerStatuses() []MCPServerStatus {
 			OutputFormat: ms.OutputFormat,
 			Healthy:      ms.Healthy,
 			HealthError:  ms.HealthError,
+			Replicas:     ms.Replicas,
 		}
 		if ms.LastCheck != nil {
 			ts := ms.LastCheck.Format(time.RFC3339)

--- a/internal/api/stack.go
+++ b/internal/api/stack.go
@@ -8,8 +8,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
 	"github.com/gridctl/gridctl/pkg/state"
 
 	"gopkg.in/yaml.v3"
@@ -297,7 +299,62 @@ func (s *Server) handleStackHealth(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Per-replica health for servers with replicas > 1. Single-replica servers
+	// are intentionally omitted so the response shape is unchanged when no
+	// server is configured for horizontal scaling.
+	health.Replicas = s.collectReplicaHealth()
+
 	writeJSON(w, health)
+}
+
+// collectReplicaHealth returns per-replica health for every registered MCP
+// server with more than one replica. Returns nil when the gateway is absent
+// or no multi-replica servers exist.
+func (s *Server) collectReplicaHealth() map[string][]config.ReplicaHealth {
+	if s.gateway == nil {
+		return nil
+	}
+	var out map[string][]config.ReplicaHealth
+	now := time.Now()
+	for _, st := range s.gateway.Status() {
+		if len(st.Replicas) <= 1 {
+			continue
+		}
+		healths := make([]config.ReplicaHealth, 0, len(st.Replicas))
+		for _, r := range st.Replicas {
+			healths = append(healths, toReplicaHealth(r, now))
+		}
+		if out == nil {
+			out = make(map[string][]config.ReplicaHealth)
+		}
+		out[st.Name] = healths
+	}
+	return out
+}
+
+// toReplicaHealth projects an mcp.ReplicaStatus to the API-facing
+// config.ReplicaHealth shape.
+func toReplicaHealth(r mcp.ReplicaStatus, now time.Time) config.ReplicaHealth {
+	h := config.ReplicaHealth{
+		ReplicaID:       r.ReplicaID,
+		State:           r.State,
+		InFlight:        r.InFlight,
+		LastError:       r.LastError,
+		RestartAttempts: r.RestartAttempts,
+		PID:             r.PID,
+		ContainerID:     r.ContainerID,
+	}
+	if !r.StartedAt.IsZero() && r.Healthy {
+		if d := now.Sub(r.StartedAt); d > 0 {
+			h.UptimeSeconds = int64(d / time.Second)
+		}
+	}
+	if r.NextRetryAt != nil && !r.NextRetryAt.IsZero() {
+		if d := r.NextRetryAt.Sub(now); d > 0 {
+			h.NextRetrySeconds = int64(d / time.Second)
+		}
+	}
+	return h
 }
 
 // handleStackSpec returns the current stack.yaml content.

--- a/internal/api/stack_test.go
+++ b/internal/api/stack_test.go
@@ -255,6 +255,21 @@ func TestHandleStackHealth_WithStackFile(t *testing.T) {
 	body := w.Body.String()
 	// Should have validation status
 	assert.Contains(t, body, `"status"`)
+	// Single-replica servers MUST NOT bloat the shape with a replicas map.
+	assert.NotContains(t, body, `"replicas"`)
+}
+
+func TestHandleStackHealth_OmitsReplicasWhenSingleReplica(t *testing.T) {
+	// No gateway and no stack means no replicas map in the response.
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/api/stack/health", nil)
+	w := httptest.NewRecorder()
+
+	s.handleStackHealth(w, req)
+
+	var got config.SpecHealth
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Nil(t, got.Replicas, "single-replica deployments must omit the replicas field")
 }
 
 func TestHandleStackPlan_WithStackFile(t *testing.T) {

--- a/pkg/config/health.go
+++ b/pkg/config/health.go
@@ -36,6 +36,27 @@ type SpecHealth struct {
 	Validation  ValidationStatus  `json:"validation"`
 	Drift       DriftStatus       `json:"drift"`
 	Dependencies DependencyStatus `json:"dependencies"`
+
+	// Replicas reports live per-replica health for every server that has
+	// more than one replica registered. Servers with replicas <= 1 are
+	// omitted so the shape is backward compatible with single-replica
+	// deployments. Keyed by server name.
+	Replicas map[string][]ReplicaHealth `json:"replicas,omitempty"`
+}
+
+// ReplicaHealth describes the live state of one replica in a server's
+// ReplicaSet. Durations use seconds so the JSON representation does not
+// depend on Go's time formatting.
+type ReplicaHealth struct {
+	ReplicaID        int    `json:"replicaId"`
+	State            string `json:"state"` // "healthy" | "unhealthy" | "restarting"
+	InFlight         int64  `json:"inFlight"`
+	UptimeSeconds    int64  `json:"uptimeSeconds,omitempty"`
+	LastError        string `json:"lastError,omitempty"`
+	NextRetrySeconds int64  `json:"nextRetrySeconds,omitempty"`
+	RestartAttempts  uint32 `json:"restartAttempts,omitempty"`
+	PID              int    `json:"pid,omitempty"`
+	ContainerID      string `json:"containerId,omitempty"`
 }
 
 // ValidationStatus summarizes the spec validation state.

--- a/pkg/logging/structured.go
+++ b/pkg/logging/structured.go
@@ -123,6 +123,13 @@ func WithComponent(logger *slog.Logger, component string) *slog.Logger {
 	return logger.With(slog.String("component", component))
 }
 
+// WithReplicaID returns a new logger scoped to the given replica id. Use on
+// the tool-call and health/reconnect paths so every line emitted for a
+// replica carries its zero-indexed id alongside the server name.
+func WithReplicaID(logger *slog.Logger, replicaID int) *slog.Logger {
+	return logger.With(slog.Int("replica_id", replicaID))
+}
+
 // LogEntry represents a structured log entry for frontend consumption.
 // This is the schema that the frontend expects when parsing logs.
 type LogEntry struct {

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -422,6 +422,7 @@ func (g *Gateway) checkReplicaHealth(ctx context.Context, serverName string, rep
 		return
 	}
 
+	logger := logging.WithReplicaID(g.logger, replica.ID())
 	now := time.Now()
 	err := pingable.Ping(ctx)
 
@@ -434,7 +435,7 @@ func (g *Gateway) checkReplicaHealth(ctx context.Context, serverName string, rep
 	if err == nil {
 		status.LastHealthy = now
 		if prev != nil && !prev.Healthy {
-			g.logger.Info("MCP server recovered", "name", serverName)
+			logger.Info("MCP server recovered", "name", serverName)
 		}
 	} else {
 		status.Error = err.Error()
@@ -442,7 +443,7 @@ func (g *Gateway) checkReplicaHealth(ctx context.Context, serverName string, rep
 			status.LastHealthy = prev.LastHealthy
 		}
 		if prev == nil || prev.Healthy {
-			g.logger.Warn("MCP server unhealthy", "name", serverName, "error", err)
+			logger.Warn("MCP server unhealthy", "name", serverName, "error", err)
 		}
 	}
 	g.setReplicaStatusLocked(serverName, replica.ID(), status)
@@ -466,16 +467,17 @@ func (g *Gateway) checkReplicaHealth(ctx context.Context, serverName string, rep
 		return
 	}
 
-	g.logger.Info("attempting reconnection", "name", serverName)
+	logger.Info("attempting reconnection", "name", serverName)
 	if reconnErr := rc.Reconnect(ctx); reconnErr != nil {
 		delay := replica.Restart().Advance(now)
-		g.logger.Warn("reconnection failed", "name", serverName, "error", reconnErr, "next_retry_in", delay)
+		logger.Warn("reconnection failed", "name", serverName, "error", reconnErr, "next_retry_in", delay)
 		return
 	}
 
 	// Reconnect succeeded — back in rotation.
 	replica.Restart().Reset()
 	replica.SetHealthy(true)
+	replica.MarkStarted(time.Now())
 
 	g.healthMu.Lock()
 	g.setReplicaStatusLocked(serverName, replica.ID(), &HealthStatus{
@@ -486,7 +488,7 @@ func (g *Gateway) checkReplicaHealth(ctx context.Context, serverName string, rep
 	g.healthMu.Unlock()
 
 	g.router.RefreshTools()
-	g.logger.Info("MCP server reconnected", "name", serverName)
+	logger.Info("MCP server reconnected", "name", serverName)
 
 	// Verify pins after reconnection using replica-0's tool surface if we
 	// can get it; otherwise use this replica's tools. Drift on reconnect is
@@ -494,7 +496,7 @@ func (g *Gateway) checkReplicaHealth(ctx context.Context, serverName string, rep
 	if g.pinningEnabledForServer(serverName) {
 		drifts, pinErr := g.schemaVerifier.VerifyOrPin(serverName, client.Tools())
 		if pinErr != nil {
-			g.logger.Warn("pins: verification failed after reconnect", "name", serverName, "error", pinErr)
+			logger.Warn("pins: verification failed after reconnect", "name", serverName, "error", pinErr)
 		} else {
 			g.handlePinDrift(serverName, drifts)
 		}
@@ -577,6 +579,72 @@ func (g *Gateway) GetHealthStatus(name string) *HealthStatus {
 	g.healthMu.RLock()
 	defer g.healthMu.RUnlock()
 	return g.health[name]
+}
+
+// ReplicaStatuses returns per-replica status for the named server, ordered by
+// replica id. Returns nil if the server is not registered.
+func (g *Gateway) ReplicaStatuses(serverName string) []ReplicaStatus {
+	set := g.router.GetReplicaSet(serverName)
+	if set == nil {
+		return nil
+	}
+	replicas := set.Replicas()
+	out := make([]ReplicaStatus, 0, len(replicas))
+
+	g.healthMu.RLock()
+	replicaHealthMap := g.replicaHealth[serverName]
+	g.healthMu.RUnlock()
+
+	for _, r := range replicas {
+		rs := ReplicaStatus{
+			ReplicaID: r.ID(),
+			Healthy:   r.Healthy(),
+			InFlight:  r.InFlight(),
+			StartedAt: r.StartedAt(),
+		}
+		attempts := r.Restart().Attempts()
+		rs.RestartAttempts = attempts
+		if nextAt := r.Restart().NextAt(); !nextAt.IsZero() {
+			t := nextAt
+			rs.NextRetryAt = &t
+		}
+		if replicaHealthMap != nil {
+			if hs, ok := replicaHealthMap[r.ID()]; ok && hs != nil {
+				if !hs.LastCheck.IsZero() {
+					t := hs.LastCheck
+					rs.LastCheck = &t
+				}
+				if !hs.LastHealthy.IsZero() {
+					t := hs.LastHealthy
+					rs.LastHealthy = &t
+				}
+				rs.LastError = hs.Error
+			}
+		}
+		switch client := r.Client().(type) {
+		case *ProcessClient:
+			rs.PID = client.PID()
+		case *StdioClient:
+			rs.ContainerID = client.ContainerID()
+		}
+		rs.State = replicaStateString(rs.Healthy, attempts > 0)
+		out = append(out, rs)
+	}
+	return out
+}
+
+// replicaStateString maps a replica's health flag and restart-attempt counter
+// to a short state label: "healthy", "restarting" (unhealthy but currently
+// backing off a retry), or "unhealthy" (unhealthy with no retry pending).
+func replicaStateString(healthy bool, hasAttempts bool) string {
+	switch {
+	case healthy:
+		return "healthy"
+	case hasAttempts:
+		return "restarting"
+	default:
+		return "unhealthy"
+	}
 }
 
 // Close stops the cleanup goroutine and closes all agent client connections.
@@ -1018,7 +1086,7 @@ func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*
 	tracer := otel.Tracer("gridctl.gateway")
 	_, routeSpan := tracer.Start(ctx, "mcp.routing")
 	routeSpan.SetAttributes(attribute.String("tool.name", params.Name))
-	client, toolName, err := g.router.RouteToolCall(params.Name)
+	replica, toolName, err := g.router.RouteToolCallReplica(params.Name)
 	if err != nil {
 		routeSpan.SetStatus(codes.Error, err.Error())
 		routeSpan.End()
@@ -1027,7 +1095,12 @@ func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*
 			IsError: true,
 		}, nil
 	}
-	routeSpan.SetAttributes(attribute.String("server.name", client.Name()))
+	client := replica.Client()
+	replicaID := replica.ID()
+	routeSpan.SetAttributes(
+		attribute.String("server.name", client.Name()),
+		attribute.Int("mcp.replica.id", replicaID),
+	)
 	routeSpan.End()
 
 	// Reject calls to servers blocked due to schema drift.
@@ -1047,11 +1120,14 @@ func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*
 	// Propagate the resolved server name to the root span so the trace-level
 	// record (built from root span attrs) carries it for UI filtering.
 	if rootSpan := trace.SpanFromContext(ctx); rootSpan.IsRecording() {
-		rootSpan.SetAttributes(attribute.String("server.name", client.Name()))
+		rootSpan.SetAttributes(
+			attribute.String("server.name", client.Name()),
+			attribute.Int("mcp.replica.id", replicaID),
+		)
 	}
 
-	// Populate trace ID on the logger so structured logs are correlated.
-	logger := g.logger
+	// Populate trace ID and replica id on the logger so structured logs are correlated.
+	logger := logging.WithReplicaID(g.logger, replicaID)
 	if sc := trace.SpanFromContext(ctx).SpanContext(); sc.IsValid() {
 		logger = logging.WithTraceID(logger, sc.TraceID().String())
 	}
@@ -1068,6 +1144,7 @@ func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*
 	span.SetAttributes(
 		attribute.String("mcp.method.name", "tools/call"),
 		attribute.String("server.name", client.Name()),
+		attribute.Int("mcp.replica.id", replicaID),
 		attribute.String("tool.name", toolName),
 		attribute.String("network.transport", networkTransport),
 	)
@@ -1075,7 +1152,9 @@ func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*
 	logger.Info("tool call started", "server", client.Name(), "tool", toolName)
 	start := time.Now()
 
+	replica.IncInFlight()
 	result, err := client.CallTool(ctx, toolName, params.Arguments)
+	replica.DecInFlight()
 	duration := time.Since(start)
 
 	if err != nil {
@@ -1104,7 +1183,7 @@ func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*
 	obs := g.toolCallObserver
 	g.mu.RUnlock()
 	if obs != nil {
-		go obs.ObserveToolCall(client.Name(), params.Arguments, result)
+		go obs.ObserveToolCall(client.Name(), replicaID, params.Arguments, result)
 	}
 
 	return result, nil
@@ -1389,6 +1468,25 @@ type MCPServerStatus struct {
 	Healthy      *bool      `json:"healthy,omitempty"`      // Health check result (nil if not yet checked)
 	LastCheck    *time.Time `json:"lastCheck,omitempty"`    // When last health check ran
 	HealthError  string     `json:"healthError,omitempty"`  // Error message if unhealthy
+
+	Replicas []ReplicaStatus `json:"replicas,omitempty"` // Per-replica status; always populated
+}
+
+// ReplicaStatus reports the live state of a single replica within a
+// ReplicaSet. Uptime is derived from StartedAt at read time by the consumer.
+type ReplicaStatus struct {
+	ReplicaID       int        `json:"replicaId"`
+	State           string     `json:"state"`                     // "healthy" | "unhealthy" | "restarting"
+	Healthy         bool       `json:"healthy"`
+	InFlight        int64      `json:"inFlight"`
+	StartedAt       time.Time  `json:"startedAt,omitempty"`
+	LastCheck       *time.Time `json:"lastCheck,omitempty"`
+	LastHealthy     *time.Time `json:"lastHealthy,omitempty"`
+	LastError       string     `json:"lastError,omitempty"`
+	RestartAttempts uint32     `json:"restartAttempts,omitempty"`
+	NextRetryAt     *time.Time `json:"nextRetryAt,omitempty"`
+	PID             int        `json:"pid,omitempty"`
+	ContainerID     string     `json:"containerId,omitempty"`
 }
 
 // resolveNetworkTransport returns the network.transport attribute value for a
@@ -1509,6 +1607,8 @@ func (g *Gateway) Status() []MCPServerStatus {
 			status.HealthError = hs.Error
 		}
 		g.healthMu.RUnlock()
+
+		status.Replicas = g.ReplicaStatuses(client.Name())
 
 		statuses = append(statuses, status)
 	}

--- a/pkg/mcp/gateway_test.go
+++ b/pkg/mcp/gateway_test.go
@@ -3159,3 +3159,58 @@ func TestGateway_HealthMonitor_SingleReplica_UnchangedBehavior(t *testing.T) {
 	}
 }
 
+func TestGateway_ReplicaStatuses_PopulatesFromReplicaSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+
+	c0 := setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}})
+	c1 := setupMockAgentClient(ctrl, "svc", []Tool{{Name: "t"}})
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin, []AgentClient{c0, c1})
+	// Simulate unhealthy replica-1 with a backoff in flight.
+	set.Replicas()[1].SetHealthy(false)
+	set.Replicas()[1].Restart().Advance(time.Now())
+	set.Replicas()[0].IncInFlight()
+
+	g.Router().AddReplicaSet(set)
+	g.SetServerMeta(MCPServerConfig{Name: "svc", Transport: TransportHTTP})
+
+	statuses := g.ReplicaStatuses("svc")
+	if len(statuses) != 2 {
+		t.Fatalf("expected 2 replica statuses, got %d", len(statuses))
+	}
+	if statuses[0].ReplicaID != 0 || !statuses[0].Healthy || statuses[0].State != "healthy" {
+		t.Errorf("replica 0 unexpected: %+v", statuses[0])
+	}
+	if statuses[0].InFlight != 1 {
+		t.Errorf("replica 0 inflight = %d, want 1", statuses[0].InFlight)
+	}
+	if statuses[1].ReplicaID != 1 || statuses[1].Healthy {
+		t.Errorf("replica 1 should be unhealthy: %+v", statuses[1])
+	}
+	if statuses[1].State != "restarting" {
+		t.Errorf("replica 1 state = %q, want restarting", statuses[1].State)
+	}
+	if statuses[1].RestartAttempts == 0 {
+		t.Error("replica 1 should carry restart attempts after Advance()")
+	}
+	if statuses[1].NextRetryAt == nil {
+		t.Error("replica 1 should carry NextRetryAt after Advance()")
+	}
+
+	// Status() should thread the same per-replica info through the API shape.
+	srvStatuses := g.Status()
+	if len(srvStatuses) != 1 {
+		t.Fatalf("expected 1 server status, got %d", len(srvStatuses))
+	}
+	if len(srvStatuses[0].Replicas) != 2 {
+		t.Fatalf("expected 2 replicas on MCPServerStatus, got %d", len(srvStatuses[0].Replicas))
+	}
+}
+
+func TestGateway_ReplicaStatuses_UnknownServer(t *testing.T) {
+	g := NewGateway()
+	if got := g.ReplicaStatuses("nope"); got != nil {
+		t.Errorf("unknown server should return nil, got %+v", got)
+	}
+}
+

--- a/pkg/mcp/process.go
+++ b/pkg/mcp/process.go
@@ -340,6 +340,17 @@ func (c *ProcessClient) Reconnect(ctx context.Context) error {
 	return nil
 }
 
+// PID returns the operating-system process id of the running child. Returns 0
+// when the process has not been started (or has exited and been cleared).
+func (c *ProcessClient) PID() int {
+	c.procMu.Lock()
+	defer c.procMu.Unlock()
+	if c.cmd == nil || c.cmd.Process == nil {
+		return 0
+	}
+	return c.cmd.Process.Pid
+}
+
 // Ping checks if the process is alive by verifying it's still running
 // and sending a JSON-RPC ping.
 func (c *ProcessClient) Ping(ctx context.Context) error {

--- a/pkg/mcp/replica_set.go
+++ b/pkg/mcp/replica_set.go
@@ -109,6 +109,9 @@ type Replica struct {
 	healthy  atomic.Bool
 	inFlight atomic.Int64
 	restart  *backoffState
+
+	startedMu sync.Mutex
+	startedAt time.Time
 }
 
 // ID returns the zero-indexed replica id within its ReplicaSet.
@@ -135,6 +138,23 @@ func (r *Replica) InFlight() int64 { return r.inFlight.Load() }
 // Restart returns the replica's restart-backoff state. Never nil.
 func (r *Replica) Restart() *backoffState { return r.restart }
 
+// StartedAt returns the time this replica was initialized or most recently
+// restarted. Zero value means the replica has not yet started.
+func (r *Replica) StartedAt() time.Time {
+	r.startedMu.Lock()
+	defer r.startedMu.Unlock()
+	return r.startedAt
+}
+
+// MarkStarted records the current time as the replica's start time. Called
+// from NewReplicaSet and from the reconnect path so uptime reflects the
+// lifetime of the currently-running backing process.
+func (r *Replica) MarkStarted(now time.Time) {
+	r.startedMu.Lock()
+	defer r.startedMu.Unlock()
+	r.startedAt = now
+}
+
 // ReplicaSet is a pool of AgentClient replicas for a single logical MCP server.
 // Dispatch is determined by the set's policy. A single-replica set behaves
 // identically to a direct AgentClient (its Pick always returns that one
@@ -159,11 +179,13 @@ func NewReplicaSet(name, policy string, clients []AgentClient) *ReplicaSet {
 		policy:   policy,
 		replicas: make([]*Replica, 0, len(clients)),
 	}
+	now := time.Now()
 	for i, c := range clients {
 		r := &Replica{
-			id:      i,
-			client:  c,
-			restart: &backoffState{},
+			id:        i,
+			client:    c,
+			restart:   &backoffState{},
+			startedAt: now,
 		}
 		r.healthy.Store(true)
 		set.replicas = append(set.replicas, r)

--- a/pkg/mcp/router.go
+++ b/pkg/mcp/router.go
@@ -171,6 +171,17 @@ func (r *Router) AggregatedTools() []Tool {
 // RouteToolCall routes a tool call to the appropriate agent. The concrete
 // replica is chosen by the set's dispatch policy.
 func (r *Router) RouteToolCall(prefixedName string) (AgentClient, string, error) {
+	replica, toolName, err := r.RouteToolCallReplica(prefixedName)
+	if err != nil {
+		return nil, "", err
+	}
+	return replica.Client(), toolName, nil
+}
+
+// RouteToolCallReplica behaves like RouteToolCall but returns the chosen
+// replica itself. Callers that need the replica id (for per-replica logging,
+// tracing, and in-flight accounting) should use this variant.
+func (r *Router) RouteToolCallReplica(prefixedName string) (*Replica, string, error) {
 	agentName, toolName, err := ParsePrefixedTool(prefixedName)
 	if err != nil {
 		return nil, "", err
@@ -187,7 +198,7 @@ func (r *Router) RouteToolCall(prefixedName string) (AgentClient, string, error)
 	if err != nil {
 		return nil, "", fmt.Errorf("agent %s: %w", agentName, err)
 	}
-	return replica.Client(), toolName, nil
+	return replica, toolName, nil
 }
 
 // ToolNameDelimiter is the separator between agent name and tool name in prefixed tool names.

--- a/pkg/mcp/stdio.go
+++ b/pkg/mcp/stdio.go
@@ -39,6 +39,11 @@ type StdioClient struct {
 	responsesMu sync.Mutex
 }
 
+// ContainerID returns the docker container id this client was bound to.
+func (c *StdioClient) ContainerID() string {
+	return c.containerID
+}
+
 // NewStdioClient creates a new stdio-based MCP client.
 func NewStdioClient(name, containerID string, cli dockerclient.DockerClient) *StdioClient {
 	c := &StdioClient{

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -55,9 +55,11 @@ type ToolCaller interface {
 type ToolCallObserver interface {
 	// ObserveToolCall is called after a tool call completes.
 	// serverName is the MCP server that handled the call.
+	// replicaID is the zero-indexed replica within that server's set, or -1
+	// when the caller did not dispatch through a ReplicaSet.
 	// arguments are the tool call arguments (input).
 	// result is the tool call response (output). May be nil on error.
-	ObserveToolCall(serverName string, arguments map[string]any, result *ToolCallResult)
+	ObserveToolCall(serverName string, replicaID int, arguments map[string]any, result *ToolCallResult)
 }
 
 // FormatSavingsRecorder receives format savings observations.

--- a/pkg/metrics/accumulator.go
+++ b/pkg/metrics/accumulator.go
@@ -24,9 +24,10 @@ type FormatSavings struct {
 
 // TokenUsage is the top-level token usage snapshot returned by the API.
 type TokenUsage struct {
-	Session       TokenCounts            `json:"session"`
-	PerServer     map[string]TokenCounts `json:"per_server"`
-	FormatSavings FormatSavings          `json:"format_savings"`
+	Session       TokenCounts                        `json:"session"`
+	PerServer     map[string]TokenCounts             `json:"per_server"`
+	PerReplica    map[string]map[int]TokenCounts     `json:"per_replica,omitempty"`
+	FormatSavings FormatSavings                      `json:"format_savings"`
 }
 
 // DataPoint is a single time-series data point with token counts.
@@ -63,6 +64,14 @@ type serverCounters struct {
 	outputTokens atomic.Int64
 }
 
+// replicaCounters holds atomic counters for a single replica. Keyed by
+// (serverName, replicaID) in the accumulator so existing per-server aggregates
+// stay untouched.
+type replicaCounters struct {
+	inputTokens  atomic.Int64
+	outputTokens atomic.Int64
+}
+
 // Accumulator collects token usage metrics with thread-safe operations.
 // Session totals use atomic counters. Historical data is stored in a ring buffer
 // of pre-aggregated 1-minute time buckets.
@@ -74,6 +83,12 @@ type Accumulator struct {
 	// Per-server totals
 	serverMu sync.RWMutex
 	servers  map[string]*serverCounters
+
+	// Per-replica totals. Cardinality is bounded by the server replica limit
+	// (config validation caps replicas at 32) so the outer map scales with
+	// server count and the inner map with replica count — a small product.
+	replicaMu sync.RWMutex
+	replicas  map[string]map[int]*replicaCounters
 
 	// Ring buffer of 1-minute buckets
 	bufMu    sync.RWMutex
@@ -107,14 +122,24 @@ func NewAccumulator(maxDataPoints int) *Accumulator {
 	}
 	return &Accumulator{
 		servers:    make(map[string]*serverCounters),
+		replicas:   make(map[string]map[int]*replicaCounters),
 		buckets:    make([]bucket, maxDataPoints),
 		maxSize:    maxDataPoints,
 		serverBufs: make(map[string]*serverBuffer),
 	}
 }
 
-// Record adds a token usage observation from a tool call.
+// Record adds a token usage observation from a tool call. Equivalent to
+// RecordReplica with replicaID=-1 (i.e. do not attribute to a replica).
 func (a *Accumulator) Record(serverName string, inputTokens, outputTokens int) {
+	a.RecordReplica(serverName, -1, inputTokens, outputTokens)
+}
+
+// RecordReplica adds a token usage observation attributed to a specific
+// replica. Per-server aggregates are updated in all cases. Pass replicaID < 0
+// to skip the per-replica update (used for servers that are not part of a
+// replica set).
+func (a *Accumulator) RecordReplica(serverName string, replicaID, inputTokens, outputTokens int) {
 	input := int64(inputTokens)
 	output := int64(outputTokens)
 
@@ -139,10 +164,43 @@ func (a *Accumulator) Record(serverName string, inputTokens, outputTokens int) {
 	sc.inputTokens.Add(input)
 	sc.outputTokens.Add(output)
 
+	if replicaID >= 0 {
+		rc := a.getOrCreateReplicaCounters(serverName, replicaID)
+		rc.inputTokens.Add(input)
+		rc.outputTokens.Add(output)
+	}
+
 	// Update time-series ring buffer
 	now := bucketKey(time.Now())
 	a.addToBucket(now, input, output)
 	a.addToServerBucket(serverName, now, input, output)
+}
+
+// getOrCreateReplicaCounters returns the per-replica counter bucket, creating
+// it on first use. Safe for concurrent access.
+func (a *Accumulator) getOrCreateReplicaCounters(serverName string, replicaID int) *replicaCounters {
+	a.replicaMu.RLock()
+	if m, ok := a.replicas[serverName]; ok {
+		if rc, ok := m[replicaID]; ok {
+			a.replicaMu.RUnlock()
+			return rc
+		}
+	}
+	a.replicaMu.RUnlock()
+
+	a.replicaMu.Lock()
+	defer a.replicaMu.Unlock()
+	m, ok := a.replicas[serverName]
+	if !ok {
+		m = make(map[int]*replicaCounters)
+		a.replicas[serverName] = m
+	}
+	rc, ok := m[replicaID]
+	if !ok {
+		rc = &replicaCounters{}
+		m[replicaID] = rc
+	}
+	return rc
 }
 
 // RecordFormatSavings records token counts before and after format conversion.
@@ -251,6 +309,26 @@ func (a *Accumulator) Snapshot() TokenUsage {
 	}
 	a.serverMu.RUnlock()
 
+	a.replicaMu.RLock()
+	var perReplica map[string]map[int]TokenCounts
+	if len(a.replicas) > 0 {
+		perReplica = make(map[string]map[int]TokenCounts, len(a.replicas))
+		for name, m := range a.replicas {
+			inner := make(map[int]TokenCounts, len(m))
+			for id, rc := range m {
+				ri := rc.inputTokens.Load()
+				ro := rc.outputTokens.Load()
+				inner[id] = TokenCounts{
+					InputTokens:  ri,
+					OutputTokens: ro,
+					TotalTokens:  ri + ro,
+				}
+			}
+			perReplica[name] = inner
+		}
+	}
+	a.replicaMu.RUnlock()
+
 	// Compute format savings
 	origTokens := a.savingsOriginal.Load()
 	fmtTokens := a.savingsFormatted.Load()
@@ -266,7 +344,8 @@ func (a *Accumulator) Snapshot() TokenUsage {
 			OutputTokens: output,
 			TotalTokens:  input + output,
 		},
-		PerServer: perServer,
+		PerServer:  perServer,
+		PerReplica: perReplica,
 		FormatSavings: FormatSavings{
 			OriginalTokens:  origTokens,
 			FormattedTokens: fmtTokens,
@@ -404,6 +483,10 @@ func (a *Accumulator) Clear() {
 	a.serverMu.Lock()
 	a.servers = make(map[string]*serverCounters)
 	a.serverMu.Unlock()
+
+	a.replicaMu.Lock()
+	a.replicas = make(map[string]map[int]*replicaCounters)
+	a.replicaMu.Unlock()
 
 	a.bufMu.Lock()
 	a.buckets = make([]bucket, a.maxSize)

--- a/pkg/metrics/accumulator_test.go
+++ b/pkg/metrics/accumulator_test.go
@@ -42,6 +42,7 @@ func TestAccumulator_Record(t *testing.T) {
 func TestAccumulator_Clear(t *testing.T) {
 	acc := NewAccumulator(100)
 	acc.Record("server-a", 100, 50)
+	acc.RecordReplica("server-a", 0, 10, 5)
 
 	acc.Clear()
 
@@ -51,6 +52,57 @@ func TestAccumulator_Clear(t *testing.T) {
 	}
 	if len(snap.PerServer) != 0 {
 		t.Errorf("per-server count after clear = %d, want 0", len(snap.PerServer))
+	}
+	if len(snap.PerReplica) != 0 {
+		t.Errorf("per-replica count after clear = %d, want 0", len(snap.PerReplica))
+	}
+}
+
+func TestAccumulator_RecordReplica(t *testing.T) {
+	acc := NewAccumulator(100)
+
+	// Two replicas of the same server + one server without replicas.
+	acc.RecordReplica("junos", 0, 100, 50)
+	acc.RecordReplica("junos", 0, 40, 20)
+	acc.RecordReplica("junos", 1, 60, 30)
+	acc.Record("github", 10, 5) // no replica_id — should not produce a per-replica entry
+
+	snap := acc.Snapshot()
+
+	// Per-server aggregates still sum across replicas.
+	junos := snap.PerServer["junos"]
+	if junos.InputTokens != 200 || junos.OutputTokens != 100 {
+		t.Errorf("per-server junos = %+v, want input=200 output=100", junos)
+	}
+
+	// Per-replica map is keyed by (server, replica_id).
+	replicaMap, ok := snap.PerReplica["junos"]
+	if !ok {
+		t.Fatalf("expected junos in per_replica; got %+v", snap.PerReplica)
+	}
+	if got := replicaMap[0].InputTokens; got != 140 {
+		t.Errorf("junos replica 0 input = %d, want 140", got)
+	}
+	if got := replicaMap[1].InputTokens; got != 60 {
+		t.Errorf("junos replica 1 input = %d, want 60", got)
+	}
+
+	// Servers without replica_id should not appear under per_replica.
+	if _, ok := snap.PerReplica["github"]; ok {
+		t.Errorf("expected github absent from per_replica when recorded without replica_id")
+	}
+}
+
+func TestAccumulator_RecordNegativeReplicaIDSkipsReplicaMap(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordReplica("server-a", -1, 100, 50)
+
+	snap := acc.Snapshot()
+	if _, ok := snap.PerServer["server-a"]; !ok {
+		t.Error("expected per-server entry for server-a even when replicaID=-1")
+	}
+	if _, ok := snap.PerReplica["server-a"]; ok {
+		t.Error("expected no per-replica entry when replicaID=-1")
 	}
 }
 

--- a/pkg/metrics/observer.go
+++ b/pkg/metrics/observer.go
@@ -21,7 +21,7 @@ func NewObserver(counter token.Counter, accumulator *Accumulator) *Observer {
 }
 
 // ObserveToolCall counts input/output tokens and records them.
-func (o *Observer) ObserveToolCall(serverName string, arguments map[string]any, result *mcp.ToolCallResult) {
+func (o *Observer) ObserveToolCall(serverName string, replicaID int, arguments map[string]any, result *mcp.ToolCallResult) {
 	inputTokens := token.CountJSON(o.counter, arguments)
 
 	outputTokens := 0
@@ -31,5 +31,5 @@ func (o *Observer) ObserveToolCall(serverName string, arguments map[string]any, 
 		}
 	}
 
-	o.accumulator.Record(serverName, inputTokens, outputTokens)
+	o.accumulator.RecordReplica(serverName, replicaID, inputTokens, outputTokens)
 }

--- a/pkg/metrics/observer_test.go
+++ b/pkg/metrics/observer_test.go
@@ -19,7 +19,7 @@ func TestObserver_ObserveToolCall(t *testing.T) {
 		},
 	}
 
-	obs.ObserveToolCall("test-server", args, result)
+	obs.ObserveToolCall("test-server", -1, args, result)
 
 	snap := acc.Snapshot()
 	if snap.Session.InputTokens == 0 {
@@ -41,12 +41,45 @@ func TestObserver_ObserveToolCall(t *testing.T) {
 	}
 }
 
+func TestObserver_PerReplica(t *testing.T) {
+	counter := token.NewHeuristicCounter(4)
+	acc := NewAccumulator(100)
+	obs := NewObserver(counter, acc)
+
+	args := map[string]any{"query": "hello"}
+	result := &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent("response")}}
+
+	obs.ObserveToolCall("multi", 0, args, result)
+	obs.ObserveToolCall("multi", 1, args, result)
+	obs.ObserveToolCall("multi", 1, args, result)
+
+	snap := acc.Snapshot()
+	serverTotal, ok := snap.PerServer["multi"]
+	if !ok {
+		t.Fatal("expected per-server entry for multi")
+	}
+	replicaMap, ok := snap.PerReplica["multi"]
+	if !ok {
+		t.Fatalf("expected per-replica entry for multi; got %+v", snap.PerReplica)
+	}
+	if len(replicaMap) != 2 {
+		t.Fatalf("expected 2 replicas, got %d", len(replicaMap))
+	}
+	if replicaMap[1].TotalTokens != 2*replicaMap[0].TotalTokens {
+		t.Errorf("replica 1 should have 2× the tokens of replica 0; got %d vs %d",
+			replicaMap[1].TotalTokens, replicaMap[0].TotalTokens)
+	}
+	if sum := replicaMap[0].TotalTokens + replicaMap[1].TotalTokens; sum != serverTotal.TotalTokens {
+		t.Errorf("replica totals should sum to server total: %d vs %d", sum, serverTotal.TotalTokens)
+	}
+}
+
 func TestObserver_NilResult(t *testing.T) {
 	counter := token.NewHeuristicCounter(4)
 	acc := NewAccumulator(100)
 	obs := NewObserver(counter, acc)
 
-	obs.ObserveToolCall("test-server", map[string]any{"key": "val"}, nil)
+	obs.ObserveToolCall("test-server", -1, map[string]any{"key": "val"}, nil)
 
 	snap := acc.Snapshot()
 	if snap.Session.InputTokens == 0 {

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"fmt"
+
 	"github.com/charmbracelet/lipgloss"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
@@ -22,6 +24,26 @@ type GatewaySummary struct {
 	Status   string // running, stopped
 	Started  string // human-readable duration
 	CodeMode string // "on" or empty
+}
+
+// MCPServerRollup is one row of the rolled-up MCP-servers table shown by
+// `gridctl status`. A server with a single replica uses "—" in the Replicas
+// column to match the UX spec.
+type MCPServerRollup struct {
+	Name     string
+	Type     string // transport label: local-process, container, ssh, external, openapi
+	Replicas string // "N/M" for sets with replicas > 1, "—" for single-replica servers
+	State    string // "healthy", "degraded (replica-N restarting, next in 4s)", "unhealthy"
+}
+
+// ReplicaDetail is one row of the expanded `gridctl status --replicas` view.
+type ReplicaDetail struct {
+	Server   string
+	Replica  int
+	Handle   string // PID for local-process, container id prefix for container-backed
+	State    string
+	Uptime   string
+	InFlight int64
 }
 
 // ContainerSummary contains data for the container status table.
@@ -167,6 +189,70 @@ func (p *Printer) Containers(containers []ContainerSummary) {
 
 	t.Render()
 	p.Println()
+}
+
+// MCPServers prints the rolled-up MCP-server status table.
+func (p *Printer) MCPServers(rows []MCPServerRollup) {
+	if len(rows) == 0 {
+		return
+	}
+
+	p.Section("MCP SERVERS")
+
+	t := table.NewWriter()
+	t.SetOutputMirror(p.out)
+	t.SetStyle(p.tableStyle())
+
+	t.AppendHeader(table.Row{"Name", "Type", "Replicas", "State"})
+	for _, r := range rows {
+		state := r.State
+		if p.isTTY {
+			state = colorReplicaState(r.State)
+		}
+		t.AppendRow(table.Row{r.Name, r.Type, r.Replicas, state})
+	}
+	t.Render()
+	p.Println()
+}
+
+// Replicas prints the per-replica detail table used by `gridctl status --replicas`.
+func (p *Printer) Replicas(rows []ReplicaDetail) {
+	if len(rows) == 0 {
+		return
+	}
+
+	p.Section("REPLICAS")
+
+	t := table.NewWriter()
+	t.SetOutputMirror(p.out)
+	t.SetStyle(p.tableStyle())
+
+	t.AppendHeader(table.Row{"Server", "Replica", "PID/Container", "State", "Uptime", "In-Flight"})
+	for _, r := range rows {
+		state := r.State
+		if p.isTTY {
+			state = colorReplicaState(r.State)
+		}
+		t.AppendRow(table.Row{r.Server, fmt.Sprintf("%d", r.Replica), r.Handle, state, r.Uptime, r.InFlight})
+	}
+	t.Render()
+	p.Println()
+}
+
+// colorReplicaState colours rollup/expanded replica states. "degraded" starts
+// with the token "degraded" so the prefix match catches the full annotation
+// ("degraded (replica-1 restarting, next in 4s)").
+func colorReplicaState(state string) string {
+	switch {
+	case state == "healthy":
+		return lipgloss.NewStyle().Foreground(ColorGreen).Render(state)
+	case state == "restarting", state == "unhealthy":
+		return lipgloss.NewStyle().Foreground(ColorRed).Render(state)
+	case len(state) >= 8 && state[:8] == "degraded":
+		return lipgloss.NewStyle().Foreground(ColorAmber).Render(state)
+	default:
+		return lipgloss.NewStyle().Foreground(ColorGray).Render(state)
+	}
 }
 
 // colorPinStatus applies color to a pin status label for TTY output.


### PR DESCRIPTION
## Description

Phase 3 of 5 for MCP server replicas (#470). Adds the observability layer on top of the replica runtime landed in #477/#478: replica_id on every log line and trace span along the tool-call path, per-replica metrics, a rolled-up CLI view with `--replicas` expansion, and per-replica breakdown on `/api/stack/health` and `/api/mcp-servers`.

## Type of Change

- [x] Feature

## Changes Made

- `pkg/mcp/gateway.go` — scoped `slog.Logger` with `replica_id` on tool-call and health/reconnect paths; `mcp.replica.id` trace-span attribute everywhere `server.name` is set on the tool-call path; in-flight counters incremented around `CallTool`; replica `StartedAt` refreshed on successful reconnect.
- `pkg/mcp/router.go` — new `RouteToolCallReplica` returning the chosen `*Replica` so the gateway can observe the dispatch.
- `pkg/mcp/gateway.go` — new `ReplicaStatus` type and `Gateway.ReplicaStatuses(name)`; `MCPServerStatus.Replicas` populated from this in `Status()`.
- `pkg/mcp/process.go`, `pkg/mcp/stdio.go` — expose `PID()` / `ContainerID()` so per-replica rows can surface a handle.
- `pkg/mcp/types.go`, `pkg/metrics/observer.go`, `pkg/metrics/accumulator.go` — `ToolCallObserver.ObserveToolCall` now carries `replicaID`; new `Accumulator.RecordReplica` keeps per-server aggregates and adds `TokenUsage.PerReplica`.
- `pkg/config/health.go`, `internal/api/stack.go` — `SpecHealth.Replicas map[string][]ReplicaHealth` populated only when a server has more than one replica, so single-replica responses are byte-identical.
- `cmd/gridctl/status.go`, `pkg/output/table.go` — new MCP SERVERS rollup table (`N/M healthy` / `degraded (replica-1 restarting, next in 4s)`) and `--replicas` flag that expands to one row per replica with PID/container, state, uptime, and in-flight count.
- `pkg/logging/structured.go` — `WithReplicaID` helper for scoped replica loggers.

## Testing

- `go test -race ./...` — passes (pre-existing `internal/api.TestHandleSkills_SourcesList_Empty` failure is unrelated and also fails on `main`).
- `golangci-lint run ./...` — 0 issues.
- `make build` — passes.
- `npm run build` — passes.
- New unit tests: `TestGateway_ReplicaStatuses_*`, `TestAccumulator_RecordReplica`, `TestObserver_PerReplica`, `TestBuildMCPRollup_*`, `TestBuildReplicaDetails*`, `TestHandleStackHealth_OmitsReplicasWhenSingleReplica`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #470