### PR TITLE
feat: wire git auth through importer, CLI, and skills API

### DIFF
--- a/cmd/gridctl/skill.go
+++ b/cmd/gridctl/skill.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,6 +11,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gridctl/gridctl/pkg/config"
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
 	"github.com/gridctl/gridctl/pkg/output"
 	"github.com/gridctl/gridctl/pkg/registry"
 	"github.com/gridctl/gridctl/pkg/skills"
@@ -33,18 +36,25 @@ var (
 	skillAddTrust      bool
 	skillAddForce      bool
 	skillAddRename     string
+	skillAddAuthToken  string
+	skillAddVaultKey   string
+	skillAddSSHKey     string
 	skillListRemote    bool
 	skillListFormat    string
 	skillUpdateDryRun  bool
 	skillUpdateForce   bool
 	skillTryDuration   string
+	skillTryAuthToken  string
+	skillTryVaultKey   string
+	skillTrySSHKey     string
 )
 
 var skillAddCmd = &cobra.Command{
-	Use:   "add <repo-url>",
-	Short: "Import skills from a git repository",
-	Long:  "Clone a repository, discover SKILL.md files, and import them into the local registry.",
-	Args:  cobra.ExactArgs(1),
+	Use:     "add <repo-url>",
+	Short:   "Import skills from a git repository",
+	Long:    "Clone a repository, discover SKILL.md files, and import them into the local registry.",
+	Args:    cobra.ExactArgs(1),
+	PreRunE: validateSkillAuthFlags(&skillAddAuthToken, &skillAddVaultKey),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runSkillAdd(args[0])
 	},
@@ -114,10 +124,11 @@ var skillValidateCmd = &cobra.Command{
 }
 
 var skillTryCmd = &cobra.Command{
-	Use:   "try <repo-url>",
-	Short: "Temporarily import a skill",
-	Long:  "Import a skill temporarily for evaluation. Automatically removed after the specified duration.",
-	Args:  cobra.ExactArgs(1),
+	Use:     "try <repo-url>",
+	Short:   "Temporarily import a skill",
+	Long:    "Import a skill temporarily for evaluation. Automatically removed after the specified duration.",
+	Args:    cobra.ExactArgs(1),
+	PreRunE: validateSkillAuthFlags(&skillTryAuthToken, &skillTryVaultKey),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runSkillTry(args[0])
 	},
@@ -130,6 +141,9 @@ func init() {
 	skillAddCmd.Flags().BoolVar(&skillAddTrust, "trust", false, "Skip security scan confirmation")
 	skillAddCmd.Flags().BoolVar(&skillAddForce, "force", false, "Overwrite existing skills")
 	skillAddCmd.Flags().StringVar(&skillAddRename, "rename", "", "Rename the skill on import (single skill only)")
+	skillAddCmd.Flags().StringVar(&skillAddAuthToken, "auth-token", "", "Personal Access Token (HTTPS only; not persisted; intended for CI use)")
+	skillAddCmd.Flags().StringVar(&skillAddVaultKey, "vault-key", "", "Resolve the PAT from this vault key (e.g. GIT_TOKEN)")
+	skillAddCmd.Flags().StringVar(&skillAddSSHKey, "ssh-key", "", "Use an SSH private key at this path (SSH URLs only)")
 
 	skillListCmd.Flags().BoolVar(&skillListRemote, "remote", false, "Show only remote (imported) skills")
 	skillListCmd.Flags().StringVar(&skillListFormat, "format", "", "Output format (json)")
@@ -138,6 +152,9 @@ func init() {
 	skillUpdateCmd.Flags().BoolVar(&skillUpdateForce, "force", false, "Force update even if no changes detected")
 
 	skillTryCmd.Flags().StringVar(&skillTryDuration, "duration", "10m", "Duration before auto-cleanup")
+	skillTryCmd.Flags().StringVar(&skillTryAuthToken, "auth-token", "", "Personal Access Token (HTTPS only; not persisted)")
+	skillTryCmd.Flags().StringVar(&skillTryVaultKey, "vault-key", "", "Resolve the PAT from this vault key")
+	skillTryCmd.Flags().StringVar(&skillTrySSHKey, "ssh-key", "", "Use an SSH private key at this path (SSH URLs only)")
 
 	skillCmd.AddCommand(skillAddCmd)
 	skillCmd.AddCommand(skillListCmd)
@@ -172,11 +189,92 @@ func skillDirPath(sk *registry.AgentSkill) string {
 
 func newImporter(store *registry.Store) *skills.Importer {
 	logger := slog.Default()
-	return skills.NewImporter(store, registryDir(), skills.LockFilePath(), logger)
+	imp := skills.NewImporter(store, registryDir(), skills.LockFilePath(), logger)
+	imp.SetCredentialResolver(cliCredentialResolver)
+	return imp
+}
+
+// validateSkillAuthFlags returns a PreRunE that rejects mutually exclusive
+// auth flag combinations.
+func validateSkillAuthFlags(token, vaultKey *string) func(*cobra.Command, []string) error {
+	return func(_ *cobra.Command, _ []string) error {
+		if *token != "" && *vaultKey != "" {
+			return errors.New("--auth-token and --vault-key are mutually exclusive")
+		}
+		return nil
+	}
+}
+
+// buildAuthConfigFromFlags translates CLI auth flags into skills.AuthConfig.
+// When --vault-key is set, the vault is unlocked (prompting if necessary)
+// and the reference is resolved immediately so Import sees a ready Token.
+func buildAuthConfigFromFlags(token, vaultKey, sshKey string) (skills.AuthConfig, error) {
+	switch {
+	case sshKey != "":
+		return skills.AuthConfig{
+			Method:        "ssh-key",
+			SSHKeyPath:    sshKey,
+			SSHPassphrase: os.Getenv("GRIDCTL_SSH_KEY_PASSPHRASE"),
+		}, nil
+	case token != "":
+		return skills.AuthConfig{Method: "token", Token: token}, nil
+	case vaultKey != "":
+		ref := fmt.Sprintf("${vault:%s}", vaultKey)
+		resolved, err := cliCredentialResolver(ref)
+		if err != nil {
+			return skills.AuthConfig{}, err
+		}
+		return skills.AuthConfig{Method: "token", Token: resolved, CredentialRef: ref}, nil
+	}
+	return skills.AuthConfig{}, nil
+}
+
+// cliCredentialResolver resolves a "${vault:KEY}" reference via the local
+// vault, unlocking it if necessary. Wired onto the CLI's Importer so
+// `skill update` can re-resolve stored references automatically.
+func cliCredentialResolver(ref string) (string, error) {
+	store, err := loadVault()
+	if err != nil {
+		return "", err
+	}
+	if err := ensureUnlocked(store); err != nil {
+		return "", err
+	}
+	resolver := config.VaultResolver(store)
+	expanded, unresolved, _ := config.ExpandString(ref, resolver)
+	if len(unresolved) > 0 {
+		return "", fmt.Errorf("vault key %q not found", unresolved[0])
+	}
+	return expanded, nil
+}
+
+// printSkillAuthHint emits an actionable suggestion for a classified git
+// auth error. Returns true when a hint was printed.
+func printSkillAuthHint(err error) bool {
+	switch {
+	case errors.Is(err, gitpkg.ErrAuthRequired), errors.Is(err, gitpkg.ErrNotFound):
+		fmt.Fprintln(os.Stderr, "hint: this repository may be private; add credentials with --auth-token or --vault-key")
+		return true
+	case errors.Is(err, gitpkg.ErrAuthFailed):
+		fmt.Fprintln(os.Stderr, "hint: credentials were rejected; verify the token has repo-read access")
+		return true
+	case errors.Is(err, gitpkg.ErrSSHAgentMissing):
+		fmt.Fprintln(os.Stderr, `hint: ssh-agent not detected; run eval "$(ssh-agent -s)" && ssh-add, or use --auth-token`)
+		return true
+	case errors.Is(err, gitpkg.ErrHostKeyMismatch):
+		fmt.Fprintln(os.Stderr, "hint: the SSH host key does not match ~/.ssh/known_hosts — investigate before retrying")
+		return true
+	}
+	return false
 }
 
 func runSkillAdd(repoURL string) error {
 	store, err := loadRegistry()
+	if err != nil {
+		return err
+	}
+
+	authCfg, err := buildAuthConfigFromFlags(skillAddAuthToken, skillAddVaultKey, skillAddSSHKey)
 	if err != nil {
 		return err
 	}
@@ -190,9 +288,12 @@ func runSkillAdd(repoURL string) error {
 		NoActivate: skillAddNoActivate,
 		Force:      skillAddForce,
 		Rename:     skillAddRename,
+		Auth:       authCfg,
 	})
 	if err != nil {
-		return err
+		classified := gitpkg.ClassifyError(err)
+		printSkillAuthHint(classified)
+		return gitpkg.RedactError(classified)
 	}
 
 	printer := output.New()
@@ -459,14 +560,22 @@ func runSkillTry(repoURL string) error {
 		return err
 	}
 
+	authCfg, err := buildAuthConfigFromFlags(skillTryAuthToken, skillTryVaultKey, skillTrySSHKey)
+	if err != nil {
+		return err
+	}
+
 	imp := newImporter(store)
 	result, err := imp.Import(skills.ImportOptions{
 		Repo:  repoURL,
 		Trust: true,
 		Force: true,
+		Auth:  authCfg,
 	})
 	if err != nil {
-		return err
+		classified := gitpkg.ClassifyError(err)
+		printSkillAuthHint(classified)
+		return gitpkg.RedactError(classified)
 	}
 
 	printer := output.New()

--- a/internal/api/skills.go
+++ b/internal/api/skills.go
@@ -2,25 +2,30 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
+	"github.com/gridctl/gridctl/pkg/config"
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
 	"github.com/gridctl/gridctl/pkg/registry"
 	"github.com/gridctl/gridctl/pkg/skills"
+	"github.com/gridctl/gridctl/pkg/vault"
 )
 
 // SkillSourceStatus represents a skill source with its update status.
 type SkillSourceStatus struct {
-	Name           string              `json:"name"`
-	Repo           string              `json:"repo"`
-	Ref            string              `json:"ref,omitempty"`
-	Path           string              `json:"path,omitempty"`
-	AutoUpdate     bool                `json:"autoUpdate"`
-	UpdateInterval string              `json:"updateInterval"`
-	Skills         []SkillSourceEntry  `json:"skills"`
-	LastFetched    string              `json:"lastFetched,omitempty"`
-	CommitSHA      string              `json:"commitSha,omitempty"`
-	UpdateAvail    bool                `json:"updateAvailable"`
+	Name           string             `json:"name"`
+	Repo           string             `json:"repo"`
+	Ref            string             `json:"ref,omitempty"`
+	Path           string             `json:"path,omitempty"`
+	AutoUpdate     bool               `json:"autoUpdate"`
+	UpdateInterval string             `json:"updateInterval"`
+	Skills         []SkillSourceEntry `json:"skills"`
+	LastFetched    string             `json:"lastFetched,omitempty"`
+	CommitSHA      string             `json:"commitSha,omitempty"`
+	UpdateAvail    bool               `json:"updateAvailable"`
 }
 
 // SkillSourceEntry represents a single skill within a source.
@@ -46,8 +51,8 @@ type SkillPreview struct {
 
 // UpdateSummary represents pending updates across all sources.
 type UpdateSummary struct {
-	Available int                    `json:"available"`
-	Sources   []SourceUpdateSummary  `json:"sources"`
+	Available int                   `json:"available"`
+	Sources   []SourceUpdateSummary `json:"sources"`
 }
 
 // SourceUpdateSummary represents update status for a single source.
@@ -58,6 +63,103 @@ type SourceUpdateSummary struct {
 	Latest    string `json:"latestSha,omitempty"`
 	HasUpdate bool   `json:"hasUpdate"`
 	Error     string `json:"error,omitempty"`
+}
+
+// AuthRequest is the optional auth payload accepted on /api/skills/sources/*
+// endpoints. Raw Token values are transient; CredentialRef (e.g.
+// "${vault:GIT_TOKEN}") is resolved against the live vault on every request.
+type AuthRequest struct {
+	Method        string `json:"method,omitempty"`        // "token" | "ssh-agent" | "ssh-key" | ""
+	Token         string `json:"token,omitempty"`         // ephemeral plaintext
+	CredentialRef string `json:"credentialRef,omitempty"` // e.g. "${vault:GIT_TOKEN}"
+	SSHUser       string `json:"sshUser,omitempty"`
+	SSHKeyPath    string `json:"sshKeyPath,omitempty"`
+}
+
+// toAuthConfig converts a request-body AuthRequest into a skills.AuthConfig,
+// resolving any CredentialRef against the provided vault. An empty request
+// (no method, no ref, no token) yields a zero-valued AuthConfig that
+// signals ambient behavior.
+func (r *AuthRequest) toAuthConfig(v *vault.Store) (skills.AuthConfig, error) {
+	if r == nil || (r.Method == "" && r.Token == "" && r.CredentialRef == "" && r.SSHKeyPath == "") {
+		return skills.AuthConfig{}, nil
+	}
+
+	method := r.Method
+	if method == "" {
+		// Infer from provided fields: token-ish wins, then ssh-key.
+		switch {
+		case r.Token != "" || r.CredentialRef != "":
+			method = "token"
+		case r.SSHKeyPath != "":
+			method = "ssh-key"
+		}
+	}
+
+	token := r.Token
+	if r.CredentialRef != "" {
+		resolved, err := resolveCredentialRef(r.CredentialRef, v)
+		if err != nil {
+			return skills.AuthConfig{}, err
+		}
+		token = resolved
+	}
+
+	return skills.AuthConfig{
+		Method:        method,
+		Token:         token,
+		CredentialRef: r.CredentialRef,
+		SSHUser:       r.SSHUser,
+		SSHKeyPath:    r.SSHKeyPath,
+	}, nil
+}
+
+// resolveCredentialRef expands a "${vault:KEY}" reference against the live
+// vault. An unresolved reference is a hard error — we never fall through
+// to an unauthenticated clone.
+func resolveCredentialRef(ref string, v *vault.Store) (string, error) {
+	if v == nil {
+		return "", fmt.Errorf("vault not configured; cannot resolve %s", ref)
+	}
+	resolver := config.VaultResolver(v)
+	expanded, unresolved, _ := config.ExpandString(ref, resolver)
+	if len(unresolved) > 0 {
+		return "", fmt.Errorf("vault key %q not found", unresolved[0])
+	}
+	return expanded, nil
+}
+
+// credentialResolver returns a skills.CredentialResolver that expands
+// references against the server's live vault.
+func (s *Server) credentialResolver() skills.CredentialResolver {
+	return func(ref string) (string, error) {
+		return resolveCredentialRef(ref, s.vaultStore)
+	}
+}
+
+// gitErrorStatus maps a classified git error to an HTTP status code.
+func gitErrorStatus(err error) int {
+	switch {
+	case errors.Is(err, gitpkg.ErrAuthRequired), errors.Is(err, gitpkg.ErrAuthFailed):
+		return http.StatusUnauthorized
+	case errors.Is(err, gitpkg.ErrNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, gitpkg.ErrProtocolMismatch),
+		errors.Is(err, gitpkg.ErrEmptyToken),
+		errors.Is(err, gitpkg.ErrHostKeyMismatch):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// writeGitError classifies and redacts an error from a git operation before
+// writing it to the response. Callers should use this rather than passing
+// raw go-git errors straight through writeJSONError.
+func writeGitError(w http.ResponseWriter, prefix string, err error) {
+	classified := gitpkg.ClassifyError(err)
+	redacted := gitpkg.RedactError(classified)
+	writeJSONError(w, prefix+redacted.Error(), gitErrorStatus(classified))
 }
 
 // handleSkillSourcesList returns all configured skill sources with update status.
@@ -134,12 +236,13 @@ func (s *Server) handleSkillSourceAdd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Repo       string   `json:"repo"`
-		Ref        string   `json:"ref,omitempty"`
-		Path       string   `json:"path,omitempty"`
-		Trust      bool     `json:"trust,omitempty"`
-		NoActivate bool     `json:"noActivate,omitempty"`
-		Selected   []string `json:"selected,omitempty"`
+		Repo       string       `json:"repo"`
+		Ref        string       `json:"ref,omitempty"`
+		Path       string       `json:"path,omitempty"`
+		Trust      bool         `json:"trust,omitempty"`
+		NoActivate bool         `json:"noActivate,omitempty"`
+		Selected   []string     `json:"selected,omitempty"`
+		Auth       *AuthRequest `json:"auth,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
@@ -151,12 +254,19 @@ func (s *Server) handleSkillSourceAdd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	authCfg, err := req.Auth.toAuthConfig(s.vaultStore)
+	if err != nil {
+		writeJSONError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	store := s.registryServer.Store()
 	registryDir := store.Dir()
 	lockPath := skills.LockFilePath()
 	logger := slog.Default()
 
 	imp := skills.NewImporter(store, registryDir, lockPath, logger)
+	imp.SetCredentialResolver(s.credentialResolver())
 	result, err := imp.Import(skills.ImportOptions{
 		Repo:       req.Repo,
 		Ref:        req.Ref,
@@ -164,9 +274,10 @@ func (s *Server) handleSkillSourceAdd(w http.ResponseWriter, r *http.Request) {
 		Trust:      req.Trust,
 		NoActivate: req.NoActivate,
 		Selected:   req.Selected,
+		Auth:       authCfg,
 	})
 	if err != nil {
-		writeJSONError(w, "Import failed: "+err.Error(), http.StatusBadRequest)
+		writeGitError(w, "Import failed: ", err)
 		return
 	}
 
@@ -239,10 +350,25 @@ func (s *Server) handleSkillSourceCheck(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	logger := slog.Default()
-	newSHA, changed, err := skills.FetchAndCompare(src.Repo, src.Ref, src.CommitSHA, logger)
+	var auth *AuthRequest
+	if r.Body != nil && r.ContentLength > 0 {
+		var req struct {
+			Auth *AuthRequest `json:"auth,omitempty"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		auth = req.Auth
+	}
+
+	authCfg, err := s.resolveCheckAuth(auth, src.CredentialRef)
 	if err != nil {
-		writeJSONError(w, "Check failed: "+err.Error(), http.StatusInternalServerError)
+		writeJSONError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	logger := slog.Default()
+	newSHA, changed, err := skills.FetchAndCompare(src.Repo, src.Ref, src.CommitSHA, authCfg, logger)
+	if err != nil {
+		writeGitError(w, "Check failed: ", err)
 		return
 	}
 
@@ -252,6 +378,26 @@ func (s *Server) handleSkillSourceCheck(w http.ResponseWriter, r *http.Request) 
 		"latestSha":  newSHA,
 		"hasUpdate":  changed,
 	})
+}
+
+// resolveCheckAuth prefers an explicit request-body auth; falls back to the
+// stored CredentialRef on the lock file entry when the request omits auth.
+func (s *Server) resolveCheckAuth(req *AuthRequest, storedRef string) (skills.AuthConfig, error) {
+	if req != nil {
+		return req.toAuthConfig(s.vaultStore)
+	}
+	if storedRef == "" {
+		return skills.AuthConfig{}, nil
+	}
+	token, err := resolveCredentialRef(storedRef, s.vaultStore)
+	if err != nil {
+		return skills.AuthConfig{}, err
+	}
+	return skills.AuthConfig{
+		Method:        "token",
+		Token:         token,
+		CredentialRef: storedRef,
+	}, nil
 }
 
 // handleSkillSourceUpdate applies available updates for a source.
@@ -280,14 +426,16 @@ func (s *Server) handleSkillSourceUpdate(w http.ResponseWriter, r *http.Request)
 	store := s.registryServer.Store()
 	registryDir := store.Dir()
 	imp := skills.NewImporter(store, registryDir, lockPath, slog.Default())
+	imp.SetCredentialResolver(s.credentialResolver())
 
-	// Update each skill from this source
+	// Update each skill from this source. Importer.Update re-resolves the
+	// stored CredentialRef from the origin using the resolver we just set.
 	var results []map[string]any
 	for skillName := range src.Skills {
 		result, err := imp.Update(skillName, false, false)
 		entry := map[string]any{"skill": skillName}
 		if err != nil {
-			entry["error"] = err.Error()
+			entry["error"] = gitpkg.RedactError(err).Error()
 		} else {
 			entry["imported"] = len(result.Imported)
 			entry["warnings"] = result.Warnings
@@ -318,6 +466,7 @@ func (s *Server) handleSkillSourcePreview(w http.ResponseWriter, r *http.Request
 	ref := r.URL.Query().Get("ref")
 	path := r.URL.Query().Get("path")
 
+	var storedRef string
 	if repo == "" {
 		lockPath := skills.LockFilePath()
 		lf, _ := skills.ReadLockFile(lockPath)
@@ -326,6 +475,7 @@ func (s *Server) handleSkillSourcePreview(w http.ResponseWriter, r *http.Request
 			if ref == "" {
 				ref = src.Ref
 			}
+			storedRef = src.CredentialRef
 		}
 	}
 
@@ -334,10 +484,24 @@ func (s *Server) handleSkillSourcePreview(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	logger := slog.Default()
-	result, err := skills.CloneAndDiscover(repo, ref, path, logger)
+	// Optional auth can be supplied in the JSON body of POST; for GET,
+	// fall back to a stored CredentialRef if the lookup above found one.
+	var req struct {
+		Auth *AuthRequest `json:"auth,omitempty"`
+	}
+	if r.Body != nil && r.ContentLength > 0 {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+	}
+	authCfg, err := s.resolveCheckAuth(req.Auth, storedRef)
 	if err != nil {
-		writeJSONError(w, "Clone failed: "+err.Error(), http.StatusBadRequest)
+		writeJSONError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	logger := slog.Default()
+	result, err := skills.CloneAndDiscover(repo, ref, path, authCfg, logger)
+	if err != nil {
+		writeGitError(w, "Clone failed: ", err)
 		return
 	}
 
@@ -403,9 +567,16 @@ func (s *Server) handleSkillUpdates(w http.ResponseWriter, _ *http.Request) {
 			Current: src.CommitSHA,
 		}
 
-		newSHA, changed, err := skills.FetchAndCompare(src.Repo, src.Ref, src.CommitSHA, logger)
+		authCfg, authErr := s.resolveCheckAuth(nil, src.CredentialRef)
+		if authErr != nil {
+			entry.Error = authErr.Error()
+			summary.Sources = append(summary.Sources, entry)
+			continue
+		}
+
+		newSHA, changed, err := skills.FetchAndCompare(src.Repo, src.Ref, src.CommitSHA, authCfg, logger)
 		if err != nil {
-			entry.Error = err.Error()
+			entry.Error = gitpkg.RedactError(err).Error()
 		} else {
 			entry.Latest = newSHA
 			entry.HasUpdate = changed

--- a/internal/api/skills_auth_test.go
+++ b/internal/api/skills_auth_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
+	"github.com/gridctl/gridctl/pkg/vault"
+)
+
+func TestAuthRequest_ToAuthConfig_Empty(t *testing.T) {
+	var r *AuthRequest
+	cfg, err := r.toAuthConfig(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Method != "" {
+		t.Errorf("expected zero AuthConfig for nil request, got %+v", cfg)
+	}
+}
+
+func TestAuthRequest_ToAuthConfig_InferToken(t *testing.T) {
+	r := &AuthRequest{Token: "abc"}
+	cfg, err := r.toAuthConfig(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Method != "token" || cfg.Token != "abc" {
+		t.Errorf("unexpected AuthConfig: %+v", cfg)
+	}
+}
+
+func TestAuthRequest_ToAuthConfig_InferSSHKey(t *testing.T) {
+	r := &AuthRequest{SSHKeyPath: "/keys/id"}
+	cfg, err := r.toAuthConfig(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Method != "ssh-key" || cfg.SSHKeyPath != "/keys/id" {
+		t.Errorf("unexpected AuthConfig: %+v", cfg)
+	}
+}
+
+func TestAuthRequest_ToAuthConfig_ResolveCredentialRef(t *testing.T) {
+	v := vault.NewStore(t.TempDir())
+	if err := v.Load(); err != nil {
+		t.Fatalf("vault load: %v", err)
+	}
+	if err := v.Set("GIT_TOKEN", "secret-abc"); err != nil {
+		t.Fatalf("vault set: %v", err)
+	}
+
+	r := &AuthRequest{CredentialRef: "${vault:GIT_TOKEN}"}
+	cfg, err := r.toAuthConfig(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Method != "token" {
+		t.Errorf("expected method=token, got %q", cfg.Method)
+	}
+	if cfg.Token != "secret-abc" {
+		t.Errorf("expected resolved token, got %q", cfg.Token)
+	}
+	if cfg.CredentialRef != "${vault:GIT_TOKEN}" {
+		t.Errorf("expected CredentialRef preserved, got %q", cfg.CredentialRef)
+	}
+}
+
+func TestAuthRequest_ToAuthConfig_UnresolvedRef(t *testing.T) {
+	v := vault.NewStore(t.TempDir())
+	if err := v.Load(); err != nil {
+		t.Fatalf("vault load: %v", err)
+	}
+
+	r := &AuthRequest{CredentialRef: "${vault:MISSING}"}
+	_, err := r.toAuthConfig(v)
+	if err == nil {
+		t.Fatal("expected error for missing vault key")
+	}
+}
+
+func TestResolveCredentialRef_NoVault(t *testing.T) {
+	_, err := resolveCredentialRef("${vault:X}", nil)
+	if err == nil {
+		t.Error("expected error when vault is nil")
+	}
+}
+
+func TestGitErrorStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"auth required", fmt.Errorf("%w: x", gitpkg.ErrAuthRequired), http.StatusUnauthorized},
+		{"auth failed", fmt.Errorf("%w: x", gitpkg.ErrAuthFailed), http.StatusUnauthorized},
+		{"not found", fmt.Errorf("%w: x", gitpkg.ErrNotFound), http.StatusNotFound},
+		{"protocol mismatch", fmt.Errorf("%w: x", gitpkg.ErrProtocolMismatch), http.StatusBadRequest},
+		{"empty token", fmt.Errorf("%w: x", gitpkg.ErrEmptyToken), http.StatusBadRequest},
+		{"host key mismatch", fmt.Errorf("%w: x", gitpkg.ErrHostKeyMismatch), http.StatusBadRequest},
+		{"other", errors.New("some random failure"), http.StatusInternalServerError},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := gitErrorStatus(c.err); got != c.want {
+				t.Errorf("gitErrorStatus(%v) = %d, want %d", c.err, got, c.want)
+			}
+		})
+	}
+}
+

--- a/pkg/skills/auth_test.go
+++ b/pkg/skills/auth_test.go
@@ -1,0 +1,179 @@
+package skills
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
+)
+
+func TestBuildAuther(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     AuthConfig
+		wantErr bool
+	}{
+		{"empty method returns NoAuth", AuthConfig{}, false},
+		{"explicit none", AuthConfig{Method: "none"}, false},
+		{"token", AuthConfig{Method: "token", Token: "abc"}, false},
+		{"ssh-agent", AuthConfig{Method: "ssh-agent", SSHUser: "git"}, false},
+		{"ssh-key", AuthConfig{Method: "ssh-key", SSHKeyPath: "/does/not/exist"}, false},
+		{"unknown method", AuthConfig{Method: "oauth"}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			auther, err := BuildAuther(c.cfg)
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q, got %v", c.cfg.Method, auther)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if auther == nil {
+				t.Fatal("expected non-nil Auther")
+			}
+		})
+	}
+}
+
+func TestResolveAuther_ExplicitWins(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "env-token")
+	auther, err := resolveAuther(AuthConfig{Method: "token", Token: "explicit"}, "https://example.com/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	auth, err := auther.AuthFor("https://example.com/repo")
+	if err != nil {
+		t.Fatalf("AuthFor: %v", err)
+	}
+	ba, ok := auth.(*http.BasicAuth)
+	if !ok {
+		t.Fatalf("expected *http.BasicAuth, got %T", auth)
+	}
+	if ba.Username != "explicit" {
+		t.Errorf("expected explicit token to win over env, got %q", ba.Username)
+	}
+}
+
+func TestResolveAuther_GitHubTokenFallback(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "env-token")
+	auther, err := resolveAuther(AuthConfig{}, "https://github.com/org/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	auth, err := auther.AuthFor("https://github.com/org/repo")
+	if err != nil {
+		t.Fatalf("AuthFor: %v", err)
+	}
+	ba, ok := auth.(*http.BasicAuth)
+	if !ok {
+		t.Fatalf("expected *http.BasicAuth, got %T", auth)
+	}
+	if ba.Username != "env-token" {
+		t.Errorf("expected GITHUB_TOKEN fallback, got %q", ba.Username)
+	}
+}
+
+func TestResolveAuther_NoFallbackForSSH(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "env-token")
+	auther, err := resolveAuther(AuthConfig{}, "git@github.com:org/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	auth, err := auther.AuthFor("git@github.com:org/repo")
+	if err != nil {
+		t.Fatalf("AuthFor: %v", err)
+	}
+	if auth != nil {
+		t.Errorf("expected NoAuth for SSH URL with no explicit config, got %T", auth)
+	}
+}
+
+func TestResolveAuther_NoFallbackForPublic(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	auther, err := resolveAuther(AuthConfig{}, "https://github.com/public/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	auth, err := auther.AuthFor("https://github.com/public/repo")
+	if err != nil {
+		t.Fatalf("AuthFor: %v", err)
+	}
+	if auth != nil {
+		t.Errorf("expected NoAuth when GITHUB_TOKEN unset, got %T", auth)
+	}
+}
+
+func TestAuthFromOrigin_NoRef(t *testing.T) {
+	imp := &Importer{}
+	cfg, err := imp.authFromOrigin(&Origin{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Method != "" {
+		t.Errorf("expected zero AuthConfig, got method %q", cfg.Method)
+	}
+}
+
+func TestAuthFromOrigin_MissingResolver(t *testing.T) {
+	imp := &Importer{}
+	_, err := imp.authFromOrigin(&Origin{CredentialRef: "${vault:GIT_TOKEN}"})
+	if !errors.Is(err, gitpkg.ErrAuthFailed) {
+		t.Errorf("expected ErrAuthFailed, got %v", err)
+	}
+}
+
+func TestAuthFromOrigin_ResolverReturnsToken(t *testing.T) {
+	imp := &Importer{}
+	imp.SetCredentialResolver(func(ref string) (string, error) {
+		if ref != "${vault:GIT_TOKEN}" {
+			return "", errors.New("unexpected ref")
+		}
+		return "resolved-secret", nil
+	})
+	cfg, err := imp.authFromOrigin(&Origin{CredentialRef: "${vault:GIT_TOKEN}"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Method != "token" || cfg.Token != "resolved-secret" {
+		t.Errorf("unexpected AuthConfig: %+v", cfg)
+	}
+	if cfg.CredentialRef != "${vault:GIT_TOKEN}" {
+		t.Errorf("expected CredentialRef preserved, got %q", cfg.CredentialRef)
+	}
+}
+
+func TestAuthFromOrigin_EmptyResolvedValue(t *testing.T) {
+	imp := &Importer{}
+	imp.SetCredentialResolver(func(string) (string, error) { return "", nil })
+	_, err := imp.authFromOrigin(&Origin{CredentialRef: "${vault:GIT_TOKEN}"})
+	if !errors.Is(err, gitpkg.ErrEmptyToken) {
+		t.Errorf("expected ErrEmptyToken, got %v", err)
+	}
+}
+
+func TestSourceAuth_ToAuthConfig(t *testing.T) {
+	var nilAuth *SourceAuth
+	if cfg := nilAuth.ToAuthConfig(); cfg.Method != "" {
+		t.Errorf("nil SourceAuth should yield zero AuthConfig, got %+v", cfg)
+	}
+	a := &SourceAuth{
+		Method:        "token",
+		CredentialRef: "${vault:X}",
+		SSHUser:       "gitlab-ci",
+		SSHKeyPath:    "/keys/id",
+	}
+	got := a.ToAuthConfig()
+	if got.Method != "token" || got.CredentialRef != "${vault:X}" ||
+		got.SSHUser != "gitlab-ci" || got.SSHKeyPath != "/keys/id" {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+	if got.Token != "" {
+		t.Error("SourceAuth should never carry a raw Token")
+	}
+}

--- a/pkg/skills/config.go
+++ b/pkg/skills/config.go
@@ -12,12 +12,39 @@ import (
 
 // SkillSource defines a remote skill source in skills.yaml.
 type SkillSource struct {
-	Name           string `yaml:"name" json:"name"`
-	Repo           string `yaml:"repo" json:"repo"`
-	Ref            string `yaml:"ref,omitempty" json:"ref,omitempty"`
-	Path           string `yaml:"path,omitempty" json:"path,omitempty"`
-	AutoUpdate     *bool  `yaml:"auto_update,omitempty" json:"autoUpdate,omitempty"`
-	UpdateInterval string `yaml:"update_interval,omitempty" json:"updateInterval,omitempty"`
+	Name           string      `yaml:"name" json:"name"`
+	Repo           string      `yaml:"repo" json:"repo"`
+	Ref            string      `yaml:"ref,omitempty" json:"ref,omitempty"`
+	Path           string      `yaml:"path,omitempty" json:"path,omitempty"`
+	AutoUpdate     *bool       `yaml:"auto_update,omitempty" json:"autoUpdate,omitempty"`
+	UpdateInterval string      `yaml:"update_interval,omitempty" json:"updateInterval,omitempty"`
+	Auth           *SourceAuth `yaml:"auth,omitempty" json:"auth,omitempty"`
+}
+
+// SourceAuth is the declarative auth block on a skills.yaml source.
+// Raw tokens must NOT appear here — use CredentialRef (e.g.
+// "${vault:GIT_TOKEN}") which is resolved against the live vault at
+// clone/fetch time.
+type SourceAuth struct {
+	Method        string `yaml:"method,omitempty" json:"method,omitempty"`
+	CredentialRef string `yaml:"credential_ref,omitempty" json:"credentialRef,omitempty"`
+	SSHUser       string `yaml:"ssh_user,omitempty" json:"sshUser,omitempty"`
+	SSHKeyPath    string `yaml:"ssh_key_path,omitempty" json:"sshKeyPath,omitempty"`
+}
+
+// ToAuthConfig converts the declarative block into a runtime AuthConfig.
+// CredentialRef is copied through unchanged; callers are responsible for
+// resolving it to a raw Token before invoking the importer.
+func (a *SourceAuth) ToAuthConfig() AuthConfig {
+	if a == nil {
+		return AuthConfig{}
+	}
+	return AuthConfig{
+		Method:        a.Method,
+		CredentialRef: a.CredentialRef,
+		SSHUser:       a.SSHUser,
+		SSHKeyPath:    a.SSHKeyPath,
+	}
 }
 
 // SkillsConfig represents the skills.yaml file.

--- a/pkg/skills/importer.go
+++ b/pkg/skills/importer.go
@@ -3,11 +3,74 @@ package skills
 import (
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"time"
 
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
 	"github.com/gridctl/gridctl/pkg/registry"
 )
+
+// AuthConfig carries authentication configuration for a git operation.
+// The Token and SSHPassphrase fields are transient — they must never be
+// persisted to disk. CredentialRef is the opaque reference string (e.g.
+// "${vault:GIT_TOKEN}") that gets stored in Origin/LockFile so that Update
+// can re-resolve it later.
+type AuthConfig struct {
+	Method         string // "", "none", "token", "ssh-agent", "ssh-key"
+	Token          string // resolved plaintext — transient, never persisted
+	CredentialRef  string // e.g. "${vault:GIT_TOKEN}" — persisted
+	SSHUser        string // defaults to "git" when empty
+	SSHKeyPath     string // required for method "ssh-key"
+	SSHPassphrase  string // transient
+	KnownHostsPath string // reserved for future host-key policy work
+}
+
+// BuildAuther constructs a git.Auther matching the AuthConfig's Method.
+// Returns an error for unknown methods. Individual Auther implementations
+// also validate their own inputs (e.g. HTTPSTokenAuth rejects empty tokens).
+func BuildAuther(cfg AuthConfig) (gitpkg.Auther, error) {
+	switch cfg.Method {
+	case "", "none":
+		return gitpkg.NoAuth{}, nil
+	case "token":
+		return gitpkg.HTTPSTokenAuth{Token: cfg.Token}, nil
+	case "ssh-agent":
+		return gitpkg.SSHAgentAuth{User: cfg.SSHUser}, nil
+	case "ssh-key":
+		return gitpkg.SSHKeyFileAuth{
+			User:           cfg.SSHUser,
+			KeyPath:        cfg.SSHKeyPath,
+			Passphrase:     cfg.SSHPassphrase,
+			KnownHostsPath: cfg.KnownHostsPath,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown auth method %q", cfg.Method)
+	}
+}
+
+// resolveAuther returns the Auther to use for a URL given an AuthConfig.
+// Precedence: explicit method > GITHUB_TOKEN env var (HTTPS only) > NoAuth.
+// This preserves backward compatibility with the pre-AuthConfig behavior.
+func resolveAuther(cfg AuthConfig, url string) (gitpkg.Auther, error) {
+	if cfg.Method != "" && cfg.Method != "none" {
+		return BuildAuther(cfg)
+	}
+	// Ambient fallback: GITHUB_TOKEN for HTTPS URLs.
+	if gitpkg.DetectProtocol(url) == gitpkg.ProtocolHTTPS {
+		if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+			return gitpkg.HTTPSTokenAuth{Token: token}, nil
+		}
+	}
+	return gitpkg.NoAuth{}, nil
+}
+
+// CredentialResolver resolves an opaque reference like "${vault:GIT_TOKEN}"
+// to its raw value. Callers (CLI, HTTP API) register one via
+// Importer.SetCredentialResolver so that Update can re-resolve credentials
+// recorded in Origin/LockFile without the importer needing to know where
+// the values live.
+type CredentialResolver func(ref string) (string, error)
 
 // ImportOptions controls the import behavior.
 type ImportOptions struct {
@@ -19,6 +82,7 @@ type ImportOptions struct {
 	Force      bool     // Overwrite existing skills
 	Rename     string   // Rename the skill on import
 	Selected   []string // Only import skills with these names (empty = import all)
+	Auth       AuthConfig
 }
 
 // ImportResult contains the results of an import operation.
@@ -44,10 +108,11 @@ type SkippedSkill struct {
 
 // Importer orchestrates the skill import process.
 type Importer struct {
-	store       *registry.Store
-	registryDir string
-	lockPath    string
-	logger      *slog.Logger
+	store              *registry.Store
+	registryDir        string
+	lockPath           string
+	logger             *slog.Logger
+	credentialResolver CredentialResolver
 }
 
 // NewImporter creates a new skill importer.
@@ -60,6 +125,15 @@ func NewImporter(store *registry.Store, registryDir, lockPath string, logger *sl
 	}
 }
 
+// SetCredentialResolver registers a resolver used to expand CredentialRef
+// values stored in Origin/LockFile when Update fetches the latest state.
+// Without a resolver, Update can still run for sources that have no stored
+// reference (ambient GITHUB_TOKEN / public repos), but will fail fast for
+// sources that do.
+func (imp *Importer) SetCredentialResolver(r CredentialResolver) {
+	imp.credentialResolver = r
+}
+
 // Import clones a repo, discovers skills, validates, scans, and imports.
 func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 	if opts.Path != "" {
@@ -68,9 +142,9 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 		}
 	}
 
-	imp.logger.Info("importing skills", "repo", opts.Repo, "ref", opts.Ref)
+	imp.logger.Info("importing skills", "repo", gitpkg.RedactURL(opts.Repo), "ref", opts.Ref)
 
-	result, err := CloneAndDiscover(opts.Repo, opts.Ref, opts.Path, imp.logger)
+	result, err := CloneAndDiscover(opts.Repo, opts.Ref, opts.Path, opts.Auth, imp.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -160,15 +234,17 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 		// Compute fingerprint
 		fp := ComputeFingerprint(discovered.Skill)
 
-		// Write origin sidecar
+		// Write origin sidecar. CredentialRef (if any) is persisted as an
+		// opaque reference string — the raw token is never written to disk.
 		origin := &Origin{
-			Repo:        opts.Repo,
-			Ref:         opts.Ref,
-			Path:        discovered.Path,
-			CommitSHA:   result.CommitSHA,
-			ImportedAt:  time.Now().UTC(),
-			ContentHash: discovered.ContentHash,
-			Fingerprint: fp,
+			Repo:          opts.Repo,
+			Ref:           opts.Ref,
+			Path:          discovered.Path,
+			CommitSHA:     result.CommitSHA,
+			ImportedAt:    time.Now().UTC(),
+			ContentHash:   discovered.ContentHash,
+			Fingerprint:   fp,
+			CredentialRef: opts.Auth.CredentialRef,
 		}
 
 		skillDir := imp.skillDir(skillName)
@@ -199,12 +275,13 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 	if len(lockedSkills) > 0 {
 		sourceName := repoToName(opts.Repo)
 		lf.SetSource(sourceName, LockedSource{
-			Repo:        opts.Repo,
-			Ref:         opts.Ref,
-			CommitSHA:   result.CommitSHA,
-			FetchedAt:   time.Now().UTC(),
-			ContentHash: result.CommitSHA,
-			Skills:      lockedSkills,
+			Repo:          opts.Repo,
+			Ref:           opts.Ref,
+			CommitSHA:     result.CommitSHA,
+			FetchedAt:     time.Now().UTC(),
+			ContentHash:   result.CommitSHA,
+			Skills:        lockedSkills,
+			CredentialRef: opts.Auth.CredentialRef,
 		})
 
 		if err := WriteLockFile(imp.lockPath, lf); err != nil {
@@ -248,9 +325,15 @@ func (imp *Importer) Update(skillName string, dryRun, force bool) (*ImportResult
 		return nil, fmt.Errorf("skill %q has no origin (not an imported skill): %w", skillName, err)
 	}
 
-	imp.logger.Info("checking for updates", "skill", skillName, "repo", origin.Repo)
+	// Re-resolve any CredentialRef stored at import time.
+	auth, err := imp.authFromOrigin(origin)
+	if err != nil {
+		return nil, err
+	}
 
-	newSHA, changed, err := FetchAndCompare(origin.Repo, origin.Ref, origin.CommitSHA, imp.logger)
+	imp.logger.Info("checking for updates", "skill", skillName, "repo", gitpkg.RedactURL(origin.Repo))
+
+	newSHA, changed, err := FetchAndCompare(origin.Repo, origin.Ref, origin.CommitSHA, auth, imp.logger)
 	if err != nil {
 		return nil, fmt.Errorf("checking updates: %w", err)
 	}
@@ -278,6 +361,7 @@ func (imp *Importer) Update(skillName string, dryRun, force bool) (*ImportResult
 		Path:  origin.Path,
 		Trust: true,
 		Force: true,
+		Auth:  auth,
 	})
 	if err != nil {
 		return result, err
@@ -370,4 +454,29 @@ func (imp *Importer) skillDir(skillName string) string {
 		return filepath.Join(imp.registryDir, "skills", skillName)
 	}
 	return filepath.Join(imp.registryDir, "skills", sk.Dir)
+}
+
+// authFromOrigin builds an AuthConfig from a stored Origin. If the origin
+// carries a CredentialRef, the configured CredentialResolver is invoked
+// to obtain the raw token. Without a resolver, a stored CredentialRef is
+// a hard failure — we never silently fall through to an unauth clone.
+func (imp *Importer) authFromOrigin(origin *Origin) (AuthConfig, error) {
+	if origin.CredentialRef == "" {
+		return AuthConfig{}, nil
+	}
+	if imp.credentialResolver == nil {
+		return AuthConfig{}, fmt.Errorf("%w: credential %q requires a resolver; vault not available", gitpkg.ErrAuthFailed, origin.CredentialRef)
+	}
+	token, err := imp.credentialResolver(origin.CredentialRef)
+	if err != nil {
+		return AuthConfig{}, fmt.Errorf("%w: resolving %q: %w", gitpkg.ErrAuthFailed, origin.CredentialRef, err)
+	}
+	if token == "" {
+		return AuthConfig{}, fmt.Errorf("%w: %q resolved to empty value", gitpkg.ErrEmptyToken, origin.CredentialRef)
+	}
+	return AuthConfig{
+		Method:        "token",
+		Token:         token,
+		CredentialRef: origin.CredentialRef,
+	}, nil
 }

--- a/pkg/skills/lockfile.go
+++ b/pkg/skills/lockfile.go
@@ -16,13 +16,16 @@ type LockFile struct {
 
 // LockedSource records the resolved state of a skill source.
 type LockedSource struct {
-	Repo        string                `yaml:"repo"`
-	Ref         string                `yaml:"ref"`
-	ResolvedRef string                `yaml:"resolved_ref,omitempty"`
-	CommitSHA   string                `yaml:"commit_sha"`
-	FetchedAt   time.Time             `yaml:"fetched_at"`
-	ContentHash string                `yaml:"content_hash"`
+	Repo        string                 `yaml:"repo"`
+	Ref         string                 `yaml:"ref"`
+	ResolvedRef string                 `yaml:"resolved_ref,omitempty"`
+	CommitSHA   string                 `yaml:"commit_sha"`
+	FetchedAt   time.Time              `yaml:"fetched_at"`
+	ContentHash string                 `yaml:"content_hash"`
 	Skills      map[string]LockedSkill `yaml:"skills"`
+	// CredentialRef is an opaque reference like "${vault:GIT_TOKEN}" used to
+	// re-resolve credentials on source update. Raw tokens are never stored.
+	CredentialRef string `yaml:"credential_ref,omitempty"`
 }
 
 // LockedSkill records per-skill metadata within a source.

--- a/pkg/skills/lockfile_test.go
+++ b/pkg/skills/lockfile_test.go
@@ -43,6 +43,33 @@ func TestLockFileReadWrite(t *testing.T) {
 	assert.Equal(t, "hash1", src.Skills["deploy"].ContentHash)
 }
 
+func TestLockFile_CredentialRefRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "skills.lock.yaml")
+
+	lf := &LockFile{
+		Sources: map[string]LockedSource{
+			"private": {
+				Repo:          "https://gitlab.internal/team/skills",
+				Ref:           "main",
+				CommitSHA:     "abc",
+				FetchedAt:     time.Now().UTC(),
+				CredentialRef: "${vault:GIT_TOKEN}",
+				Skills:        map[string]LockedSkill{"x": {Path: "x"}},
+			},
+		},
+	}
+	require.NoError(t, WriteLockFile(path, lf))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "${vault:GIT_TOKEN}")
+
+	got, err := ReadLockFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "${vault:GIT_TOKEN}", got.Sources["private"].CredentialRef)
+}
+
 func TestLockFileReadNotFound(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nonexistent.yaml")

--- a/pkg/skills/origin.go
+++ b/pkg/skills/origin.go
@@ -18,6 +18,10 @@ type Origin struct {
 	ImportedAt  time.Time    `json:"importedAt"`
 	ContentHash string       `json:"contentHash"`
 	Fingerprint *Fingerprint `json:"fingerprint,omitempty"`
+	// CredentialRef is an opaque reference like "${vault:GIT_TOKEN}" used to
+	// re-resolve credentials on skill update. Raw token values are never
+	// persisted — only the reference string.
+	CredentialRef string `json:"credentialRef,omitempty"`
 }
 
 const originFileName = ".origin.json"

--- a/pkg/skills/origin_test.go
+++ b/pkg/skills/origin_test.go
@@ -76,3 +76,43 @@ func TestReadOriginInvalid(t *testing.T) {
 	_, err := ReadOrigin(dir)
 	assert.Error(t, err)
 }
+
+func TestOrigin_CredentialRefRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	origin := &Origin{
+		Repo:          "https://github.com/org/private",
+		Ref:           "main",
+		CommitSHA:     "deadbeef",
+		ImportedAt:    time.Now().UTC(),
+		ContentHash:   "aabbcc",
+		CredentialRef: "${vault:GIT_TOKEN}",
+	}
+	require.NoError(t, WriteOrigin(dir, origin))
+
+	// Verify the token REFERENCE is persisted but no raw value ever is.
+	raw, err := os.ReadFile(filepath.Join(dir, ".origin.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "${vault:GIT_TOKEN}")
+
+	got, err := ReadOrigin(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "${vault:GIT_TOKEN}", got.CredentialRef)
+}
+
+func TestOrigin_NoCredentialRefOmitted(t *testing.T) {
+	dir := t.TempDir()
+
+	origin := &Origin{
+		Repo:        "https://github.com/org/public",
+		Ref:         "main",
+		CommitSHA:   "abc",
+		ImportedAt:  time.Now().UTC(),
+		ContentHash: "hash",
+	}
+	require.NoError(t, WriteOrigin(dir, origin))
+
+	raw, err := os.ReadFile(filepath.Join(dir, ".origin.json"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "credentialRef")
+}

--- a/pkg/skills/remote.go
+++ b/pkg/skills/remote.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	"github.com/gridctl/gridctl/pkg/builder"
 	gitpkg "github.com/gridctl/gridctl/pkg/git"
@@ -33,22 +32,22 @@ type DiscoveredSkill struct {
 	ContentHash string
 }
 
-// skillsAuth returns a transport.AuthMethod built from the GITHUB_TOKEN env
-// var, or nil if the env var is not set. The token-backed flow will be
-// replaced by a pluggable Auther interface in a follow-up change; keeping it
-// as a private helper here preserves the current behavior.
-func skillsAuth() transport.AuthMethod {
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-		return &http.BasicAuth{Username: token, Password: ""}
+// authMethodFor maps an AuthConfig + URL into the concrete
+// transport.AuthMethod that go-git uses. Errors surface as-is from the
+// underlying Auther (e.g. ErrEmptyToken, ErrProtocolMismatch).
+func authMethodFor(cfg AuthConfig, url string) (transport.AuthMethod, error) {
+	auther, err := resolveAuther(cfg, url)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	return auther.AuthFor(url)
 }
 
 // CloneAndDiscover clones a repo and discovers all SKILL.md files.
-func CloneAndDiscover(repo, ref, subPath string, logger *slog.Logger) (*CloneResult, error) {
-	repoPath, err := cloneShallow(repo, ref, logger)
+func CloneAndDiscover(repo, ref, subPath string, auth AuthConfig, logger *slog.Logger) (*CloneResult, error) {
+	repoPath, err := cloneShallow(repo, ref, auth, logger)
 	if err != nil {
-		return nil, fmt.Errorf("cloning repository: %w", err)
+		return nil, fmt.Errorf("cloning repository: %w", gitpkg.RedactError(err))
 	}
 
 	commitSHA, err := gitpkg.HeadCommit(repoPath)
@@ -77,7 +76,7 @@ func CloneAndDiscover(repo, ref, subPath string, logger *slog.Logger) (*CloneRes
 }
 
 // FetchAndCompare fetches the latest from a remote and compares with current.
-func FetchAndCompare(repo, ref string, currentSHA string, logger *slog.Logger) (string, bool, error) {
+func FetchAndCompare(repo, ref, currentSHA string, auth AuthConfig, logger *slog.Logger) (string, bool, error) {
 	repoPath, err := builder.URLToPath(repo)
 	if err != nil {
 		return "", false, fmt.Errorf("getting cache path: %w", err)
@@ -88,8 +87,13 @@ func FetchAndCompare(repo, ref string, currentSHA string, logger *slog.Logger) (
 		return "", true, nil
 	}
 
-	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{Auth: skillsAuth()}, logger); err != nil {
-		logger.Warn("fetch failed", "error", err)
+	authMethod, err := authMethodFor(auth, repo)
+	if err != nil {
+		return currentSHA, false, gitpkg.RedactError(err)
+	}
+
+	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{Auth: authMethod}, logger); err != nil {
+		logger.Warn("fetch failed", "error", gitpkg.RedactError(err))
 		return currentSHA, false, nil
 	}
 
@@ -119,7 +123,7 @@ func ListRemoteTags(repoPath string) ([]string, error) {
 	return gitpkg.ListTags(repoPath)
 }
 
-func cloneShallow(url, ref string, logger *slog.Logger) (string, error) {
+func cloneShallow(url, ref string, auth AuthConfig, logger *slog.Logger) (string, error) {
 	if err := builder.EnsureReposCacheDir(); err != nil {
 		return "", fmt.Errorf("creating cache dir: %w", err)
 	}
@@ -131,7 +135,12 @@ func cloneShallow(url, ref string, logger *slog.Logger) (string, error) {
 
 	// If repo exists, fetch updates instead
 	if _, err := os.Stat(repoPath); err == nil {
-		return updateExisting(repoPath, ref, logger)
+		return updateExisting(repoPath, url, ref, auth, logger)
+	}
+
+	authMethod, err := authMethodFor(auth, url)
+	if err != nil {
+		return "", err
 	}
 
 	cloneRef := ref
@@ -144,7 +153,7 @@ func cloneShallow(url, ref string, logger *slog.Logger) (string, error) {
 		Ref:     cloneRef,
 		Depth:   1,
 		AllTags: true,
-		Auth:    skillsAuth(),
+		Auth:    authMethod,
 	}, logger)
 	if err != nil {
 		return "", fmt.Errorf("cloning: %w", err)
@@ -173,7 +182,7 @@ func cloneShallow(url, ref string, logger *slog.Logger) (string, error) {
 	return repoPath, nil
 }
 
-func updateExisting(repoPath, ref string, logger *slog.Logger) (string, error) {
+func updateExisting(repoPath, url, ref string, auth AuthConfig, logger *slog.Logger) (string, error) {
 	logger.Info("updating cached repository")
 
 	// Fail fast on a corrupt cache (mirrors previous behavior).
@@ -183,8 +192,13 @@ func updateExisting(repoPath, ref string, logger *slog.Logger) (string, error) {
 		return "", fmt.Errorf("opening cached repo (removed): %w", err)
 	}
 
-	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{AllTags: true, Auth: skillsAuth()}, logger); err != nil {
-		logger.Warn("fetch failed, using cached", "error", err)
+	authMethod, err := authMethodFor(auth, url)
+	if err != nil {
+		return "", err
+	}
+
+	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{AllTags: true, Auth: authMethod}, logger); err != nil {
+		logger.Warn("fetch failed, using cached", "error", gitpkg.RedactError(err))
 	}
 
 	if ref != "" {

--- a/pkg/skills/updater.go
+++ b/pkg/skills/updater.go
@@ -127,7 +127,14 @@ func checkAllUpdates(registryDir string, logger *slog.Logger) *UpdateStatus {
 				return
 			}
 
-			newSHA, changed, err := FetchAndCompare(origin.Repo, origin.Ref, origin.CommitSHA, logger)
+			// Background check uses ambient auth only. A stored CredentialRef
+			// is recorded on origin, but resolving vault refs from a
+			// background goroutine requires a wired resolver — skip that
+			// source rather than fail loudly.
+			if origin.CredentialRef != "" {
+				return
+			}
+			newSHA, changed, err := FetchAndCompare(origin.Repo, origin.Ref, origin.CommitSHA, AuthConfig{}, logger)
 			if err != nil {
 				mu.Lock()
 				status.Errors = append(status.Errors, fmt.Sprintf("%s: %v", name, err))


### PR DESCRIPTION
## Description

Wires the auth primitives from #502 through the skills importer, CLI, and HTTP API. Adds `AuthConfig` on `ImportOptions`, `CredentialRef` on Origin + LockedSource, CLI flags (`--auth-token`, `--vault-key`, `--ssh-key`), auth request body on `/api/skills/sources/*`, and classified + redacted error responses.

PR 3 of 5 for private-repo support. Public flows stay backward-compatible — `GITHUB_TOKEN` still works as the ambient HTTPS fallback; flagless CLI calls unchanged; UI stays untouched (that's PR 4).

## Type of Change

- [x] New feature (additive, non-breaking)

## Changes Made

**Importer (`pkg/skills`)**
- `AuthConfig` struct on `ImportOptions`; `BuildAuther` constructs the right `git.Auther` per method; `resolveAuther` preserves `GITHUB_TOKEN` fallback for HTTPS and falls to `NoAuth` otherwise
- `CredentialResolver` type + `Importer.SetCredentialResolver` so `Update` can re-resolve stored refs; `authFromOrigin` fails loudly (`ErrAuthFailed`) when no resolver is wired for a credential-bearing origin
- `Origin.CredentialRef` and `LockedSource.CredentialRef` persist only the `${vault:KEY}` reference — never raw tokens
- `SourceAuth` block on `skills.yaml` sources + `ToAuthConfig()` converter
- `CloneAndDiscover` / `FetchAndCompare` now take `AuthConfig`; URL + error redaction via `gitpkg.RedactURL` / `gitpkg.RedactError`
- Old `skillsAuth()` helper removed

**CLI (`cmd/gridctl/skill.go`)**
- `--auth-token`, `--vault-key`, `--ssh-key` on `skill add` and `skill try`; mutual exclusion via `PreRunE`
- `cliCredentialResolver` unlocks the vault lazily and resolves `${vault:KEY}`
- `printSkillAuthHint` emits actionable guidance on classified auth errors

**HTTP API (`internal/api/skills.go`)**
- `AuthRequest` in request bodies for add / preview / check / update; vault refs resolved against the live `Server.vaultStore` on every request
- `writeGitError` + `gitErrorStatus` classify and redact errors, mapping sentinels to 401 / 404 / 400 / 500 as appropriate
- Background updater skips sources with stored `CredentialRef` (no resolver in background context)

**Tests**
- `pkg/skills/auth_test.go`: 10 tests — `BuildAuther` per method, `resolveAuther` fallback precedence, `authFromOrigin`, `SourceAuth`
- `pkg/skills/origin_test.go` / `lockfile_test.go`: `CredentialRef` round-trip verifying raw tokens never hit disk
- `internal/api/skills_auth_test.go`: 8 tests — `AuthRequest.toAuthConfig` (nil / token / ssh-key / vault-resolved / missing vault key / nil vault); `gitErrorStatus` for each sentinel

## Testing

- `go build ./...` — clean
- `go test -race ./...` — all pass (one pre-existing flake in `internal/api` unrelated to this diff)
- `golangci-lint run ./...` — 0 issues
- `go mod tidy` — empty diff (no new deps)
- `pkg/skills` coverage 48.7% (up from 47.3%)
- `pkg/git` coverage 89.3% (unchanged)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #500