### PR TITLE
test: integration coverage and docs for MCP replicas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,8 +167,9 @@ gridctl/
 │   │   ├── openapi_client.go # OpenAPI-backed MCP client
 │   │   ├── sse.go        # SSE server (northbound)
 │   │   ├── session.go    # Session management
-│   │   ├── router.go     # Tool routing
-│   │   ├── gateway.go    # Protocol bridge logic
+│   │   ├── router.go     # Tool routing (name → ReplicaSet)
+│   │   ├── replica_set.go # Replica pool (round-robin / least-connections dispatch + restart backoff 1s → 30s cap, ±25% jitter)
+│   │   ├── gateway.go    # Protocol bridge logic, per-replica health monitor + reconnect
 │   │   ├── handler.go    # HTTP handlers
 │   │   ├── expand.go     # Environment variable expansion
 │   │   ├── codemode.go       # Code mode orchestrator
@@ -228,9 +229,18 @@ gridctl/
 │   └── _mock-servers/    # Mock MCP servers for testing
 └── tests/
     └── integration/      # Integration tests (build tag: integration)
-        ├── orchestrator_test.go
-        ├── runtime_test.go
-        └── openapi_test.go
+        ├── transport_test.go         # TestMain, mock-server harness, freePort/startMockServer/waitForPort
+        ├── gateway_lifecycle_test.go # Gateway register/unregister/health monitor/shutdown
+        ├── hot_reload_test.go        # Reload handler: add/remove/modify servers
+        ├── runtime_test.go           # Full stack lifecycle, resources, networks
+        ├── podman_test.go            # Podman rootless networking
+        ├── skills_executor_test.go   # Skill execution workflows (DAGs, timeouts)
+        ├── openapi_test.go           # OpenAPI spec parsing + auth
+        ├── replica_kill_one_test.go       # Kill one replica, verify exclusion + survivors
+        ├── replica_all_down_test.go       # All replicas down → structured error
+        ├── replica_restart_storm_test.go  # Backoff prevents reconnect spin
+        ├── replica_stackless_mode_test.go # Multi-replica register in stackless mode
+        └── replica_mixed_counts_test.go   # 1-replica + 3-replica server in one gateway
 ```
 
 ## Build Commands
@@ -605,6 +615,8 @@ When the vault is locked, all endpoints except `status`, `unlock`, and `lock` re
 
 **Tool prefixing:** Tools are prefixed with server name to avoid collisions:
 - `server-name__tool-name` (e.g., `itential-mcp__get_workflows`)
+
+**Replica sets:** Each registered server is a `ReplicaSet` in the router — a pool of 1..N `AgentClient` replicas sharing one server name and one tool namespace. Set `replicas: N` (and optionally `replica_policy: round-robin | least-connections`) in `mcp-servers[]` to spawn N independent processes. Validation caps at 32 and rejects replicas on `external` / `openapi` transports. Per-replica health monitor pings each replica independently, excludes failures from dispatch, and reconnects with exponential backoff (1s → 30s cap, ±25% jitter, reset on success). When every replica is unhealthy, tool calls fail with `no healthy replicas: <server>`. Every log line and trace span on the tool-call path carries a `replica_id`; `gridctl status --replicas` and `/api/stack/health` expose the per-replica breakdown. See [docs/scaling.md](docs/scaling.md).
 
 ## Stack YAML Schema
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Guides and references for gridctl.
 
 | Document | Description |
 |----------|-------------|
+| [Scaling stdio servers](scaling.md) | Run multiple replicas of a single MCP server — policies, trade-offs, observability |
 | [Troubleshooting](troubleshooting.md) | Common errors and resolutions — runtime, networking, vault, hot reload |
 
 ## Quick Links

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -322,6 +322,8 @@ mcp-servers:
 | `output_format` | string | No | — | Output format override: `"json"`, `"toon"`, `"csv"`, or `"text"`. Overrides `gateway.output_format` for this server |
 | `pin_schemas` | bool | No | — | Override schema pinning for this server. `false` disables pinning regardless of gateway setting. Omit to inherit from `gateway.security.schema_pinning.enabled` |
 | `ready_timeout` | duration | No | `30s` | Readiness wait for container-based HTTP/SSE servers. Accepts any `time.Duration` string (e.g. `"60s"`, `"2m"`). When a container does not become ready within this window, the container is stopped and removed so a retry starts clean. Ignored for stdio, external, local process, SSH, and OpenAPI servers |
+| `replicas` | int | No | `1` | Number of independent processes to spawn for this server. Values >1 load-balance JSON-RPC tool calls across replicas using `replica_policy`. Range: 1–32. Not supported for external URL or OpenAPI transports. See [Scaling stdio servers](scaling.md) |
+| `replica_policy` | string | No | `"round-robin"` | Dispatch policy when `replicas > 1`: `"round-robin"` or `"least-connections"` |
 
 **Type determination rules:**
 - Must have exactly one of: `image`, `source`, `url`, `command` (alone), `ssh` + `command`, or `openapi`

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -1,0 +1,150 @@
+# Scaling stdio Servers
+
+Guidance for running multiple replicas of a single MCP server behind one gateway entry.
+
+---
+
+## When to Use Replicas
+
+Run `replicas: N` when one stdio process per server is a liability. Typical symptoms:
+
+- **Head-of-line blocking.** A single synchronous stdio server serializes every tool call across every connected user. Slow or SSH-heavy tools block unrelated calls.
+- **Crash survivability.** One panic takes the server offline for everyone. Replicas are independent processes — a crash of replica-1 leaves replicas 0 and 2 serving requests.
+- **Horizontal scaling under one namespace.** Operators want N processes for throughput without duplicating the server under `junos-a`, `junos-b`, `junos-c` and teaching every client about three tool namespaces.
+
+Skip replicas when the downstream tool already holds a single shared resource (one database connection, one API token with strict rate limits) — N processes will contend on that resource without speedup.
+
+---
+
+## Supported Transports
+
+| Transport | Replicas supported | Why |
+|-----------|--------------------|-----|
+| Container (image/source) | Yes | Each replica is its own container with a unique name |
+| Local process (command) | Yes | Each replica is its own host process with its own pipes |
+| SSH (ssh + command) | Yes | Each replica is its own SSH session |
+| External URL | **No** | gridctl does not manage the process — scaling is the operator's responsibility on the remote end |
+| OpenAPI | **No** | Stateless HTTP, no process to replicate — put a load balancer in front of the upstream API |
+
+Setting `replicas > 1` on `external` or `openapi` servers fails validation with the path `mcp-servers[N].replicas` so the error is unambiguous.
+
+---
+
+## Configuration
+
+```yaml
+mcp-servers:
+  - name: junos
+    command:
+      - .venv/bin/python
+      - servers/junos-mcp-server/jmcp.py
+      - --transport
+      - stdio
+    replicas: 3
+    replica_policy: least-connections
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `replicas` | int | `1` | Number of independent processes to spawn. Range: 1–32 |
+| `replica_policy` | string | `"round-robin"` | Dispatch policy: `"round-robin"` or `"least-connections"` |
+
+Upper bound of 32 is a sanity check — higher values are almost always a config error.
+
+---
+
+## Dispatch Policies
+
+### `round-robin` (default)
+
+Each call advances a per-server cursor. Calls land on replicas `0, 1, 2, 0, 1, 2, …` skipping any currently-unhealthy replica. O(1) routing overhead.
+
+Use when tool calls have similar cost and you want predictable, even distribution.
+
+### `least-connections`
+
+Each call goes to the healthy replica with the lowest in-flight count, breaking ties by lowest replica id. Counter increments on dispatch, decrements on response. O(N) routing overhead — negligible at the 32-replica cap.
+
+Use when tool calls have highly variable runtimes (e.g. some take 50ms, others take 30s). Keeps slow calls from pinning a single replica while fast ones pile up.
+
+---
+
+## Operator Trade-offs
+
+- **Memory multiplied by N.** Three Python MCP servers cost three Python runtimes and three sets of imported libraries. Measure before scaling past 3–4.
+- **Shared external resources stay single-threaded.** If the server holds one DB connection or one API token, replicas share the same bottleneck. They give you crash survivability but no throughput gain.
+- **Tool namespace is unchanged.** Clients still see one `junos__*` tool surface. The replica choice is invisible — never shows up in tool names, tool arguments, or response envelopes.
+- **Schema pinning stays per-server.** All replicas must expose the same tool schema. If one replica's schema drifts, the gateway logs a WARN — treat it like any other schema-drift event.
+
+---
+
+## Health and Restart Behavior
+
+Every replica is pinged independently on the gateway's health-check interval. A replica that fails a ping is:
+
+1. Marked unhealthy and excluded from dispatch immediately.
+2. Scheduled for reconnection with exponential backoff: **1s → 2s → 4s → 8s → 16s → 30s cap**, with ±25% jitter to prevent a fleet of replicas from resynchronizing their retries.
+3. Returned to rotation on the first successful reconnect. The backoff resets — the next failure starts at 1s again.
+
+If **every** replica is unhealthy, tool calls return a structured error naming the server and including the per-replica failure reason. Clients see `no healthy replicas` instead of a hanging call.
+
+Restart storms are bounded by the backoff. A binary that crashes on startup will attempt reconnection a handful of times per minute, not once per health-check tick — the CPU cannot spin.
+
+---
+
+## Observability
+
+Per-replica state is surfaced through every existing gridctl observability surface:
+
+- **Logs.** Every log line on the tool-call path carries a `replica_id` field alongside the server name. Grep by `replica_id=1` to isolate one replica's story.
+- **Traces.** Each tool-call span gets a `mcp.replica.id` attribute. Use it to filter a trace waterfall to the slow replica.
+- **CLI status.** `gridctl status` rolls up replica health per server:
+  ```
+  NAME   TYPE             REPLICAS   STATE
+  junos  local-process    3/3        healthy
+  junos  local-process    2/3        degraded (replica-1 restarting, next in 4s)
+  ```
+  `gridctl status --replicas` expands to one row per replica with PID/container-id, uptime, and in-flight count.
+- **REST API.** `/api/stack/health` includes a `replicas` array for every server with a replica set, each entry carrying `replicaId`, `state`, `inFlight`, `restartAttempts`, `nextRetryAt`, and the transport-specific handle (`pid` or `containerId`).
+- **Metrics.** `pkg/metrics/accumulator.go` tracks per-replica counters. Per-server aggregates remain (they sum across replicas).
+
+---
+
+## Quick Examples
+
+### Multi-user Python server with least-connections
+
+```yaml
+mcp-servers:
+  - name: junos
+    command:
+      - .venv/bin/python
+      - servers/junos-mcp-server/jmcp.py
+    replicas: 3
+    replica_policy: least-connections
+```
+
+### Container server with three replicas
+
+```yaml
+mcp-servers:
+  - name: github
+    image: ghcr.io/github/github-mcp-server:latest
+    transport: stdio
+    replicas: 3
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+```
+
+Each replica becomes a separate container. Container names are deterministic (`<stack>-<server>-replica-<id>`) so re-applying is idempotent.
+
+### Rejected configurations
+
+```yaml
+mcp-servers:
+  - name: remote
+    url: https://mcp.example.com/sse
+    replicas: 3                  # ❌ validation error: external transport cannot use replicas
+```
+
+Validation surfaces the exact path (`mcp-servers[N].replicas`) so CI can fail fast.

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -591,8 +591,17 @@ func (g *Gateway) ReplicaStatuses(serverName string) []ReplicaStatus {
 	replicas := set.Replicas()
 	out := make([]ReplicaStatus, 0, len(replicas))
 
+	// Snapshot per-replica health under the lock so later iteration cannot
+	// race with the health monitor's concurrent writes to replicaHealth[...].
+	replicaHealthSnap := make(map[int]HealthStatus, len(replicas))
 	g.healthMu.RLock()
-	replicaHealthMap := g.replicaHealth[serverName]
+	if m := g.replicaHealth[serverName]; m != nil {
+		for id, hs := range m {
+			if hs != nil {
+				replicaHealthSnap[id] = *hs
+			}
+		}
+	}
 	g.healthMu.RUnlock()
 
 	for _, r := range replicas {
@@ -608,18 +617,16 @@ func (g *Gateway) ReplicaStatuses(serverName string) []ReplicaStatus {
 			t := nextAt
 			rs.NextRetryAt = &t
 		}
-		if replicaHealthMap != nil {
-			if hs, ok := replicaHealthMap[r.ID()]; ok && hs != nil {
-				if !hs.LastCheck.IsZero() {
-					t := hs.LastCheck
-					rs.LastCheck = &t
-				}
-				if !hs.LastHealthy.IsZero() {
-					t := hs.LastHealthy
-					rs.LastHealthy = &t
-				}
-				rs.LastError = hs.Error
+		if hs, ok := replicaHealthSnap[r.ID()]; ok {
+			if !hs.LastCheck.IsZero() {
+				t := hs.LastCheck
+				rs.LastCheck = &t
 			}
+			if !hs.LastHealthy.IsZero() {
+				t := hs.LastHealthy
+				rs.LastHealthy = &t
+			}
+			rs.LastError = hs.Error
 		}
 		switch client := r.Client().(type) {
 		case *ProcessClient:

--- a/tests/integration/replica_all_down_test.go
+++ b/tests/integration/replica_all_down_test.go
@@ -1,0 +1,132 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// TestReplicas_AllReplicasDown verifies that when every replica of a server is
+// unhealthy, tool calls fail fast with an error that names the server.
+func TestReplicas_AllReplicasDown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if mockHTTPServerBin == "" {
+		t.Skip("mock server binary not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const serverName = "junos"
+	ports := []int{freePort(t), freePort(t), freePort(t)}
+	cmds := make([]*exec.Cmd, len(ports))
+	for i, p := range ports {
+		cmd := exec.Command(mockHTTPServerBin, "-port", fmt.Sprintf("%d", p))
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start mock replica-%d: %v", i, err)
+		}
+		cmds[i] = cmd
+	}
+	t.Cleanup(func() {
+		for _, cmd := range cmds {
+			if cmd != nil && cmd.Process != nil {
+				cmd.Process.Kill() //nolint:errcheck
+				cmd.Wait()         //nolint:errcheck
+			}
+		}
+	})
+	for _, p := range ports {
+		waitForPort(t, ctx, p)
+	}
+
+	gw := mcp.NewGateway()
+	defer gw.Close()
+
+	cfgs := make([]mcp.MCPServerConfig, len(ports))
+	for i, p := range ports {
+		cfgs[i] = mcp.MCPServerConfig{
+			Name:      serverName,
+			Transport: mcp.TransportHTTP,
+			Endpoint:  fmt.Sprintf("http://127.0.0.1:%d/mcp", p),
+		}
+	}
+	if err := gw.RegisterMCPReplicaSet(ctx, serverName, mcp.ReplicaPolicyRoundRobin, cfgs); err != nil {
+		t.Fatalf("RegisterMCPReplicaSet: %v", err)
+	}
+
+	healthCtx, healthCancel := context.WithCancel(ctx)
+	defer healthCancel()
+	gw.StartHealthMonitor(healthCtx, 100*time.Millisecond)
+
+	// Kill every replica.
+	for i, cmd := range cmds {
+		if err := cmd.Process.Kill(); err != nil {
+			t.Fatalf("kill replica-%d: %v", i, err)
+		}
+		cmd.Wait() //nolint:errcheck
+	}
+
+	// Poll until all three replicas are marked unhealthy (up to 5s).
+	deadline := time.Now().Add(5 * time.Second)
+	var statuses []mcp.ReplicaStatus
+	for time.Now().Before(deadline) {
+		statuses = gw.ReplicaStatuses(serverName)
+		allDown := len(statuses) == len(ports)
+		for _, rs := range statuses {
+			if rs.Healthy {
+				allDown = false
+				break
+			}
+		}
+		if allDown {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	for i, rs := range statuses {
+		if rs.Healthy {
+			t.Fatalf("expected replica-%d to be unhealthy after process kill", i)
+		}
+	}
+
+	// Rollup health should also reflect the outage.
+	hs := gw.GetHealthStatus(serverName)
+	if hs == nil {
+		t.Fatal("expected rollup health status, got nil")
+	}
+	if hs.Healthy {
+		t.Error("expected rollup Healthy=false when all replicas are down")
+	}
+
+	// Tool call should return an error result naming the server and the
+	// no-healthy-replicas failure reason.
+	result, err := gw.HandleToolsCall(ctx, mcp.ToolCallParams{
+		Name:      mcp.PrefixTool(serverName, "echo"),
+		Arguments: map[string]any{"message": "nobody home"},
+	})
+	if err != nil {
+		t.Fatalf("HandleToolsCall returned Go error (expected structured IsError): %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected tool call result to have IsError=true when all replicas are down")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected tool call error to include Content")
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, serverName) {
+		t.Errorf("expected error to name server %q, got: %q", serverName, text)
+	}
+	if !strings.Contains(text, mcp.ErrNoHealthyReplicas.Error()) {
+		t.Errorf("expected error to mention %q, got: %q", mcp.ErrNoHealthyReplicas.Error(), text)
+	}
+}

--- a/tests/integration/replica_kill_one_test.go
+++ b/tests/integration/replica_kill_one_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// TestReplicas_KillOneReplica verifies that killing one replica's backend
+// process causes the health monitor to mark it unhealthy, exclude it from
+// dispatch, and keep the surviving replicas serving tool calls without error.
+func TestReplicas_KillOneReplica(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if mockHTTPServerBin == "" {
+		t.Skip("mock server binary not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Start three mock HTTP servers; keep handles so we can kill one mid-test.
+	ports := []int{freePort(t), freePort(t), freePort(t)}
+	cmds := make([]*exec.Cmd, len(ports))
+	for i, p := range ports {
+		cmd := exec.Command(mockHTTPServerBin, "-port", fmt.Sprintf("%d", p))
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start mock replica-%d: %v", i, err)
+		}
+		cmds[i] = cmd
+	}
+	t.Cleanup(func() {
+		for _, cmd := range cmds {
+			if cmd != nil && cmd.Process != nil {
+				cmd.Process.Kill() //nolint:errcheck
+				cmd.Wait()         //nolint:errcheck
+			}
+		}
+	})
+	for _, p := range ports {
+		waitForPort(t, ctx, p)
+	}
+
+	gw := mcp.NewGateway()
+	defer gw.Close()
+
+	cfgs := make([]mcp.MCPServerConfig, len(ports))
+	for i, p := range ports {
+		cfgs[i] = mcp.MCPServerConfig{
+			Name:      "junos",
+			Transport: mcp.TransportHTTP,
+			Endpoint:  fmt.Sprintf("http://127.0.0.1:%d/mcp", p),
+		}
+	}
+	if err := gw.RegisterMCPReplicaSet(ctx, "junos", mcp.ReplicaPolicyRoundRobin, cfgs); err != nil {
+		t.Fatalf("RegisterMCPReplicaSet: %v", err)
+	}
+
+	healthCtx, healthCancel := context.WithCancel(ctx)
+	defer healthCancel()
+	gw.StartHealthMonitor(healthCtx, 100*time.Millisecond)
+
+	// Kill replica-1.
+	if err := cmds[1].Process.Kill(); err != nil {
+		t.Fatalf("kill replica-1: %v", err)
+	}
+	cmds[1].Wait() //nolint:errcheck
+
+	// Poll until replica-1 is marked unhealthy (up to 5s).
+	deadline := time.Now().Add(5 * time.Second)
+	var statuses []mcp.ReplicaStatus
+	for time.Now().Before(deadline) {
+		statuses = gw.ReplicaStatuses("junos")
+		if len(statuses) == 3 && !statuses[1].Healthy {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if len(statuses) != 3 {
+		t.Fatalf("expected 3 replica statuses, got %d", len(statuses))
+	}
+	if statuses[1].Healthy {
+		t.Fatalf("expected replica-1 to be marked unhealthy after process kill")
+	}
+	if !statuses[0].Healthy || !statuses[2].Healthy {
+		t.Errorf("expected replicas 0 and 2 to remain healthy; got r0=%v r2=%v",
+			statuses[0].Healthy, statuses[2].Healthy)
+	}
+
+	// Surviving replicas should continue serving tool calls. Call echo several
+	// times; dispatch should skip replica-1 and every call should succeed.
+	for i := 0; i < 6; i++ {
+		result, err := gw.HandleToolsCall(ctx, mcp.ToolCallParams{
+			Name:      mcp.PrefixTool("junos", "echo"),
+			Arguments: map[string]any{"message": fmt.Sprintf("call-%d", i)},
+		})
+		if err != nil {
+			t.Fatalf("tool call %d: %v", i, err)
+		}
+		if result.IsError {
+			t.Fatalf("tool call %d returned IsError; content=%v", i, result.Content)
+		}
+	}
+}

--- a/tests/integration/replica_mixed_counts_test.go
+++ b/tests/integration/replica_mixed_counts_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// TestReplicas_MixedCounts verifies that a gateway hosting servers with
+// different replica counts (one single-replica, one multi-replica) routes
+// tool calls to the correct set and exposes accurate per-server status.
+// Round-robin on the multi-replica server should rotate through every
+// replica across successive calls.
+func TestReplicas_MixedCounts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if mockHTTPServerBin == "" {
+		t.Skip("mock server binary not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const singleName = "github"
+	const tripleName = "junos"
+
+	singlePort := freePort(t)
+	triplePorts := []int{freePort(t), freePort(t), freePort(t)}
+
+	startMockServer(t, mockHTTPServerBin, "-port", fmt.Sprintf("%d", singlePort))
+	for _, p := range triplePorts {
+		startMockServer(t, mockHTTPServerBin, "-port", fmt.Sprintf("%d", p))
+	}
+	waitForPort(t, ctx, singlePort)
+	for _, p := range triplePorts {
+		waitForPort(t, ctx, p)
+	}
+
+	gw := mcp.NewGateway()
+	defer gw.Close()
+
+	singleCfg := mcp.MCPServerConfig{
+		Name:      singleName,
+		Transport: mcp.TransportHTTP,
+		Endpoint:  fmt.Sprintf("http://127.0.0.1:%d/mcp", singlePort),
+	}
+	if err := gw.RegisterMCPReplicaSet(ctx, singleName, mcp.ReplicaPolicyRoundRobin, []mcp.MCPServerConfig{singleCfg}); err != nil {
+		t.Fatalf("register %s: %v", singleName, err)
+	}
+
+	tripleCfgs := make([]mcp.MCPServerConfig, len(triplePorts))
+	for i, p := range triplePorts {
+		tripleCfgs[i] = mcp.MCPServerConfig{
+			Name:      tripleName,
+			Transport: mcp.TransportHTTP,
+			Endpoint:  fmt.Sprintf("http://127.0.0.1:%d/mcp", p),
+		}
+	}
+	if err := gw.RegisterMCPReplicaSet(ctx, tripleName, mcp.ReplicaPolicyRoundRobin, tripleCfgs); err != nil {
+		t.Fatalf("register %s: %v", tripleName, err)
+	}
+
+	if got := len(gw.ReplicaStatuses(singleName)); got != 1 {
+		t.Errorf("expected 1 replica for %s, got %d", singleName, got)
+	}
+	if got := len(gw.ReplicaStatuses(tripleName)); got != 3 {
+		t.Errorf("expected 3 replicas for %s, got %d", tripleName, got)
+	}
+
+	// Both servers should appear in gateway Status with the right Replicas shape.
+	gwStatuses := gw.Status()
+	if len(gwStatuses) != 2 {
+		t.Fatalf("expected 2 servers in gateway Status, got %d", len(gwStatuses))
+	}
+	byName := map[string]mcp.MCPServerStatus{}
+	for _, s := range gwStatuses {
+		byName[s.Name] = s
+	}
+	if got := len(byName[singleName].Replicas); got != 1 {
+		t.Errorf("%s Status: expected 1 Replica entry, got %d", singleName, got)
+	}
+	if got := len(byName[tripleName].Replicas); got != 3 {
+		t.Errorf("%s Status: expected 3 Replica entries, got %d", tripleName, got)
+	}
+
+	// Tool calls on the single-replica server succeed.
+	single, err := gw.HandleToolsCall(ctx, mcp.ToolCallParams{
+		Name:      mcp.PrefixTool(singleName, "echo"),
+		Arguments: map[string]any{"message": "single"},
+	})
+	if err != nil || single.IsError {
+		t.Fatalf("tool call on %s: err=%v isError=%v", singleName, err, single.IsError)
+	}
+
+	// Round-robin on the triple-replica server: fire 6 calls and count how
+	// many times each replica observed an in-flight increment. Because
+	// IncInFlight/DecInFlight wrap each call, in-flight always reads back to
+	// zero afterwards — so we record ids by snapshotting replicas between
+	// calls via a tiny probe: inject pick order through ReplicaStatuses'
+	// restart attempts would be invasive, so instead we validate uniqueness
+	// by observing that every call succeeds (if RR skipped replicas, a dead
+	// backend would surface). Here we only assert all calls succeed.
+	for i := 0; i < 6; i++ {
+		result, err := gw.HandleToolsCall(ctx, mcp.ToolCallParams{
+			Name:      mcp.PrefixTool(tripleName, "echo"),
+			Arguments: map[string]any{"message": fmt.Sprintf("triple-%d", i)},
+		})
+		if err != nil {
+			t.Fatalf("tool call %d on %s: %v", i, tripleName, err)
+		}
+		if result.IsError {
+			t.Fatalf("tool call %d on %s returned IsError: %v", i, tripleName, result.Content)
+		}
+	}
+
+	// Round-robin dispatch should have touched every replica across 6 calls.
+	// Use Pick() directly on the router's replica set to observe id rotation.
+	set := gw.Router().GetReplicaSet(tripleName)
+	if set == nil {
+		t.Fatal("expected triple replica set on router")
+	}
+	seen := map[int]bool{}
+	for i := 0; i < 2*set.Size(); i++ {
+		r, err := set.Pick()
+		if err != nil {
+			t.Fatalf("Pick %d: %v", i, err)
+		}
+		seen[r.ID()] = true
+	}
+	if len(seen) != set.Size() {
+		t.Errorf("round-robin did not touch every replica across %d picks; saw ids=%v", 2*set.Size(), seen)
+	}
+
+	// A short health-monitor burst should not flip any replica unhealthy.
+	healthCtx, healthCancel := context.WithCancel(ctx)
+	defer healthCancel()
+	gw.StartHealthMonitor(healthCtx, 100*time.Millisecond)
+	time.Sleep(400 * time.Millisecond)
+
+	for name := range byName {
+		for i, rs := range gw.ReplicaStatuses(name) {
+			if !rs.Healthy {
+				t.Errorf("%s replica %d unexpectedly unhealthy during monitor: %q", name, i, rs.LastError)
+			}
+		}
+	}
+}

--- a/tests/integration/replica_restart_storm_test.go
+++ b/tests/integration/replica_restart_storm_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// TestReplicas_RestartStorm verifies that a replica whose backing process
+// exits immediately does not trigger unbounded Reconnect attempts. The
+// exponential backoff state must gate retries so the loop cannot spin.
+//
+// The test simulates the gateway health loop directly: tick at 50ms (well
+// below the 1s backoff floor), ask ShouldTry before each Reconnect, and
+// Advance on failure. Over a 3-second window the backoff schedule (1s, 2s,
+// 4s … ±25% jitter) caps the number of Reconnect attempts to a small
+// constant — far below the ~60 attempts an unthrottled loop would produce.
+func TestReplicas_RestartStorm(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Immediate-exit binary. Reconnect starts it, sends initialize, and waits
+	// for a response that never comes — drainPendingRequests fails the pending
+	// call as soon as stdout EOFs, so each attempt returns quickly.
+	client := mcp.NewProcessClient("flaky", []string{"/bin/sh", "-c", "exit 1"}, "", nil)
+	t.Cleanup(func() { client.Close() }) //nolint:errcheck
+
+	set := mcp.NewReplicaSet("flaky", mcp.ReplicaPolicyRoundRobin, []mcp.AgentClient{client})
+	reps := set.Replicas()
+	if len(reps) != 1 {
+		t.Fatalf("expected 1 replica in set, got %d", len(reps))
+	}
+	replica := reps[0]
+	replica.SetHealthy(false)
+
+	const window = 3 * time.Second
+	const tick = 50 * time.Millisecond
+
+	attempts := 0
+	advances := make([]time.Time, 0, 8)
+	start := time.Now()
+	for time.Since(start) < window {
+		now := time.Now()
+		if replica.Restart().ShouldTry(now) {
+			reconnCtx, reconnCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+			err := client.Reconnect(reconnCtx)
+			reconnCancel()
+			if err == nil {
+				t.Fatalf("expected Reconnect to fail on immediate-exit binary, got nil")
+			}
+			replica.Restart().Advance(time.Now())
+			advances = append(advances, time.Now())
+			attempts++
+		}
+		time.Sleep(tick)
+	}
+
+	// Without backoff this loop would run ~60 times (3s / 50ms). Backoff with
+	// 1s floor, doubling, ±25% jitter caps us at roughly 2–4 attempts.
+	if attempts < 2 {
+		t.Errorf("expected at least 2 reconnect attempts in %v, got %d", window, attempts)
+	}
+	if attempts > 5 {
+		t.Errorf("expected backoff to cap reconnect attempts in %v; got %d (restart storm not throttled)", window, attempts)
+	}
+
+	// Inter-attempt spacing should grow roughly monotonically — the second
+	// gap must be at least as large as the minimum-jittered 1s floor.
+	if len(advances) >= 2 {
+		firstGap := advances[1].Sub(advances[0])
+		// 1s base with ±25% jitter → minimum ≈ 750ms.
+		if firstGap < 600*time.Millisecond {
+			t.Errorf("expected first backoff gap ≥ ~750ms (jittered 1s), got %v", firstGap)
+		}
+	}
+
+	// Restart state should record the attempts and a future NextRetryAt.
+	if got := replica.Restart().Attempts(); got < uint32(attempts) {
+		t.Errorf("expected Attempts ≥ %d, got %d", attempts, got)
+	}
+	if !replica.Restart().NextAt().After(start) {
+		t.Errorf("expected NextAt to be scheduled after test start; got %v", replica.Restart().NextAt())
+	}
+}

--- a/tests/integration/replica_stackless_mode_test.go
+++ b/tests/integration/replica_stackless_mode_test.go
@@ -1,0 +1,132 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// TestReplicas_StacklessMode verifies that the gateway — when running without
+// an orchestrator (stackless mode) — accepts a multi-replica registration,
+// initializes every replica, routes tool calls across them, and surfaces
+// per-replica state through ReplicaStatuses.
+//
+// Stackless mode is the cold-load path used by `gridctl serve` and the
+// /api/stack/initialize endpoint. The defining characteristic is that
+// registration happens outside any container lifecycle: each replica carries
+// its own runtime handle (endpoint for HTTP, container id for stdio). This
+// test exercises that contract with HTTP replicas so Docker is not required.
+func TestReplicas_StacklessMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if mockHTTPServerBin == "" {
+		t.Skip("mock server binary not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const serverName = "junos"
+	ports := []int{freePort(t), freePort(t), freePort(t)}
+	for _, p := range ports {
+		startMockServer(t, mockHTTPServerBin, "-port", fmt.Sprintf("%d", p))
+	}
+	for _, p := range ports {
+		waitForPort(t, ctx, p)
+	}
+
+	gw := mcp.NewGateway()
+	defer gw.Close()
+
+	// Materialize one MCPServerConfig per replica — the shape that
+	// server_registrar produces when Replicas > 1 in stack.yaml.
+	cfgs := make([]mcp.MCPServerConfig, len(ports))
+	endpoints := make(map[string]bool, len(ports))
+	for i, p := range ports {
+		endpoint := fmt.Sprintf("http://127.0.0.1:%d/mcp", p)
+		cfgs[i] = mcp.MCPServerConfig{
+			Name:      serverName,
+			Transport: mcp.TransportHTTP,
+			Endpoint:  endpoint,
+		}
+		endpoints[endpoint] = true
+	}
+
+	if err := gw.RegisterMCPReplicaSet(ctx, serverName, mcp.ReplicaPolicyLeastConnections, cfgs); err != nil {
+		t.Fatalf("RegisterMCPReplicaSet: %v", err)
+	}
+
+	statuses := gw.ReplicaStatuses(serverName)
+	if len(statuses) != len(ports) {
+		t.Fatalf("expected %d replica statuses, got %d", len(ports), len(statuses))
+	}
+	for i, rs := range statuses {
+		if rs.ReplicaID != i {
+			t.Errorf("replica %d: expected ReplicaID=%d, got %d", i, i, rs.ReplicaID)
+		}
+		if !rs.Healthy {
+			t.Errorf("replica %d: expected Healthy=true right after registration", i)
+		}
+	}
+
+	// Gateway Status should surface the replicas on the single logical server.
+	gwStatuses := gw.Status()
+	if len(gwStatuses) != 1 {
+		t.Fatalf("expected 1 server in gateway Status, got %d", len(gwStatuses))
+	}
+	if gwStatuses[0].Name != serverName {
+		t.Errorf("expected Status name %q, got %q", serverName, gwStatuses[0].Name)
+	}
+	if len(gwStatuses[0].Replicas) != len(ports) {
+		t.Errorf("expected Status.Replicas len=%d, got %d", len(ports), len(gwStatuses[0].Replicas))
+	}
+
+	// A single server name — tool list must not leak replica ids into the
+	// prefix. Every tool is exposed as "<serverName>__<tool>".
+	toolsRes, err := gw.HandleToolsList()
+	if err != nil {
+		t.Fatalf("HandleToolsList: %v", err)
+	}
+	prefix := serverName + mcp.ToolNameDelimiter
+	if len(toolsRes.Tools) == 0 {
+		t.Fatal("expected aggregated tools from replica set, got none")
+	}
+	for _, tool := range toolsRes.Tools {
+		if len(tool.Name) <= len(prefix) || tool.Name[:len(prefix)] != prefix {
+			t.Errorf("tool %q lacks expected prefix %q", tool.Name, prefix)
+		}
+	}
+
+	// Tool call should succeed; least-connections routes to the lowest-id
+	// idle replica for the first call.
+	result, err := gw.HandleToolsCall(ctx, mcp.ToolCallParams{
+		Name:      mcp.PrefixTool(serverName, "echo"),
+		Arguments: map[string]any{"message": "stackless"},
+	})
+	if err != nil {
+		t.Fatalf("HandleToolsCall: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected successful tool call, got IsError=true: %v", result.Content)
+	}
+
+	// Fast-health check should not flip any replica to unhealthy — every
+	// backend is alive. Run a short monitor window to exercise the per-replica
+	// pings via gateway.ReplicaStatuses.
+	healthCtx, healthCancel := context.WithCancel(ctx)
+	defer healthCancel()
+	gw.StartHealthMonitor(healthCtx, 100*time.Millisecond)
+	time.Sleep(400 * time.Millisecond)
+
+	for i, rs := range gw.ReplicaStatuses(serverName) {
+		if !rs.Healthy {
+			t.Errorf("replica %d flipped unhealthy during health monitor; lastError=%q", i, rs.LastError)
+		}
+	}
+}


### PR DESCRIPTION
## Description

Final phase of the MCP replicas feature: integration tests covering the replica lifecycle, operator docs for the scaling guide, and schema/AGENTS reference updates. Also fixes a data race in `ReplicaStatuses` that the new tests surfaced.

## Type of Change

- [x] Tests
- [x] Documentation
- [x] Bug fix (race)

## Changes Made

- Five new integration tests under `tests/integration/`:
  - `replica_kill_one_test.go` — kill one replica, verify health monitor marks it unhealthy, excludes it from dispatch, survivors keep serving
  - `replica_all_down_test.go` — every replica down returns a structured `no healthy replicas: <server>` error
  - `replica_restart_storm_test.go` — immediate-exit binary is throttled by exponential backoff (1s → 2s → 4s…)
  - `replica_stackless_mode_test.go` — multi-replica registration without orchestrator; replica set, status, tool routing all work
  - `replica_mixed_counts_test.go` — 1-replica and 3-replica servers coexist in one gateway; round-robin touches every replica
- `docs/scaling.md` new operator guide (when to use, supported transports, dispatch policies, trade-offs, backoff, observability)
- `docs/config-schema.md` adds `replicas` and `replica_policy` rows to MCP server fields
- `docs/README.md` links the new scaling guide
- `AGENTS.md` replica semantics section + updated directory tree
- `pkg/mcp/gateway.go` — `ReplicaStatuses` now snapshots per-replica health under the read lock instead of iterating the map after releasing it (fixes race surfaced by the new tests)

## Testing

```
golangci-lint run ./...                                  # 0 issues
go test -race -count=1 ./pkg/mcp/...                     # pass
go test -tags integration -race -run ^TestReplicas_ ./...# 5/5 pass
go test -tags integration -race -run ^TestGateway ./...  # no regression
make build                                               # pass (web + go)
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #470