### PR TITLE
refactor: extract shared pkg/git clone helpers

### DIFF
--- a/pkg/builder/git.go
+++ b/pkg/builder/git.go
@@ -5,8 +5,9 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
+	gogit "github.com/go-git/go-git/v5"
+
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
 )
 
 // CloneOrUpdate clones a git repository or updates it if it already exists.
@@ -32,42 +33,23 @@ func CloneOrUpdate(url, ref string, logger *slog.Logger) (string, error) {
 }
 
 func cloneRepo(url, ref, destPath string, logger *slog.Logger) (string, error) {
-	logger.Info("cloning repository", "url", url)
-
-	cloneOpts := &git.CloneOptions{
-		URL:      url,
-		Progress: nil, // Could add os.Stdout for progress
-	}
-
-	// If ref is specified and looks like a branch, set it
-	if ref != "" {
-		cloneOpts.ReferenceName = plumbing.NewBranchReferenceName(ref)
-		cloneOpts.SingleBranch = true
-	}
-
-	repo, err := git.PlainClone(destPath, false, cloneOpts)
+	repo, err := gitpkg.Clone(destPath, gitpkg.CloneOptions{
+		URL: url,
+		Ref: ref,
+	}, logger)
 	if err != nil {
-		// If branch clone failed, try without SingleBranch
-		if ref != "" {
-			os.RemoveAll(destPath)
-			cloneOpts.SingleBranch = false
-			cloneOpts.ReferenceName = ""
-			repo, err = git.PlainClone(destPath, false, cloneOpts)
-			if err != nil {
-				return "", fmt.Errorf("cloning repository: %w", err)
-			}
-			// Checkout the specific ref
-			if err := checkoutRef(repo, ref); err != nil {
-				return "", err
-			}
-		} else {
-			return "", fmt.Errorf("cloning repository: %w", err)
+		return "", fmt.Errorf("cloning repository: %w", err)
+	}
+
+	// Land on ref explicitly so the single-branch fallback path ends in the
+	// right worktree state. On the happy path this is a no-op.
+	if ref != "" {
+		if err := gitpkg.Checkout(repo, ref); err != nil {
+			return "", err
 		}
 	}
 
-	// Get current commit for logging
-	head, err := repo.Head()
-	if err == nil {
+	if head, err := repo.Head(); err == nil {
 		logger.Info("cloned repository", "commit", head.Hash().String()[:8])
 	}
 
@@ -77,104 +59,33 @@ func cloneRepo(url, ref, destPath string, logger *slog.Logger) (string, error) {
 func updateRepo(repoPath, ref string, logger *slog.Logger) (string, error) {
 	logger.Info("updating cached repository")
 
-	repo, err := git.PlainOpen(repoPath)
+	repo, err := gitpkg.Open(repoPath)
 	if err != nil {
-		// If we can't open, remove and re-clone
-		os.RemoveAll(repoPath)
+		_ = os.RemoveAll(repoPath)
 		return "", fmt.Errorf("opening repository (will need to re-clone): %w", err)
 	}
 
-	// Get the worktree
-	wt, err := repo.Worktree()
-	if err != nil {
-		return "", fmt.Errorf("getting worktree: %w", err)
-	}
-
-	// Fetch updates
-	err = repo.Fetch(&git.FetchOptions{
-		Force: true,
-	})
-	if err != nil && err != git.NoErrAlreadyUpToDate {
-		// Non-fatal, continue with what we have
+	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{}, logger); err != nil {
 		logger.Warn("fetch failed, using existing", "error", err)
 	}
 
-	// Checkout the ref
 	if ref != "" {
-		if err := checkoutRef(repo, ref); err != nil {
+		if err := gitpkg.Checkout(repo, ref); err != nil {
 			return "", err
 		}
 	}
 
-	// Pull latest
-	err = wt.Pull(&git.PullOptions{
-		Force: true,
-	})
-	if err != nil && err != git.NoErrAlreadyUpToDate {
-		// Non-fatal for detached HEAD
-		if err != git.ErrNonFastForwardUpdate {
+	// Pull latest (best-effort; a detached HEAD or non-fast-forward is non-fatal)
+	if wt, wtErr := repo.Worktree(); wtErr == nil {
+		err := wt.Pull(&gogit.PullOptions{Force: true})
+		if err != nil && err != gogit.NoErrAlreadyUpToDate && err != gogit.ErrNonFastForwardUpdate {
 			logger.Warn("pull failed, using existing", "error", err)
 		}
 	}
 
-	// Get current commit for logging
-	head, err := repo.Head()
-	if err == nil {
+	if head, err := repo.Head(); err == nil {
 		logger.Info("repository at commit", "commit", head.Hash().String()[:8])
 	}
 
 	return repoPath, nil
-}
-
-func checkoutRef(repo *git.Repository, ref string) error {
-	wt, err := repo.Worktree()
-	if err != nil {
-		return fmt.Errorf("getting worktree: %w", err)
-	}
-
-	// Try as branch first
-	branchRef := plumbing.NewBranchReferenceName(ref)
-	err = wt.Checkout(&git.CheckoutOptions{
-		Branch: branchRef,
-		Force:  true,
-	})
-	if err == nil {
-		return nil
-	}
-
-	// Try as remote branch
-	remoteBranchRef := plumbing.NewRemoteReferenceName("origin", ref)
-	err = wt.Checkout(&git.CheckoutOptions{
-		Branch: remoteBranchRef,
-		Force:  true,
-	})
-	if err == nil {
-		return nil
-	}
-
-	// Try as tag
-	tagRef := plumbing.NewTagReferenceName(ref)
-	err = wt.Checkout(&git.CheckoutOptions{
-		Branch: tagRef,
-		Force:  true,
-	})
-	if err == nil {
-		return nil
-	}
-
-	// Try as commit hash
-	hash := plumbing.NewHash(ref)
-	if hash.IsZero() {
-		return fmt.Errorf("invalid ref: %s", ref)
-	}
-
-	err = wt.Checkout(&git.CheckoutOptions{
-		Hash:  hash,
-		Force: true,
-	})
-	if err != nil {
-		return fmt.Errorf("checking out ref %s: %w", ref, err)
-	}
-
-	return nil
 }

--- a/pkg/builder/git_test.go
+++ b/pkg/builder/git_test.go
@@ -195,27 +195,4 @@ func TestCloneOrUpdate_Update(t *testing.T) {
 	}
 }
 
-func TestCheckoutRef_InvalidRef(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping git test in short mode")
-	}
-
-	bareRepo := initBareRepo(t)
-	cloneDir := filepath.Join(t.TempDir(), "clone")
-	logger := newTestLogger()
-
-	_, err := cloneRepo(bareRepo, "", cloneDir, logger)
-	if err != nil {
-		t.Fatalf("clone: %v", err)
-	}
-
-	repo, err := git.PlainOpen(cloneDir)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-
-	err = checkoutRef(repo, "nonexistent-branch-xyz")
-	if err == nil {
-		t.Fatal("expected error for nonexistent ref")
-	}
-}
+// Checkout logic moved to pkg/git; see pkg/git/clone_test.go:TestCheckout_InvalidRef.

--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -1,0 +1,180 @@
+// Package git contains shared git helpers used by both the skills importer
+// (pkg/skills) and the MCP server source builder (pkg/builder).
+//
+// The helpers are thin wrappers over go-git that factor out duplicated
+// clone/fetch/checkout logic. They do not know anything about gridctl's
+// cache layout or authentication strategy: callers compute destination
+// paths and pass in a transport.AuthMethod (or nil).
+package git
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+// CloneOptions configures a Clone call.
+type CloneOptions struct {
+	URL     string
+	Ref     string               // if set and branch-style, attempted as single-branch clone first
+	Depth   int                  // 0 = full history
+	AllTags bool                 // fetch all tags
+	Auth    transport.AuthMethod // nil = unauthenticated
+}
+
+// FetchOptions configures a Fetch call.
+type FetchOptions struct {
+	AllTags bool
+	Auth    transport.AuthMethod
+}
+
+// Clone performs a plain git clone into destPath. When Ref is set it first
+// attempts a single-branch clone of that ref (as a branch); if that fails it
+// removes destPath and retries with a full clone. Callers are responsible for
+// a subsequent Checkout when they need to land on a non-branch ref (tag,
+// commit, remote branch) after the full-clone fallback.
+func Clone(destPath string, opts CloneOptions, logger *slog.Logger) (*gogit.Repository, error) {
+	logger.Info("cloning repository", "url", opts.URL)
+
+	cloneOpts := &gogit.CloneOptions{
+		URL:   opts.URL,
+		Depth: opts.Depth,
+		Auth:  opts.Auth,
+	}
+	if opts.AllTags {
+		cloneOpts.Tags = gogit.AllTags
+	}
+	if opts.Ref != "" {
+		cloneOpts.ReferenceName = plumbing.NewBranchReferenceName(opts.Ref)
+		cloneOpts.SingleBranch = true
+	}
+
+	repo, err := gogit.PlainClone(destPath, false, cloneOpts)
+	if err != nil && opts.Ref != "" {
+		// Ref may not be a branch; retry with a full clone.
+		_ = os.RemoveAll(destPath)
+		cloneOpts.SingleBranch = false
+		cloneOpts.ReferenceName = ""
+		repo, err = gogit.PlainClone(destPath, false, cloneOpts)
+	}
+	return repo, err
+}
+
+// Fetch updates the cached repository at repoPath from its remote.
+// Returns nil if the remote had no new refs.
+func Fetch(repoPath string, opts FetchOptions, logger *slog.Logger) error {
+	r, err := gogit.PlainOpen(repoPath)
+	if err != nil {
+		return fmt.Errorf("opening repository: %w", err)
+	}
+	fetchOpts := &gogit.FetchOptions{
+		Force: true,
+		Auth:  opts.Auth,
+	}
+	if opts.AllTags {
+		fetchOpts.Tags = gogit.AllTags
+	}
+	if err := r.Fetch(fetchOpts); err != nil && err != gogit.NoErrAlreadyUpToDate {
+		return err
+	}
+	return nil
+}
+
+// Checkout lands the worktree on ref, trying in order: tag, local branch,
+// remote branch (origin), commit hash. Force is used so uncommitted changes
+// in the worktree (unlikely in a cache) are discarded.
+func Checkout(repo *gogit.Repository, ref string) error {
+	wt, err := repo.Worktree()
+	if err != nil {
+		return fmt.Errorf("getting worktree: %w", err)
+	}
+
+	if err := wt.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.NewTagReferenceName(ref),
+		Force:  true,
+	}); err == nil {
+		return nil
+	}
+	if err := wt.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName(ref),
+		Force:  true,
+	}); err == nil {
+		return nil
+	}
+	if err := wt.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.NewRemoteReferenceName("origin", ref),
+		Force:  true,
+	}); err == nil {
+		return nil
+	}
+
+	hash := plumbing.NewHash(ref)
+	if !hash.IsZero() {
+		if err := wt.Checkout(&gogit.CheckoutOptions{
+			Hash:  hash,
+			Force: true,
+		}); err == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unable to checkout ref %q", ref)
+}
+
+// ResolveRef returns the commit hash for ref by consulting, in order:
+// tag, remote branch (origin), local branch.
+func ResolveRef(repo *gogit.Repository, ref string) (string, error) {
+	if t, err := repo.Tag(ref); err == nil {
+		return t.Hash().String(), nil
+	}
+	if r, err := repo.Reference(plumbing.NewRemoteReferenceName("origin", ref), true); err == nil {
+		return r.Hash().String(), nil
+	}
+	if b, err := repo.Reference(plumbing.NewBranchReferenceName(ref), true); err == nil {
+		return b.Hash().String(), nil
+	}
+	return "", fmt.Errorf("unable to resolve ref %q", ref)
+}
+
+// Open is a thin wrapper around gogit.PlainOpen. It lets callers avoid
+// importing go-git directly for routine repository access.
+func Open(repoPath string) (*gogit.Repository, error) {
+	return gogit.PlainOpen(repoPath)
+}
+
+// HeadCommit returns the HEAD commit hash for the repository at repoPath.
+func HeadCommit(repoPath string) (string, error) {
+	r, err := gogit.PlainOpen(repoPath)
+	if err != nil {
+		return "", err
+	}
+	h, err := r.Head()
+	if err != nil {
+		return "", err
+	}
+	return h.Hash().String(), nil
+}
+
+// ListTags returns every tag name from the repository at repoPath.
+func ListTags(repoPath string) ([]string, error) {
+	r, err := gogit.PlainOpen(repoPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening repository: %w", err)
+	}
+	it, err := r.Tags()
+	if err != nil {
+		return nil, fmt.Errorf("listing tags: %w", err)
+	}
+	var tags []string
+	if err := it.ForEach(func(ref *plumbing.Reference) error {
+		tags = append(tags, ref.Name().Short())
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("iterating tags: %w", err)
+	}
+	return tags, nil
+}

--- a/pkg/git/clone_test.go
+++ b/pkg/git/clone_test.go
@@ -1,0 +1,293 @@
+package git
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+
+	"github.com/gridctl/gridctl/pkg/logging"
+)
+
+func testLogger() *slog.Logger {
+	return logging.NewDiscardLogger()
+}
+
+// initBareRepo creates a bare repo with one commit on master and one annotated
+// tag "v1.0.0", and returns its path.
+func initBareRepo(t *testing.T) string {
+	t.Helper()
+
+	workDir := t.TempDir()
+	repo, err := gogit.PlainInit(workDir, false)
+	if err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("# Test repo"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if _, err := wt.Add("README.md"); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	sig := &object.Signature{Name: "test", Email: "test@test.com"}
+	commitHash, err := wt.Commit("initial commit", &gogit.CommitOptions{Author: sig})
+	if err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	if _, err := repo.CreateTag("v1.0.0", commitHash, &gogit.CreateTagOptions{
+		Tagger:  sig,
+		Message: "v1.0.0",
+	}); err != nil {
+		t.Fatalf("create tag: %v", err)
+	}
+
+	bareDir := t.TempDir()
+	if _, err := gogit.PlainClone(bareDir, true, &gogit.CloneOptions{URL: workDir, Tags: gogit.AllTags}); err != nil {
+		t.Fatalf("clone to bare: %v", err)
+	}
+
+	return bareDir
+}
+
+func TestClone_NoRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	dest := filepath.Join(t.TempDir(), "clone")
+
+	_, err := Clone(dest, CloneOptions{URL: bare}, testLogger())
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "README.md")); err != nil {
+		t.Errorf("expected README.md in clone: %v", err)
+	}
+}
+
+func TestClone_WithBranchRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	dest := filepath.Join(t.TempDir(), "clone")
+
+	_, err := Clone(dest, CloneOptions{URL: bare, Ref: "master"}, testLogger())
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+}
+
+func TestClone_WithTagRefFallsBack(t *testing.T) {
+	// A tag ref is not a branch, so single-branch clone should fail and
+	// fall back to a full clone. The caller is responsible for a
+	// subsequent Checkout, which is verified in TestCheckout_Tag.
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	dest := filepath.Join(t.TempDir(), "clone")
+
+	_, err := Clone(dest, CloneOptions{URL: bare, Ref: "v1.0.0", AllTags: true}, testLogger())
+	if err != nil {
+		t.Fatalf("Clone with tag ref: %v", err)
+	}
+}
+
+func TestClone_InvalidURL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	dest := filepath.Join(t.TempDir(), "clone")
+	_, err := Clone(dest, CloneOptions{URL: "/nonexistent/path"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestFetch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	dest := filepath.Join(t.TempDir(), "clone")
+	if _, err := Clone(dest, CloneOptions{URL: bare}, testLogger()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	if err := Fetch(dest, FetchOptions{AllTags: true}, testLogger()); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+}
+
+func TestFetch_InvalidRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	err := Fetch(t.TempDir(), FetchOptions{}, testLogger())
+	if err == nil {
+		t.Fatal("expected error fetching from a non-repo directory")
+	}
+}
+
+func TestCheckout_Tag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	dest := filepath.Join(t.TempDir(), "clone")
+	if _, err := Clone(dest, CloneOptions{URL: bare, AllTags: true}, testLogger()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	repo, err := gogit.PlainOpen(dest)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := Checkout(repo, "v1.0.0"); err != nil {
+		t.Fatalf("Checkout tag: %v", err)
+	}
+}
+
+func TestCheckout_InvalidRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	dest := filepath.Join(t.TempDir(), "clone")
+	if _, err := Clone(dest, CloneOptions{URL: bare}, testLogger()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	repo, err := gogit.PlainOpen(dest)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := Checkout(repo, "does-not-exist-xyz"); err == nil {
+		t.Fatal("expected error for nonexistent ref")
+	}
+}
+
+func TestResolveRef_Tag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	dest := filepath.Join(t.TempDir(), "clone")
+	if _, err := Clone(dest, CloneOptions{URL: bare, AllTags: true}, testLogger()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	repo, err := gogit.PlainOpen(dest)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	sha, err := ResolveRef(repo, "v1.0.0")
+	if err != nil {
+		t.Fatalf("ResolveRef: %v", err)
+	}
+	if sha == "" {
+		t.Fatal("empty sha")
+	}
+}
+
+func TestResolveRef_Unknown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	dest := filepath.Join(t.TempDir(), "clone")
+	if _, err := Clone(dest, CloneOptions{URL: bare}, testLogger()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	repo, err := gogit.PlainOpen(dest)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := ResolveRef(repo, "does-not-exist"); err == nil {
+		t.Fatal("expected error for unknown ref")
+	}
+}
+
+func TestHeadCommit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	dest := filepath.Join(t.TempDir(), "clone")
+	if _, err := Clone(dest, CloneOptions{URL: bare}, testLogger()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	sha, err := HeadCommit(dest)
+	if err != nil {
+		t.Fatalf("HeadCommit: %v", err)
+	}
+	if len(sha) != 40 {
+		t.Errorf("expected 40-char sha, got %q", sha)
+	}
+}
+
+func TestHeadCommit_InvalidRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	if _, err := HeadCommit(t.TempDir()); err == nil {
+		t.Fatal("expected error for non-repo directory")
+	}
+}
+
+func TestListTags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	bare := initBareRepo(t)
+	dest := filepath.Join(t.TempDir(), "clone")
+	if _, err := Clone(dest, CloneOptions{URL: bare, AllTags: true}, testLogger()); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	tags, err := ListTags(dest)
+	if err != nil {
+		t.Fatalf("ListTags: %v", err)
+	}
+	found := false
+	for _, tag := range tags {
+		if tag == "v1.0.0" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected to find v1.0.0 in tags, got %v", tags)
+	}
+}
+
+func TestListTags_InvalidRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	if _, err := ListTags(t.TempDir()); err == nil {
+		t.Fatal("expected error for non-repo directory")
+	}
+}
+

--- a/pkg/skills/remote.go
+++ b/pkg/skills/remote.go
@@ -10,10 +10,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
+
 	"github.com/gridctl/gridctl/pkg/builder"
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
 	"github.com/gridctl/gridctl/pkg/registry"
 )
 
@@ -32,6 +33,17 @@ type DiscoveredSkill struct {
 	ContentHash string
 }
 
+// skillsAuth returns a transport.AuthMethod built from the GITHUB_TOKEN env
+// var, or nil if the env var is not set. The token-backed flow will be
+// replaced by a pluggable Auther interface in a follow-up change; keeping it
+// as a private helper here preserves the current behavior.
+func skillsAuth() transport.AuthMethod {
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		return &http.BasicAuth{Username: token, Password: ""}
+	}
+	return nil
+}
+
 // CloneAndDiscover clones a repo and discovers all SKILL.md files.
 func CloneAndDiscover(repo, ref, subPath string, logger *slog.Logger) (*CloneResult, error) {
 	repoPath, err := cloneShallow(repo, ref, logger)
@@ -39,7 +51,7 @@ func CloneAndDiscover(repo, ref, subPath string, logger *slog.Logger) (*CloneRes
 		return nil, fmt.Errorf("cloning repository: %w", err)
 	}
 
-	commitSHA, err := getHeadCommit(repoPath)
+	commitSHA, err := gitpkg.HeadCommit(repoPath)
 	if err != nil {
 		return nil, fmt.Errorf("getting HEAD commit: %w", err)
 	}
@@ -71,24 +83,23 @@ func FetchAndCompare(repo, ref string, currentSHA string, logger *slog.Logger) (
 		return "", false, fmt.Errorf("getting cache path: %w", err)
 	}
 
-	r, err := git.PlainOpen(repoPath)
-	if err != nil {
+	if _, err := os.Stat(repoPath); err != nil {
 		// Repo not cached, needs full clone
 		return "", true, nil
 	}
 
-	fetchOpts := &git.FetchOptions{Force: true}
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-		fetchOpts.Auth = &http.BasicAuth{Username: token, Password: ""}
-	}
-
-	if err := r.Fetch(fetchOpts); err != nil && err != git.NoErrAlreadyUpToDate {
+	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{Auth: skillsAuth()}, logger); err != nil {
 		logger.Warn("fetch failed", "error", err)
 		return currentSHA, false, nil
 	}
 
+	r, err := gitpkg.Open(repoPath)
+	if err != nil {
+		return currentSHA, false, nil
+	}
+
 	if ref != "" {
-		newSHA, err := resolveRef(r, ref)
+		newSHA, err := gitpkg.ResolveRef(r, ref)
 		if err != nil {
 			return currentSHA, false, nil
 		}
@@ -103,27 +114,9 @@ func FetchAndCompare(repo, ref string, currentSHA string, logger *slog.Logger) (
 	return newSHA, newSHA != currentSHA, nil
 }
 
-// ListRemoteTags returns all tags from a remote repository.
+// ListRemoteTags returns all tags from a cached repository.
 func ListRemoteTags(repoPath string) ([]string, error) {
-	r, err := git.PlainOpen(repoPath)
-	if err != nil {
-		return nil, fmt.Errorf("opening repository: %w", err)
-	}
-
-	tagIter, err := r.Tags()
-	if err != nil {
-		return nil, fmt.Errorf("listing tags: %w", err)
-	}
-
-	var tags []string
-	if err := tagIter.ForEach(func(ref *plumbing.Reference) error {
-		tags = append(tags, ref.Name().Short())
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf("iterating tags: %w", err)
-	}
-
-	return tags, nil
+	return gitpkg.ListTags(repoPath)
 }
 
 func cloneShallow(url, ref string, logger *slog.Logger) (string, error) {
@@ -136,46 +129,30 @@ func cloneShallow(url, ref string, logger *slog.Logger) (string, error) {
 		return "", fmt.Errorf("getting cache path: %w", err)
 	}
 
-	cloneOpts := &git.CloneOptions{
-		URL:   url,
-		Depth: 1,
-		Tags:  git.AllTags,
-	}
-
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-		cloneOpts.Auth = &http.BasicAuth{Username: token, Password: ""}
-	}
-
 	// If repo exists, fetch updates instead
 	if _, err := os.Stat(repoPath); err == nil {
 		return updateExisting(repoPath, ref, logger)
 	}
 
-	logger.Info("cloning repository", "url", url)
-
-	if ref != "" && !IsSemVerConstraint(ref) {
-		cloneOpts.ReferenceName = plumbing.NewBranchReferenceName(ref)
-		cloneOpts.SingleBranch = true
+	cloneRef := ref
+	if IsSemVerConstraint(ref) {
+		// Semver constraints require a full clone so tags are available.
+		cloneRef = ""
 	}
-
-	r, err := git.PlainClone(repoPath, false, cloneOpts)
+	r, err := gitpkg.Clone(repoPath, gitpkg.CloneOptions{
+		URL:     url,
+		Ref:     cloneRef,
+		Depth:   1,
+		AllTags: true,
+		Auth:    skillsAuth(),
+	}, logger)
 	if err != nil {
-		// Retry without single-branch restriction
-		if ref != "" {
-			_ = os.RemoveAll(repoPath)
-			cloneOpts.SingleBranch = false
-			cloneOpts.ReferenceName = ""
-			r, err = git.PlainClone(repoPath, false, cloneOpts)
-		}
-		if err != nil {
-			return "", fmt.Errorf("cloning: %w", err)
-		}
+		return "", fmt.Errorf("cloning: %w", err)
 	}
 
-	// Handle semver constraints or specific refs
 	if ref != "" {
 		if IsSemVerConstraint(ref) {
-			tags, err := ListRemoteTags(repoPath)
+			tags, err := gitpkg.ListTags(repoPath)
 			if err != nil {
 				return "", err
 			}
@@ -183,11 +160,11 @@ func cloneShallow(url, ref string, logger *slog.Logger) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			if err := checkoutRef(r, resolvedTag); err != nil {
+			if err := gitpkg.Checkout(r, resolvedTag); err != nil {
 				return "", err
 			}
 		} else {
-			if err := checkoutRef(r, ref); err != nil {
+			if err := gitpkg.Checkout(r, ref); err != nil {
 				return "", err
 			}
 		}
@@ -199,24 +176,20 @@ func cloneShallow(url, ref string, logger *slog.Logger) (string, error) {
 func updateExisting(repoPath, ref string, logger *slog.Logger) (string, error) {
 	logger.Info("updating cached repository")
 
-	r, err := git.PlainOpen(repoPath)
+	// Fail fast on a corrupt cache (mirrors previous behavior).
+	r, err := gitpkg.Open(repoPath)
 	if err != nil {
 		_ = os.RemoveAll(repoPath)
 		return "", fmt.Errorf("opening cached repo (removed): %w", err)
 	}
 
-	fetchOpts := &git.FetchOptions{Force: true, Tags: git.AllTags}
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-		fetchOpts.Auth = &http.BasicAuth{Username: token, Password: ""}
-	}
-
-	if err := r.Fetch(fetchOpts); err != nil && err != git.NoErrAlreadyUpToDate {
+	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{AllTags: true, Auth: skillsAuth()}, logger); err != nil {
 		logger.Warn("fetch failed, using cached", "error", err)
 	}
 
 	if ref != "" {
 		if IsSemVerConstraint(ref) {
-			tags, err := ListRemoteTags(repoPath)
+			tags, err := gitpkg.ListTags(repoPath)
 			if err != nil {
 				logger.Warn("failed to list tags, using cached", "error", err)
 				return repoPath, nil
@@ -226,87 +199,18 @@ func updateExisting(repoPath, ref string, logger *slog.Logger) (string, error) {
 				logger.Warn("failed to resolve constraint, using cached", "constraint", ref, "error", err)
 				return repoPath, nil
 			}
-			if err := checkoutRef(r, resolvedTag); err != nil {
+			if err := gitpkg.Checkout(r, resolvedTag); err != nil {
 				logger.Warn("failed to checkout tag, using cached", "tag", resolvedTag, "error", err)
 				return repoPath, nil
 			}
 		} else {
-			if err := checkoutRef(r, ref); err != nil {
+			if err := gitpkg.Checkout(r, ref); err != nil {
 				logger.Warn("failed to checkout ref, using cached", "ref", ref, "error", err)
 			}
 		}
 	}
 
 	return repoPath, nil
-}
-
-func checkoutRef(r *git.Repository, ref string) error {
-	wt, err := r.Worktree()
-	if err != nil {
-		return fmt.Errorf("getting worktree: %w", err)
-	}
-
-	// Try tag first
-	tagRef := plumbing.NewTagReferenceName(ref)
-	if err := wt.Checkout(&git.CheckoutOptions{Branch: tagRef, Force: true}); err == nil {
-		return nil
-	}
-
-	// Try branch
-	branchRef := plumbing.NewBranchReferenceName(ref)
-	if err := wt.Checkout(&git.CheckoutOptions{Branch: branchRef, Force: true}); err == nil {
-		return nil
-	}
-
-	// Try remote branch
-	remoteRef := plumbing.NewRemoteReferenceName("origin", ref)
-	if err := wt.Checkout(&git.CheckoutOptions{Branch: remoteRef, Force: true}); err == nil {
-		return nil
-	}
-
-	// Try commit hash
-	hash := plumbing.NewHash(ref)
-	if !hash.IsZero() {
-		if err := wt.Checkout(&git.CheckoutOptions{Hash: hash, Force: true}); err == nil {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("unable to checkout ref %q", ref)
-}
-
-func resolveRef(r *git.Repository, ref string) (string, error) {
-	// Try tag
-	tagRef, err := r.Tag(ref)
-	if err == nil {
-		return tagRef.Hash().String(), nil
-	}
-
-	// Try remote branch
-	remoteRef, err := r.Reference(plumbing.NewRemoteReferenceName("origin", ref), true)
-	if err == nil {
-		return remoteRef.Hash().String(), nil
-	}
-
-	// Try branch
-	branchRef, err := r.Reference(plumbing.NewBranchReferenceName(ref), true)
-	if err == nil {
-		return branchRef.Hash().String(), nil
-	}
-
-	return "", fmt.Errorf("unable to resolve ref %q", ref)
-}
-
-func getHeadCommit(repoPath string) (string, error) {
-	r, err := git.PlainOpen(repoPath)
-	if err != nil {
-		return "", err
-	}
-	head, err := r.Head()
-	if err != nil {
-		return "", err
-	}
-	return head.Hash().String(), nil
 }
 
 func discoverSkills(searchDir, repoRoot string) ([]DiscoveredSkill, error) {


### PR DESCRIPTION
## Description

Extracts the duplicated clone/fetch/checkout logic from `pkg/skills/remote.go` and `pkg/builder/git.go` into a new shared `pkg/git/` package. Pure refactor — no behavior change, no new features.

This is the first of five PRs in the private-repo auth track. It lands the shared foundation so the `Auther` interface, error classification, and credential redaction can plug in cleanly in follow-ups without doubling maintenance cost across two near-identical files.

## Type of Change

- [x] Refactor (non-breaking change)

## Changes Made

- New `pkg/git` package: `Clone` / `Fetch` / `Checkout` / `ResolveRef` / `Open` / `HeadCommit` / `ListTags` helpers over go-git
- `CloneOptions` / `FetchOptions` already accept `transport.AuthMethod` so the `Auther` interface can plug in with no signature churn later
- `pkg/skills/remote.go` thin composition over `pkg/git`; `GITHUB_TOKEN` auth behavior preserved via a local helper
- `pkg/builder/git.go` thin composition over `pkg/git`; builder-specific `Pull()` + no-auth behavior preserved exactly
- Coverage: `pkg/git` 81.2% (new), `pkg/skills` 47.7% (up from 43.1%), `pkg/builder` 79.2% (up from 75.8%)

## Testing

- `go build ./...` — clean
- `go test -race ./pkg/git/... ./pkg/skills/... ./pkg/builder/...` — all pass
- `golangci-lint run ./...` — 0 issues
- Public signatures (`CloneAndDiscover`, `FetchAndCompare`, `ListRemoteTags`, `CloneOrUpdate`) unchanged
- `GITHUB_TOKEN` env var still used by the skills importer exactly as before

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #500