### PR TITLE
feat: add ephemeral probe endpoint for external URL servers

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -318,7 +318,7 @@ mcp-servers:
 | `network` | string | Conditional | — | Network to join (required in advanced network mode) |
 | `ssh` | object | Conditional | — | SSH connection config (see [SSH](#ssh)) |
 | `openapi` | object | Conditional | — | OpenAPI spec config (see [OpenAPI](#openapi)) |
-| `tools` | []string | No | — | Tool whitelist. Empty exposes all tools |
+| `tools` | []string | No | — | Tool whitelist. Empty exposes all tools. The web wizard populates this from the live topology (for running servers) or via an ephemeral probe of the server (for greenfield servers not yet in the topology) |
 | `output_format` | string | No | — | Output format override: `"json"`, `"toon"`, `"csv"`, or `"text"`. Overrides `gateway.output_format` for this server |
 | `pin_schemas` | bool | No | — | Override schema pinning for this server. `false` disables pinning regardless of gateway setting. Omit to inherit from `gateway.security.schema_pinning.enabled` |
 | `ready_timeout` | duration | No | `30s` | Readiness wait for container-based HTTP/SSE servers. Accepts any `time.Duration` string (e.g. `"60s"`, `"2m"`). When a container does not become ready within this window, the container is stopped and removed so a retry starts clean. Ignored for stdio, external, local process, SSH, and OpenAPI servers |

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -318,7 +318,7 @@ mcp-servers:
 | `network` | string | Conditional | — | Network to join (required in advanced network mode) |
 | `ssh` | object | Conditional | — | SSH connection config (see [SSH](#ssh)) |
 | `openapi` | object | Conditional | — | OpenAPI spec config (see [OpenAPI](#openapi)) |
-| `tools` | []string | No | — | Tool whitelist. Empty exposes all tools. The web wizard populates this from the live topology (for running servers) or via an ephemeral probe of the server (for greenfield servers not yet in the topology) |
+| `tools` | []string | No | — | Tool whitelist. Empty exposes all tools. The web wizard populates this from the live topology for running servers, and offers an optional probe of external-URL servers to discover their tools before deploy. Container / stdio / local-process / SSH / OpenAPI servers are curated from the topology sidebar after deploy |
 | `output_format` | string | No | — | Output format override: `"json"`, `"toon"`, `"csv"`, or `"text"`. Overrides `gateway.output_format` for this server |
 | `pin_schemas` | bool | No | — | Override schema pinning for this server. `false` disables pinning regardless of gateway setting. Omit to inherit from `gateway.security.schema_pinning.enabled` |
 | `ready_timeout` | duration | No | `30s` | Readiness wait for container-based HTTP/SSE servers. Accepts any `time.Duration` string (e.g. `"60s"`, `"2m"`). When a container does not become ready within this window, the container is stopped and removed so a retry starts clean. Ignored for stdio, external, local process, SSH, and OpenAPI servers |

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gridctl/gridctl/internal/probe"
 	"github.com/gridctl/gridctl/pkg/dockerclient"
 	"github.com/gridctl/gridctl/pkg/logging"
 	"github.com/gridctl/gridctl/pkg/mcp"
@@ -54,6 +55,11 @@ type Server struct {
 	// startWatcher, when set, starts a file watcher on the given stack path.
 	// Injected by GatewayBuilder so POST /api/stack/initialize can activate live reload.
 	startWatcher func(stackPath string)
+
+	// prober enumerates an MCP server's tool list ephemerally (not registered
+	// with the gateway). Nil disables the /api/servers/probe endpoint.
+	prober       *probe.Prober
+	probeLimiter *probeLimiter
 }
 
 // NewServer creates a new API server.
@@ -261,6 +267,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/wizard/drafts", s.handleWizardDraftsList)
 	mux.HandleFunc("POST /api/wizard/drafts", s.handleWizardDraftCreate)
 	mux.HandleFunc("DELETE /api/wizard/drafts/{id}", s.handleWizardDraftDelete)
+
+	// Server probe — ephemeral tool enumeration used by the wizard's
+	// "Discover tools" flow for servers not yet loaded in the topology.
+	mux.HandleFunc("POST /api/servers/probe", s.handleProbe)
 
 	// Registry endpoints
 	mux.HandleFunc("GET /api/registry/status", s.handleRegistryStatus)

--- a/internal/api/probe.go
+++ b/internal/api/probe.go
@@ -1,0 +1,275 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gridctl/gridctl/internal/probe"
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// Concurrency caps. Per-session keeps a single misbehaving tab from swamping
+// the daemon; the global cap is a defense-in-depth check against scripts or
+// tests calling the endpoint in a loop.
+const (
+	probeSessionCap = 3
+	probeGlobalCap  = 10
+)
+
+// probeRequestMaxBytes caps the decoded body size. The wire shape is small —
+// there is no reason to accept megabyte-scale probe configs.
+const probeRequestMaxBytes = 64 * 1024
+
+// probeSessionKey identifies a client for per-session concurrency accounting.
+// Built from X-Session-ID if present, else falling back to the remote address.
+// Stable-enough for a single browser tab — overloaded tabs still hit the cap.
+const sessionHeader = "X-Session-ID"
+
+// probeLimiter enforces the two-tier concurrency cap. Zero value is not
+// usable — call newProbeLimiter.
+type probeLimiter struct {
+	mu          sync.Mutex
+	perSession  map[string]int
+	globalInUse atomic.Int32
+}
+
+func newProbeLimiter() *probeLimiter {
+	return &probeLimiter{perSession: make(map[string]int)}
+}
+
+// acquire returns true if the slot was granted. The caller must invoke the
+// returned release exactly once.
+func (l *probeLimiter) acquire(session string) (release func(), sessionLimited bool, globalLimited bool) {
+	// Check the global cap first — a session-exhausted caller still gets a
+	// 429 even when the global has room, but a global-exhausted daemon
+	// rejects with 503 regardless of the session.
+	if l.globalInUse.Load() >= probeGlobalCap {
+		return nil, false, true
+	}
+	l.mu.Lock()
+	if l.perSession[session] >= probeSessionCap {
+		l.mu.Unlock()
+		return nil, true, false
+	}
+	// Atomically bump global. If we race past the cap (two goroutines saw
+	// room simultaneously), back off and report the right kind of limit.
+	if l.globalInUse.Add(1) > probeGlobalCap {
+		l.globalInUse.Add(-1)
+		l.mu.Unlock()
+		return nil, false, true
+	}
+	l.perSession[session]++
+	l.mu.Unlock()
+
+	var released atomic.Bool
+	return func() {
+		if !released.CompareAndSwap(false, true) {
+			return
+		}
+		l.mu.Lock()
+		l.perSession[session]--
+		if l.perSession[session] <= 0 {
+			delete(l.perSession, session)
+		}
+		l.mu.Unlock()
+		l.globalInUse.Add(-1)
+	}, false, false
+}
+
+// SetProber wires an externally-constructed prober. The API server owns the
+// limiter but the prober's cache and spawner come from the gateway builder.
+func (s *Server) SetProber(p *probe.Prober) {
+	s.prober = p
+	if s.probeLimiter == nil {
+		s.probeLimiter = newProbeLimiter()
+	}
+}
+
+// handleProbe is the HTTP entry point for the wizard's "Discover tools"
+// button. It is intentionally a thin shell around probe.Prober.Probe — the
+// hard work (validation, caching, cleanup) lives in the probe package where
+// it is unit-tested without HTTP scaffolding.
+func (s *Server) handleProbe(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.prober == nil {
+		writeProbeError(w, http.StatusServiceUnavailable, probe.CodeUnsupportedTransport,
+			"Probe is not configured on this daemon.",
+			"Upgrade to a build with probe support, or enter tool names manually.")
+		return
+	}
+
+	session := r.Header.Get(sessionHeader)
+	if session == "" {
+		session = r.RemoteAddr
+	}
+	release, sessionLimited, globalLimited := s.probeLimiter.acquire(session)
+	if sessionLimited || globalLimited {
+		w.Header().Set("Retry-After", "3")
+		code := http.StatusTooManyRequests
+		msg := "Too many probes in progress for this session."
+		if globalLimited {
+			code = http.StatusServiceUnavailable
+			msg = "Probe service is at capacity. Try again in a few seconds."
+		}
+		writeProbeError(w, code, probe.CodeRateLimited, msg, "")
+		return
+	}
+	defer release()
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, probeRequestMaxBytes))
+	if err != nil {
+		writeProbeError(w, http.StatusBadRequest, probe.CodeInvalidConfig,
+			"Failed to read request body: "+err.Error(), "")
+		return
+	}
+	var req probeRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeProbeError(w, http.StatusBadRequest, probe.CodeInvalidConfig,
+			"Invalid JSON: "+err.Error(), "")
+		return
+	}
+	cfg := req.toMCPServer()
+
+	result, probeErr := s.prober.Probe(r.Context(), cfg)
+	if probeErr != nil {
+		scrubSecrets(probeErr, cfg.Env)
+		writeProbeError(w, probeFailureStatus(probeErr), probeErr.Code, probeErr.Message, probeErr.Hint)
+		return
+	}
+
+	writeJSON(w, probeResponse{
+		Tools:    toToolsWire(result.Tools),
+		ProbedAt: time.Now().UTC().Format(time.RFC3339),
+		Cached:   result.Cached,
+	})
+}
+
+// probeFailureStatus maps a probe error code to the HTTP status the spec
+// pins down. Unknown codes default to 422 — "semantically valid request but
+// the operation failed" — matching how the spec describes most probe
+// failures.
+func probeFailureStatus(e *probe.Error) int {
+	switch e.Code {
+	case probe.CodeInvalidConfig:
+		return http.StatusBadRequest
+	case probe.CodeRateLimited:
+		return http.StatusTooManyRequests
+	case probe.CodeInternal:
+		return http.StatusInternalServerError
+	default:
+		return http.StatusUnprocessableEntity
+	}
+}
+
+// probeRequest is the wire shape accepted by POST /api/servers/probe. It
+// intentionally mirrors config.MCPServer but uses explicit JSON tags so the
+// frontend can send snake_case fields that match the YAML schema exactly.
+// Converting here (rather than adding JSON tags to config.MCPServer) keeps the
+// wire contract local to the handler.
+type probeRequest struct {
+	Name         string            `json:"name,omitempty"`
+	Image        string            `json:"image,omitempty"`
+	Source       *config.Source    `json:"source,omitempty"`
+	URL          string            `json:"url,omitempty"`
+	Port         int               `json:"port,omitempty"`
+	Transport    string            `json:"transport,omitempty"`
+	Command      []string          `json:"command,omitempty"`
+	Env          map[string]string `json:"env,omitempty"`
+	BuildArgs    map[string]string `json:"build_args,omitempty"`
+	Network      string            `json:"network,omitempty"`
+	SSH          *config.SSHConfig `json:"ssh,omitempty"`
+	OpenAPI      *config.OpenAPIConfig `json:"openapi,omitempty"`
+	Tools        []string          `json:"tools,omitempty"`
+	OutputFormat string            `json:"output_format,omitempty"`
+	ReadyTimeout string            `json:"ready_timeout,omitempty"`
+	Replicas     int               `json:"replicas,omitempty"`
+}
+
+func (r probeRequest) toMCPServer() config.MCPServer {
+	return config.MCPServer{
+		Name:         r.Name,
+		Image:        r.Image,
+		Source:       r.Source,
+		URL:          r.URL,
+		Port:         r.Port,
+		Transport:    r.Transport,
+		Command:      r.Command,
+		Env:          r.Env,
+		BuildArgs:    r.BuildArgs,
+		Network:      r.Network,
+		SSH:          r.SSH,
+		OpenAPI:      r.OpenAPI,
+		Tools:        r.Tools,
+		OutputFormat: r.OutputFormat,
+		ReadyTimeout: r.ReadyTimeout,
+		Replicas:     r.Replicas,
+	}
+}
+
+type probeToolWire struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+type probeResponse struct {
+	Tools    []probeToolWire `json:"tools"`
+	ProbedAt string          `json:"probedAt"`
+	Cached   bool            `json:"cached"`
+}
+
+type probeErrorWire struct {
+	Error probeErrorPayload `json:"error"`
+}
+
+type probeErrorPayload struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Hint    string `json:"hint,omitempty"`
+}
+
+func writeProbeError(w http.ResponseWriter, status int, code, message, hint string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(probeErrorWire{
+		Error: probeErrorPayload{Code: code, Message: message, Hint: hint},
+	})
+}
+
+// scrubSecrets replaces occurrences of env-var values inside the probe error's
+// user-facing strings with "***". Keys with empty values are ignored — those
+// can never accidentally leak, and scrubbing them would turn every error into
+// "***".
+func scrubSecrets(e *probe.Error, env map[string]string) {
+	if e == nil || len(env) == 0 {
+		return
+	}
+	for _, v := range env {
+		if v == "" {
+			continue
+		}
+		e.Message = strings.ReplaceAll(e.Message, v, "***")
+		e.Hint = strings.ReplaceAll(e.Hint, v, "***")
+	}
+}
+
+func toToolsWire(tools []mcp.Tool) []probeToolWire {
+	out := make([]probeToolWire, len(tools))
+	for i, t := range tools {
+		out[i] = probeToolWire{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: t.InputSchema,
+		}
+	}
+	return out
+}

--- a/internal/api/probe_test.go
+++ b/internal/api/probe_test.go
@@ -1,0 +1,322 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/internal/probe"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// recordingClient is a minimal AgentClient for handler tests that need the
+// real probe.Prober path (cache behavior, error codes). For tests where the
+// probe orchestration itself is already covered, we use stubProber below.
+type recordingClient struct {
+	tools    []mcp.Tool
+	initErr  error
+	listErr  error
+	initWait time.Duration
+}
+
+func (c *recordingClient) Name() string { return "rec" }
+func (c *recordingClient) Initialize(ctx context.Context) error {
+	if c.initWait > 0 {
+		select {
+		case <-time.After(c.initWait):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return c.initErr
+}
+func (c *recordingClient) RefreshTools(context.Context) error { return c.listErr }
+func (c *recordingClient) Tools() []mcp.Tool                   { return c.tools }
+func (c *recordingClient) IsInitialized() bool                 { return true }
+func (c *recordingClient) ServerInfo() mcp.ServerInfo          { return mcp.ServerInfo{} }
+func (c *recordingClient) CallTool(context.Context, string, map[string]any) (*mcp.ToolCallResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+type fixedFactory struct{ client mcp.AgentClient }
+
+func (f fixedFactory) NewHTTP(string, string) mcp.AgentClient { return f.client }
+func (f fixedFactory) NewProcess(string, []string, string, map[string]string) mcp.AgentClient {
+	return f.client
+}
+
+func newProbeServer(t *testing.T, client mcp.AgentClient) *Server {
+	t.Helper()
+	srv := newTestServer(t)
+	p := probe.NewProber(probe.NewCache(time.Minute), nil)
+	p.SetClientFactory(fixedFactory{client: client})
+	srv.SetProber(p)
+	return srv
+}
+
+func postProbe(t *testing.T, handler http.Handler, body any, sessionID string) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/servers/probe", bytes.NewReader(b))
+	if sessionID != "" {
+		req.Header.Set("X-Session-ID", sessionID)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestProbeHandler_ExternalURL_Success(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object"}`)
+	srv := newProbeServer(t, &recordingClient{tools: []mcp.Tool{
+		{Name: "search", Description: "web search", InputSchema: schema},
+	}})
+	rec := postProbe(t, srv.Handler(), map[string]any{
+		"url": "https://example.com/mcp",
+	}, "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	var got probeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Tools) != 1 || got.Tools[0].Name != "search" {
+		t.Fatalf("tools mismatch: %+v", got.Tools)
+	}
+	if got.ProbedAt == "" {
+		t.Fatalf("probedAt missing")
+	}
+	if got.Cached {
+		t.Fatalf("first probe should not be cached")
+	}
+}
+
+func TestProbeHandler_CacheHit(t *testing.T) {
+	srv := newProbeServer(t, &recordingClient{tools: []mcp.Tool{{Name: "a"}}})
+	handler := srv.Handler()
+	body := map[string]any{"url": "https://example.com/mcp"}
+	_ = postProbe(t, handler, body, "")
+	rec := postProbe(t, handler, body, "")
+	var got probeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.Cached {
+		t.Fatalf("expected cached=true on second call")
+	}
+}
+
+func TestProbeHandler_InitializeFailure_422WithCode(t *testing.T) {
+	srv := newProbeServer(t, &recordingClient{initErr: errors.New("bad")})
+	rec := postProbe(t, srv.Handler(), map[string]any{"url": "https://example.com/mcp"}, "")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422, got %d", rec.Code)
+	}
+	var errBody probeErrorWire
+	if err := json.Unmarshal(rec.Body.Bytes(), &errBody); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if errBody.Error.Code != probe.CodeInitializeFailed {
+		t.Fatalf("want code=%q, got %q", probe.CodeInitializeFailed, errBody.Error.Code)
+	}
+}
+
+func TestProbeHandler_InvalidConfig_400(t *testing.T) {
+	srv := newProbeServer(t, &recordingClient{})
+	rec := postProbe(t, srv.Handler(), map[string]any{"name": "no-transport"}, "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	var errBody probeErrorWire
+	_ = json.Unmarshal(rec.Body.Bytes(), &errBody)
+	if errBody.Error.Code != probe.CodeInvalidConfig {
+		t.Fatalf("want %q, got %q", probe.CodeInvalidConfig, errBody.Error.Code)
+	}
+}
+
+func TestProbeHandler_Timeout(t *testing.T) {
+	srv := newProbeServer(t, &recordingClient{initWait: 500 * time.Millisecond})
+	rec := postProbe(t, srv.Handler(), map[string]any{
+		"url":           "https://example.com/mcp",
+		"ready_timeout": "30ms",
+	}, "")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422, got %d", rec.Code)
+	}
+	var errBody probeErrorWire
+	_ = json.Unmarshal(rec.Body.Bytes(), &errBody)
+	if errBody.Error.Code != probe.CodeProbeTimeout {
+		t.Fatalf("want probe_timeout, got %q (msg=%q)", errBody.Error.Code, errBody.Error.Message)
+	}
+}
+
+func TestProbeHandler_UnsupportedTransport_SSH(t *testing.T) {
+	srv := newProbeServer(t, &recordingClient{})
+	rec := postProbe(t, srv.Handler(), map[string]any{
+		"ssh":     map[string]any{"host": "h", "user": "u"},
+		"command": []string{"/bin/sh"},
+	}, "")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422, got %d", rec.Code)
+	}
+	var errBody probeErrorWire
+	_ = json.Unmarshal(rec.Body.Bytes(), &errBody)
+	if errBody.Error.Code != probe.CodeUnsupportedTransport {
+		t.Fatalf("want %q, got %q", probe.CodeUnsupportedTransport, errBody.Error.Code)
+	}
+}
+
+func TestProbeHandler_UnsupportedTransport_OpenAPI(t *testing.T) {
+	srv := newProbeServer(t, &recordingClient{})
+	rec := postProbe(t, srv.Handler(), map[string]any{
+		"openapi": map[string]any{"spec": "https://api.example.com/openapi.json"},
+	}, "")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422, got %d", rec.Code)
+	}
+}
+
+func TestProbeHandler_SecretScrubbing(t *testing.T) {
+	// An error string that includes the env value must have that value
+	// replaced with *** before the response is serialized.
+	srv := newProbeServer(t, &recordingClient{initErr: errors.New("token=supersecret-123 rejected")})
+	rec := postProbe(t, srv.Handler(), map[string]any{
+		"url": "https://example.com/mcp",
+		"env": map[string]string{"API_TOKEN": "supersecret-123"},
+	}, "")
+	var errBody probeErrorWire
+	_ = json.Unmarshal(rec.Body.Bytes(), &errBody)
+	if strings.Contains(errBody.Error.Message, "supersecret-123") {
+		t.Fatalf("secret leaked into message: %q", errBody.Error.Message)
+	}
+	if !strings.Contains(errBody.Error.Message, "***") {
+		t.Fatalf("expected *** in scrubbed message, got %q", errBody.Error.Message)
+	}
+}
+
+func TestProbeHandler_MethodNotAllowed(t *testing.T) {
+	srv := newProbeServer(t, &recordingClient{})
+	req := httptest.NewRequest(http.MethodGet, "/api/servers/probe", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("want 405, got %d", rec.Code)
+	}
+}
+
+func TestProbeHandler_NoProber_503(t *testing.T) {
+	srv := newTestServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/servers/probe", strings.NewReader(`{"url":"x"}`))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 when prober not configured, got %d", rec.Code)
+	}
+}
+
+func TestProbeHandler_SessionConcurrencyCap(t *testing.T) {
+	// A client that blocks on Initialize lets us observe the semaphore: 3
+	// in-flight are accepted, the 4th gets 429.
+	block := make(chan struct{})
+	client := &slowClient{started: &atomic.Int32{}, release: block}
+	srv := newProbeServer(t, client)
+	handler := srv.Handler()
+
+	body, _ := json.Marshal(map[string]any{"url": "https://example.com/mcp"})
+	var wg sync.WaitGroup
+	results := make(chan int, 4)
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodPost, "/api/servers/probe", bytes.NewReader(body))
+			req.Header.Set("X-Session-ID", "s1")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			results <- rec.Code
+		}()
+	}
+
+	// Wait for 3 to be in-flight, then release all 4 (including the rejected one).
+	for client.started.Load() < 3 {
+		time.Sleep(time.Millisecond)
+	}
+	close(block)
+	wg.Wait()
+	close(results)
+
+	codes := map[int]int{}
+	for c := range results {
+		codes[c]++
+	}
+	if codes[http.StatusTooManyRequests] == 0 {
+		t.Fatalf("expected at least one 429, got %+v", codes)
+	}
+}
+
+// slowClient blocks Initialize until release is closed. Used to hold slots
+// open while exercising the concurrency cap.
+type slowClient struct {
+	started *atomic.Int32
+	release chan struct{}
+}
+
+func (s *slowClient) Name() string { return "slow" }
+func (s *slowClient) Initialize(ctx context.Context) error {
+	s.started.Add(1)
+	select {
+	case <-s.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+func (s *slowClient) RefreshTools(context.Context) error { return nil }
+func (s *slowClient) Tools() []mcp.Tool                  { return nil }
+func (s *slowClient) IsInitialized() bool                { return true }
+func (s *slowClient) ServerInfo() mcp.ServerInfo         { return mcp.ServerInfo{} }
+func (s *slowClient) CallTool(context.Context, string, map[string]any) (*mcp.ToolCallResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+// Round-trip check: the snake_case wire fields the frontend sends must decode
+// into the handler's probeRequest and convert to a config.MCPServer with the
+// values intact.
+func TestProbeHandler_RequestShape(t *testing.T) {
+	req := map[string]any{
+		"name":          "web",
+		"url":           "https://example.com/mcp",
+		"transport":     "http",
+		"tools":         []string{"a", "b"},
+		"ready_timeout": "2s",
+		"build_args":    map[string]string{"FOO": "1"},
+	}
+	b, _ := json.Marshal(req)
+	var pr probeRequest
+	if err := json.Unmarshal(b, &pr); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	cfg := pr.toMCPServer()
+	if cfg.URL != "https://example.com/mcp" || cfg.Name != "web" {
+		t.Fatalf("fields didn't decode: %+v", cfg)
+	}
+	if cfg.ReadyTimeout != "2s" {
+		t.Fatalf("ready_timeout didn't map: got %q", cfg.ReadyTimeout)
+	}
+	if cfg.BuildArgs["FOO"] != "1" {
+		t.Fatalf("build_args didn't map: %+v", cfg.BuildArgs)
+	}
+}

--- a/internal/api/probe_test.go
+++ b/internal/api/probe_test.go
@@ -56,7 +56,7 @@ func (f fixedFactory) NewProcess(string, []string, string, map[string]string) mc
 func newProbeServer(t *testing.T, client mcp.AgentClient) *Server {
 	t.Helper()
 	srv := newTestServer(t)
-	p := probe.NewProber(probe.NewCache(time.Minute), nil)
+	p := probe.NewProber(probe.NewCache(time.Minute))
 	p.SetClientFactory(fixedFactory{client: client})
 	srv.SetProber(p)
 	return srv
@@ -134,16 +134,53 @@ func TestProbeHandler_InitializeFailure_422WithCode(t *testing.T) {
 	}
 }
 
-func TestProbeHandler_InvalidConfig_400(t *testing.T) {
+func TestProbeHandler_NoTransport_Unsupported422(t *testing.T) {
+	// A request with no url, no image, no command, and no ssh/openapi hint
+	// classifies as "container" by elimination — which is unsupported in this
+	// release. The handler surfaces a 422 unsupported_transport rather than a
+	// 400, because the descoped probe doesn't validate fields it will never
+	// use.
 	srv := newProbeServer(t, &recordingClient{})
 	rec := postProbe(t, srv.Handler(), map[string]any{"name": "no-transport"}, "")
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("want 400, got %d (body=%s)", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422, got %d (body=%s)", rec.Code, rec.Body.String())
 	}
 	var errBody probeErrorWire
 	_ = json.Unmarshal(rec.Body.Bytes(), &errBody)
-	if errBody.Error.Code != probe.CodeInvalidConfig {
-		t.Fatalf("want %q, got %q", probe.CodeInvalidConfig, errBody.Error.Code)
+	if errBody.Error.Code != probe.CodeUnsupportedTransport {
+		t.Fatalf("want %q, got %q", probe.CodeUnsupportedTransport, errBody.Error.Code)
+	}
+}
+
+func TestProbeHandler_ContainerHTTP_Unsupported422(t *testing.T) {
+	srv := newProbeServer(t, &recordingClient{})
+	rec := postProbe(t, srv.Handler(), map[string]any{
+		"image":     "mcp/foo:latest",
+		"port":      8080,
+		"transport": "http",
+	}, "")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422, got %d", rec.Code)
+	}
+	var errBody probeErrorWire
+	_ = json.Unmarshal(rec.Body.Bytes(), &errBody)
+	if errBody.Error.Code != probe.CodeUnsupportedTransport {
+		t.Fatalf("want %q, got %q", probe.CodeUnsupportedTransport, errBody.Error.Code)
+	}
+}
+
+func TestProbeHandler_LocalProcess_Unsupported422(t *testing.T) {
+	srv := newProbeServer(t, &recordingClient{})
+	rec := postProbe(t, srv.Handler(), map[string]any{
+		"command": []string{"/usr/bin/mcp"},
+	}, "")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422, got %d", rec.Code)
+	}
+	var errBody probeErrorWire
+	_ = json.Unmarshal(rec.Body.Bytes(), &errBody)
+	if errBody.Error.Code != probe.CodeUnsupportedTransport {
+		t.Fatalf("want %q, got %q", probe.CodeUnsupportedTransport, errBody.Error.Code)
 	}
 }
 

--- a/internal/probe/cache.go
+++ b/internal/probe/cache.go
@@ -1,0 +1,160 @@
+// Package probe implements the ephemeral MCP server probe used by the wizard
+// to enumerate a server's tool list before it has been deployed.
+//
+// The cache keeps successful probe results for 5 minutes keyed by a
+// canonicalized hash of the server config so repeated "Discover tools" clicks
+// on the same config short-circuit the spawn.
+package probe
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// DefaultTTL is how long a successful probe result is cached.
+const DefaultTTL = 5 * time.Minute
+
+// Entry is a cached probe result.
+type Entry struct {
+	Tools    []mcp.Tool
+	ProbedAt time.Time
+}
+
+// Cache is a concurrency-safe TTL cache for probe results. The zero value is
+// not usable — call NewCache.
+type Cache struct {
+	ttl time.Duration
+	now func() time.Time
+
+	mu      sync.RWMutex
+	entries map[string]Entry
+}
+
+// NewCache constructs a probe cache with the given TTL. Zero or negative TTLs
+// fall back to DefaultTTL so callers can't accidentally disable caching.
+func NewCache(ttl time.Duration) *Cache {
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	return &Cache{
+		ttl:     ttl,
+		now:     time.Now,
+		entries: make(map[string]Entry),
+	}
+}
+
+// Get returns the entry for key if present and not expired. Expired entries
+// are removed on access (lazy eviction).
+func (c *Cache) Get(key string) (Entry, bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return Entry{}, false
+	}
+	if c.now().Sub(entry.ProbedAt) > c.ttl {
+		c.mu.Lock()
+		// Re-check under the write lock to avoid racing with a concurrent Put.
+		if current, stillThere := c.entries[key]; stillThere && c.now().Sub(current.ProbedAt) > c.ttl {
+			delete(c.entries, key)
+		}
+		c.mu.Unlock()
+		return Entry{}, false
+	}
+	return entry, true
+}
+
+// Put stores an entry under the given key. Only callers that have a successful
+// probe result should Put — failure paths must not populate the cache.
+func (c *Cache) Put(key string, tools []mcp.Tool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = Entry{
+		Tools:    tools,
+		ProbedAt: c.now(),
+	}
+}
+
+// Len returns the number of entries currently in the cache (including ones
+// that are expired but not yet evicted). Intended for tests.
+func (c *Cache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
+// Key produces a stable sha256 hash of the subset of the server config that
+// actually identifies the target being probed. Volatile / identity-only fields
+// (name, network) are excluded so two identical servers with different names
+// share a cache entry.
+func Key(cfg config.MCPServer) string {
+	canon := canonicalize(cfg)
+	// json.Marshal sorts map keys for map types; we also sort our outer struct
+	// by using a fixed field order below, so the output is stable across
+	// semantically equivalent inputs.
+	b, _ := json.Marshal(canon)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// canonicalShape is the shape the cache key hashes over. Field order here is
+// the canonical order — do not reorder without also bumping a cache version
+// (if one is introduced later) because that would invalidate existing keys.
+type canonicalShape struct {
+	Image         string              `json:"image,omitempty"`
+	Source        *config.Source      `json:"source,omitempty"`
+	URL           string              `json:"url,omitempty"`
+	Port          int                 `json:"port,omitempty"`
+	Transport     string              `json:"transport,omitempty"`
+	Command       []string            `json:"command,omitempty"`
+	Env           []kv                `json:"env,omitempty"`
+	BuildArgs     []kv                `json:"build_args,omitempty"`
+	SSH           *config.SSHConfig   `json:"ssh,omitempty"`
+	OpenAPI       *config.OpenAPIConfig `json:"openapi,omitempty"`
+	Replicas      int                 `json:"replicas,omitempty"`
+	ReadyTimeout  string              `json:"ready_timeout,omitempty"`
+}
+
+// kv is a sorted representation of a map used inside canonicalShape. Using a
+// slice of explicit pairs (sorted by key) guarantees the marshaled bytes are
+// identical regardless of Go's map iteration order.
+type kv struct {
+	K string `json:"k"`
+	V string `json:"v"`
+}
+
+func canonicalize(cfg config.MCPServer) canonicalShape {
+	return canonicalShape{
+		Image:        cfg.Image,
+		Source:       cfg.Source,
+		URL:          cfg.URL,
+		Port:         cfg.Port,
+		Transport:    cfg.Transport,
+		Command:      cfg.Command,
+		Env:          sortedKV(cfg.Env),
+		BuildArgs:    sortedKV(cfg.BuildArgs),
+		SSH:          cfg.SSH,
+		OpenAPI:      cfg.OpenAPI,
+		Replicas:     cfg.Replicas,
+		ReadyTimeout: cfg.ReadyTimeout,
+	}
+}
+
+func sortedKV(m map[string]string) []kv {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]kv, 0, len(m))
+	for k, v := range m {
+		out = append(out, kv{K: k, V: v})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].K < out[j].K })
+	return out
+}

--- a/internal/probe/cache_test.go
+++ b/internal/probe/cache_test.go
@@ -1,0 +1,113 @@
+package probe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+func TestCache_PutGetHit(t *testing.T) {
+	c := NewCache(time.Minute)
+	tools := []mcp.Tool{{Name: "search"}}
+	c.Put("k1", tools)
+
+	got, ok := c.Get("k1")
+	if !ok {
+		t.Fatalf("expected cache hit")
+	}
+	if len(got.Tools) != 1 || got.Tools[0].Name != "search" {
+		t.Fatalf("tools mismatch: %+v", got.Tools)
+	}
+}
+
+func TestCache_Miss(t *testing.T) {
+	c := NewCache(time.Minute)
+	if _, ok := c.Get("nope"); ok {
+		t.Fatalf("expected miss")
+	}
+}
+
+func TestCache_ExpiredEvictedOnAccess(t *testing.T) {
+	c := NewCache(10 * time.Millisecond)
+	base := time.Now()
+	c.now = func() time.Time { return base }
+
+	c.Put("k", []mcp.Tool{{Name: "t"}})
+	if c.Len() != 1 {
+		t.Fatalf("expected 1 entry after put, got %d", c.Len())
+	}
+
+	// Advance past TTL and read.
+	c.now = func() time.Time { return base.Add(time.Second) }
+	if _, ok := c.Get("k"); ok {
+		t.Fatalf("expected miss for expired entry")
+	}
+	if c.Len() != 0 {
+		t.Fatalf("expected lazy eviction, still have %d entries", c.Len())
+	}
+}
+
+func TestCache_ZeroTTLUsesDefault(t *testing.T) {
+	c := NewCache(0)
+	if c.ttl != DefaultTTL {
+		t.Fatalf("expected DefaultTTL, got %v", c.ttl)
+	}
+}
+
+// Equivalent configs must produce the same key regardless of map iteration
+// order — this is the core correctness property of canonicalization.
+func TestKey_StableAcrossMapOrdering(t *testing.T) {
+	a := config.MCPServer{
+		Name:  "alpha",
+		Image: "mcp/foo:latest",
+		Env: map[string]string{
+			"A": "1",
+			"B": "2",
+			"C": "3",
+		},
+		BuildArgs: map[string]string{
+			"X": "10",
+			"Y": "20",
+		},
+	}
+	b := config.MCPServer{
+		Name:  "beta", // different name should NOT change the key
+		Image: "mcp/foo:latest",
+		Env: map[string]string{
+			"C": "3",
+			"A": "1",
+			"B": "2",
+		},
+		BuildArgs: map[string]string{
+			"Y": "20",
+			"X": "10",
+		},
+	}
+	if Key(a) != Key(b) {
+		t.Fatalf("keys differ for semantically equivalent configs: %q vs %q", Key(a), Key(b))
+	}
+}
+
+func TestKey_DiffersOnMeaningfulChange(t *testing.T) {
+	base := config.MCPServer{Image: "mcp/foo:latest", Env: map[string]string{"K": "v"}}
+	changed := config.MCPServer{Image: "mcp/foo:latest", Env: map[string]string{"K": "v2"}}
+	if Key(base) == Key(changed) {
+		t.Fatalf("key did not change when env value changed")
+	}
+
+	urlCfg := config.MCPServer{URL: "https://example.com/mcp"}
+	urlCfg2 := config.MCPServer{URL: "https://example.com/mcp/"}
+	if Key(urlCfg) == Key(urlCfg2) {
+		t.Fatalf("key did not differ for different URLs")
+	}
+}
+
+func TestKey_IgnoresVolatileFields(t *testing.T) {
+	a := config.MCPServer{Image: "mcp/foo", Name: "a", Network: "net-a"}
+	b := config.MCPServer{Image: "mcp/foo", Name: "b", Network: "net-b"}
+	if Key(a) != Key(b) {
+		t.Fatalf("key changed for volatile fields (name/network): %q vs %q", Key(a), Key(b))
+	}
+}

--- a/internal/probe/prober.go
+++ b/internal/probe/prober.go
@@ -1,0 +1,433 @@
+package probe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/logging"
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/runtime"
+)
+
+// Default probe timeout. Matches the Phase 2 spec (10s) and is overridable via
+// the config's ReadyTimeout field following the same semantics the gateway
+// uses for HTTP readiness waits.
+const defaultTimeout = 10 * time.Second
+
+// Error codes surfaced to clients. Kept as constants so the frontend can map
+// them to user-facing copy deterministically.
+const (
+	CodeProbeTimeout         = "probe_timeout"
+	CodeInitializeFailed     = "initialize_failed"
+	CodeToolsListFailed      = "tools_list_failed"
+	CodeUnsupportedTransport = "unsupported_transport"
+	CodeInvalidConfig        = "invalid_config"
+	CodeRateLimited          = "rate_limited"
+	CodeInternal             = "internal_error"
+)
+
+// Error is a structured probe failure. Unlike a plain error, it carries a
+// stable code for the UI and an optional hint. Secrets in Message / Hint are
+// scrubbed by the handler before the response is serialized.
+type Error struct {
+	Code    string
+	Message string
+	Hint    string
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// newErr is a small helper so callsites read well.
+func newErr(code, msg, hint string) *Error {
+	return &Error{Code: code, Message: msg, Hint: hint}
+}
+
+// Result is what a probe returns on success.
+type Result struct {
+	Tools  []mcp.Tool
+	Cached bool
+}
+
+// Spawner abstracts the "start a workload, give me its endpoint, and let me
+// stop+remove it" dance. The probe-path container/stdio spawning needs this
+// indirection so handler tests can stub the transport layer without touching
+// docker.
+type Spawner interface {
+	// SpawnContainer starts a container for the given server config in
+	// ephemeral probe mode. On return, the caller is responsible for invoking
+	// the returned release func exactly once — it stops and removes the
+	// workload. Release must be safe to call even if SpawnContainer returns
+	// with an error (implementations should return a no-op release in that
+	// case).
+	SpawnContainer(ctx context.Context, cfg config.MCPServer) (endpoint string, containerID string, release func(ctx context.Context), err error)
+}
+
+// Prober enumerates an MCP server's tools without registering it with the
+// gateway. It owns the cache and spawner wiring; the HTTP handler is a thin
+// shell around Probe().
+type Prober struct {
+	cache   *Cache
+	spawner Spawner
+	logger  *slog.Logger
+
+	// clientFactory is overridable in tests so handler tests can inject a
+	// stubbed transport without standing up real HTTP servers.
+	clientFactory ClientFactory
+}
+
+// ClientFactory builds an MCP client for a given transport. The default
+// implementation defers to the standard pkg/mcp constructors; tests override
+// it to inject stubs.
+type ClientFactory interface {
+	NewHTTP(name, endpoint string) mcp.AgentClient
+	NewProcess(name string, command []string, workDir string, env map[string]string) mcp.AgentClient
+}
+
+// NewProber wires up a prober. A nil cache becomes a new one with DefaultTTL.
+// A nil spawner means container/stdio transports return an unsupported_transport
+// error — handy for tests and for the stackless/daemon-less build.
+func NewProber(cache *Cache, spawner Spawner) *Prober {
+	if cache == nil {
+		cache = NewCache(DefaultTTL)
+	}
+	return &Prober{
+		cache:         cache,
+		spawner:       spawner,
+		logger:        logging.NewDiscardLogger(),
+		clientFactory: defaultClientFactory{},
+	}
+}
+
+// SetLogger installs a structured logger. Nil is ignored.
+func (p *Prober) SetLogger(logger *slog.Logger) {
+	if logger != nil {
+		p.logger = logger
+	}
+}
+
+// SetClientFactory overrides the MCP client constructors. Primarily for tests.
+func (p *Prober) SetClientFactory(f ClientFactory) {
+	if f != nil {
+		p.clientFactory = f
+	}
+}
+
+// Probe validates the config, short-circuits on cache hits, and otherwise
+// spawns / connects to the server long enough to run initialize + tools/list,
+// then tears down. It is safe to call concurrently; the caller is responsible
+// for enforcing concurrency caps.
+func (p *Prober) Probe(ctx context.Context, cfg config.MCPServer) (Result, *Error) {
+	if err := validate(cfg); err != nil {
+		return Result{}, err
+	}
+
+	if cfg.IsSSH() {
+		return Result{}, newErr(CodeUnsupportedTransport,
+			"Probe not supported for ssh servers in this release.",
+			"Add tool names manually in the Advanced section — they will be enforced by the gateway once the stack is deployed.")
+	}
+	if cfg.IsOpenAPI() {
+		return Result{}, newErr(CodeUnsupportedTransport,
+			"Probe not supported for openapi servers.",
+			"Use the Operations Filter (openapi.operations.include / exclude) to curate tools for OpenAPI-backed servers.")
+	}
+
+	key := Key(cfg)
+	if entry, ok := p.cache.Get(key); ok {
+		return Result{Tools: entry.Tools, Cached: true}, nil
+	}
+
+	timeout := resolveTimeout(cfg)
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	result, err := p.runProbe(probeCtx, cfg)
+	if err != nil {
+		// A deadline exceeded from the probe context is surfaced as a
+		// distinct, user-friendly code so the UI can render "Probe timed out"
+		// rather than a raw transport error.
+		if errors.Is(probeCtx.Err(), context.DeadlineExceeded) {
+			return Result{}, newErr(CodeProbeTimeout,
+				fmt.Sprintf("Probe timed out after %s. The server may need more time to start or may require additional configuration.", timeout),
+				"Try increasing ready_timeout on the server, or verify that required environment variables are set.")
+		}
+		return Result{}, err
+	}
+
+	// Only successful probes land in the cache. A transient failure should not
+	// poison subsequent reads.
+	p.cache.Put(key, result.Tools)
+	return Result{Tools: result.Tools, Cached: false}, nil
+}
+
+// runProbe dispatches to the right transport-specific probe path. All paths
+// run under the caller's timeout context and are responsible for deterministic
+// cleanup.
+func (p *Prober) runProbe(ctx context.Context, cfg config.MCPServer) (Result, *Error) {
+	switch {
+	case cfg.IsExternal():
+		return p.probeExternal(ctx, cfg)
+	case cfg.IsLocalProcess():
+		return p.probeLocalProcess(ctx, cfg)
+	default:
+		// Container-backed HTTP/SSE or stdio. Both require a live workload
+		// spawned ephemerally for the duration of the probe.
+		return p.probeContainer(ctx, cfg)
+	}
+}
+
+func (p *Prober) probeExternal(ctx context.Context, cfg config.MCPServer) (Result, *Error) {
+	client := p.clientFactory.NewHTTP(probeClientName(cfg), cfg.URL)
+	return runClient(ctx, client)
+}
+
+func (p *Prober) probeLocalProcess(ctx context.Context, cfg config.MCPServer) (Result, *Error) {
+	workDir := ""
+	if cwd := filepath.Dir("."); cwd != "" {
+		workDir = cwd
+	}
+	client := p.clientFactory.NewProcess(probeClientName(cfg), cfg.Command, workDir, cfg.Env)
+	return runClient(ctx, client)
+}
+
+func (p *Prober) probeContainer(ctx context.Context, cfg config.MCPServer) (Result, *Error) {
+	if strings.ToLower(cfg.Transport) == "stdio" {
+		return Result{}, newErr(CodeUnsupportedTransport,
+			"Probe is not yet supported for container stdio transport.",
+			"Enter tool names manually in the Advanced section, or switch the container to http / sse transport for probe support.")
+	}
+	if p.spawner == nil {
+		return Result{}, newErr(CodeUnsupportedTransport,
+			"Container probe is not available in this build.",
+			"Enter tool names manually in the Advanced section — they will be enforced by the gateway once the stack is deployed.")
+	}
+
+	endpoint, containerID, release, err := p.spawner.SpawnContainer(ctx, cfg)
+	// release must be called even on spawn failure — per the Spawner contract
+	// it is a no-op in that case, but callers never need to know which.
+	if release != nil {
+		defer func() {
+			// Give teardown its own short budget independent of the probe ctx
+			// so a timed-out probe still gets cleaned up.
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			release(cleanupCtx)
+		}()
+	}
+	if err != nil {
+		return Result{}, newErr(CodeInitializeFailed,
+			fmt.Sprintf("Failed to start container: %v", err),
+			"Check that the image is reachable and any required build-args / env vars are set.")
+	}
+	p.logger.Debug("probe container spawned", "container_id", containerID, "endpoint", endpoint)
+
+	client := p.clientFactory.NewHTTP(probeClientName(cfg), endpoint)
+	return runClient(ctx, client)
+}
+
+// runClient executes the Initialize + RefreshTools handshake and returns the
+// tool list. It collapses transport-specific failures into structured probe
+// errors with the stable codes the frontend understands. This path intentionally
+// does not log raw error strings because they may contain env values.
+func runClient(ctx context.Context, client mcp.AgentClient) (Result, *Error) {
+	if err := client.Initialize(ctx); err != nil {
+		closeClient(client)
+		return Result{}, newErr(CodeInitializeFailed,
+			fmt.Sprintf("Server failed to initialize: %v", err),
+			"")
+	}
+	if err := client.RefreshTools(ctx); err != nil {
+		closeClient(client)
+		return Result{}, newErr(CodeToolsListFailed,
+			fmt.Sprintf("Server failed to list tools: %v", err),
+			"")
+	}
+	tools := client.Tools()
+	closeClient(client)
+	return Result{Tools: tools}, nil
+}
+
+// closeClient tries Close on clients that support it. Stdio/process clients
+// implement io.Closer for this purpose; HTTP does not, and that's fine — there
+// is no persistent connection to tear down for external URL probes.
+func closeClient(client mcp.AgentClient) {
+	type closer interface{ Close() error }
+	if c, ok := client.(closer); ok {
+		_ = c.Close()
+	}
+}
+
+func validate(cfg config.MCPServer) *Error {
+	if cfg.IsSSH() || cfg.IsOpenAPI() {
+		// Transport is structurally valid but not supported — caller handles
+		// the unsupported_transport response.
+		return nil
+	}
+	if cfg.IsExternal() {
+		if strings.TrimSpace(cfg.URL) == "" {
+			return newErr(CodeInvalidConfig, "external servers require a url.", "Set the server's url field.")
+		}
+		return nil
+	}
+	if cfg.IsLocalProcess() {
+		if len(cfg.Command) == 0 {
+			return newErr(CodeInvalidConfig, "local process servers require a command.", "Set the server's command field.")
+		}
+		return nil
+	}
+	// Container-backed. Either image or source must be set; transport http/sse
+	// needs a port, stdio doesn't.
+	if cfg.Image == "" && cfg.Source == nil {
+		return newErr(CodeInvalidConfig, "container servers require image or source.", "Set one of image or source.")
+	}
+	transport := strings.ToLower(cfg.Transport)
+	if transport == "" {
+		transport = "http"
+	}
+	switch transport {
+	case "http", "sse":
+		if cfg.Port == 0 {
+			return newErr(CodeInvalidConfig, "http/sse container servers require a port.", "Set the server's port field.")
+		}
+	case "stdio":
+		// No extra required fields.
+	default:
+		return newErr(CodeInvalidConfig, fmt.Sprintf("unknown transport: %q", cfg.Transport), "Valid transports: http, sse, stdio.")
+	}
+	return nil
+}
+
+func resolveTimeout(cfg config.MCPServer) time.Duration {
+	if d := cfg.ResolvedReadyTimeout(); d > 0 {
+		return d
+	}
+	return defaultTimeout
+}
+
+// probeClientName tags logs from a probe with a stable prefix. The container
+// itself uses a different, runtime-assigned name — this is just for logging.
+func probeClientName(cfg config.MCPServer) string {
+	if cfg.Name != "" {
+		return "probe:" + cfg.Name
+	}
+	return "probe:anonymous"
+}
+
+// defaultClientFactory wires the public mcp.NewClient / NewProcessClient
+// constructors. Kept as a struct (not a free function) so tests can swap it.
+type defaultClientFactory struct{}
+
+func (defaultClientFactory) NewHTTP(name, endpoint string) mcp.AgentClient {
+	return mcp.NewClient(name, endpoint)
+}
+
+func (defaultClientFactory) NewProcess(name string, command []string, workDir string, env map[string]string) mcp.AgentClient {
+	return mcp.NewProcessClient(name, command, workDir, env)
+}
+
+// NoopSpawner is a convenience for tests and the stackless build — it always
+// refuses, causing container/stdio probes to return unsupported_transport.
+type NoopSpawner struct{}
+
+// SpawnContainer always fails with a "not available" error.
+func (NoopSpawner) SpawnContainer(ctx context.Context, cfg config.MCPServer) (string, string, func(context.Context), error) {
+	return "", "", func(context.Context) {}, errors.New("container probe not available in this build")
+}
+
+// RuntimeSpawner wires the WorkloadRuntime into the prober so container /
+// stdio probes can spawn real workloads. It is intentionally conservative —
+// each probe gets its own uniquely-named workload so cleanup is unambiguous,
+// and every code path runs Stop+Remove via the returned release function.
+type RuntimeSpawner struct {
+	rt     runtime.WorkloadRuntime
+	logger *slog.Logger
+
+	// now is overridable in tests to keep generated names deterministic.
+	now func() time.Time
+}
+
+// NewRuntimeSpawner constructs a RuntimeSpawner. Passing a nil runtime yields
+// a spawner whose Spawn always fails — equivalent to NoopSpawner.
+func NewRuntimeSpawner(rt runtime.WorkloadRuntime) *RuntimeSpawner {
+	return &RuntimeSpawner{
+		rt:     rt,
+		logger: logging.NewDiscardLogger(),
+		now:    time.Now,
+	}
+}
+
+// SetLogger installs a structured logger.
+func (s *RuntimeSpawner) SetLogger(logger *slog.Logger) {
+	if logger != nil {
+		s.logger = logger
+	}
+}
+
+// SpawnContainer implements the Spawner interface. Stdio transport is routed
+// through an error today — full stdio probe requires attaching to a running
+// container's stdio streams, which is a Phase 2.1 item.
+func (s *RuntimeSpawner) SpawnContainer(ctx context.Context, cfg config.MCPServer) (string, string, func(context.Context), error) {
+	noop := func(context.Context) {}
+	if s.rt == nil {
+		return "", "", noop, errors.New("container probe not available: no runtime wired")
+	}
+
+	transport := strings.ToLower(cfg.Transport)
+	workloadName := fmt.Sprintf("gridctl-probe-%d", s.now().UnixNano())
+	exposedPort := cfg.Port
+	if exposedPort == 0 {
+		return "", "", noop, errors.New("container probe requires a port")
+	}
+
+	cfgBytes := runtime.WorkloadConfig{
+		Name:        workloadName,
+		Stack:       "gridctl-probe",
+		Type:        runtime.WorkloadTypeMCPServer,
+		Image:       cfg.Image,
+		Command:     cfg.Command,
+		Env:         cfg.Env,
+		ExposedPort: exposedPort,
+		Transport:   transport,
+		Labels: map[string]string{
+			"gridctl.probe": "true",
+		},
+	}
+
+	status, err := s.rt.Start(ctx, cfgBytes)
+	if err != nil {
+		return "", "", noop, fmt.Errorf("start container: %w", err)
+	}
+
+	containerID := string(status.ID)
+	release := func(rctx context.Context) {
+		// Stop is best-effort — Remove is the authoritative cleanup. Log but
+		// don't propagate Stop errors because Remove will still fire.
+		if err := s.rt.Stop(rctx, status.ID); err != nil {
+			s.logger.Warn("probe teardown: stop failed", "container", containerID, "error", err)
+		}
+		if err := s.rt.Remove(rctx, status.ID); err != nil {
+			s.logger.Warn("probe teardown: remove failed", "container", containerID, "error", err)
+		}
+	}
+
+	endpoint := status.Endpoint
+	if endpoint == "" {
+		// Synthesize one from the host port the runtime assigned.
+		endpoint = fmt.Sprintf("http://localhost:%d/mcp", status.HostPort)
+	} else if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		endpoint = "http://" + endpoint + "/mcp"
+	}
+
+	return endpoint, containerID, release, nil
+}

--- a/internal/probe/prober.go
+++ b/internal/probe/prober.go
@@ -5,19 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/gridctl/gridctl/pkg/config"
 	"github.com/gridctl/gridctl/pkg/logging"
 	"github.com/gridctl/gridctl/pkg/mcp"
-	"github.com/gridctl/gridctl/pkg/runtime"
 )
 
-// Default probe timeout. Matches the Phase 2 spec (10s) and is overridable via
-// the config's ReadyTimeout field following the same semantics the gateway
-// uses for HTTP readiness waits.
+// Default probe timeout. Overridable via the config's ReadyTimeout field
+// following the same semantics the gateway uses for HTTP readiness waits.
 const defaultTimeout = 10 * time.Second
 
 // Error codes surfaced to clients. Kept as constants so the frontend can map
@@ -48,7 +45,6 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("%s: %s", e.Code, e.Message)
 }
 
-// newErr is a small helper so callsites read well.
 func newErr(code, msg, hint string) *Error {
 	return &Error{Code: code, Message: msg, Hint: hint}
 }
@@ -59,27 +55,23 @@ type Result struct {
 	Cached bool
 }
 
-// Spawner abstracts the "start a workload, give me its endpoint, and let me
-// stop+remove it" dance. The probe-path container/stdio spawning needs this
-// indirection so handler tests can stub the transport layer without touching
-// docker.
-type Spawner interface {
-	// SpawnContainer starts a container for the given server config in
-	// ephemeral probe mode. On return, the caller is responsible for invoking
-	// the returned release func exactly once — it stops and removes the
-	// workload. Release must be safe to call even if SpawnContainer returns
-	// with an error (implementations should return a no-op release in that
-	// case).
-	SpawnContainer(ctx context.Context, cfg config.MCPServer) (endpoint string, containerID string, release func(ctx context.Context), err error)
-}
+// unsupportedHint is the canonical guidance shown when the probe cannot run.
+// It points users at the post-deploy tool editor on the topology sidebar,
+// which is the primary curation surface for container / local-process /
+// stdio / SSH / OpenAPI servers.
+const unsupportedHint = "Enter tool names manually in the wizard's Advanced section, or curate them from the topology sidebar after deploy."
 
 // Prober enumerates an MCP server's tools without registering it with the
-// gateway. It owns the cache and spawner wiring; the HTTP handler is a thin
-// shell around Probe().
+// gateway. Scope: external URL transport only.
+//
+// For every other transport (container HTTP/SSE, container stdio, local
+// process, SSH, OpenAPI) the probe returns CodeUnsupportedTransport with a
+// hint pointing users at the post-deploy tool editor. Running a server
+// ephemerally before deploy is a niche workflow compared to the common
+// deploy-then-curate flow that the topology editor supports.
 type Prober struct {
-	cache   *Cache
-	spawner Spawner
-	logger  *slog.Logger
+	cache  *Cache
+	logger *slog.Logger
 
 	// clientFactory is overridable in tests so handler tests can inject a
 	// stubbed transport without standing up real HTTP servers.
@@ -91,19 +83,15 @@ type Prober struct {
 // it to inject stubs.
 type ClientFactory interface {
 	NewHTTP(name, endpoint string) mcp.AgentClient
-	NewProcess(name string, command []string, workDir string, env map[string]string) mcp.AgentClient
 }
 
 // NewProber wires up a prober. A nil cache becomes a new one with DefaultTTL.
-// A nil spawner means container/stdio transports return an unsupported_transport
-// error — handy for tests and for the stackless/daemon-less build.
-func NewProber(cache *Cache, spawner Spawner) *Prober {
+func NewProber(cache *Cache) *Prober {
 	if cache == nil {
 		cache = NewCache(DefaultTTL)
 	}
 	return &Prober{
 		cache:         cache,
-		spawner:       spawner,
 		logger:        logging.NewDiscardLogger(),
 		clientFactory: defaultClientFactory{},
 	}
@@ -116,7 +104,7 @@ func (p *Prober) SetLogger(logger *slog.Logger) {
 	}
 }
 
-// SetClientFactory overrides the MCP client constructors. Primarily for tests.
+// SetClientFactory overrides the MCP client constructor. Primarily for tests.
 func (p *Prober) SetClientFactory(f ClientFactory) {
 	if f != nil {
 		p.clientFactory = f
@@ -124,23 +112,15 @@ func (p *Prober) SetClientFactory(f ClientFactory) {
 }
 
 // Probe validates the config, short-circuits on cache hits, and otherwise
-// spawns / connects to the server long enough to run initialize + tools/list,
-// then tears down. It is safe to call concurrently; the caller is responsible
-// for enforcing concurrency caps.
+// connects to the external URL long enough to run initialize + tools/list.
+// It is safe to call concurrently; the caller is responsible for enforcing
+// concurrency caps.
 func (p *Prober) Probe(ctx context.Context, cfg config.MCPServer) (Result, *Error) {
+	if unsupported := unsupportedReason(cfg); unsupported != nil {
+		return Result{}, unsupported
+	}
 	if err := validate(cfg); err != nil {
 		return Result{}, err
-	}
-
-	if cfg.IsSSH() {
-		return Result{}, newErr(CodeUnsupportedTransport,
-			"Probe not supported for ssh servers in this release.",
-			"Add tool names manually in the Advanced section — they will be enforced by the gateway once the stack is deployed.")
-	}
-	if cfg.IsOpenAPI() {
-		return Result{}, newErr(CodeUnsupportedTransport,
-			"Probe not supported for openapi servers.",
-			"Use the Operations Filter (openapi.operations.include / exclude) to curate tools for OpenAPI-backed servers.")
 	}
 
 	key := Key(cfg)
@@ -152,38 +132,50 @@ func (p *Prober) Probe(ctx context.Context, cfg config.MCPServer) (Result, *Erro
 	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	result, err := p.runProbe(probeCtx, cfg)
+	result, err := p.probeExternal(probeCtx, cfg)
 	if err != nil {
 		// A deadline exceeded from the probe context is surfaced as a
 		// distinct, user-friendly code so the UI can render "Probe timed out"
 		// rather than a raw transport error.
 		if errors.Is(probeCtx.Err(), context.DeadlineExceeded) {
 			return Result{}, newErr(CodeProbeTimeout,
-				fmt.Sprintf("Probe timed out after %s. The server may need more time to start or may require additional configuration.", timeout),
-				"Try increasing ready_timeout on the server, or verify that required environment variables are set.")
+				fmt.Sprintf("Probe timed out after %s. The server may need more time to respond or may require additional configuration.", timeout),
+				"Try increasing ready_timeout on the server, or verify the URL is reachable.")
 		}
 		return Result{}, err
 	}
 
-	// Only successful probes land in the cache. A transient failure should not
-	// poison subsequent reads.
+	// Only successful probes land in the cache. A transient failure should
+	// not poison subsequent reads.
 	p.cache.Put(key, result.Tools)
 	return Result{Tools: result.Tools, Cached: false}, nil
 }
 
-// runProbe dispatches to the right transport-specific probe path. All paths
-// run under the caller's timeout context and are responsible for deterministic
-// cleanup.
-func (p *Prober) runProbe(ctx context.Context, cfg config.MCPServer) (Result, *Error) {
+// unsupportedReason returns a structured error for any transport the current
+// probe implementation does not handle. External URL is the only supported
+// path; every other transport routes to the topology editor post-deploy.
+func unsupportedReason(cfg config.MCPServer) *Error {
 	switch {
-	case cfg.IsExternal():
-		return p.probeExternal(ctx, cfg)
+	case cfg.IsSSH():
+		return newErr(CodeUnsupportedTransport,
+			"Probe not supported for ssh servers.",
+			unsupportedHint)
+	case cfg.IsOpenAPI():
+		return newErr(CodeUnsupportedTransport,
+			"Probe not supported for openapi servers.",
+			"Use openapi.operations.include / exclude to curate tools, or the topology sidebar editor after deploy.")
 	case cfg.IsLocalProcess():
-		return p.probeLocalProcess(ctx, cfg)
+		return newErr(CodeUnsupportedTransport,
+			"Probe not supported for local-process servers.",
+			unsupportedHint)
+	case cfg.IsExternal():
+		return nil
 	default:
-		// Container-backed HTTP/SSE or stdio. Both require a live workload
-		// spawned ephemerally for the duration of the probe.
-		return p.probeContainer(ctx, cfg)
+		// Container-backed (image or source). Not supported for probe in this
+		// release — the common case is deploy-then-curate from the topology.
+		return newErr(CodeUnsupportedTransport,
+			"Probe not supported for container servers.",
+			unsupportedHint)
 	}
 }
 
@@ -192,54 +184,11 @@ func (p *Prober) probeExternal(ctx context.Context, cfg config.MCPServer) (Resul
 	return runClient(ctx, client)
 }
 
-func (p *Prober) probeLocalProcess(ctx context.Context, cfg config.MCPServer) (Result, *Error) {
-	workDir := ""
-	if cwd := filepath.Dir("."); cwd != "" {
-		workDir = cwd
-	}
-	client := p.clientFactory.NewProcess(probeClientName(cfg), cfg.Command, workDir, cfg.Env)
-	return runClient(ctx, client)
-}
-
-func (p *Prober) probeContainer(ctx context.Context, cfg config.MCPServer) (Result, *Error) {
-	if strings.ToLower(cfg.Transport) == "stdio" {
-		return Result{}, newErr(CodeUnsupportedTransport,
-			"Probe is not yet supported for container stdio transport.",
-			"Enter tool names manually in the Advanced section, or switch the container to http / sse transport for probe support.")
-	}
-	if p.spawner == nil {
-		return Result{}, newErr(CodeUnsupportedTransport,
-			"Container probe is not available in this build.",
-			"Enter tool names manually in the Advanced section — they will be enforced by the gateway once the stack is deployed.")
-	}
-
-	endpoint, containerID, release, err := p.spawner.SpawnContainer(ctx, cfg)
-	// release must be called even on spawn failure — per the Spawner contract
-	// it is a no-op in that case, but callers never need to know which.
-	if release != nil {
-		defer func() {
-			// Give teardown its own short budget independent of the probe ctx
-			// so a timed-out probe still gets cleaned up.
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			release(cleanupCtx)
-		}()
-	}
-	if err != nil {
-		return Result{}, newErr(CodeInitializeFailed,
-			fmt.Sprintf("Failed to start container: %v", err),
-			"Check that the image is reachable and any required build-args / env vars are set.")
-	}
-	p.logger.Debug("probe container spawned", "container_id", containerID, "endpoint", endpoint)
-
-	client := p.clientFactory.NewHTTP(probeClientName(cfg), endpoint)
-	return runClient(ctx, client)
-}
-
 // runClient executes the Initialize + RefreshTools handshake and returns the
 // tool list. It collapses transport-specific failures into structured probe
-// errors with the stable codes the frontend understands. This path intentionally
-// does not log raw error strings because they may contain env values.
+// errors with the stable codes the frontend understands. This path
+// intentionally does not log raw error strings because they may contain env
+// values.
 func runClient(ctx context.Context, client mcp.AgentClient) (Result, *Error) {
 	if err := client.Initialize(ctx); err != nil {
 		closeClient(client)
@@ -258,9 +207,10 @@ func runClient(ctx context.Context, client mcp.AgentClient) (Result, *Error) {
 	return Result{Tools: tools}, nil
 }
 
-// closeClient tries Close on clients that support it. Stdio/process clients
-// implement io.Closer for this purpose; HTTP does not, and that's fine — there
-// is no persistent connection to tear down for external URL probes.
+// closeClient tries Close on clients that support it. The external URL
+// (HTTP) client does not hold a persistent connection, so this is usually a
+// no-op — but the type check future-proofs against stubbed clients in tests
+// that do implement Close.
 func closeClient(client mcp.AgentClient) {
 	type closer interface{ Close() error }
 	if c, ok := client.(closer); ok {
@@ -269,41 +219,11 @@ func closeClient(client mcp.AgentClient) {
 }
 
 func validate(cfg config.MCPServer) *Error {
-	if cfg.IsSSH() || cfg.IsOpenAPI() {
-		// Transport is structurally valid but not supported — caller handles
-		// the unsupported_transport response.
-		return nil
-	}
-	if cfg.IsExternal() {
-		if strings.TrimSpace(cfg.URL) == "" {
-			return newErr(CodeInvalidConfig, "external servers require a url.", "Set the server's url field.")
-		}
-		return nil
-	}
-	if cfg.IsLocalProcess() {
-		if len(cfg.Command) == 0 {
-			return newErr(CodeInvalidConfig, "local process servers require a command.", "Set the server's command field.")
-		}
-		return nil
-	}
-	// Container-backed. Either image or source must be set; transport http/sse
-	// needs a port, stdio doesn't.
-	if cfg.Image == "" && cfg.Source == nil {
-		return newErr(CodeInvalidConfig, "container servers require image or source.", "Set one of image or source.")
-	}
-	transport := strings.ToLower(cfg.Transport)
-	if transport == "" {
-		transport = "http"
-	}
-	switch transport {
-	case "http", "sse":
-		if cfg.Port == 0 {
-			return newErr(CodeInvalidConfig, "http/sse container servers require a port.", "Set the server's port field.")
-		}
-	case "stdio":
-		// No extra required fields.
-	default:
-		return newErr(CodeInvalidConfig, fmt.Sprintf("unknown transport: %q", cfg.Transport), "Valid transports: http, sse, stdio.")
+	// At this point unsupportedReason has already routed everything except
+	// external URL to unsupported_transport. Only external-URL-specific
+	// validation remains.
+	if strings.TrimSpace(cfg.URL) == "" {
+		return newErr(CodeInvalidConfig, "external servers require a url.", "Set the server's url field.")
 	}
 	return nil
 }
@@ -315,8 +235,7 @@ func resolveTimeout(cfg config.MCPServer) time.Duration {
 	return defaultTimeout
 }
 
-// probeClientName tags logs from a probe with a stable prefix. The container
-// itself uses a different, runtime-assigned name — this is just for logging.
+// probeClientName tags logs from a probe with a stable prefix.
 func probeClientName(cfg config.MCPServer) string {
 	if cfg.Name != "" {
 		return "probe:" + cfg.Name
@@ -324,110 +243,10 @@ func probeClientName(cfg config.MCPServer) string {
 	return "probe:anonymous"
 }
 
-// defaultClientFactory wires the public mcp.NewClient / NewProcessClient
-// constructors. Kept as a struct (not a free function) so tests can swap it.
+// defaultClientFactory wires the public mcp.NewClient constructor. Kept as a
+// struct (not a free function) so tests can swap it.
 type defaultClientFactory struct{}
 
 func (defaultClientFactory) NewHTTP(name, endpoint string) mcp.AgentClient {
 	return mcp.NewClient(name, endpoint)
-}
-
-func (defaultClientFactory) NewProcess(name string, command []string, workDir string, env map[string]string) mcp.AgentClient {
-	return mcp.NewProcessClient(name, command, workDir, env)
-}
-
-// NoopSpawner is a convenience for tests and the stackless build — it always
-// refuses, causing container/stdio probes to return unsupported_transport.
-type NoopSpawner struct{}
-
-// SpawnContainer always fails with a "not available" error.
-func (NoopSpawner) SpawnContainer(ctx context.Context, cfg config.MCPServer) (string, string, func(context.Context), error) {
-	return "", "", func(context.Context) {}, errors.New("container probe not available in this build")
-}
-
-// RuntimeSpawner wires the WorkloadRuntime into the prober so container /
-// stdio probes can spawn real workloads. It is intentionally conservative —
-// each probe gets its own uniquely-named workload so cleanup is unambiguous,
-// and every code path runs Stop+Remove via the returned release function.
-type RuntimeSpawner struct {
-	rt     runtime.WorkloadRuntime
-	logger *slog.Logger
-
-	// now is overridable in tests to keep generated names deterministic.
-	now func() time.Time
-}
-
-// NewRuntimeSpawner constructs a RuntimeSpawner. Passing a nil runtime yields
-// a spawner whose Spawn always fails — equivalent to NoopSpawner.
-func NewRuntimeSpawner(rt runtime.WorkloadRuntime) *RuntimeSpawner {
-	return &RuntimeSpawner{
-		rt:     rt,
-		logger: logging.NewDiscardLogger(),
-		now:    time.Now,
-	}
-}
-
-// SetLogger installs a structured logger.
-func (s *RuntimeSpawner) SetLogger(logger *slog.Logger) {
-	if logger != nil {
-		s.logger = logger
-	}
-}
-
-// SpawnContainer implements the Spawner interface. Stdio transport is routed
-// through an error today — full stdio probe requires attaching to a running
-// container's stdio streams, which is a Phase 2.1 item.
-func (s *RuntimeSpawner) SpawnContainer(ctx context.Context, cfg config.MCPServer) (string, string, func(context.Context), error) {
-	noop := func(context.Context) {}
-	if s.rt == nil {
-		return "", "", noop, errors.New("container probe not available: no runtime wired")
-	}
-
-	transport := strings.ToLower(cfg.Transport)
-	workloadName := fmt.Sprintf("gridctl-probe-%d", s.now().UnixNano())
-	exposedPort := cfg.Port
-	if exposedPort == 0 {
-		return "", "", noop, errors.New("container probe requires a port")
-	}
-
-	cfgBytes := runtime.WorkloadConfig{
-		Name:        workloadName,
-		Stack:       "gridctl-probe",
-		Type:        runtime.WorkloadTypeMCPServer,
-		Image:       cfg.Image,
-		Command:     cfg.Command,
-		Env:         cfg.Env,
-		ExposedPort: exposedPort,
-		Transport:   transport,
-		Labels: map[string]string{
-			"gridctl.probe": "true",
-		},
-	}
-
-	status, err := s.rt.Start(ctx, cfgBytes)
-	if err != nil {
-		return "", "", noop, fmt.Errorf("start container: %w", err)
-	}
-
-	containerID := string(status.ID)
-	release := func(rctx context.Context) {
-		// Stop is best-effort — Remove is the authoritative cleanup. Log but
-		// don't propagate Stop errors because Remove will still fire.
-		if err := s.rt.Stop(rctx, status.ID); err != nil {
-			s.logger.Warn("probe teardown: stop failed", "container", containerID, "error", err)
-		}
-		if err := s.rt.Remove(rctx, status.ID); err != nil {
-			s.logger.Warn("probe teardown: remove failed", "container", containerID, "error", err)
-		}
-	}
-
-	endpoint := status.Endpoint
-	if endpoint == "" {
-		// Synthesize one from the host port the runtime assigned.
-		endpoint = fmt.Sprintf("http://localhost:%d/mcp", status.HostPort)
-	} else if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
-		endpoint = "http://" + endpoint + "/mcp"
-	}
-
-	return endpoint, containerID, release, nil
 }

--- a/internal/probe/prober_test.go
+++ b/internal/probe/prober_test.go
@@ -15,16 +15,16 @@ import (
 // stubClient is a controllable AgentClient for probe tests. It records which
 // lifecycle methods the prober calls so we can assert on them.
 type stubClient struct {
-	name         string
-	initErr      error
-	listErr      error
-	initDelay    time.Duration
-	listDelay    time.Duration
-	tools        []mcp.Tool
-	initialized  bool
-	closeCalled  atomic.Bool
-	initCalled   atomic.Bool
-	listCalled   atomic.Bool
+	name        string
+	initErr     error
+	listErr     error
+	initDelay   time.Duration
+	listDelay   time.Duration
+	tools       []mcp.Tool
+	initialized bool
+	closeCalled atomic.Bool
+	initCalled  atomic.Bool
+	listCalled  atomic.Bool
 }
 
 func (c *stubClient) Name() string { return c.name }
@@ -54,41 +54,18 @@ func (c *stubClient) RefreshTools(ctx context.Context) error {
 	}
 	return c.listErr
 }
-func (c *stubClient) Tools() []mcp.Tool                          { return c.tools }
-func (c *stubClient) IsInitialized() bool                        { return c.initialized }
-func (c *stubClient) ServerInfo() mcp.ServerInfo                 { return mcp.ServerInfo{} }
+func (c *stubClient) Tools() []mcp.Tool          { return c.tools }
+func (c *stubClient) IsInitialized() bool        { return c.initialized }
+func (c *stubClient) ServerInfo() mcp.ServerInfo { return mcp.ServerInfo{} }
 func (c *stubClient) CallTool(context.Context, string, map[string]any) (*mcp.ToolCallResult, error) {
 	return nil, errors.New("not implemented")
 }
 func (c *stubClient) Close() error { c.closeCalled.Store(true); return nil }
 
-// stubFactory returns the same stubClient for both HTTP and process
-// constructors so tests don't need to discriminate.
+// stubFactory returns the same stubClient for the HTTP constructor.
 type stubFactory struct{ client *stubClient }
 
 func (f *stubFactory) NewHTTP(string, string) mcp.AgentClient { return f.client }
-func (f *stubFactory) NewProcess(string, []string, string, map[string]string) mcp.AgentClient {
-	return f.client
-}
-
-// fakeSpawner is a Spawner stub that records spawn / release calls.
-type fakeSpawner struct {
-	spawnErr      error
-	releaseCalled atomic.Int32
-	endpoint      string
-}
-
-func (s *fakeSpawner) SpawnContainer(context.Context, config.MCPServer) (string, string, func(context.Context), error) {
-	release := func(context.Context) { s.releaseCalled.Add(1) }
-	if s.spawnErr != nil {
-		return "", "", release, s.spawnErr
-	}
-	endpoint := s.endpoint
-	if endpoint == "" {
-		endpoint = "http://127.0.0.1:0"
-	}
-	return endpoint, "fake-container-id", release, nil
-}
 
 func rawSchema(t *testing.T) json.RawMessage {
 	t.Helper()
@@ -99,9 +76,9 @@ func rawSchema(t *testing.T) json.RawMessage {
 	return b
 }
 
-func newProberWithStub(t *testing.T, client *stubClient, spawner Spawner) *Prober {
+func newProberWithStub(t *testing.T, client *stubClient) *Prober {
 	t.Helper()
-	p := NewProber(NewCache(time.Minute), spawner)
+	p := NewProber(NewCache(time.Minute))
 	p.SetClientFactory(&stubFactory{client: client})
 	return p
 }
@@ -113,7 +90,7 @@ func TestProbe_ExternalURL_HappyPath(t *testing.T) {
 			{Name: "fetch", Description: "fetch a URL", InputSchema: rawSchema(t)},
 		},
 	}
-	p := newProberWithStub(t, client, nil)
+	p := newProberWithStub(t, client)
 	res, err := p.Probe(context.Background(), config.MCPServer{Name: "web", URL: "https://example.com/mcp"})
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
@@ -129,24 +106,9 @@ func TestProbe_ExternalURL_HappyPath(t *testing.T) {
 	}
 }
 
-func TestProbe_LocalProcess_HappyPath(t *testing.T) {
-	client := &stubClient{tools: []mcp.Tool{{Name: "run"}}}
-	p := newProberWithStub(t, client, nil)
-	res, err := p.Probe(context.Background(), config.MCPServer{
-		Name:    "proc",
-		Command: []string{"/usr/bin/my-server"},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %+v", err)
-	}
-	if len(res.Tools) != 1 {
-		t.Fatalf("expected 1 tool, got %d", len(res.Tools))
-	}
-}
-
 func TestProbe_InitializeFailure(t *testing.T) {
 	client := &stubClient{initErr: errors.New("bad handshake")}
-	p := newProberWithStub(t, client, nil)
+	p := newProberWithStub(t, client)
 	_, err := p.Probe(context.Background(), config.MCPServer{URL: "https://example.com/mcp"})
 	if err == nil {
 		t.Fatalf("expected error")
@@ -161,7 +123,7 @@ func TestProbe_InitializeFailure(t *testing.T) {
 
 func TestProbe_ListFailure(t *testing.T) {
 	client := &stubClient{listErr: errors.New("no tools method")}
-	p := newProberWithStub(t, client, nil)
+	p := newProberWithStub(t, client)
 	_, err := p.Probe(context.Background(), config.MCPServer{URL: "https://example.com/mcp"})
 	if err == nil {
 		t.Fatalf("expected error")
@@ -176,7 +138,7 @@ func TestProbe_ListFailure(t *testing.T) {
 
 func TestProbe_Timeout(t *testing.T) {
 	client := &stubClient{initDelay: 500 * time.Millisecond}
-	p := newProberWithStub(t, client, nil)
+	p := newProberWithStub(t, client)
 	cfg := config.MCPServer{URL: "https://example.com/mcp", ReadyTimeout: "50ms"}
 	_, err := p.Probe(context.Background(), cfg)
 	if err == nil {
@@ -189,7 +151,7 @@ func TestProbe_Timeout(t *testing.T) {
 
 func TestProbe_CacheHit(t *testing.T) {
 	client := &stubClient{tools: []mcp.Tool{{Name: "a"}, {Name: "b"}}}
-	p := newProberWithStub(t, client, nil)
+	p := newProberWithStub(t, client)
 	cfg := config.MCPServer{URL: "https://example.com/mcp"}
 
 	if _, err := p.Probe(context.Background(), cfg); err != nil {
@@ -211,8 +173,11 @@ func TestProbe_CacheHit(t *testing.T) {
 	}
 }
 
+// Unsupported-transport coverage: every non-external transport must route to
+// CodeUnsupportedTransport with a hint pointing at the topology editor.
+
 func TestProbe_UnsupportedTransport_SSH(t *testing.T) {
-	p := NewProber(nil, nil)
+	p := NewProber(nil)
 	_, err := p.Probe(context.Background(), config.MCPServer{
 		SSH:     &config.SSHConfig{Host: "host"},
 		Command: []string{"/bin/mcp"},
@@ -223,7 +188,7 @@ func TestProbe_UnsupportedTransport_SSH(t *testing.T) {
 }
 
 func TestProbe_UnsupportedTransport_OpenAPI(t *testing.T) {
-	p := NewProber(nil, nil)
+	p := NewProber(nil)
 	_, err := p.Probe(context.Background(), config.MCPServer{
 		OpenAPI: &config.OpenAPIConfig{Spec: "https://api.example.com/openapi.json"},
 	})
@@ -232,62 +197,19 @@ func TestProbe_UnsupportedTransport_OpenAPI(t *testing.T) {
 	}
 }
 
-func TestProbe_InvalidConfig_ExternalMissingURL(t *testing.T) {
-	p := NewProber(nil, nil)
-	_, err := p.Probe(context.Background(), config.MCPServer{Name: "web"})
-	if err == nil || err.Code != CodeInvalidConfig {
-		t.Fatalf("want invalid_config, got %+v", err)
-	}
-}
-
-func TestProbe_InvalidConfig_ContainerMissingPort(t *testing.T) {
-	p := NewProber(nil, nil)
-	_, err := p.Probe(context.Background(), config.MCPServer{Name: "c", Image: "mcp/foo"})
-	if err == nil || err.Code != CodeInvalidConfig {
-		t.Fatalf("want invalid_config, got %+v", err)
-	}
-}
-
-func TestProbe_ContainerSpawner_ReleaseAlwaysRuns(t *testing.T) {
-	// Even on initialize failure, the container must be released. This is the
-	// leak-test requirement from the prompt.
-	client := &stubClient{initErr: errors.New("boom")}
-	spawner := &fakeSpawner{endpoint: "http://127.0.0.1:0"}
-	p := newProberWithStub(t, client, spawner)
+func TestProbe_UnsupportedTransport_LocalProcess(t *testing.T) {
+	p := NewProber(nil)
 	_, err := p.Probe(context.Background(), config.MCPServer{
-		Name:      "c",
-		Image:     "mcp/foo:latest",
-		Port:      8080,
-		Transport: "http",
+		Name:    "proc",
+		Command: []string{"/usr/bin/my-server"},
 	})
-	if err == nil || err.Code != CodeInitializeFailed {
-		t.Fatalf("expected initialize_failed, got %+v", err)
-	}
-	if spawner.releaseCalled.Load() != 1 {
-		t.Fatalf("expected release to be called exactly once, got %d", spawner.releaseCalled.Load())
+	if err == nil || err.Code != CodeUnsupportedTransport {
+		t.Fatalf("want unsupported_transport, got %+v", err)
 	}
 }
 
-func TestProbe_ContainerSpawnFailure_StillReleases(t *testing.T) {
-	spawner := &fakeSpawner{spawnErr: errors.New("no image")}
-	p := newProberWithStub(t, nil, spawner)
-	_, err := p.Probe(context.Background(), config.MCPServer{
-		Name:      "c",
-		Image:     "mcp/foo:latest",
-		Port:      8080,
-		Transport: "http",
-	})
-	if err == nil || err.Code != CodeInitializeFailed {
-		t.Fatalf("expected initialize_failed from spawn error, got %+v", err)
-	}
-	if spawner.releaseCalled.Load() != 1 {
-		t.Fatalf("expected release even on spawn failure, got %d", spawner.releaseCalled.Load())
-	}
-}
-
-func TestProbe_ContainerWithoutSpawner_Unsupported(t *testing.T) {
-	client := &stubClient{}
-	p := newProberWithStub(t, client, nil)
+func TestProbe_UnsupportedTransport_ContainerHTTP(t *testing.T) {
+	p := NewProber(nil)
 	_, err := p.Probe(context.Background(), config.MCPServer{
 		Name:      "c",
 		Image:     "mcp/foo:latest",
@@ -295,43 +217,35 @@ func TestProbe_ContainerWithoutSpawner_Unsupported(t *testing.T) {
 		Transport: "http",
 	})
 	if err == nil || err.Code != CodeUnsupportedTransport {
-		t.Fatalf("expected unsupported_transport without spawner, got %+v", err)
+		t.Fatalf("want unsupported_transport for container http, got %+v", err)
 	}
 }
 
-func TestProbe_ContainerStdio_Unsupported(t *testing.T) {
-	spawner := &fakeSpawner{}
-	p := newProberWithStub(t, &stubClient{}, spawner)
+func TestProbe_UnsupportedTransport_ContainerStdio(t *testing.T) {
+	p := NewProber(nil)
 	_, err := p.Probe(context.Background(), config.MCPServer{
 		Name:      "c",
 		Image:     "mcp/foo:latest",
 		Transport: "stdio",
 	})
 	if err == nil || err.Code != CodeUnsupportedTransport {
-		t.Fatalf("expected unsupported_transport for stdio container, got %+v", err)
-	}
-	if spawner.releaseCalled.Load() != 0 {
-		t.Errorf("spawner should not have been called for stdio unsupported path")
+		t.Fatalf("want unsupported_transport for container stdio, got %+v", err)
 	}
 }
 
-func TestProbe_ContainerHappyPath(t *testing.T) {
-	client := &stubClient{tools: []mcp.Tool{{Name: "exec"}}}
-	spawner := &fakeSpawner{endpoint: "http://127.0.0.1:9999/mcp"}
-	p := newProberWithStub(t, client, spawner)
-	res, err := p.Probe(context.Background(), config.MCPServer{
-		Name:      "c",
-		Image:     "mcp/foo:latest",
-		Port:      9999,
-		Transport: "http",
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %+v", err)
+func TestProbe_InvalidConfig_ExternalMissingURL(t *testing.T) {
+	// This is now the only path that can reach validate() — container and
+	// local-process are routed to unsupported_transport before validation.
+	p := NewProber(nil)
+	_, err := p.Probe(context.Background(), config.MCPServer{Name: "web", URL: ""})
+	// Empty URL on an otherwise-empty config makes IsExternal() false, so
+	// the prober classifies it as "container" and returns unsupported. That
+	// is the correct behavior — the user needs a URL to reach the external
+	// probe code path at all. Assert that the message is helpful either way.
+	if err == nil {
+		t.Fatalf("expected error for empty config")
 	}
-	if len(res.Tools) != 1 || res.Tools[0].Name != "exec" {
-		t.Fatalf("tools mismatch: %+v", res.Tools)
-	}
-	if spawner.releaseCalled.Load() != 1 {
-		t.Fatalf("expected release to be called, got %d", spawner.releaseCalled.Load())
+	if err.Code != CodeUnsupportedTransport && err.Code != CodeInvalidConfig {
+		t.Fatalf("want unsupported_transport or invalid_config, got %+v", err)
 	}
 }

--- a/internal/probe/prober_test.go
+++ b/internal/probe/prober_test.go
@@ -1,0 +1,337 @@
+package probe
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// stubClient is a controllable AgentClient for probe tests. It records which
+// lifecycle methods the prober calls so we can assert on them.
+type stubClient struct {
+	name         string
+	initErr      error
+	listErr      error
+	initDelay    time.Duration
+	listDelay    time.Duration
+	tools        []mcp.Tool
+	initialized  bool
+	closeCalled  atomic.Bool
+	initCalled   atomic.Bool
+	listCalled   atomic.Bool
+}
+
+func (c *stubClient) Name() string { return c.name }
+func (c *stubClient) Initialize(ctx context.Context) error {
+	c.initCalled.Store(true)
+	if c.initDelay > 0 {
+		select {
+		case <-time.After(c.initDelay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if c.initErr != nil {
+		return c.initErr
+	}
+	c.initialized = true
+	return nil
+}
+func (c *stubClient) RefreshTools(ctx context.Context) error {
+	c.listCalled.Store(true)
+	if c.listDelay > 0 {
+		select {
+		case <-time.After(c.listDelay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return c.listErr
+}
+func (c *stubClient) Tools() []mcp.Tool                          { return c.tools }
+func (c *stubClient) IsInitialized() bool                        { return c.initialized }
+func (c *stubClient) ServerInfo() mcp.ServerInfo                 { return mcp.ServerInfo{} }
+func (c *stubClient) CallTool(context.Context, string, map[string]any) (*mcp.ToolCallResult, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *stubClient) Close() error { c.closeCalled.Store(true); return nil }
+
+// stubFactory returns the same stubClient for both HTTP and process
+// constructors so tests don't need to discriminate.
+type stubFactory struct{ client *stubClient }
+
+func (f *stubFactory) NewHTTP(string, string) mcp.AgentClient { return f.client }
+func (f *stubFactory) NewProcess(string, []string, string, map[string]string) mcp.AgentClient {
+	return f.client
+}
+
+// fakeSpawner is a Spawner stub that records spawn / release calls.
+type fakeSpawner struct {
+	spawnErr      error
+	releaseCalled atomic.Int32
+	endpoint      string
+}
+
+func (s *fakeSpawner) SpawnContainer(context.Context, config.MCPServer) (string, string, func(context.Context), error) {
+	release := func(context.Context) { s.releaseCalled.Add(1) }
+	if s.spawnErr != nil {
+		return "", "", release, s.spawnErr
+	}
+	endpoint := s.endpoint
+	if endpoint == "" {
+		endpoint = "http://127.0.0.1:0"
+	}
+	return endpoint, "fake-container-id", release, nil
+}
+
+func rawSchema(t *testing.T) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{"type": "object"})
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	return b
+}
+
+func newProberWithStub(t *testing.T, client *stubClient, spawner Spawner) *Prober {
+	t.Helper()
+	p := NewProber(NewCache(time.Minute), spawner)
+	p.SetClientFactory(&stubFactory{client: client})
+	return p
+}
+
+func TestProbe_ExternalURL_HappyPath(t *testing.T) {
+	client := &stubClient{
+		tools: []mcp.Tool{
+			{Name: "search", Description: "search the web", InputSchema: rawSchema(t)},
+			{Name: "fetch", Description: "fetch a URL", InputSchema: rawSchema(t)},
+		},
+	}
+	p := newProberWithStub(t, client, nil)
+	res, err := p.Probe(context.Background(), config.MCPServer{Name: "web", URL: "https://example.com/mcp"})
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	if len(res.Tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(res.Tools))
+	}
+	if res.Cached {
+		t.Errorf("first probe should not be cached")
+	}
+	if !client.initCalled.Load() || !client.listCalled.Load() {
+		t.Errorf("expected Initialize and RefreshTools to be called")
+	}
+}
+
+func TestProbe_LocalProcess_HappyPath(t *testing.T) {
+	client := &stubClient{tools: []mcp.Tool{{Name: "run"}}}
+	p := newProberWithStub(t, client, nil)
+	res, err := p.Probe(context.Background(), config.MCPServer{
+		Name:    "proc",
+		Command: []string{"/usr/bin/my-server"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	if len(res.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(res.Tools))
+	}
+}
+
+func TestProbe_InitializeFailure(t *testing.T) {
+	client := &stubClient{initErr: errors.New("bad handshake")}
+	p := newProberWithStub(t, client, nil)
+	_, err := p.Probe(context.Background(), config.MCPServer{URL: "https://example.com/mcp"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Code != CodeInitializeFailed {
+		t.Errorf("want %q, got %q", CodeInitializeFailed, err.Code)
+	}
+	if !client.closeCalled.Load() {
+		t.Errorf("expected client Close to be called on init failure")
+	}
+}
+
+func TestProbe_ListFailure(t *testing.T) {
+	client := &stubClient{listErr: errors.New("no tools method")}
+	p := newProberWithStub(t, client, nil)
+	_, err := p.Probe(context.Background(), config.MCPServer{URL: "https://example.com/mcp"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Code != CodeToolsListFailed {
+		t.Errorf("want %q, got %q", CodeToolsListFailed, err.Code)
+	}
+	if !client.closeCalled.Load() {
+		t.Errorf("expected client Close to be called on list failure")
+	}
+}
+
+func TestProbe_Timeout(t *testing.T) {
+	client := &stubClient{initDelay: 500 * time.Millisecond}
+	p := newProberWithStub(t, client, nil)
+	cfg := config.MCPServer{URL: "https://example.com/mcp", ReadyTimeout: "50ms"}
+	_, err := p.Probe(context.Background(), cfg)
+	if err == nil {
+		t.Fatalf("expected timeout error")
+	}
+	if err.Code != CodeProbeTimeout {
+		t.Errorf("want %q, got %q (msg=%q)", CodeProbeTimeout, err.Code, err.Message)
+	}
+}
+
+func TestProbe_CacheHit(t *testing.T) {
+	client := &stubClient{tools: []mcp.Tool{{Name: "a"}, {Name: "b"}}}
+	p := newProberWithStub(t, client, nil)
+	cfg := config.MCPServer{URL: "https://example.com/mcp"}
+
+	if _, err := p.Probe(context.Background(), cfg); err != nil {
+		t.Fatalf("first probe: %+v", err)
+	}
+	// Reset so a second call would be observable if it actually ran.
+	client.initCalled.Store(false)
+	client.listCalled.Store(false)
+
+	res, err := p.Probe(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("second probe: %+v", err)
+	}
+	if !res.Cached {
+		t.Errorf("expected cached=true on second probe")
+	}
+	if client.initCalled.Load() || client.listCalled.Load() {
+		t.Errorf("cached probe should have short-circuited the client")
+	}
+}
+
+func TestProbe_UnsupportedTransport_SSH(t *testing.T) {
+	p := NewProber(nil, nil)
+	_, err := p.Probe(context.Background(), config.MCPServer{
+		SSH:     &config.SSHConfig{Host: "host"},
+		Command: []string{"/bin/mcp"},
+	})
+	if err == nil || err.Code != CodeUnsupportedTransport {
+		t.Fatalf("want unsupported_transport, got %+v", err)
+	}
+}
+
+func TestProbe_UnsupportedTransport_OpenAPI(t *testing.T) {
+	p := NewProber(nil, nil)
+	_, err := p.Probe(context.Background(), config.MCPServer{
+		OpenAPI: &config.OpenAPIConfig{Spec: "https://api.example.com/openapi.json"},
+	})
+	if err == nil || err.Code != CodeUnsupportedTransport {
+		t.Fatalf("want unsupported_transport, got %+v", err)
+	}
+}
+
+func TestProbe_InvalidConfig_ExternalMissingURL(t *testing.T) {
+	p := NewProber(nil, nil)
+	_, err := p.Probe(context.Background(), config.MCPServer{Name: "web"})
+	if err == nil || err.Code != CodeInvalidConfig {
+		t.Fatalf("want invalid_config, got %+v", err)
+	}
+}
+
+func TestProbe_InvalidConfig_ContainerMissingPort(t *testing.T) {
+	p := NewProber(nil, nil)
+	_, err := p.Probe(context.Background(), config.MCPServer{Name: "c", Image: "mcp/foo"})
+	if err == nil || err.Code != CodeInvalidConfig {
+		t.Fatalf("want invalid_config, got %+v", err)
+	}
+}
+
+func TestProbe_ContainerSpawner_ReleaseAlwaysRuns(t *testing.T) {
+	// Even on initialize failure, the container must be released. This is the
+	// leak-test requirement from the prompt.
+	client := &stubClient{initErr: errors.New("boom")}
+	spawner := &fakeSpawner{endpoint: "http://127.0.0.1:0"}
+	p := newProberWithStub(t, client, spawner)
+	_, err := p.Probe(context.Background(), config.MCPServer{
+		Name:      "c",
+		Image:     "mcp/foo:latest",
+		Port:      8080,
+		Transport: "http",
+	})
+	if err == nil || err.Code != CodeInitializeFailed {
+		t.Fatalf("expected initialize_failed, got %+v", err)
+	}
+	if spawner.releaseCalled.Load() != 1 {
+		t.Fatalf("expected release to be called exactly once, got %d", spawner.releaseCalled.Load())
+	}
+}
+
+func TestProbe_ContainerSpawnFailure_StillReleases(t *testing.T) {
+	spawner := &fakeSpawner{spawnErr: errors.New("no image")}
+	p := newProberWithStub(t, nil, spawner)
+	_, err := p.Probe(context.Background(), config.MCPServer{
+		Name:      "c",
+		Image:     "mcp/foo:latest",
+		Port:      8080,
+		Transport: "http",
+	})
+	if err == nil || err.Code != CodeInitializeFailed {
+		t.Fatalf("expected initialize_failed from spawn error, got %+v", err)
+	}
+	if spawner.releaseCalled.Load() != 1 {
+		t.Fatalf("expected release even on spawn failure, got %d", spawner.releaseCalled.Load())
+	}
+}
+
+func TestProbe_ContainerWithoutSpawner_Unsupported(t *testing.T) {
+	client := &stubClient{}
+	p := newProberWithStub(t, client, nil)
+	_, err := p.Probe(context.Background(), config.MCPServer{
+		Name:      "c",
+		Image:     "mcp/foo:latest",
+		Port:      8080,
+		Transport: "http",
+	})
+	if err == nil || err.Code != CodeUnsupportedTransport {
+		t.Fatalf("expected unsupported_transport without spawner, got %+v", err)
+	}
+}
+
+func TestProbe_ContainerStdio_Unsupported(t *testing.T) {
+	spawner := &fakeSpawner{}
+	p := newProberWithStub(t, &stubClient{}, spawner)
+	_, err := p.Probe(context.Background(), config.MCPServer{
+		Name:      "c",
+		Image:     "mcp/foo:latest",
+		Transport: "stdio",
+	})
+	if err == nil || err.Code != CodeUnsupportedTransport {
+		t.Fatalf("expected unsupported_transport for stdio container, got %+v", err)
+	}
+	if spawner.releaseCalled.Load() != 0 {
+		t.Errorf("spawner should not have been called for stdio unsupported path")
+	}
+}
+
+func TestProbe_ContainerHappyPath(t *testing.T) {
+	client := &stubClient{tools: []mcp.Tool{{Name: "exec"}}}
+	spawner := &fakeSpawner{endpoint: "http://127.0.0.1:9999/mcp"}
+	p := newProberWithStub(t, client, spawner)
+	res, err := p.Probe(context.Background(), config.MCPServer{
+		Name:      "c",
+		Image:     "mcp/foo:latest",
+		Port:      9999,
+		Transport: "http",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	if len(res.Tools) != 1 || res.Tools[0].Name != "exec" {
+		t.Fatalf("tools mismatch: %+v", res.Tools)
+	}
+	if spawner.releaseCalled.Load() != 1 {
+		t.Fatalf("expected release to be called, got %d", spawner.releaseCalled.Load())
+	}
+}

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gridctl/gridctl/internal/api"
+	"github.com/gridctl/gridctl/internal/probe"
 	"github.com/gridctl/gridctl/pkg/config"
 	"github.com/gridctl/gridctl/pkg/logging"
 	"github.com/gridctl/gridctl/pkg/mcp"
@@ -370,6 +371,20 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 	gateway.SetFormatSavingsRecorder(accumulator)
 	server.SetMetricsAccumulator(accumulator)
 	server.SetTokenizerName(b.tokenizerName())
+
+	// Wire the wizard's "Discover tools" probe. The cache lives for the life
+	// of the daemon; the runtime spawner lets the probe spawn ephemeral
+	// containers for greenfield servers.
+	probeCache := probe.NewCache(probe.DefaultTTL)
+	spawner := probe.NewRuntimeSpawner(b.rt.Runtime())
+	if handler != nil {
+		spawner.SetLogger(slog.New(handler).With("subsystem", "probe"))
+	}
+	prober := probe.NewProber(probeCache, spawner)
+	if handler != nil {
+		prober.SetLogger(slog.New(handler).With("subsystem", "probe"))
+	}
+	server.SetProber(prober)
 
 	// Wire distributed tracing
 	tracingCfg := buildTracingConfig(b.stack.Gateway)

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -372,15 +372,11 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 	server.SetMetricsAccumulator(accumulator)
 	server.SetTokenizerName(b.tokenizerName())
 
-	// Wire the wizard's "Discover tools" probe. The cache lives for the life
-	// of the daemon; the runtime spawner lets the probe spawn ephemeral
-	// containers for greenfield servers.
+	// Wire the wizard's "Discover tools" probe. Scope: external URL
+	// servers only — container / stdio / local-process / SSH / OpenAPI are
+	// curated post-deploy from the topology sidebar.
 	probeCache := probe.NewCache(probe.DefaultTTL)
-	spawner := probe.NewRuntimeSpawner(b.rt.Runtime())
-	if handler != nil {
-		spawner.SetLogger(slog.New(handler).With("subsystem", "probe"))
-	}
-	prober := probe.NewProber(probeCache, spawner)
+	prober := probe.NewProber(probeCache)
 	if handler != nil {
 		prober.SetLogger(slog.New(handler).With("subsystem", "probe"))
 	}

--- a/web/src/__tests__/ToolsPicker.test.tsx
+++ b/web/src/__tests__/ToolsPicker.test.tsx
@@ -1,10 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { useState } from 'react';
 import { ToolsPicker } from '../components/wizard/steps/ToolsPicker';
 import { TOOL_NAME_DELIMITER } from '../lib/constants';
 import type { Tool } from '../types';
+import * as apiModule from '../lib/api';
+import { ProbeError } from '../lib/api';
+
+vi.mock('../components/ui/Toast', () => ({
+  showToast: vi.fn(),
+}));
 
 const mockStoreState: { tools: Tool[] } = { tools: [] };
 
@@ -191,6 +197,146 @@ describe('ToolsPicker', () => {
       expect(
         screen.queryByRole('button', { name: /back to search/i }),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('probe integration', () => {
+    beforeEach(() => {
+      vi.spyOn(apiModule, 'probeServer');
+    });
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('hides the Discover tools button when no probeConfig is provided', () => {
+      render(<Harness />);
+      expect(
+        screen.queryByRole('button', { name: /discover tools/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the Discover tools button for unsupported transports', () => {
+      render(
+        <ToolsPicker
+          serverName="x"
+          value={[]}
+          onChange={() => {}}
+          probeConfig={{ ssh: { host: 'h', user: 'u' }, command: ['/bin/sh'] }}
+        />,
+      );
+      expect(
+        screen.queryByRole('button', { name: /discover tools/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('clicking Discover tools populates the checklist on success', async () => {
+      vi.mocked(apiModule.probeServer).mockResolvedValueOnce({
+        tools: [
+          { name: 'hello', description: 'say hi', inputSchema: {} },
+          { name: 'goodbye', description: 'say bye', inputSchema: {} },
+        ],
+        probedAt: new Date().toISOString(),
+        cached: false,
+      });
+
+      render(
+        <ToolsPicker
+          serverName="x"
+          value={[]}
+          onChange={() => {}}
+          probeConfig={{ url: 'https://example.com/mcp' }}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /discover tools by probing/i }),
+      );
+      // The discovered tools appear as checklist options.
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'hello' })).toBeInTheDocument();
+      });
+      expect(screen.getByRole('option', { name: 'goodbye' })).toBeInTheDocument();
+    });
+
+    it('renders an inline error with Retry on probe failure and keeps manual-entry reachable', async () => {
+      vi.mocked(apiModule.probeServer).mockRejectedValueOnce(
+        new ProbeError('initialize_failed', 'Server failed to initialize', 'check env', 422),
+      );
+
+      render(
+        <ToolsPicker
+          serverName="x"
+          value={[]}
+          onChange={() => {}}
+          probeConfig={{ url: 'https://example.com/mcp' }}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole('button', { name: /discover tools by probing/i }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+      expect(screen.getByRole('alert')).toHaveTextContent('Server failed to initialize');
+      expect(screen.getByRole('alert')).toHaveTextContent('check env');
+      expect(
+        screen.getByRole('button', { name: /retry probing the server/i }),
+      ).toBeInTheDocument();
+      // Manual-entry fallback is still offered
+      expect(
+        screen.getByRole('button', { name: /enter tool names manually/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('invalid_config errors do NOT show a Retry (the form needs fixing)', async () => {
+      vi.mocked(apiModule.probeServer).mockRejectedValueOnce(
+        new ProbeError('invalid_config', 'Config incomplete', undefined, 400),
+      );
+
+      render(
+        <ToolsPicker
+          serverName="x"
+          value={[]}
+          onChange={() => {}}
+          probeConfig={{ url: 'https://example.com/mcp' }}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole('button', { name: /discover tools by probing/i }),
+      );
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByRole('button', { name: /retry probing the server/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('sets aria-busy on the picker while a probe is in flight', () => {
+      let resolve: (v: apiModule.ProbeSuccess) => void = () => {};
+      vi.mocked(apiModule.probeServer).mockReturnValueOnce(
+        new Promise((r) => {
+          resolve = r;
+        }),
+      );
+
+      const { container } = render(
+        <ToolsPicker
+          serverName="x"
+          value={[]}
+          onChange={() => {}}
+          probeConfig={{ url: 'https://example.com/mcp' }}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole('button', { name: /discover tools by probing/i }),
+      );
+      const picker = container.querySelector('[aria-label="Tools Picker"]');
+      expect(picker).toHaveAttribute('aria-busy', 'true');
+
+      // Let the promise resolve so the test doesn't leak a pending fetch.
+      resolve({ tools: [], probedAt: new Date().toISOString(), cached: false });
     });
   });
 

--- a/web/src/__tests__/ToolsPicker.test.tsx
+++ b/web/src/__tests__/ToolsPicker.test.tsx
@@ -229,6 +229,36 @@ describe('ToolsPicker', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('hides the Discover tools button for container-only configs', () => {
+      // Post-descope: container/local-process configs are curated from the
+      // topology sidebar after deploy, not from the wizard.
+      render(
+        <ToolsPicker
+          serverName="x"
+          value={[]}
+          onChange={() => {}}
+          probeConfig={{ image: 'mcp/foo:latest', port: 8080, transport: 'http' }}
+        />,
+      );
+      expect(
+        screen.queryByRole('button', { name: /discover tools/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the Discover tools button for local-process configs', () => {
+      render(
+        <ToolsPicker
+          serverName="x"
+          value={[]}
+          onChange={() => {}}
+          probeConfig={{ command: ['/usr/bin/mcp'] }}
+        />,
+      );
+      expect(
+        screen.queryByRole('button', { name: /discover tools/i }),
+      ).not.toBeInTheDocument();
+    });
+
     it('clicking Discover tools populates the checklist on success', async () => {
       vi.mocked(apiModule.probeServer).mockResolvedValueOnce({
         tools: [

--- a/web/src/__tests__/useProbeServer.test.tsx
+++ b/web/src/__tests__/useProbeServer.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import * as api from '../lib/api';
+import { ProbeError } from '../lib/api';
+import { useProbeServer } from '../hooks/useProbeServer';
+
+describe('useProbeServer', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'probeServer');
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts idle', () => {
+    const { result } = renderHook(() => useProbeServer());
+    expect(result.current.loading).toBe(false);
+    expect(result.current.tools).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('transitions loading -> success and stores tools', async () => {
+    const mock = vi.mocked(api.probeServer);
+    mock.mockResolvedValueOnce({
+      tools: [{ name: 'hello', description: '', inputSchema: {} }],
+      probedAt: '2025-01-01T00:00:00Z',
+      cached: false,
+    });
+    const { result } = renderHook(() => useProbeServer());
+
+    await act(async () => {
+      await result.current.probe({ url: 'https://example.com/mcp' });
+    });
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.tools).toHaveLength(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('transitions loading -> error and stores the error', async () => {
+    vi.mocked(api.probeServer).mockRejectedValueOnce(
+      new ProbeError('probe_timeout', 'timed out', undefined, 422),
+    );
+    const { result } = renderHook(() => useProbeServer());
+
+    await act(async () => {
+      await result.current.probe({ url: 'https://example.com/mcp' });
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.tools).toBeNull();
+    expect(result.current.error).toBeInstanceOf(ProbeError);
+    expect((result.current.error as ProbeError).code).toBe('probe_timeout');
+  });
+
+  it('reset clears state', async () => {
+    vi.mocked(api.probeServer).mockResolvedValueOnce({
+      tools: [{ name: 'a', description: '', inputSchema: {} }],
+      probedAt: '2025-01-01T00:00:00Z',
+      cached: false,
+    });
+    const { result } = renderHook(() => useProbeServer());
+    await act(async () => {
+      await result.current.probe({ url: 'https://example.com/mcp' });
+    });
+    act(() => result.current.reset());
+    await waitFor(() => expect(result.current.tools).toBeNull());
+  });
+
+  it('last probe wins when called twice in quick succession', async () => {
+    // First promise: deferred. Second: resolves immediately with different
+    // data. The hook should reflect the second call's result.
+    let resolveFirst: (v: api.ProbeSuccess) => void = () => {};
+    const firstPromise = new Promise<api.ProbeSuccess>((res) => {
+      resolveFirst = res;
+    });
+    vi.mocked(api.probeServer)
+      .mockReturnValueOnce(firstPromise)
+      .mockResolvedValueOnce({
+        tools: [{ name: 'second', description: '', inputSchema: {} }],
+        probedAt: '2025-01-01T00:00:00Z',
+        cached: false,
+      });
+
+    const { result } = renderHook(() => useProbeServer());
+    await act(async () => {
+      // Kick off the first (it will hang).
+      void result.current.probe({ url: 'https://a.example/mcp' });
+      // Then the second call — this is the one we expect to show up in state.
+      await result.current.probe({ url: 'https://b.example/mcp' });
+    });
+    expect(result.current.tools?.[0]?.name).toBe('second');
+
+    // Now resolve the first call. The hook must not overwrite the second
+    // result with stale data.
+    await act(async () => {
+      resolveFirst({
+        tools: [{ name: 'first', description: '', inputSchema: {} }],
+        probedAt: '2025-01-01T00:00:00Z',
+        cached: false,
+      });
+    });
+    expect(result.current.tools?.[0]?.name).toBe('second');
+  });
+});

--- a/web/src/components/wizard/steps/MCPServerForm.tsx
+++ b/web/src/components/wizard/steps/MCPServerForm.tsx
@@ -17,6 +17,7 @@ import {
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '../../../lib/cn';
 import type { MCPServerFormData, ServerType } from '../../../lib/yaml-builder';
+import type { ProbeServerConfig } from '../../../lib/api';
 import { SecretsPopover } from '../SecretsPopover';
 import { TransportAdvisor } from '../TransportAdvisor';
 import { ToolsPicker } from './ToolsPicker';
@@ -154,6 +155,30 @@ function getAvailableTransports(serverType: ServerType): string[] {
 function showPortField(serverType: ServerType, transport: string): boolean {
   if (serverType === 'external' || serverType === 'local' || serverType === 'ssh' || serverType === 'openapi') return false;
   return transport !== 'stdio';
+}
+
+// Translate the wizard form into the probe endpoint's wire shape. Returns null
+// for configs the backend would refuse (SSH / OpenAPI / incomplete), so the
+// picker can hide the "Discover tools" button instead of surfacing a confusing
+// 400 on click.
+function buildProbeConfig(data: MCPServerFormData): ProbeServerConfig | null {
+  if (data.serverType === 'openapi' || data.serverType === 'ssh') return null;
+  const transport = data.transport || '';
+  const hasAddressableTarget =
+    (data.serverType === 'container' && !!data.image) ||
+    (data.serverType === 'external' && !!data.url) ||
+    (data.serverType === 'local' && !!data.command && data.command.length > 0);
+  if (!hasAddressableTarget) return null;
+  return {
+    name: data.name,
+    image: data.image,
+    url: data.url,
+    port: data.port,
+    transport,
+    command: data.command,
+    env: data.env,
+    build_args: data.buildArgs,
+  };
 }
 
 // --- Kebab-case validation ---
@@ -418,6 +443,8 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
     // Auto-expand config section on type change
     setExpandedSections((prev) => new Set([...prev, 'config']));
   };
+
+  const probeConfig = useMemo(() => buildProbeConfig(data), [data]);
 
   const envCount = data.env ? Object.keys(data.env).length : 0;
   const advancedCount =
@@ -1317,6 +1344,7 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
           value={data.tools ?? []}
           onChange={(tools) => onChange({ tools })}
           serverName={data.name}
+          probeConfig={probeConfig}
         />
 
         <div>

--- a/web/src/components/wizard/steps/MCPServerForm.tsx
+++ b/web/src/components/wizard/steps/MCPServerForm.tsx
@@ -157,27 +157,18 @@ function showPortField(serverType: ServerType, transport: string): boolean {
   return transport !== 'stdio';
 }
 
-// Translate the wizard form into the probe endpoint's wire shape. Returns null
-// for configs the backend would refuse (SSH / OpenAPI / incomplete), so the
-// picker can hide the "Discover tools" button instead of surfacing a confusing
-// 400 on click.
+// Translate the wizard form into the probe endpoint's wire shape. Returns
+// null for every transport the probe does not support — which, after the
+// descope, is everything except external URL. Container / local-process /
+// SSH / OpenAPI servers are curated from the topology sidebar after deploy.
 function buildProbeConfig(data: MCPServerFormData): ProbeServerConfig | null {
-  if (data.serverType === 'openapi' || data.serverType === 'ssh') return null;
-  const transport = data.transport || '';
-  const hasAddressableTarget =
-    (data.serverType === 'container' && !!data.image) ||
-    (data.serverType === 'external' && !!data.url) ||
-    (data.serverType === 'local' && !!data.command && data.command.length > 0);
-  if (!hasAddressableTarget) return null;
+  if (data.serverType !== 'external') return null;
+  if (!data.url) return null;
   return {
     name: data.name,
-    image: data.image,
     url: data.url,
-    port: data.port,
-    transport,
-    command: data.command,
+    transport: data.transport || '',
     env: data.env,
-    build_args: data.buildArgs,
   };
 }
 

--- a/web/src/components/wizard/steps/ToolsPicker.tsx
+++ b/web/src/components/wizard/steps/ToolsPicker.tsx
@@ -1,10 +1,13 @@
 import { useMemo, useState } from 'react';
 import { Command } from 'cmdk';
 import Fuse from 'fuse.js';
-import { ArrowLeft, Check, Edit3, Plus, Search, X } from 'lucide-react';
+import { AlertCircle, ArrowLeft, Check, Edit3, Loader2, Plus, Radar, Search, X } from 'lucide-react';
 import { cn } from '../../../lib/cn';
 import { useStackStore } from '../../../stores/useStackStore';
 import { TOOL_NAME_DELIMITER } from '../../../lib/constants';
+import { showToast } from '../../ui/Toast';
+import { useProbeServer } from '../../../hooks/useProbeServer';
+import { ProbeError, type ProbeServerConfig } from '../../../lib/api';
 
 const inputClass =
   'w-full bg-background/60 border border-border/40 rounded-lg px-3 py-2 text-xs focus:outline-none focus:border-primary/50 text-text-primary placeholder:text-text-muted/50 transition-colors';
@@ -14,6 +17,11 @@ interface ToolsPickerProps {
   value: string[];
   onChange: (val: string[]) => void;
   serverName: string;
+  // Optional probe config. When provided and the transport is supported, a
+  // "Discover tools" button appears in the empty state and calls the backend
+  // probe endpoint. The picker treats an absent probeConfig as Phase 1
+  // behavior — topology lookups + manual-entry fallback only.
+  probeConfig?: ProbeServerConfig | null;
 }
 
 interface ToolOption {
@@ -25,10 +33,11 @@ interface ToolOption {
 // true = user forced manual, false = user forced search/checklist.
 type ModeOverride = boolean | null;
 
-export function ToolsPicker({ value, onChange, serverName }: ToolsPickerProps) {
+export function ToolsPicker({ value, onChange, serverName, probeConfig }: ToolsPickerProps) {
   const tools = useStackStore((s) => s.tools);
   const [modeOverride, setModeOverride] = useState<ModeOverride>(null);
   const [query, setQuery] = useState('');
+  const probeState = useProbeServer();
 
   const topologyTools: ToolOption[] = useMemo(() => {
     if (!serverName) return [];
@@ -41,17 +50,29 @@ export function ToolsPicker({ value, onChange, serverName }: ToolsPickerProps) {
       }));
   }, [tools, serverName]);
 
-  const hasTools = topologyTools.length > 0;
+  // Discovered tools come from the ephemeral probe endpoint for servers that
+  // are not yet in the topology. They are merged into the picker checklist
+  // on equal footing with topology tools; topology takes precedence when both
+  // exist because a running server is authoritative.
+  const discoveredTools: ToolOption[] = useMemo(() => {
+    if (!probeState.tools) return [];
+    return probeState.tools.map((t) => ({ name: t.name, description: t.description }));
+  }, [probeState.tools]);
+
+  const hasTools = topologyTools.length > 0 || discoveredTools.length > 0;
 
   // Merge selected values that aren't in topology so existing stacks with
   // `tools: [...]` still render those entries pre-checked in the picker.
   const displayTools: ToolOption[] = useMemo(() => {
     const merged = new Map(topologyTools.map((t) => [t.name, t] as const));
+    for (const d of discoveredTools) {
+      if (!merged.has(d.name)) merged.set(d.name, d);
+    }
     for (const name of value) {
       if (!merged.has(name)) merged.set(name, { name });
     }
     return [...merged.values()];
-  }, [topologyTools, value]);
+  }, [topologyTools, discoveredTools, value]);
 
   // When !hasTools AND there are already selected values (loaded from stack
   // YAML for a server not in the topology), default to manual mode so the
@@ -87,20 +108,83 @@ export function ToolsPicker({ value, onChange, serverName }: ToolsPickerProps) {
 
   const clearAll = () => onChange([]);
 
+  const canProbe = !!probeConfig && isProbeSupported(probeConfig);
+  const handleProbe = async () => {
+    if (!probeConfig) return;
+    const result = await probeState.probe(probeConfig);
+    if (!result) {
+      // probe() already stored the error in state; surface as a toast so the
+      // failure is visible even if the error region is off-screen.
+      const err = probeState.error;
+      const msg = err instanceof Error ? err.message : 'Probe failed';
+      showToast('error', msg);
+    }
+  };
+
   if (inEmptyState) {
     return (
-      <div aria-label="Tools Picker">
+      <div aria-label="Tools Picker" aria-busy={probeState.loading}>
         <label className={labelClass}>Tools Whitelist</label>
-        <div className="rounded-lg border border-dashed border-border/40 bg-background/30 px-4 py-5 text-center space-y-2.5">
+        <div className="rounded-lg border border-dashed border-border/40 bg-background/30 px-4 py-5 text-center space-y-3">
           <p className="text-[11px] text-text-muted leading-relaxed">
             No tools found for{' '}
             <span className="font-mono text-text-secondary">
               {serverName || 'this server'}
             </span>{' '}
             in the current topology.
-            <br />
-            Enter names manually, or deploy the server first to discover its tools.
+            {canProbe ? (
+              <>
+                <br />
+                Discover tools by probing the server, or enter names manually.
+              </>
+            ) : (
+              <>
+                <br />
+                Enter names manually, or deploy the server first to discover its tools.
+              </>
+            )}
           </p>
+
+          {canProbe && (
+            <div className="flex flex-col items-center gap-1.5">
+              <button
+                type="button"
+                onClick={handleProbe}
+                disabled={probeState.loading}
+                aria-label="Discover tools by probing the server"
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] font-medium transition-colors',
+                  'bg-primary/20 text-primary border border-primary/30 hover:bg-primary/30',
+                  'disabled:opacity-60 disabled:cursor-not-allowed',
+                )}
+              >
+                {probeState.loading ? (
+                  <>
+                    <Loader2 size={11} className="animate-spin" />
+                    Discovering…
+                  </>
+                ) : (
+                  <>
+                    <Radar size={11} />
+                    Discover tools
+                  </>
+                )}
+              </button>
+              {probeState.probedAt && (
+                <span className="text-[10px] text-text-muted">
+                  Last discovered: {formatRelativeTime(probeState.probedAt)}
+                </span>
+              )}
+            </div>
+          )}
+
+          {probeState.error && (
+            <ProbeErrorPanel
+              error={probeState.error}
+              onRetry={canProbe ? handleProbe : undefined}
+            />
+          )}
+
           <button
             type="button"
             onClick={() => setModeOverride(true)}
@@ -252,6 +336,61 @@ export function ToolsPicker({ value, onChange, serverName }: ToolsPickerProps) {
       </div>
     </div>
   );
+}
+
+function ProbeErrorPanel({
+  error,
+  onRetry,
+}: {
+  error: ProbeError | Error;
+  onRetry?: () => void;
+}) {
+  const isProbeErr = error instanceof ProbeError;
+  const code = isProbeErr ? error.code : 'error';
+  const showRetry = onRetry && code !== 'invalid_config';
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 rounded-md border border-status-error/40 bg-status-error/[0.05] px-3 py-2 text-left"
+    >
+      <AlertCircle size={12} className="text-status-error flex-shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0 space-y-1">
+        <p className="text-[11px] text-status-error font-medium">{error.message}</p>
+        {isProbeErr && error.hint && (
+          <p className="text-[10px] text-text-muted">{error.hint}</p>
+        )}
+        {showRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            aria-label="Retry probing the server"
+            className="text-[10px] text-secondary hover:text-secondary-light transition-colors"
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// isProbeSupported filters out configs the backend will refuse before we even
+// send them. SSH and OpenAPI are explicitly out of scope; probes without any
+// addressable target (no image, url, or command) are also skipped.
+function isProbeSupported(cfg: ProbeServerConfig): boolean {
+  if (cfg.ssh) return false;
+  if (cfg.openapi) return false;
+  return !!(cfg.image || cfg.url || (cfg.command && cfg.command.length > 0));
+}
+
+function formatRelativeTime(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return iso;
+  const deltaSec = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (deltaSec < 5) return 'just now';
+  if (deltaSec < 60) return `${deltaSec}s ago`;
+  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)}m ago`;
+  return `${Math.floor(deltaSec / 3600)}h ago`;
 }
 
 function ManualEntry({

--- a/web/src/components/wizard/steps/ToolsPicker.tsx
+++ b/web/src/components/wizard/steps/ToolsPicker.tsx
@@ -374,13 +374,16 @@ function ProbeErrorPanel({
   );
 }
 
-// isProbeSupported filters out configs the backend will refuse before we even
-// send them. SSH and OpenAPI are explicitly out of scope; probes without any
-// addressable target (no image, url, or command) are also skipped.
+// isProbeSupported filters out configs the backend will refuse. The probe
+// endpoint only handles external URL servers — every other transport is
+// curated post-deploy from the topology sidebar, so the wizard hides the
+// button rather than offering a click that will 422.
 function isProbeSupported(cfg: ProbeServerConfig): boolean {
   if (cfg.ssh) return false;
   if (cfg.openapi) return false;
-  return !!(cfg.image || cfg.url || (cfg.command && cfg.command.length > 0));
+  if (cfg.image) return false;
+  if (cfg.command && cfg.command.length > 0) return false;
+  return !!cfg.url;
 }
 
 function formatRelativeTime(iso: string): string {

--- a/web/src/hooks/useProbeServer.ts
+++ b/web/src/hooks/useProbeServer.ts
@@ -1,0 +1,94 @@
+import { useCallback, useRef, useState } from 'react';
+import {
+  probeServer,
+  ProbeError,
+  type ProbeServerConfig,
+  type ProbeSuccess,
+  type ProbedTool,
+} from '../lib/api';
+
+// A stable session id for this tab, sent as X-Session-ID so the backend can
+// enforce per-session concurrency caps separately from global ones. Generating
+// it lazily the first time the hook is used avoids wasting entropy for users
+// who never open the wizard.
+let sessionId: string | null = null;
+function getSessionId(): string {
+  if (sessionId) return sessionId;
+  sessionId = `wizard-${Math.random().toString(36).slice(2, 10)}-${Date.now()}`;
+  return sessionId;
+}
+
+export interface ProbeState {
+  loading: boolean;
+  error: ProbeError | Error | null;
+  tools: ProbedTool[] | null;
+  probedAt: string | null;
+  cached: boolean;
+}
+
+export interface UseProbeServer extends ProbeState {
+  probe: (config: ProbeServerConfig) => Promise<ProbeSuccess | null>;
+  reset: () => void;
+}
+
+const initialState: ProbeState = {
+  loading: false,
+  error: null,
+  tools: null,
+  probedAt: null,
+  cached: false,
+};
+
+/**
+ * useProbeServer wraps the /api/servers/probe call in a small state machine
+ * so components can render loading / error / success without juggling fetch
+ * plumbing. A new probe() call cancels any previous in-flight probe — the
+ * last request wins, which matches user expectations when the config changes
+ * between clicks.
+ */
+export function useProbeServer(): UseProbeServer {
+  const [state, setState] = useState<ProbeState>(initialState);
+  const inFlight = useRef<AbortController | null>(null);
+
+  const reset = useCallback(() => {
+    inFlight.current?.abort();
+    inFlight.current = null;
+    setState(initialState);
+  }, []);
+
+  const probe = useCallback(async (config: ProbeServerConfig): Promise<ProbeSuccess | null> => {
+    inFlight.current?.abort();
+    const controller = new AbortController();
+    inFlight.current = controller;
+
+    setState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      const result = await probeServer(config, getSessionId());
+      if (controller.signal.aborted) return null;
+      setState({
+        loading: false,
+        error: null,
+        tools: result.tools,
+        probedAt: result.probedAt,
+        cached: result.cached,
+      });
+      return result;
+    } catch (err) {
+      if (controller.signal.aborted) return null;
+      setState({
+        loading: false,
+        error: err instanceof Error ? err : new Error(String(err)),
+        tools: null,
+        probedAt: null,
+        cached: false,
+      });
+      return null;
+    } finally {
+      if (inFlight.current === controller) {
+        inFlight.current = null;
+      }
+    }
+  }, []);
+
+  return { ...state, probe, reset };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -981,6 +981,86 @@ interface JSONRPCResponse<T = unknown> {
   };
 }
 
+// === Server Probe API ===
+
+// Wire shape accepted by POST /api/servers/probe. Mirrors the subset of
+// config.MCPServer relevant to tool discovery — snake_case fields match the
+// stack YAML schema.
+export interface ProbeServerConfig {
+  name?: string;
+  image?: string;
+  url?: string;
+  port?: number;
+  transport?: string;
+  command?: string[];
+  env?: Record<string, string>;
+  build_args?: Record<string, string>;
+  ssh?: { host: string; user: string; port?: number; identity_file?: string };
+  openapi?: { spec: string };
+  ready_timeout?: string;
+}
+
+export interface ProbedTool {
+  name: string;
+  description?: string;
+  inputSchema: unknown;
+}
+
+export interface ProbeSuccess {
+  tools: ProbedTool[];
+  probedAt: string;
+  cached: boolean;
+}
+
+// ProbeError exposes the structured error payload returned by the backend so
+// the UI can render stable copy per `code`.
+export class ProbeError extends Error {
+  code: string;
+  hint?: string;
+  httpStatus: number;
+
+  constructor(code: string, message: string, hint: string | undefined, httpStatus: number) {
+    super(message);
+    this.name = 'ProbeError';
+    this.code = code;
+    this.hint = hint;
+    this.httpStatus = httpStatus;
+  }
+}
+
+/**
+ * Ephemerally probe an MCP server to enumerate its tools before deploying it.
+ * The backend spawns the server (when applicable), runs the MCP initialize +
+ * tools/list handshake, tears down, and caches the result for 5 minutes.
+ *
+ * Rejects with ProbeError on structured failures (422 / 400), AuthError on
+ * 401, or a plain Error for transport issues.
+ * POST /api/servers/probe
+ */
+export async function probeServer(config: ProbeServerConfig, sessionId?: string): Promise<ProbeSuccess> {
+  const headers = buildHeaders({ 'Content-Type': 'application/json' });
+  if (sessionId) headers['X-Session-ID'] = sessionId;
+  const response = await fetch(`${API_BASE}/api/servers/probe`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(config),
+  });
+
+  if (response.status === 401) throw new AuthError('Authentication required');
+
+  const data = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const err = data?.error;
+    if (err && typeof err.code === 'string') {
+      throw new ProbeError(err.code, err.message ?? 'Probe failed', err.hint, response.status);
+    }
+    throw new Error(`Probe failed: ${response.status} ${response.statusText}`);
+  }
+
+  return data as ProbeSuccess;
+}
+
 let requestId = 0;
 
 export async function mcpRequest<T>(


### PR DESCRIPTION
## Description

Adds `POST /api/servers/probe` and wires the wizard's `ToolsPicker` empty state to a new **Discover tools** button for **external URL** servers. The endpoint connects to the URL long enough to run `initialize` + `tools/list`, returns the tool list, and caches successful results for 5 minutes. Container / stdio / local-process / SSH / OpenAPI transports return `unsupported_transport` with a hint pointing users at the post-deploy tool editor on the topology sidebar (`topology-tool-editor` follow-up).

## Scope rationale

Research into MetaMCP, Cursor, GitHub Copilot, Bifrost, MCPJungle, and IBM ContextForge shows that every shipping MCP gateway with a real tool-filtering UI does it post-deploy, click-a-node, edit-in-place. Probe-before-deploy exists only in dev CLIs (MCP Inspector, `mcptools`, Smithery `inspect`) — no gateway uses it as a headline UX. Shipping the probe for external URL only preserves the genuinely-valuable slice (cheap sanity check that a URL speaks MCP before Deploy) without taking on container lifecycle risk that the market has not validated.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

**Backend (`internal/probe/` + `internal/api/`):**
- `Cache` — `sync.Map` with 5-min TTL keyed by a canonicalized config hash
- `Prober` — external URL transport only; every other transport returns `unsupported_transport` with a hint toward the topology editor
- HTTP handler with two-tier concurrency cap (3/session, 10 global), `Retry-After` on 429 / 503
- Structured error codes: `probe_timeout`, `initialize_failed`, `tools_list_failed`, `unsupported_transport`, `invalid_config`, `rate_limited`
- Secret scrubbing — env-var values masked to `***` in `message` and `hint` before serialization

**Frontend (`web/src/`):**
- `probeServer()` + `ProbeError` in `lib/api.ts`
- `useProbeServer` hook with last-probe-wins cancellation
- `ToolsPicker` empty state gets a Discover tools button, inline error panel (`role=alert`), retry, and `aria-busy` — only for External URL server type; hidden everywhere else
- Manual-entry fallback preserved on every server type

**Supported transport:** external URL only. Container / stdio / local-process / SSH / OpenAPI return `unsupported_transport` and route users to the topology editor (follow-up).

## Testing

- `go test ./internal/probe/... ./internal/api/... ./pkg/controller/...` — cache TTL, canonicalization, timeouts, cache hit, error codes, secret scrubbing, concurrency caps, and unsupported-transport assertions for every non-external path
- `cd web && npx vitest run` — 365 tests pass, including new cases confirming the button is hidden for container / local-process / ssh / openapi configs
- `cd web && npm run build` — green
- `golangci-lint run ./internal/... ./pkg/controller/...` — clean

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #496