### PR TITLE
feat: add git auth primitives

### DIFF
--- a/pkg/git/auth.go
+++ b/pkg/git/auth.go
@@ -1,0 +1,138 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	gossh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
+)
+
+// Protocol describes how a git URL is accessed.
+type Protocol string
+
+const (
+	ProtocolHTTPS   Protocol = "https"
+	ProtocolSSH     Protocol = "ssh"
+	ProtocolLocal   Protocol = "local"
+	ProtocolUnknown Protocol = "unknown"
+)
+
+// scpSyntax matches SCP-style git URLs (user@host:path).
+var scpSyntax = regexp.MustCompile(`^[a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+:`)
+
+// DetectProtocol classifies a git remote URL by its scheme.
+func DetectProtocol(url string) Protocol {
+	switch {
+	case url == "":
+		return ProtocolUnknown
+	case strings.HasPrefix(url, "https://"), strings.HasPrefix(url, "http://"):
+		return ProtocolHTTPS
+	case strings.HasPrefix(url, "ssh://"):
+		return ProtocolSSH
+	case scpSyntax.MatchString(url):
+		return ProtocolSSH
+	case strings.HasPrefix(url, "file://"),
+		strings.HasPrefix(url, "/"),
+		strings.HasPrefix(url, "./"),
+		strings.HasPrefix(url, "../"),
+		strings.HasPrefix(url, "~/"):
+		return ProtocolLocal
+	default:
+		return ProtocolUnknown
+	}
+}
+
+// Auther returns a transport.AuthMethod appropriate for the given URL.
+// A nil AuthMethod with a nil error means "no credentials required"; a
+// non-nil error surfaces misconfiguration (wrong protocol, missing agent,
+// empty token) so callers don't silently fall through to an unauthenticated
+// clone that then fails with a cryptic "repository not found".
+type Auther interface {
+	AuthFor(url string) (transport.AuthMethod, error)
+}
+
+// NoAuth produces no credentials for any URL. Use it for public repositories
+// or when ambient go-git mechanisms handle auth transparently.
+type NoAuth struct{}
+
+// AuthFor always returns (nil, nil).
+func (NoAuth) AuthFor(string) (transport.AuthMethod, error) { return nil, nil }
+
+// HTTPSTokenAuth sends a Personal Access Token as HTTP basic-auth username
+// with an empty password — the shape GitHub, GitLab, Bitbucket, and most
+// self-hosted servers accept for PAT-based authentication.
+type HTTPSTokenAuth struct {
+	Token string
+}
+
+// AuthFor returns an *http.BasicAuth carrying the PAT, or an error if the
+// token is empty or the URL is not HTTPS.
+func (a HTTPSTokenAuth) AuthFor(url string) (transport.AuthMethod, error) {
+	if a.Token == "" {
+		return nil, ErrEmptyToken
+	}
+	if p := DetectProtocol(url); p != ProtocolHTTPS {
+		return nil, fmt.Errorf("%w: HTTPSTokenAuth requires an https:// URL, got %q (%s)", ErrProtocolMismatch, url, p)
+	}
+	return &http.BasicAuth{Username: a.Token, Password: ""}, nil
+}
+
+// SSHAgentAuth delegates authentication to the user's running ssh-agent.
+// The User field defaults to "git" when empty.
+type SSHAgentAuth struct {
+	User string
+}
+
+// AuthFor returns a PublicKeysCallback backed by the ambient ssh-agent, or
+// ErrSSHAgentMissing if no agent socket is available.
+func (a SSHAgentAuth) AuthFor(url string) (transport.AuthMethod, error) {
+	if p := DetectProtocol(url); p != ProtocolSSH {
+		return nil, fmt.Errorf("%w: SSHAgentAuth requires an ssh:// or user@host:path URL, got %q (%s)", ErrProtocolMismatch, url, p)
+	}
+	if os.Getenv("SSH_AUTH_SOCK") == "" {
+		return nil, ErrSSHAgentMissing
+	}
+	user := a.User
+	if user == "" {
+		user = gossh.DefaultUsername
+	}
+	cb, err := gossh.NewSSHAgentAuth(user)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrSSHAgentMissing, err)
+	}
+	return cb, nil
+}
+
+// SSHKeyFileAuth authenticates using an on-disk private key file. The User
+// field defaults to "git" when empty.
+//
+// Host-key verification uses go-git's default behavior for this PR; a
+// stricter TOFU / accept-new host-key policy and explicit KnownHostsPath
+// handling will be wired through in a follow-up change. KnownHostsPath is
+// reserved for that future work.
+type SSHKeyFileAuth struct {
+	User           string
+	KeyPath        string
+	Passphrase     string
+	KnownHostsPath string // reserved for a follow-up change
+}
+
+// AuthFor loads the private key file and returns an SSH PublicKeys auth.
+func (a SSHKeyFileAuth) AuthFor(url string) (transport.AuthMethod, error) {
+	if p := DetectProtocol(url); p != ProtocolSSH {
+		return nil, fmt.Errorf("%w: SSHKeyFileAuth requires an ssh:// or user@host:path URL, got %q (%s)", ErrProtocolMismatch, url, p)
+	}
+	user := a.User
+	if user == "" {
+		user = gossh.DefaultUsername
+	}
+	auth, err := gossh.NewPublicKeysFromFile(user, a.KeyPath, a.Passphrase)
+	if err != nil {
+		return nil, fmt.Errorf("loading ssh key from %q: %w", a.KeyPath, err)
+	}
+	return auth, nil
+}

--- a/pkg/git/auth_test.go
+++ b/pkg/git/auth_test.go
@@ -1,0 +1,107 @@
+package git
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+func TestDetectProtocol(t *testing.T) {
+	cases := []struct {
+		url  string
+		want Protocol
+	}{
+		{"", ProtocolUnknown},
+		{"https://github.com/org/repo", ProtocolHTTPS},
+		{"http://gitlab.internal/org/repo", ProtocolHTTPS},
+		{"ssh://git@github.com/org/repo", ProtocolSSH},
+		{"git@github.com:org/repo.git", ProtocolSSH},
+		{"user.name@host-1.example:path/repo", ProtocolSSH},
+		{"/var/local/cache/repo", ProtocolLocal},
+		{"./local-repo", ProtocolLocal},
+		{"../sibling-repo", ProtocolLocal},
+		{"file:///var/repos/r", ProtocolLocal},
+		{"~/my-repo", ProtocolLocal},
+		{"garbage", ProtocolUnknown},
+	}
+	for _, c := range cases {
+		if got := DetectProtocol(c.url); got != c.want {
+			t.Errorf("DetectProtocol(%q) = %q, want %q", c.url, got, c.want)
+		}
+	}
+}
+
+func TestNoAuth(t *testing.T) {
+	auth, err := NoAuth{}.AuthFor("https://example.com/repo")
+	if err != nil || auth != nil {
+		t.Errorf("NoAuth should return (nil, nil), got (%v, %v)", auth, err)
+	}
+}
+
+func TestHTTPSTokenAuth_EmptyToken(t *testing.T) {
+	_, err := HTTPSTokenAuth{}.AuthFor("https://example.com/repo")
+	if !errors.Is(err, ErrEmptyToken) {
+		t.Errorf("expected ErrEmptyToken, got %v", err)
+	}
+}
+
+func TestHTTPSTokenAuth_WrongProtocol(t *testing.T) {
+	_, err := HTTPSTokenAuth{Token: "x"}.AuthFor("git@github.com:a/b")
+	if !errors.Is(err, ErrProtocolMismatch) {
+		t.Errorf("expected ErrProtocolMismatch, got %v", err)
+	}
+}
+
+func TestHTTPSTokenAuth_HappyPath(t *testing.T) {
+	auth, err := HTTPSTokenAuth{Token: "abc123"}.AuthFor("https://github.com/a/b")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ba, ok := auth.(*http.BasicAuth)
+	if !ok {
+		t.Fatalf("expected *http.BasicAuth, got %T", auth)
+	}
+	if ba.Username != "abc123" || ba.Password != "" {
+		t.Errorf("unexpected basic auth: user=%q pass=%q", ba.Username, ba.Password)
+	}
+}
+
+func TestSSHAgentAuth_WrongProtocol(t *testing.T) {
+	_, err := SSHAgentAuth{}.AuthFor("https://github.com/a/b")
+	if !errors.Is(err, ErrProtocolMismatch) {
+		t.Errorf("expected ErrProtocolMismatch, got %v", err)
+	}
+}
+
+func TestSSHAgentAuth_MissingAgent(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "")
+	_, err := SSHAgentAuth{}.AuthFor("git@github.com:a/b")
+	if !errors.Is(err, ErrSSHAgentMissing) {
+		t.Errorf("expected ErrSSHAgentMissing, got %v", err)
+	}
+}
+
+func TestSSHAgentAuth_HappyPath(t *testing.T) {
+	if os.Getenv("SSH_AUTH_SOCK") == "" {
+		t.Skip("SSH_AUTH_SOCK unset; skipping agent-backed test")
+	}
+	if _, err := (SSHAgentAuth{}).AuthFor("git@github.com:a/b"); err != nil {
+		t.Errorf("unexpected error when agent is available: %v", err)
+	}
+}
+
+func TestSSHKeyFileAuth_WrongProtocol(t *testing.T) {
+	_, err := SSHKeyFileAuth{KeyPath: "/dev/null"}.AuthFor("https://github.com/a/b")
+	if !errors.Is(err, ErrProtocolMismatch) {
+		t.Errorf("expected ErrProtocolMismatch, got %v", err)
+	}
+}
+
+func TestSSHKeyFileAuth_MissingFile(t *testing.T) {
+	_, err := SSHKeyFileAuth{KeyPath: "/definitely/does/not/exist/keyfile"}.AuthFor("git@github.com:a/b")
+	if err == nil {
+		t.Error("expected error loading nonexistent key file")
+	}
+}

--- a/pkg/git/errors.go
+++ b/pkg/git/errors.go
@@ -1,0 +1,78 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+// Sentinel errors classify git-operation failures so callers can render
+// actionable UI messages without string-matching raw go-git output.
+var (
+	// ErrAuthRequired: the remote rejected the request because no
+	// credentials were presented.
+	ErrAuthRequired = errors.New("authentication required")
+
+	// ErrAuthFailed: credentials were presented but rejected.
+	ErrAuthFailed = errors.New("authentication failed")
+
+	// ErrNotFound: the remote returned a "not found" response. On hosts
+	// like GitHub this may also mean a private repository accessed without
+	// sufficient credentials.
+	ErrNotFound = errors.New("repository not found")
+
+	// ErrHostKeyMismatch: the SSH host key did not match the local
+	// known_hosts — a potential man-in-the-middle indicator.
+	ErrHostKeyMismatch = errors.New("ssh host key mismatch")
+
+	// ErrSSHAgentMissing: ssh-agent was unavailable (socket missing or
+	// SSH_AUTH_SOCK unset) when SSH-agent auth was requested.
+	ErrSSHAgentMissing = errors.New("ssh agent not available")
+
+	// ErrEmptyToken: a token-based Auther was constructed with an empty
+	// token. Reported eagerly rather than falling through to an
+	// unauthenticated clone that then fails with a cryptic error.
+	ErrEmptyToken = errors.New("token is empty")
+
+	// ErrProtocolMismatch: an Auther was asked to produce credentials for
+	// a URL whose protocol does not match the auth mechanism (e.g., an
+	// HTTPS token against an SSH URL).
+	ErrProtocolMismatch = errors.New("protocol mismatch")
+)
+
+// ClassifyError maps raw go-git (or network) errors to sentinels in this
+// package, wrapping the original so errors.Is / errors.As still find it.
+// Unknown errors are returned unchanged — the caller is free to wrap them
+// with its own context.
+func ClassifyError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, transport.ErrAuthenticationRequired):
+		return fmt.Errorf("%w: %w", ErrAuthRequired, err)
+	case errors.Is(err, transport.ErrAuthorizationFailed):
+		return fmt.Errorf("%w: %w", ErrAuthFailed, err)
+	case errors.Is(err, transport.ErrRepositoryNotFound):
+		return fmt.Errorf("%w: %w", ErrNotFound, err)
+	}
+
+	// Fall back to substring matching for errors that upstream does not
+	// expose as typed sentinels. Each pattern is documented near its case.
+	msg := err.Error()
+	switch {
+	// go-git's SSH host-key check surfaces as a knownhosts package error
+	// whose text contains "knownhosts:" and "mismatch". See
+	// github.com/go-git/go-git/v5/plumbing/transport/ssh/knownhosts.go.
+	case strings.Contains(msg, "knownhosts:") && strings.Contains(msg, "mismatch"):
+		return fmt.Errorf("%w: %w", ErrHostKeyMismatch, err)
+	// xanzy/ssh-agent surfaces "SSH_AUTH_SOCK" or "SSH agent" text when the
+	// socket can't be dialed.
+	case strings.Contains(msg, "SSH_AUTH_SOCK") || strings.Contains(msg, "SSH agent"):
+		return fmt.Errorf("%w: %w", ErrSSHAgentMissing, err)
+	}
+
+	return err
+}

--- a/pkg/git/errors_test.go
+++ b/pkg/git/errors_test.go
@@ -1,0 +1,67 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+func TestClassifyError(t *testing.T) {
+	cases := []struct {
+		name string
+		in   error
+		want error // nil = expect input returned unchanged
+	}{
+		{"nil", nil, nil},
+		{"auth required", transport.ErrAuthenticationRequired, ErrAuthRequired},
+		{"auth failed", transport.ErrAuthorizationFailed, ErrAuthFailed},
+		{"not found", transport.ErrRepositoryNotFound, ErrNotFound},
+		{"wrapped auth required", fmt.Errorf("upload-pack: %w", transport.ErrAuthenticationRequired), ErrAuthRequired},
+		{"knownhosts mismatch", errors.New("knownhosts: key mismatch for host github.com"), ErrHostKeyMismatch},
+		{"ssh agent missing (socket)", errors.New("dial unix $SSH_AUTH_SOCK: no such file"), ErrSSHAgentMissing},
+		{"ssh agent missing (text)", errors.New("failed to connect to SSH agent"), ErrSSHAgentMissing},
+		{"unknown", errors.New("random network fail"), nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ClassifyError(c.in)
+			if c.in == nil {
+				if got != nil {
+					t.Errorf("ClassifyError(nil) = %v, want nil", got)
+				}
+				return
+			}
+			if c.want == nil {
+				// Unknown errors should round-trip unchanged.
+				if got != c.in {
+					t.Errorf("expected input returned unchanged, got %v", got)
+				}
+				return
+			}
+			if !errors.Is(got, c.want) {
+				t.Errorf("expected classified error to satisfy errors.Is(%v), got %v", c.want, got)
+			}
+			// Original cause must also remain reachable.
+			if !errors.Is(got, c.in) {
+				t.Errorf("expected classified error to still wrap %v, got %v", c.in, got)
+			}
+		})
+	}
+}
+
+func TestSentinelsAreDistinct(t *testing.T) {
+	sentinels := []error{
+		ErrAuthRequired, ErrAuthFailed, ErrNotFound,
+		ErrHostKeyMismatch, ErrSSHAgentMissing,
+		ErrEmptyToken, ErrProtocolMismatch,
+	}
+	seen := make(map[error]struct{}, len(sentinels))
+	for _, s := range sentinels {
+		if _, dup := seen[s]; dup {
+			t.Errorf("duplicate sentinel identity: %v", s)
+		}
+		seen[s] = struct{}{}
+	}
+}

--- a/pkg/git/redact.go
+++ b/pkg/git/redact.go
@@ -1,0 +1,80 @@
+package git
+
+import (
+	"net/url"
+	"regexp"
+)
+
+// tokenPatterns is a short defense-in-depth list of credential-shaped
+// substrings that must never survive into logs or error text. This is NOT
+// a substitute for careful log construction — it only catches accidental
+// leaks from error messages constructed by third-party libraries.
+var tokenPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`ghp_[A-Za-z0-9]{36,}`),         // GitHub classic PAT
+	regexp.MustCompile(`github_pat_[A-Za-z0-9_]{60,}`), // GitHub fine-grained PAT
+	regexp.MustCompile(`glpat-[A-Za-z0-9_-]{20,}`),     // GitLab PAT
+}
+
+// embeddedURLUserinfo matches the userinfo component of an HTTP(S) URL so
+// we can strip it. The capture group retains scheme://, then we drop
+// everything up to and including the '@'.
+var embeddedURLUserinfo = regexp.MustCompile(`(https?://)[^@\s/]+@`)
+
+// RedactURL returns a version of raw with any userinfo stripped.
+//
+//	https://TOKEN@host/path → https://host/path
+//	git@host:path           → git@host:path       (SCP-style, unchanged)
+//	non-URL text            → unchanged
+func RedactURL(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	// SCP-style user@host:path has no userinfo component; leave intact.
+	if scpSyntax.MatchString(raw) {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" {
+		return raw
+	}
+	if u.User == nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
+}
+
+// RedactString scrubs known token patterns and URL userinfo from arbitrary
+// text. Use it on strings whose construction you do not fully control,
+// e.g. error messages returned from go-git.
+func RedactString(s string) string {
+	for _, re := range tokenPatterns {
+		s = re.ReplaceAllString(s, "[REDACTED]")
+	}
+	s = embeddedURLUserinfo.ReplaceAllString(s, "$1")
+	return s
+}
+
+// RedactError returns an error whose message has been scrubbed of
+// credential-shaped content. The original error is preserved via Unwrap so
+// errors.Is / errors.As continue to work as expected. Returns nil when err
+// is nil, and returns err unchanged when the message does not contain any
+// redactable content.
+func RedactError(err error) error {
+	if err == nil {
+		return nil
+	}
+	redacted := RedactString(err.Error())
+	if redacted == err.Error() {
+		return err
+	}
+	return &redactedError{msg: redacted, wrapped: err}
+}
+
+type redactedError struct {
+	msg     string
+	wrapped error
+}
+
+func (e *redactedError) Error() string { return e.msg }
+func (e *redactedError) Unwrap() error { return e.wrapped }

--- a/pkg/git/redact_test.go
+++ b/pkg/git/redact_test.go
@@ -1,0 +1,100 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRedactURL(t *testing.T) {
+	cases := []struct {
+		in, out string
+	}{
+		{"", ""},
+		{"https://example.com/foo/bar", "https://example.com/foo/bar"},
+		{"https://TOKEN@github.com/org/repo", "https://github.com/org/repo"},
+		{"https://user:password@git.example.com/org/repo.git", "https://git.example.com/org/repo.git"},
+		{"http://ghp_abc@host/path", "http://host/path"},
+		{"git@github.com:org/repo.git", "git@github.com:org/repo.git"}, // SCP-style unchanged
+		{"ssh://git@github.com/org/repo", "ssh://github.com/org/repo"},
+		{"just some text", "just some text"},
+		{"/local/path/to/repo", "/local/path/to/repo"},
+	}
+	for _, c := range cases {
+		if got := RedactURL(c.in); got != c.out {
+			t.Errorf("RedactURL(%q) = %q, want %q", c.in, got, c.out)
+		}
+	}
+}
+
+func TestRedactString_GitHubClassicPAT(t *testing.T) {
+	in := "push failed with ghp_" + strings.Repeat("a", 36)
+	got := RedactString(in)
+	if strings.Contains(got, "ghp_") {
+		t.Errorf("expected token stripped, got %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Errorf("expected redaction marker, got %q", got)
+	}
+}
+
+func TestRedactString_GitHubFineGrainedPAT(t *testing.T) {
+	in := "clone failed: github_pat_" + strings.Repeat("x", 82)
+	got := RedactString(in)
+	if strings.Contains(got, "github_pat_") {
+		t.Errorf("expected fine-grained PAT stripped, got %q", got)
+	}
+}
+
+func TestRedactString_GitLabPAT(t *testing.T) {
+	in := "auth error: glpat-" + strings.Repeat("b", 20)
+	got := RedactString(in)
+	if strings.Contains(got, "glpat-") {
+		t.Errorf("expected GitLab PAT stripped, got %q", got)
+	}
+}
+
+func TestRedactString_EmbeddedUserinfo(t *testing.T) {
+	in := "fetch failed for https://abcdef@example.com/repo"
+	got := RedactString(in)
+	if strings.Contains(got, "abcdef@") {
+		t.Errorf("expected userinfo stripped, got %q", got)
+	}
+	if !strings.Contains(got, "https://example.com/repo") {
+		t.Errorf("expected cleaned URL, got %q", got)
+	}
+}
+
+func TestRedactString_NoChange(t *testing.T) {
+	in := "all clean, nothing to redact here"
+	if got := RedactString(in); got != in {
+		t.Errorf("expected unchanged, got %q", got)
+	}
+}
+
+func TestRedactError_Nil(t *testing.T) {
+	if RedactError(nil) != nil {
+		t.Error("RedactError(nil) should be nil")
+	}
+}
+
+func TestRedactError_Unchanged(t *testing.T) {
+	err := errors.New("clean error message")
+	if got := RedactError(err); got != err {
+		t.Errorf("expected identical error returned, got %v", got)
+	}
+}
+
+func TestRedactError_Wraps(t *testing.T) {
+	base := errors.New("base cause")
+	wrapped := fmt.Errorf("fetch https://ghp_%s@host failed: %w",
+		strings.Repeat("x", 36), base)
+	red := RedactError(wrapped)
+	if strings.Contains(red.Error(), "ghp_") {
+		t.Errorf("redacted message still contains token: %q", red.Error())
+	}
+	if !errors.Is(red, base) {
+		t.Error("expected errors.Is to see through redaction wrapper")
+	}
+}


### PR DESCRIPTION
## Description

Adds auth primitives to `pkg/git/`: redaction helpers, an `Auther` interface with four implementations, and typed error classification. Primitives only — no caller-site changes yet.

This is PR 2 of 5 for private-repo support. PR 3 will wire these into the skills importer and MCP builder.

## Type of Change

- [x] New feature (additive, non-breaking)

## Changes Made

- `pkg/git/errors.go`: 7 sentinel errors + `ClassifyError` mapping go-git `transport` sentinels and known-hosts/ssh-agent strings to typed classes
- `pkg/git/redact.go`: `RedactURL`, `RedactString`, `RedactError` — strip userinfo from URLs and scrub GitHub/GitLab PAT shapes; `RedactError` preserves `errors.Is` / `errors.As`
- `pkg/git/auth.go`: `Protocol` + `DetectProtocol` (HTTPS / SSH / Local / Unknown) + `Auther` interface + four implementations — `NoAuth`, `HTTPSTokenAuth`, `SSHAgentAuth`, `SSHKeyFileAuth`
- Every Auther fails fast on protocol mismatch, empty token, or missing ssh-agent — no silent fall-through to unauth clones
- Host-key TOFU policy is deferred; `SSHKeyFileAuth.KnownHostsPath` is reserved and documented

## Testing

- `go build ./...` / `go test -race ./pkg/git/...` / `golangci-lint run ./...` — all pass
- `go mod tidy` produces no diff (no new dependencies; SSH support comes from existing transitive deps)
- `pkg/git` coverage 89.3% (up from 81.2%)
- No caller-site changes: `grep` for the new exported symbols outside `pkg/git` returns zero hits

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #500