### PR TITLE
test: stabilize reload watcher debounce test

### DIFF
--- a/pkg/reload/watcher_test.go
+++ b/pkg/reload/watcher_test.go
@@ -112,7 +112,10 @@ func TestWatcher_MultipleWritesDebounced(t *testing.T) {
 		callCount.Add(1)
 		return nil
 	})
-	watcher.SetDebounce(100 * time.Millisecond)
+	// Use a generous debounce window so the five rapid writes reliably
+	// coalesce even under slow CI runners and the -race detector, where
+	// each os.WriteFile + fsnotify propagation can take tens of ms.
+	watcher.SetDebounce(500 * time.Millisecond)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -134,8 +137,8 @@ func TestWatcher_MultipleWritesDebounced(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	// Wait for debounce
-	time.Sleep(300 * time.Millisecond)
+	// Wait for debounce + processing headroom.
+	time.Sleep(800 * time.Millisecond)
 
 	if callCount.Load() != 1 {
 		t.Errorf("expected rapid writes to be debounced to 1 call, got %d", callCount.Load())


### PR DESCRIPTION
## Description

`TestWatcher_MultipleWritesDebounced` was failing consistently on CI (3 retries, 3 failures) because the 100ms debounce window is too tight. The test writes 5 files with 20ms gaps, expecting them all to coalesce into one callback. Under `-race` on a loaded CI runner, individual `os.WriteFile` + fsnotify propagation can exceed 20ms each, pushing later writes outside the debounce window and firing a second callback.

Widens the debounce window from 100ms to 500ms and the final wait from 300ms to 800ms so the test has real headroom. The write pattern (5 rapid writes) still exercises the coalescing behavior; only the timing is more forgiving.

## Type of Change

- [x] Test-only fix (non-breaking)

## Changes Made

- `pkg/reload/watcher_test.go`: debounce window 100ms → 500ms; final wait 300ms → 800ms; comment explains why

## Testing

- `go test -race -count=10 -run TestWatcher_MultipleWritesDebounced ./pkg/reload/` — 10/10 pass locally
- `go test -race ./pkg/reload/` — full suite passes
- `golangci-lint run ./pkg/reload/` — 0 issues

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed