### PR TITLE
feat: add searchable tools picker to wizard MCP server form

### DIFF
--- a/web/src/__tests__/ToolsPicker.test.tsx
+++ b/web/src/__tests__/ToolsPicker.test.tsx
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useState } from 'react';
+import { ToolsPicker } from '../components/wizard/steps/ToolsPicker';
+import { TOOL_NAME_DELIMITER } from '../lib/constants';
+import type { Tool } from '../types';
+
+const mockStoreState: { tools: Tool[] } = { tools: [] };
+
+vi.mock('../stores/useStackStore', () => ({
+  useStackStore: vi.fn((selector: (s: { tools: Tool[] }) => unknown) =>
+    selector(mockStoreState),
+  ),
+}));
+
+const SERVER = 'db';
+
+function tool(name: string, description?: string): Tool {
+  return {
+    name: `${SERVER}${TOOL_NAME_DELIMITER}${name}`,
+    description,
+    inputSchema: {},
+  };
+}
+
+function Harness({
+  serverName = SERVER,
+  initial = [] as string[],
+  onChangeSpy,
+}: {
+  serverName?: string;
+  initial?: string[];
+  onChangeSpy?: (v: string[]) => void;
+}) {
+  const [value, setValue] = useState<string[]>(initial);
+  return (
+    <ToolsPicker
+      serverName={serverName}
+      value={value}
+      onChange={(v) => {
+        setValue(v);
+        onChangeSpy?.(v);
+      }}
+    />
+  );
+}
+
+beforeEach(() => {
+  mockStoreState.tools = [];
+});
+
+describe('ToolsPicker', () => {
+  describe('checklist mode', () => {
+    beforeEach(() => {
+      mockStoreState.tools = [
+        tool('query', 'Run a SQL query'),
+        tool('insert', 'Insert a row'),
+        tool('delete_row', 'Delete a row by id'),
+      ];
+    });
+
+    it('renders an option for every topology tool and strips the server prefix', () => {
+      render(<Harness />);
+      expect(screen.getByRole('option', { name: 'query' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'insert' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'delete_row' })).toBeInTheDocument();
+    });
+
+    it('shows "0 of 3 selected" when nothing is chosen', () => {
+      render(<Harness />);
+      const header = screen.getByText(/selected — empty means all tools exposed/);
+      expect(header).toHaveTextContent('0 of 3');
+    });
+
+    it('pre-checks tools already in value (backward compat with existing stacks)', () => {
+      render(<Harness initial={['query']} />);
+      expect(screen.getByRole('option', { name: 'query' })).toHaveAttribute(
+        'aria-checked',
+        'true',
+      );
+      expect(screen.getByRole('option', { name: 'insert' })).toHaveAttribute(
+        'aria-checked',
+        'false',
+      );
+    });
+
+    it('toggles selection on click and emits the new array via onChange', () => {
+      const onChange = vi.fn();
+      render(<Harness onChangeSpy={onChange} />);
+      fireEvent.click(screen.getByRole('option', { name: 'query' }));
+      expect(onChange).toHaveBeenLastCalledWith(['query']);
+      fireEvent.click(screen.getByRole('option', { name: 'insert' }));
+      expect(onChange).toHaveBeenLastCalledWith(['query', 'insert']);
+      // Toggling off removes it
+      fireEvent.click(screen.getByRole('option', { name: 'query' }));
+      expect(onChange).toHaveBeenLastCalledWith(['insert']);
+    });
+
+    it('"Select all" selects every visible tool', () => {
+      const onChange = vi.fn();
+      render(<Harness onChangeSpy={onChange} />);
+      fireEvent.click(screen.getByRole('button', { name: /select all visible tools/i }));
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.arrayContaining(['query', 'insert', 'delete_row']),
+      );
+      expect(onChange.mock.calls.at(-1)![0]).toHaveLength(3);
+    });
+
+    it('"Clear" deselects everything', () => {
+      const onChange = vi.fn();
+      render(<Harness initial={['query', 'insert']} onChangeSpy={onChange} />);
+      fireEvent.click(screen.getByRole('button', { name: /clear all selected tools/i }));
+      expect(onChange).toHaveBeenLastCalledWith([]);
+    });
+
+    it('fuzzy search narrows the visible list and "Select all" only affects visible', () => {
+      const onChange = vi.fn();
+      render(<Harness onChangeSpy={onChange} />);
+      const input = screen.getByPlaceholderText('Search tools...');
+      fireEvent.change(input, { target: { value: 'query' } });
+      // Only the matching tool remains visible
+      expect(screen.getByRole('option', { name: 'query' })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: 'insert' })).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /select all visible tools/i }));
+      expect(onChange).toHaveBeenLastCalledWith(['query']);
+    });
+
+    it('shows an empty-filter message when no tool matches the search query', () => {
+      render(<Harness />);
+      const input = screen.getByPlaceholderText('Search tools...');
+      fireEvent.change(input, { target: { value: 'zzz-nonexistent' } });
+      expect(screen.getByText(/No tools match/)).toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows neutral empty copy (not an error) when no topology tools and no prior selections', () => {
+      render(<Harness />);
+      expect(screen.getByText(/No tools found for/)).toBeInTheDocument();
+      // Not styled/phrased as an error
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('exposes manual entry within one click from the empty state', () => {
+      render(<Harness />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /enter tool names manually/i }),
+      );
+      // Now the manual-entry "Add tool" button is visible
+      expect(screen.getByRole('button', { name: /add tool/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('manual-entry mode', () => {
+    it('defaults to manual mode when no topology tools but prior values exist', () => {
+      render(<Harness initial={['custom_tool']} />);
+      // The manual-entry input is visible
+      expect(screen.getByRole('textbox', { name: /tool 1/i })).toHaveValue('custom_tool');
+    });
+
+    it('adds and removes tools in manual mode and emits updated arrays', () => {
+      const onChange = vi.fn();
+      render(<Harness initial={['first']} onChangeSpy={onChange} />);
+      fireEvent.click(screen.getByRole('button', { name: /add tool/i }));
+      expect(onChange).toHaveBeenLastCalledWith(['first', '']);
+
+      const input2 = screen.getByRole('textbox', { name: /tool 2/i });
+      fireEvent.change(input2, { target: { value: 'second' } });
+      expect(onChange).toHaveBeenLastCalledWith(['first', 'second']);
+
+      fireEvent.click(screen.getByRole('button', { name: /remove tool 1/i }));
+      expect(onChange).toHaveBeenLastCalledWith(['second']);
+    });
+
+    it('"Back to search" returns to checklist mode when topology tools are available', () => {
+      mockStoreState.tools = [tool('query')];
+      render(<Harness />);
+      // Start in checklist; toggle into manual
+      fireEvent.click(
+        screen.getByRole('button', { name: /enter tool names manually/i }),
+      );
+      expect(screen.queryByRole('option', { name: 'query' })).not.toBeInTheDocument();
+      // Back to search
+      fireEvent.click(screen.getByRole('button', { name: /back to search/i }));
+      expect(screen.getByRole('option', { name: 'query' })).toBeInTheDocument();
+    });
+
+    it('does not offer "Back to search" when topology has no tools', () => {
+      render(<Harness initial={['custom']} />);
+      expect(
+        screen.queryByRole('button', { name: /back to search/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('persistence of selection across store re-renders', () => {
+    it('keeps selection when topology tools update (simulates step navigation / rehydration)', () => {
+      mockStoreState.tools = [tool('query'), tool('insert')];
+      const { rerender } = render(<Harness initial={['query']} />);
+      expect(screen.getByRole('option', { name: 'query' })).toHaveAttribute(
+        'aria-checked',
+        'true',
+      );
+      // Simulate topology gaining a new tool (e.g., after deploy) — selection persists
+      mockStoreState.tools = [tool('query'), tool('insert'), tool('vacuum')];
+      rerender(<Harness initial={['query']} />);
+      expect(screen.getByRole('option', { name: 'query' })).toHaveAttribute(
+        'aria-checked',
+        'true',
+      );
+    });
+
+    it('surfaces selected names that are not in the topology so they can be unchecked', () => {
+      mockStoreState.tools = [tool('query')];
+      render(<Harness initial={['query', 'legacy_tool']} />);
+      expect(screen.getByRole('option', { name: 'query' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'legacy_tool' })).toHaveAttribute(
+        'aria-checked',
+        'true',
+      );
+    });
+  });
+});

--- a/web/src/components/wizard/steps/MCPServerForm.tsx
+++ b/web/src/components/wizard/steps/MCPServerForm.tsx
@@ -19,6 +19,7 @@ import { cn } from '../../../lib/cn';
 import type { MCPServerFormData, ServerType } from '../../../lib/yaml-builder';
 import { SecretsPopover } from '../SecretsPopover';
 import { TransportAdvisor } from '../TransportAdvisor';
+import { ToolsPicker } from './ToolsPicker';
 
 // --- Server type definitions ---
 
@@ -365,65 +366,6 @@ function CommandArrayBuilder({
               value={item}
               onChange={(e) => updateItem(i, e.target.value)}
               placeholder={i === 0 ? 'command' : `arg ${i}`}
-              className={cn(inputClass, 'flex-1 font-mono')}
-            />
-            <button
-              type="button"
-              onClick={() => removeItem(i)}
-              className="p-1 text-text-muted hover:text-status-error transition-colors flex-shrink-0"
-            >
-              <X size={12} />
-            </button>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// --- Tools Whitelist ---
-
-function ToolsWhitelist({
-  value,
-  onChange,
-}: {
-  value: string[];
-  onChange: (val: string[]) => void;
-}) {
-  const addItem = () => onChange([...value, '']);
-  const updateItem = (idx: number, val: string) => {
-    const next = [...value];
-    next[idx] = val;
-    onChange(next);
-  };
-  const removeItem = (idx: number) => {
-    onChange(value.filter((_, i) => i !== idx));
-  };
-
-  return (
-    <div>
-      <div className="flex items-center justify-between mb-1.5">
-        <label className={labelClass}>Tools Whitelist</label>
-        <button
-          type="button"
-          onClick={addItem}
-          className="flex items-center gap-1 text-[10px] text-secondary hover:text-secondary-light transition-colors"
-        >
-          <Plus size={10} />
-          Add tool
-        </button>
-      </div>
-      {value.length === 0 && (
-        <p className="text-[10px] text-text-muted/60 italic py-2">All tools exposed (no whitelist)</p>
-      )}
-      <div className="space-y-1.5">
-        {value.map((item, i) => (
-          <div key={i} className="flex items-center gap-1.5">
-            <input
-              type="text"
-              value={item}
-              onChange={(e) => updateItem(i, e.target.value)}
-              placeholder="tool-name"
               className={cn(inputClass, 'flex-1 font-mono')}
             />
             <button
@@ -1371,9 +1313,10 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
         onToggle={() => toggleSection('advanced')}
         badge={advancedCount > 0 ? `${advancedCount}` : undefined}
       >
-        <ToolsWhitelist
+        <ToolsPicker
           value={data.tools ?? []}
           onChange={(tools) => onChange({ tools })}
+          serverName={data.name}
         />
 
         <div>

--- a/web/src/components/wizard/steps/ToolsPicker.tsx
+++ b/web/src/components/wizard/steps/ToolsPicker.tsx
@@ -1,0 +1,315 @@
+import { useMemo, useState } from 'react';
+import { Command } from 'cmdk';
+import Fuse from 'fuse.js';
+import { ArrowLeft, Check, Edit3, Plus, Search, X } from 'lucide-react';
+import { cn } from '../../../lib/cn';
+import { useStackStore } from '../../../stores/useStackStore';
+import { TOOL_NAME_DELIMITER } from '../../../lib/constants';
+
+const inputClass =
+  'w-full bg-background/60 border border-border/40 rounded-lg px-3 py-2 text-xs focus:outline-none focus:border-primary/50 text-text-primary placeholder:text-text-muted/50 transition-colors';
+const labelClass = 'block text-xs text-text-secondary mb-1.5';
+
+interface ToolsPickerProps {
+  value: string[];
+  onChange: (val: string[]) => void;
+  serverName: string;
+}
+
+interface ToolOption {
+  name: string;
+  description?: string;
+}
+
+// Tri-state mode override: null = auto-select based on context,
+// true = user forced manual, false = user forced search/checklist.
+type ModeOverride = boolean | null;
+
+export function ToolsPicker({ value, onChange, serverName }: ToolsPickerProps) {
+  const tools = useStackStore((s) => s.tools);
+  const [modeOverride, setModeOverride] = useState<ModeOverride>(null);
+  const [query, setQuery] = useState('');
+
+  const topologyTools: ToolOption[] = useMemo(() => {
+    if (!serverName) return [];
+    const prefix = `${serverName}${TOOL_NAME_DELIMITER}`;
+    return (tools ?? [])
+      .filter((t) => t.name.startsWith(prefix))
+      .map((t) => ({
+        name: t.name.slice(prefix.length),
+        description: t.description,
+      }));
+  }, [tools, serverName]);
+
+  const hasTools = topologyTools.length > 0;
+
+  // Merge selected values that aren't in topology so existing stacks with
+  // `tools: [...]` still render those entries pre-checked in the picker.
+  const displayTools: ToolOption[] = useMemo(() => {
+    const merged = new Map(topologyTools.map((t) => [t.name, t] as const));
+    for (const name of value) {
+      if (!merged.has(name)) merged.set(name, { name });
+    }
+    return [...merged.values()];
+  }, [topologyTools, value]);
+
+  // When !hasTools AND there are already selected values (loaded from stack
+  // YAML for a server not in the topology), default to manual mode so the
+  // user can see and edit their entries.
+  const autoManual = !hasTools && value.length > 0;
+  const inManualMode = modeOverride ?? autoManual;
+  const inEmptyState = !hasTools && !inManualMode;
+
+  const fuse = useMemo(
+    () => new Fuse(displayTools, { keys: ['name', 'description'], threshold: 0.4 }),
+    [displayTools],
+  );
+
+  const visible = useMemo(() => {
+    if (!query.trim()) return displayTools;
+    return fuse.search(query).map((r) => r.item);
+  }, [fuse, query, displayTools]);
+
+  const selected = useMemo(() => new Set(value), [value]);
+
+  const toggle = (name: string) => {
+    const next = new Set(selected);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    onChange([...next]);
+  };
+
+  const selectAllVisible = () => {
+    const next = new Set(selected);
+    visible.forEach((o) => next.add(o.name));
+    onChange([...next]);
+  };
+
+  const clearAll = () => onChange([]);
+
+  if (inEmptyState) {
+    return (
+      <div aria-label="Tools Picker">
+        <label className={labelClass}>Tools Whitelist</label>
+        <div className="rounded-lg border border-dashed border-border/40 bg-background/30 px-4 py-5 text-center space-y-2.5">
+          <p className="text-[11px] text-text-muted leading-relaxed">
+            No tools found for{' '}
+            <span className="font-mono text-text-secondary">
+              {serverName || 'this server'}
+            </span>{' '}
+            in the current topology.
+            <br />
+            Enter names manually, or deploy the server first to discover its tools.
+          </p>
+          <button
+            type="button"
+            onClick={() => setModeOverride(true)}
+            className="inline-flex items-center gap-1 text-[10px] text-secondary hover:text-secondary-light transition-colors"
+          >
+            <Edit3 size={10} />
+            Enter tool names manually
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (inManualMode) {
+    return (
+      <div aria-label="Tools Picker">
+        <div className="flex items-center justify-between mb-1.5">
+          <label className={cn(labelClass, 'mb-0')}>Tools Whitelist</label>
+          {hasTools && (
+            <button
+              type="button"
+              onClick={() => setModeOverride(false)}
+              className="flex items-center gap-1 text-[10px] text-secondary hover:text-secondary-light transition-colors"
+            >
+              <ArrowLeft size={10} />
+              Back to search
+            </button>
+          )}
+        </div>
+        <ManualEntry value={value} onChange={onChange} />
+      </div>
+    );
+  }
+
+  // Checklist mode
+  return (
+    <div aria-label="Tools Picker">
+      <div className="flex items-center justify-between mb-1.5">
+        <label className={labelClass + ' mb-0'}>Tools Whitelist</label>
+        <button
+          type="button"
+          onClick={() => setModeOverride(true)}
+          className="flex items-center gap-1 text-[10px] text-secondary hover:text-secondary-light transition-colors"
+        >
+          <Edit3 size={10} />
+          Enter tool names manually
+        </button>
+      </div>
+
+      <div className="rounded-lg border border-border/40 bg-background/60 overflow-hidden">
+        {/* Count + quick actions */}
+        <div className="flex items-center gap-2 px-3 py-2 text-[10px] text-text-muted border-b border-border/30">
+          <span>
+            <span className="text-text-secondary font-medium">{selected.size}</span> of{' '}
+            <span className="text-text-secondary font-medium">{displayTools.length}</span>{' '}
+            selected — empty means all tools exposed
+          </span>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              type="button"
+              onClick={selectAllVisible}
+              aria-label="Select all visible tools"
+              className="text-[10px] text-secondary hover:text-secondary-light transition-colors"
+            >
+              Select all
+            </button>
+            <span className="text-border" aria-hidden="true">
+              ·
+            </span>
+            <button
+              type="button"
+              onClick={clearAll}
+              aria-label="Clear all selected tools"
+              className="text-[10px] text-secondary hover:text-secondary-light transition-colors"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+
+        <Command shouldFilter={false} label="Tools Picker" className="flex flex-col">
+          <div className="flex items-center gap-2 px-3 py-2 border-b border-border/30">
+            <Search size={12} className="text-text-muted flex-shrink-0" aria-hidden="true" />
+            <Command.Input
+              value={query}
+              onValueChange={setQuery}
+              placeholder="Search tools..."
+              aria-label="Search tools"
+              className="flex-1 bg-transparent outline-none text-xs text-text-primary placeholder:text-text-muted/60"
+            />
+          </div>
+
+          <Command.List
+            className="max-h-60 overflow-y-auto"
+            aria-label="Available tools"
+          >
+            <Command.Empty>
+              <p className="text-[11px] text-text-muted/60 italic py-4 px-3 text-center">
+                No tools match "{query}"
+              </p>
+            </Command.Empty>
+            {visible.map((opt) => {
+              const isSelected = selected.has(opt.name);
+              return (
+                <Command.Item
+                  key={opt.name}
+                  value={opt.name}
+                  onSelect={() => toggle(opt.name)}
+                  aria-checked={isSelected}
+                  aria-label={opt.name}
+                  className={cn(
+                    'flex items-start gap-2.5 px-3 py-2 cursor-pointer select-none outline-none transition-colors',
+                    'hover:bg-surface-highlight/50',
+                    '[&[data-selected=true]]:bg-primary/[0.06]',
+                    isSelected && 'bg-primary/[0.03]',
+                  )}
+                >
+                  <div
+                    className={cn(
+                      'mt-0.5 w-3.5 h-3.5 rounded border flex items-center justify-center flex-shrink-0 transition-colors',
+                      isSelected
+                        ? 'bg-primary/20 border-primary/60'
+                        : 'border-border/60 bg-background/50',
+                    )}
+                    aria-hidden="true"
+                  >
+                    {isSelected && <Check size={10} className="text-primary" />}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div
+                      className={cn(
+                        'text-xs font-mono truncate',
+                        isSelected ? 'text-text-primary' : 'text-text-secondary',
+                      )}
+                    >
+                      {opt.name}
+                    </div>
+                    {opt.description && (
+                      <div className="text-[10px] text-text-muted truncate">
+                        {opt.description}
+                      </div>
+                    )}
+                  </div>
+                </Command.Item>
+              );
+            })}
+          </Command.List>
+        </Command>
+      </div>
+    </div>
+  );
+}
+
+function ManualEntry({
+  value,
+  onChange,
+}: {
+  value: string[];
+  onChange: (val: string[]) => void;
+}) {
+  const addItem = () => onChange([...value, '']);
+  const updateItem = (idx: number, val: string) => {
+    const next = [...value];
+    next[idx] = val;
+    onChange(next);
+  };
+  const removeItem = (idx: number) => {
+    onChange(value.filter((_, i) => i !== idx));
+  };
+
+  return (
+    <div>
+      <div className="flex justify-end mb-1.5">
+        <button
+          type="button"
+          onClick={addItem}
+          className="flex items-center gap-1 text-[10px] text-secondary hover:text-secondary-light transition-colors"
+        >
+          <Plus size={10} />
+          Add tool
+        </button>
+      </div>
+      {value.length === 0 && (
+        <p className="text-[10px] text-text-muted/60 italic py-2">
+          All tools exposed (no whitelist)
+        </p>
+      )}
+      <div className="space-y-1.5">
+        {value.map((item, i) => (
+          <div key={i} className="flex items-center gap-1.5">
+            <input
+              type="text"
+              value={item}
+              onChange={(e) => updateItem(i, e.target.value)}
+              placeholder="tool-name"
+              aria-label={`Tool ${i + 1}`}
+              className={cn(inputClass, 'flex-1 font-mono')}
+            />
+            <button
+              type="button"
+              onClick={() => removeItem(i)}
+              aria-label={`Remove tool ${i + 1}`}
+              className="p-1 text-text-muted hover:text-status-error transition-colors flex-shrink-0"
+            >
+              <X size={12} />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Replaces the manual text-input tools whitelist in the MCP server wizard with a searchable, multi-select picker that auto-populates from tools already loaded in the topology and falls back to manual entry when none are available.

## Type of Change

- [x] New feature

## Changes Made

- New `ToolsPicker` component using `cmdk` + `fuse.js` (both already in tree — zero new deps)
- Three display modes: searchable checklist, neutral empty state, manual-entry fallback (always one click away)
- Auto-populates from `useStackStore.tools` filtered by server name prefix; merges any pre-existing selected names so existing stacks render fully pre-checked
- Wired into the Advanced section of `MCPServerForm`, replacing the old `ToolsWhitelist` function (deleted, no dead code)
- 16 component tests covering select/clear/search/toggle-manual, persistence across re-renders, and backward compat with non-topology selections

## Testing

- `tsc -b` clean
- `npm run build` clean
- `vitest run` — 352/352 pass (16 new ToolsPicker tests)
- Manual QA: empty state renders neutral copy + manual-entry switch; checklist mode supports keyboard nav via cmdk primitives; selections persist through wizard step navigation

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #494