### PR TITLE
feat: replicas wizard input and canvas badge (phase 4 of #470)

### DIFF
--- a/web/src/__tests__/CustomNode.test.tsx
+++ b/web/src/__tests__/CustomNode.test.tsx
@@ -71,6 +71,21 @@ describe('CustomNode', () => {
     expect(screen.getByText('OpenAPI')).toBeInTheDocument();
   });
 
+  it('renders ×N replica badge when replicaCount > 1', () => {
+    render(<CustomNode data={makeServerData({ replicaCount: 3 })} />);
+    expect(screen.getByText('×3')).toBeInTheDocument();
+  });
+
+  it('omits replica badge for single-replica servers', () => {
+    render(<CustomNode data={makeServerData({ replicaCount: 1 })} />);
+    expect(screen.queryByText(/^×/)).not.toBeInTheDocument();
+  });
+
+  it('omits replica badge when replicaCount is undefined', () => {
+    render(<CustomNode data={makeServerData()} />);
+    expect(screen.queryByText(/^×/)).not.toBeInTheDocument();
+  });
+
   it('renders resource node with image', () => {
     const data: ResourceNodeData = {
       type: 'resource',

--- a/web/src/__tests__/MCPServerForm.test.tsx
+++ b/web/src/__tests__/MCPServerForm.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MCPServerForm } from '../components/wizard/steps/MCPServerForm';
 import type { MCPServerFormData } from '../lib/yaml-builder';
-import { buildYAML } from '../lib/yaml-builder';
+import { buildYAML, parseYAMLToForm } from '../lib/yaml-builder';
 
 function defaultData(overrides?: Partial<MCPServerFormData>): MCPServerFormData {
   return { name: '', serverType: 'container', ...overrides };
@@ -520,5 +520,149 @@ describe('YAML serialization — new fields', () => {
       data: { name: 'my-server', serverType: 'container', image: 'test:latest' },
     });
     expect(yaml).not.toContain('pin_schemas');
+  });
+
+  it('serializes replicas when > 1', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: { name: 'junos', serverType: 'local', command: ['python', 'srv.py'], replicas: 3 },
+    });
+    expect(yaml).toContain('replicas: 3');
+  });
+
+  it('omits replicas: 1 (matches Go omitempty)', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: { name: 'junos', serverType: 'container', image: 'test:latest', replicas: 1 },
+    });
+    expect(yaml).not.toContain('replicas');
+  });
+
+  it('serializes replica_policy only when non-default', () => {
+    const withDefault = buildYAML({
+      type: 'mcp-server',
+      data: { name: 'junos', serverType: 'container', image: 'test:latest', replicas: 3, replicaPolicy: 'round-robin' },
+    });
+    expect(withDefault).not.toContain('replica_policy');
+
+    const withCustom = buildYAML({
+      type: 'mcp-server',
+      data: { name: 'junos', serverType: 'container', image: 'test:latest', replicas: 3, replicaPolicy: 'least-connections' },
+    });
+    expect(withCustom).toContain('replica_policy: least-connections');
+  });
+
+  it('round-trips replicas + least-connections policy through YAML', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'junos',
+        serverType: 'local',
+        command: ['python', 'jmcp.py'],
+        replicas: 3,
+        replicaPolicy: 'least-connections',
+      },
+    });
+    const parsed = parseYAMLToForm(yaml, 'mcp-server');
+    expect('error' in parsed).toBe(false);
+    if ('error' in parsed) return;
+    expect(parsed.data.name).toBe('junos');
+    expect((parsed.data as MCPServerFormData).replicas).toBe(3);
+    expect((parsed.data as MCPServerFormData).replicaPolicy).toBe('least-connections');
+  });
+});
+
+describe('MCPServerForm — replicas UI', () => {
+  it('shows replicas input for container serverType', () => {
+    render(
+      <MCPServerForm
+        data={defaultData({ serverType: 'container', image: 'test:latest' })}
+        onChange={() => {}}
+      />,
+    );
+    // Expand Advanced section
+    fireEvent.click(screen.getByText('Advanced'));
+    expect(screen.getByText('Replicas')).toBeInTheDocument();
+  });
+
+  it('shows replicas input for local and ssh serverTypes', () => {
+    const { rerender } = render(
+      <MCPServerForm
+        data={defaultData({ serverType: 'local' })}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText('Advanced'));
+    expect(screen.getByText('Replicas')).toBeInTheDocument();
+
+    rerender(
+      <MCPServerForm
+        data={defaultData({ serverType: 'ssh', ssh: { host: 'h', user: 'u' } })}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('Replicas')).toBeInTheDocument();
+  });
+
+  it('hides replicas input for external and openapi serverTypes', () => {
+    const { rerender } = render(
+      <MCPServerForm
+        data={defaultData({ serverType: 'external', url: 'http://x' })}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText('Advanced'));
+    expect(screen.queryByText('Replicas')).not.toBeInTheDocument();
+
+    rerender(
+      <MCPServerForm
+        data={defaultData({ serverType: 'openapi', openapi: { spec: 'https://x/y.yaml' } })}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.queryByText('Replicas')).not.toBeInTheDocument();
+  });
+
+  it('clamps replicas input to [1, 32] and omits default via onChange', () => {
+    const onChange = vi.fn();
+    render(
+      <MCPServerForm
+        data={defaultData({ serverType: 'container', image: 'test:latest' })}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('Advanced'));
+    const input = screen.getByLabelText('Replicas') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '50' } });
+    expect(onChange).toHaveBeenLastCalledWith({ replicas: 32 });
+
+    fireEvent.change(input, { target: { value: '0' } });
+    expect(onChange).toHaveBeenLastCalledWith({ replicas: undefined });
+
+    fireEvent.change(input, { target: { value: '1' } });
+    expect(onChange).toHaveBeenLastCalledWith({ replicas: undefined });
+
+    fireEvent.change(input, { target: { value: '4' } });
+    expect(onChange).toHaveBeenLastCalledWith({ replicas: 4 });
+  });
+
+  it('shows replica policy selector only when replicas > 1', () => {
+    const { rerender } = render(
+      <MCPServerForm
+        data={defaultData({ serverType: 'container', image: 'test:latest', replicas: 1 })}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText('Advanced'));
+    expect(screen.queryByText('Replica Policy')).not.toBeInTheDocument();
+
+    rerender(
+      <MCPServerForm
+        data={defaultData({ serverType: 'container', image: 'test:latest', replicas: 3 })}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('Replica Policy')).toBeInTheDocument();
   });
 });

--- a/web/src/components/graph/CustomNode.tsx
+++ b/web/src/components/graph/CustomNode.tsx
@@ -33,6 +33,8 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
   const transport = isServer ? (data as MCPServerNodeData).transport : null;
   const TransportIcon = getTransportIcon(transport);
   const toolCount = isServer ? (data as MCPServerNodeData).toolCount : null;
+  const replicaCount = isServer ? (data as MCPServerNodeData).replicaCount ?? 1 : 1;
+  const hasReplicas = isServer && replicaCount > 1;
 
   // Get endpoint/containerId for MCP servers
   const endpoint = isServer ? (data as MCPServerNodeData).endpoint : null;
@@ -107,6 +109,17 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
               <span className="w-1.5 h-1.5 rounded-full bg-cyan-400 animate-pulse" />
               <span className="text-[9px] text-cyan-400 font-medium">active</span>
             </div>
+          )}
+          {/* Inline replica count when > 1. Shown in both compact and full modes
+              so horizontal-scale servers are recognisable at a glance. */}
+          {hasReplicas && (
+            <span
+              className="text-[10px] text-violet-300/80 font-mono tracking-tight"
+              title={`${replicaCount} replicas`}
+              aria-label={`${replicaCount} replicas`}
+            >
+              ×{replicaCount}
+            </span>
           )}
           {/* Inline tool count in compact mode */}
           {isCompact && isServer && toolCount !== null && toolCount !== undefined && (

--- a/web/src/components/wizard/steps/MCPServerForm.tsx
+++ b/web/src/components/wizard/steps/MCPServerForm.tsx
@@ -116,22 +116,23 @@ interface FieldVisibility {
   openapi: boolean;
   buildArgs: boolean;
   network: boolean;
+  replicas: boolean;
 }
 
 function getFieldVisibility(serverType: ServerType): FieldVisibility {
   switch (serverType) {
     case 'container':
-      return { image: true, port: true, transport: true, command: true, source: false, url: false, ssh: false, openapi: false, buildArgs: false, network: true };
+      return { image: true, port: true, transport: true, command: true, source: false, url: false, ssh: false, openapi: false, buildArgs: false, network: true, replicas: true };
     case 'source':
-      return { image: false, port: true, transport: true, command: false, source: true, url: false, ssh: false, openapi: false, buildArgs: true, network: true };
+      return { image: false, port: true, transport: true, command: false, source: true, url: false, ssh: false, openapi: false, buildArgs: true, network: true, replicas: true };
     case 'external':
-      return { image: false, port: false, transport: true, command: false, source: false, url: true, ssh: false, openapi: false, buildArgs: false, network: false };
+      return { image: false, port: false, transport: true, command: false, source: false, url: true, ssh: false, openapi: false, buildArgs: false, network: false, replicas: false };
     case 'local':
-      return { image: false, port: false, transport: false, command: true, source: false, url: false, ssh: false, openapi: false, buildArgs: false, network: false };
+      return { image: false, port: false, transport: false, command: true, source: false, url: false, ssh: false, openapi: false, buildArgs: false, network: false, replicas: true };
     case 'ssh':
-      return { image: false, port: false, transport: false, command: true, source: false, url: false, ssh: true, openapi: false, buildArgs: false, network: false };
+      return { image: false, port: false, transport: false, command: true, source: false, url: false, ssh: true, openapi: false, buildArgs: false, network: false, replicas: true };
     case 'openapi':
-      return { image: false, port: false, transport: false, command: false, source: false, url: false, ssh: false, openapi: true, buildArgs: false, network: false };
+      return { image: false, port: false, transport: false, command: false, source: false, url: false, ssh: false, openapi: true, buildArgs: false, network: false, replicas: false };
   }
 }
 
@@ -477,7 +478,13 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
   };
 
   const envCount = data.env ? Object.keys(data.env).length : 0;
-  const advancedCount = (data.tools?.length ?? 0) + (data.outputFormat ? 1 : 0) + (data.buildArgs ? Object.keys(data.buildArgs).length : 0) + (data.network ? 1 : 0) + (data.pinSchemas !== undefined ? 1 : 0);
+  const advancedCount =
+    (data.tools?.length ?? 0) +
+    (data.outputFormat ? 1 : 0) +
+    (data.buildArgs ? Object.keys(data.buildArgs).length : 0) +
+    (data.network ? 1 : 0) +
+    (data.pinSchemas !== undefined ? 1 : 0) +
+    (data.replicas !== undefined && data.replicas !== 1 ? 1 : 0);
 
   return (
     <div className="space-y-3">
@@ -1423,6 +1430,47 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
           </select>
           <p className="text-[10px] text-text-muted mt-1">Override the gateway-level schema pinning setting for this server</p>
         </div>
+
+        {visibility.replicas && (
+          <div>
+            <label className={labelClass}>Replicas</label>
+            <input
+              type="number"
+              aria-label="Replicas"
+              value={data.replicas ?? 1}
+              onChange={(e) => {
+                const n = Number(e.target.value);
+                if (!Number.isFinite(n)) return;
+                const clamped = Math.max(1, Math.min(32, Math.trunc(n)));
+                onChange({ replicas: clamped === 1 ? undefined : clamped });
+              }}
+              placeholder="1"
+              min={1}
+              max={32}
+              className={cn(inputClass, errors?.replicas && 'border-status-error/50')}
+            />
+            <FieldError error={errors?.replicas} />
+            <p className="text-[10px] text-text-muted mt-1">Number of parallel instances to run (1–32). Supported for container, local-process, and SSH transports.</p>
+            {data.replicas !== undefined && data.replicas > 1 && (
+              <div className="mt-3">
+                <label className={labelClass}>Replica Policy</label>
+                <select
+                  aria-label="Replica Policy"
+                  value={data.replicaPolicy ?? 'round-robin'}
+                  onChange={(e) => {
+                    const v = e.target.value as 'round-robin' | 'least-connections';
+                    onChange({ replicaPolicy: v === 'round-robin' ? undefined : v });
+                  }}
+                  className={inputClass}
+                >
+                  <option value="round-robin">Round-robin</option>
+                  <option value="least-connections">Least connections</option>
+                </select>
+                <p className="text-[10px] text-text-muted mt-1">How tool calls are distributed across replicas</p>
+              </div>
+            )}
+          </div>
+        )}
       </Section>
     </div>
   );

--- a/web/src/lib/graph/nodes.ts
+++ b/web/src/lib/graph/nodes.ts
@@ -94,6 +94,7 @@ export function createMCPServerNodes(mcpServers: MCPServerStatus[]): Node[] {
       openapi: server.openapi,
       openapiSpec: server.openapiSpec,
       outputFormat: server.outputFormat,
+      replicaCount: server.replicas?.length,
     },
     draggable: true,
   }));

--- a/web/src/lib/yaml-builder.ts
+++ b/web/src/lib/yaml-builder.ts
@@ -68,6 +68,9 @@ export interface MCPServerFormData {
   outputFormat?: string;
   network?: string;
   pinSchemas?: boolean;
+  // Replicas
+  replicas?: number;
+  replicaPolicy?: 'round-robin' | 'least-connections';
 }
 
 export interface ResourceFormData {
@@ -249,6 +252,15 @@ function buildMCPServer(data: MCPServerFormData, indentLevel = 2): string {
   if (data.network) lines.push(`${inner}network: ${data.network}`);
   if (data.pinSchemas !== undefined) lines.push(`${inner}pin_schemas: ${data.pinSchemas}`);
 
+  // Replicas: mirror Go's omitempty semantics — skip the default (1) and the
+  // default policy (round-robin) so single-replica specs stay byte-identical.
+  if (data.replicas && data.replicas !== 1) {
+    lines.push(`${inner}replicas: ${data.replicas}`);
+  }
+  if (data.replicaPolicy && data.replicaPolicy !== 'round-robin') {
+    lines.push(`${inner}replica_policy: ${data.replicaPolicy}`);
+  }
+
   return lines.join('\n');
 }
 
@@ -401,7 +413,13 @@ export function parseYAMLToForm(yaml: string, resourceType: ResourceType): Wizar
 
     // Return minimal parsed data based on type
     switch (resourceType) {
-      case 'mcp-server':
+      case 'mcp-server': {
+        const parsedReplicas = Number(result.replicas);
+        const rawPolicy = result.replica_policy as string | undefined;
+        const replicaPolicy =
+          rawPolicy === 'least-connections' || rawPolicy === 'round-robin'
+            ? rawPolicy
+            : undefined;
         return {
           type: 'mcp-server',
           data: {
@@ -409,8 +427,11 @@ export function parseYAMLToForm(yaml: string, resourceType: ResourceType): Wizar
             serverType: 'container',
             image: result.image as string,
             transport: result.transport as string,
+            replicas: Number.isFinite(parsedReplicas) && parsedReplicas > 0 ? parsedReplicas : undefined,
+            replicaPolicy,
           },
         };
+      }
       case 'resource':
         return {
           type: 'resource',

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -15,6 +15,24 @@ export interface ServerInfo {
   tokenizer?: string; // active tokenizer mode: "embedded" or "api"
 }
 
+// Per-replica runtime status matching mcp.ReplicaStatus on the Go side.
+// Present only when a server has a replica set; single-replica servers may
+// still populate a single-element array.
+export interface ReplicaStatus {
+  replicaId: number;
+  state: 'healthy' | 'unhealthy' | 'restarting' | string;
+  healthy: boolean;
+  inFlight: number;
+  startedAt?: string; // RFC3339 timestamp
+  lastCheck?: string;
+  lastHealthy?: string;
+  lastError?: string;
+  restartAttempts?: number;
+  nextRetryAt?: string;
+  pid?: number;
+  containerId?: string;
+}
+
 // MCP Server status matching mcp.MCPServerStatus
 export interface MCPServerStatus {
   name: string;
@@ -34,6 +52,7 @@ export interface MCPServerStatus {
   openapi?: boolean; // True for OpenAPI-backed servers
   openapiSpec?: string; // OpenAPI spec URL or file path
   outputFormat?: string; // Configured output format (e.g. "toon", "csv")
+  replicas?: ReplicaStatus[]; // Per-replica runtime status
 }
 
 // Resource status for non-MCP containers
@@ -165,6 +184,7 @@ export interface MCPServerNodeData extends NodeDataBase {
   isProcessing?: boolean; // Playground: true when this server has an active tool call
   pinStatus?: 'pinned' | 'drift' | 'blocked' | 'approved_pending_redeploy';
   pinDriftCount?: number;
+  replicaCount?: number; // Number of replicas (omitted or 1 = single-replica)
 }
 
 export interface ResourceNodeData extends NodeDataBase {


### PR DESCRIPTION
## Description

Phase 4 of 5 for MCP server replicas (#470). Wires `replicas` (and `replica_policy`) through the web wizard and visual editor so operators can configure horizontal scaling without hand-editing YAML. Matches the Go-side `omitempty` semantics so single-replica specs stay byte-identical.

## Type of Change

- [x] Feature

## Changes Made

- `web/src/lib/yaml-builder.ts` — adds `replicas?: number` and `replicaPolicy?: 'round-robin' | 'least-connections'` to `MCPServerFormData`; builder omits `replicas: 1` and `replica_policy: round-robin` to mirror Go's `omitempty`; parser restores both fields for round-trip.
- `web/src/components/wizard/steps/MCPServerForm.tsx` — new `replicas` key on `FieldVisibility`, true only for container/source/local/ssh (hidden on external + openapi per backend validation). Numeric input in the Advanced section with clamp to [1, 32]; values of 1 normalise to `undefined`. Policy selector appears only when replicas > 1.
- `web/src/components/graph/CustomNode.tsx`, `web/src/lib/graph/nodes.ts`, `web/src/types/index.ts` — new `ReplicaStatus` TS type mirroring Go's `mcp.ReplicaStatus`; `MCPServerStatus.replicas?: ReplicaStatus[]` carries the `/api/mcp-servers` payload; `MCPServerNodeData.replicaCount?` feeds a small `×N` badge in the node header, shown in both compact and full modes for `replicaCount > 1`.

## Testing

- `npm test` — all 336 unit tests pass, including new cases:
  - Form visibility per transport (container/source/local/ssh show replicas; external/openapi hide it)
  - Clamp to [1, 32] and omit-on-default (replicas=1 → undefined in onChange)
  - Policy selector gated by replicas > 1
  - YAML round-trip for replicas=3 + least-connections
  - Canvas ×N badge visible for replicaCount > 1, absent for 1/undefined
- `npm run lint` — no new issues introduced (same 33 pre-existing problems as `main`).
- `npm run build` — passes.
- `make build` — Go binary still builds with embedded web assets.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #470