### PR TITLE
feat: add git auth UI to skill wizard and MCP source form

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -262,7 +262,11 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("DELETE /api/skills/sources/{name}", s.handleSkillSourceRemove)
 	mux.HandleFunc("POST /api/skills/sources/{name}/check", s.handleSkillSourceCheck)
 	mux.HandleFunc("POST /api/skills/sources/{name}/update", s.handleSkillSourceUpdate)
+	// Preview accepts either GET (query params, no auth) or POST (JSON body,
+	// with optional auth) so the wizard can pass credentials without
+	// leaking them into query strings or browser history.
 	mux.HandleFunc("GET /api/skills/sources/{name}/preview", s.handleSkillSourcePreview)
+	mux.HandleFunc("POST /api/skills/sources/{name}/preview", s.handleSkillSourcePreview)
 
 	// Wizard endpoints
 	mux.HandleFunc("GET /api/wizard/drafts", s.handleWizardDraftsList)

--- a/internal/api/skills.go
+++ b/internal/api/skills.go
@@ -452,7 +452,8 @@ func (s *Server) handleSkillSourceUpdate(w http.ResponseWriter, r *http.Request)
 }
 
 // handleSkillSourcePreview previews skills in a source without importing.
-// GET /api/skills/sources/{name}/preview
+// GET  /api/skills/sources/{name}/preview  — query-param driven, no auth
+// POST /api/skills/sources/{name}/preview  — JSON body with optional auth
 func (s *Server) handleSkillSourcePreview(w http.ResponseWriter, r *http.Request) {
 	sourceName := r.PathValue("name")
 
@@ -461,10 +462,29 @@ func (s *Server) handleSkillSourcePreview(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Get repo URL from query params or lock file
+	// Query-param values are the GET path; POST bodies override/augment.
 	repo := r.URL.Query().Get("repo")
 	ref := r.URL.Query().Get("ref")
 	path := r.URL.Query().Get("path")
+
+	var reqBody struct {
+		Repo string       `json:"repo,omitempty"`
+		Ref  string       `json:"ref,omitempty"`
+		Path string       `json:"path,omitempty"`
+		Auth *AuthRequest `json:"auth,omitempty"`
+	}
+	if r.Method == http.MethodPost && r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&reqBody)
+		if reqBody.Repo != "" {
+			repo = reqBody.Repo
+		}
+		if reqBody.Ref != "" {
+			ref = reqBody.Ref
+		}
+		if reqBody.Path != "" {
+			path = reqBody.Path
+		}
+	}
 
 	var storedRef string
 	if repo == "" {
@@ -480,19 +500,11 @@ func (s *Server) handleSkillSourcePreview(w http.ResponseWriter, r *http.Request
 	}
 
 	if repo == "" {
-		writeJSONError(w, "repo URL required (query param or existing source)", http.StatusBadRequest)
+		writeJSONError(w, "repo URL required (query param, body, or existing source)", http.StatusBadRequest)
 		return
 	}
 
-	// Optional auth can be supplied in the JSON body of POST; for GET,
-	// fall back to a stored CredentialRef if the lookup above found one.
-	var req struct {
-		Auth *AuthRequest `json:"auth,omitempty"`
-	}
-	if r.Body != nil && r.ContentLength > 0 {
-		_ = json.NewDecoder(r.Body).Decode(&req)
-	}
-	authCfg, err := s.resolveCheckAuth(req.Auth, storedRef)
+	authCfg, err := s.resolveCheckAuth(reqBody.Auth, storedRef)
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusBadRequest)
 		return

--- a/web/src/__tests__/AddSourceStep.test.tsx
+++ b/web/src/__tests__/AddSourceStep.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AddSourceStep } from '../components/wizard/steps/AddSourceStep';
+
+// Re-export the real HTTPError class so the component can use `instanceof`
+// against the error type that our mocked previewSkillSource rejects with.
+vi.mock('../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
+  return {
+    ...actual,
+    fetchSkillSources: vi.fn().mockResolvedValue([]),
+    previewSkillSource: vi.fn(),
+    fetchVaultSecrets: vi.fn().mockResolvedValue([]),
+    createVaultSecret: vi.fn(),
+  };
+});
+
+vi.mock('../components/ui/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+import { previewSkillSource, HTTPError } from '../lib/api';
+
+const mockPreview = vi.mocked(previewSkillSource);
+
+describe('AddSourceStep — auth card', () => {
+  beforeEach(() => {
+    mockPreview.mockReset();
+  });
+
+  it('auth card is collapsed by default and labelled optional', () => {
+    render(<AddSourceStep onPreviewLoaded={vi.fn()} />);
+    const toggle = screen.getByRole('button', { name: /authentication/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle.textContent).toMatch(/optional/i);
+  });
+
+  it('clicking the toggle expands the auth card', () => {
+    render(<AddSourceStep onPreviewLoaded={vi.fn()} />);
+    const toggle = screen.getByRole('button', { name: /authentication/i });
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText(/vault secret/i)).toBeInTheDocument();
+    expect(screen.getByText(/paste token/i)).toBeInTheDocument();
+  });
+
+  it('auto-opens and shows a banner when scan fails with 401', async () => {
+    mockPreview.mockRejectedValueOnce(new HTTPError(401, 'authentication required'));
+
+    render(<AddSourceStep onPreviewLoaded={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText(/https:\/\/github/i), {
+      target: { value: 'https://github.com/acme/private' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /scan for skills/i }));
+
+    await waitFor(() => {
+      const toggle = screen.getByRole('button', { name: /authentication/i });
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    });
+    expect(screen.getByText(/requires authentication/i)).toBeInTheDocument();
+  });
+
+  it('auto-opens with "not found" banner on 404', async () => {
+    mockPreview.mockRejectedValueOnce(new HTTPError(404, 'repository not found'));
+
+    render(<AddSourceStep onPreviewLoaded={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText(/https:\/\/github/i), {
+      target: { value: 'https://github.com/acme/private' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /scan for skills/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/if this is a private repository/i)).toBeInTheDocument();
+    });
+  });
+
+  it('passes the paste-token to previewSkillSource on retry', async () => {
+    mockPreview.mockResolvedValueOnce({
+      repo: 'https://github.com/acme/private',
+      ref: '',
+      commitSha: 'abc',
+      skills: [
+        {
+          name: 's',
+          description: '',
+          body: '',
+          valid: true,
+          errors: [],
+          warnings: [],
+          findings: [],
+          exists: false,
+        },
+      ],
+    });
+    const onPreview = vi.fn();
+
+    render(<AddSourceStep onPreviewLoaded={onPreview} />);
+    fireEvent.change(screen.getByPlaceholderText(/https:\/\/github/i), {
+      target: { value: 'https://github.com/acme/private' },
+    });
+
+    // Expand the auth card, switch to paste, enter a token.
+    fireEvent.click(screen.getByRole('button', { name: /authentication/i }));
+    fireEvent.click(screen.getByLabelText(/paste token/i));
+    fireEvent.change(screen.getByPlaceholderText(/personal access token/i), {
+      target: { value: 'my-pat' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /scan for skills/i }));
+
+    await waitFor(() => expect(mockPreview).toHaveBeenCalledTimes(1));
+    const [, params] = mockPreview.mock.calls[0];
+    expect(params?.auth).toEqual({ method: 'token', token: 'my-pat' });
+    expect(onPreview).toHaveBeenCalledWith(
+      expect.any(Array),
+      'https://github.com/acme/private',
+      '',
+      '',
+      { method: 'token', token: 'my-pat' },
+    );
+  });
+
+  it('omits auth for SSH URLs (ambient ssh-agent)', async () => {
+    mockPreview.mockResolvedValueOnce({
+      repo: 'git@github.com:acme/private.git',
+      ref: '',
+      commitSha: 'abc',
+      skills: [
+        {
+          name: 's',
+          description: '',
+          body: '',
+          valid: true,
+          errors: [],
+          warnings: [],
+          findings: [],
+          exists: false,
+        },
+      ],
+    });
+
+    render(<AddSourceStep onPreviewLoaded={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText(/https:\/\/github/i), {
+      target: { value: 'git@github.com:acme/private.git' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /authentication/i }));
+    // SSH variant shows a hint inside the expanded body, not token inputs.
+    // The phrase also appears in the collapsed toggle label, so just assert
+    // that the panel is expanded and the password input is absent.
+    expect(screen.queryByPlaceholderText(/personal access token/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/using ssh-agent/i).length).toBeGreaterThanOrEqual(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /scan for skills/i }));
+    await waitFor(() => expect(mockPreview).toHaveBeenCalledTimes(1));
+    const [, params] = mockPreview.mock.calls[0];
+    expect(params?.auth).toBeUndefined();
+  });
+});

--- a/web/src/__tests__/MCPServerForm.test.tsx
+++ b/web/src/__tests__/MCPServerForm.test.tsx
@@ -498,6 +498,57 @@ describe('YAML serialization — new fields', () => {
     expect(yaml).not.toContain('tls:');
   });
 
+  it('serializes source.auth as a credential_ref (vault reference)', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'my-server',
+        serverType: 'source',
+        source: {
+          type: 'git',
+          url: 'https://gitlab.internal/team/mcp-foo.git',
+          ref: 'main',
+          auth: { method: 'token', credentialRef: '${vault:GIT_TOKEN}' },
+        },
+      },
+    });
+    expect(yaml).toContain('auth:');
+    expect(yaml).toContain('method: token');
+    expect(yaml).toContain('credential_ref: "${vault:GIT_TOKEN}"');
+  });
+
+  it('never emits a raw token field under source.auth', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'my-server',
+        serverType: 'source',
+        source: {
+          type: 'git',
+          url: 'https://gitlab.internal/team/mcp-foo.git',
+          auth: { method: 'token', credentialRef: '${vault:GIT_TOKEN}' },
+        },
+      },
+    });
+    expect(yaml).not.toMatch(/\btoken:\s/);
+  });
+
+  it('omits the source.auth block entirely when credentialRef is missing', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'my-server',
+        serverType: 'source',
+        source: {
+          type: 'git',
+          url: 'https://github.com/public/repo.git',
+        },
+      },
+    });
+    expect(yaml).not.toContain('auth:');
+    expect(yaml).not.toContain('credential_ref');
+  });
+
   it('serializes pin_schemas: true when enabled', () => {
     const yaml = buildYAML({
       type: 'mcp-server',

--- a/web/src/components/wizard/steps/AddSourceStep.tsx
+++ b/web/src/components/wizard/steps/AddSourceStep.tsx
@@ -7,19 +7,57 @@ import {
   ExternalLink,
   FolderGit2,
   Clock,
+  ShieldCheck,
+  ChevronDown,
+  ChevronRight,
+  KeyRound,
+  X,
 } from 'lucide-react';
 import { cn } from '../../../lib/cn';
 import { Button } from '../../ui/Button';
-import { previewSkillSource, fetchSkillSources } from '../../../lib/api';
+import {
+  previewSkillSource,
+  fetchSkillSources,
+  HTTPError,
+  type SkillAuth,
+} from '../../../lib/api';
 import { showToast } from '../../ui/Toast';
+import { SecretsPopover } from '../SecretsPopover';
 import type { SkillPreview, SkillSourceStatus } from '../../../types';
 
 interface AddSourceStepProps {
-  onPreviewLoaded: (skills: SkillPreview[], repo: string, ref: string, path: string) => void;
+  onPreviewLoaded: (
+    skills: SkillPreview[],
+    repo: string,
+    ref: string,
+    path: string,
+    auth: SkillAuth | undefined,
+  ) => void;
 }
 
 const GITHUB_URL_REGEX = /^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/?$/;
 const GIT_URL_REGEX = /^(?:https?:\/\/|git@)[\w.-]+[:/][\w.-]+\/[\w.-]+(?:\.git)?$/;
+
+type AuthMode = 'vault' | 'token';
+
+function isSSHUrl(url: string): boolean {
+  const trimmed = url.trim();
+  return trimmed.startsWith('git@') || trimmed.startsWith('ssh://');
+}
+
+// Classify a scan error to decide whether to auto-open the auth card.
+function shouldOpenAuthCard(err: unknown): boolean {
+  if (err instanceof HTTPError) {
+    if (err.status === 401 || err.status === 404) return true;
+  }
+  const msg = err instanceof Error ? err.message.toLowerCase() : '';
+  return (
+    msg.includes('authentication required') ||
+    msg.includes('authentication failed') ||
+    msg.includes('repository not found') ||
+    msg.includes('credentials were rejected')
+  );
+}
 
 export function AddSourceStep({ onPreviewLoaded }: AddSourceStepProps) {
   const [url, setUrl] = useState('');
@@ -30,6 +68,15 @@ export function AddSourceStep({ onPreviewLoaded }: AddSourceStepProps) {
   const [recentSources, setRecentSources] = useState<SkillSourceStatus[]>([]);
   const [loadedRecent, setLoadedRecent] = useState(false);
   const urlInputRef = useRef<HTMLInputElement>(null);
+
+  // Auth card state — the whole card is transient, never persisted.
+  const [authOpen, setAuthOpen] = useState(false);
+  const [authMode, setAuthMode] = useState<AuthMode>('vault');
+  const [vaultRef, setVaultRef] = useState<string>('');
+  const [pasteToken, setPasteToken] = useState<string>('');
+  const [authBanner, setAuthBanner] = useState<string | null>(null);
+
+  const ssh = isSSHUrl(url);
 
   // Load recent sources on mount
   const loadRecent = useCallback(async () => {
@@ -58,6 +105,19 @@ export function AddSourceStep({ onPreviewLoaded }: AddSourceStepProps) {
     return null;
   };
 
+  // Build a SkillAuth from the current card state, or undefined to signal
+  // "ambient" (no auth header at all) which preserves public-repo behavior.
+  const buildAuth = useCallback((): SkillAuth | undefined => {
+    if (ssh) return undefined; // ambient ssh-agent
+    if (authMode === 'vault' && vaultRef) {
+      return { method: 'token', credentialRef: vaultRef };
+    }
+    if (authMode === 'token' && pasteToken) {
+      return { method: 'token', token: pasteToken };
+    }
+    return undefined;
+  }, [ssh, authMode, vaultRef, pasteToken]);
+
   const handleScan = async () => {
     const trimmedUrl = url.trim();
     if (!trimmedUrl) return;
@@ -69,6 +129,9 @@ export function AddSourceStep({ onPreviewLoaded }: AddSourceStepProps) {
 
     setLoading(true);
     setError(null);
+    setAuthBanner(null);
+
+    const auth = buildAuth();
 
     try {
       const sourceName = trimmedUrl.split('/').pop()?.replace(/\.git$/, '') ?? 'source';
@@ -76,6 +139,7 @@ export function AddSourceStep({ onPreviewLoaded }: AddSourceStepProps) {
         repo: trimmedUrl,
         ref: ref || undefined,
         path: path || undefined,
+        auth,
       });
 
       if (result.skills.length === 0) {
@@ -83,11 +147,20 @@ export function AddSourceStep({ onPreviewLoaded }: AddSourceStepProps) {
         return;
       }
 
-      onPreviewLoaded(result.skills, trimmedUrl, ref, path);
+      onPreviewLoaded(result.skills, trimmedUrl, ref, path, auth);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to scan repository';
       setError(msg);
       showToast('error', msg);
+
+      if (shouldOpenAuthCard(err) && !ssh) {
+        setAuthOpen(true);
+        setAuthBanner(
+          err instanceof HTTPError && err.status === 404
+            ? 'Not found. If this is a private repository, add credentials below and try again.'
+            : 'This repository requires authentication.',
+        );
+      }
     } finally {
       setLoading(false);
     }
@@ -188,6 +261,124 @@ export function AddSourceStep({ onPreviewLoaded }: AddSourceStepProps) {
           </div>
         </div>
 
+        {/* Auth card — inline collapsible. Collapsed by default; auto-opens
+            on 401/404 from a scan. Transient only: never persisted. */}
+        <div
+          data-testid="auth-card"
+          className={cn(
+            'rounded-lg border border-border/30 bg-white/[0.02] transition-colors',
+            authOpen && 'border-border/50 bg-white/[0.03]',
+          )}
+        >
+          <button
+            type="button"
+            aria-expanded={authOpen}
+            aria-controls="auth-card-body"
+            onClick={() => setAuthOpen((v) => !v)}
+            className="w-full flex items-center gap-2 px-3 py-2 text-[11px] text-text-secondary hover:text-text-primary transition-colors"
+          >
+            <ShieldCheck size={12} className="text-primary/70" />
+            <span className="font-medium">Authentication</span>
+            <span className="text-text-muted text-[10px]">
+              {ssh ? '— using ssh-agent' : authOpen ? '' : '(optional)'}
+            </span>
+            <span className="ml-auto text-text-muted">
+              {authOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+            </span>
+          </button>
+
+          {authOpen && (
+            <div
+              id="auth-card-body"
+              className="px-3 pb-3 pt-1 space-y-2.5 border-t border-border/20"
+            >
+              {authBanner && (
+                <div className="flex items-start gap-1.5 text-[10px] text-status-pending bg-status-pending/5 border border-status-pending/20 rounded-md px-2 py-1.5">
+                  <AlertCircle size={10} className="mt-0.5 flex-shrink-0" />
+                  <span>{authBanner}</span>
+                </div>
+              )}
+
+              {ssh ? (
+                <div className="flex items-center gap-1.5 text-[10px] text-text-muted">
+                  <KeyRound size={10} />
+                  <span>Using ssh-agent — no token needed.</span>
+                </div>
+              ) : (
+                <>
+                  {/* Mode selector — real radios for accessibility */}
+                  <fieldset className="flex gap-1 text-[10px]">
+                    <legend className="sr-only">Authentication method</legend>
+                    {(
+                      [
+                        { v: 'vault', label: 'Vault secret', sub: 'recommended' },
+                        { v: 'token', label: 'Paste token', sub: 'not saved' },
+                      ] as const
+                    ).map((opt) => (
+                      <label
+                        key={opt.v}
+                        className={cn(
+                          'flex-1 cursor-pointer rounded-md px-2 py-1.5 border text-center transition-colors',
+                          authMode === opt.v
+                            ? 'bg-primary/10 border-primary/30 text-primary'
+                            : 'bg-white/[0.02] border-white/[0.06] text-text-muted hover:text-text-secondary',
+                        )}
+                      >
+                        <input
+                          type="radio"
+                          name="auth-mode"
+                          value={opt.v}
+                          checked={authMode === opt.v}
+                          onChange={() => setAuthMode(opt.v)}
+                          className="sr-only"
+                        />
+                        <span className="block font-medium">{opt.label}</span>
+                        <span className="block text-[9px] opacity-70">{opt.sub}</span>
+                      </label>
+                    ))}
+                  </fieldset>
+
+                  {authMode === 'vault' ? (
+                    <div className="flex items-center gap-2">
+                      {vaultRef ? (
+                        <div className="flex-1 flex items-center justify-between gap-2 bg-background/60 border border-border/40 rounded-md px-2 py-1.5 text-[10px] font-mono text-text-primary">
+                          <span className="truncate">{vaultRef}</span>
+                          <button
+                            type="button"
+                            onClick={() => setVaultRef('')}
+                            className="text-text-muted hover:text-status-error transition-colors"
+                            aria-label="Clear vault selection"
+                          >
+                            <X size={11} />
+                          </button>
+                        </div>
+                      ) : (
+                        <div className="flex-1 text-[10px] text-text-muted italic px-1">
+                          Choose a vault key →
+                        </div>
+                      )}
+                      <SecretsPopover onSelect={setVaultRef} />
+                    </div>
+                  ) : (
+                    <>
+                      <input
+                        type="password"
+                        value={pasteToken}
+                        onChange={(e) => setPasteToken(e.target.value)}
+                        placeholder="Personal Access Token"
+                        className="w-full bg-background/60 border border-border/40 rounded-md px-2 py-1.5 text-[11px] font-mono focus:outline-none focus:border-primary/50 text-text-primary placeholder:text-text-muted/50 transition-colors"
+                      />
+                      <p className="text-[10px] text-text-muted">
+                        Used once for this scan — not saved anywhere.
+                      </p>
+                    </>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
         {/* Scan button */}
         <Button
           variant="primary"
@@ -208,6 +399,13 @@ export function AddSourceStep({ onPreviewLoaded }: AddSourceStepProps) {
             </>
           )}
         </Button>
+
+        {/* First-run tip when the list is empty */}
+        {loadedRecent && recentSources.length === 0 && (
+          <p className="text-[10px] text-text-muted text-center italic">
+            Private repo? Set your token in Vault first, then choose it above.
+          </p>
+        )}
       </div>
 
       {/* Recent sources */}

--- a/web/src/components/wizard/steps/MCPServerForm.tsx
+++ b/web/src/components/wizard/steps/MCPServerForm.tsx
@@ -13,6 +13,7 @@ import {
   Zap,
   AlertCircle,
   KeyRound,
+  ShieldCheck,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '../../../lib/cn';
@@ -641,6 +642,20 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
                       />
                     </div>
                   </div>
+                  <SourceAuthField
+                    value={data.source?.auth?.credentialRef}
+                    onChange={(credentialRef) =>
+                      onChange({
+                        source: {
+                          ...data.source,
+                          type: 'git',
+                          auth: credentialRef
+                            ? { method: 'token', credentialRef }
+                            : undefined,
+                        } as MCPServerFormData['source'],
+                      })
+                    }
+                  />
                 </>
               ) : (
                 <div>
@@ -1434,6 +1449,71 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
           </div>
         )}
       </Section>
+    </div>
+  );
+}
+
+// SourceAuthField — inline collapsible "Repository Authentication" block for
+// private git sources. Persisted to YAML as a vault reference only (no raw
+// tokens); the server resolves it against the live vault at clone time.
+function SourceAuthField({
+  value,
+  onChange,
+}: {
+  value: string | undefined;
+  onChange: (credentialRef: string | undefined) => void;
+}) {
+  const [open, setOpen] = useState(Boolean(value));
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-border/30 bg-white/[0.02] transition-colors',
+        open && 'border-border/50 bg-white/[0.03]',
+      )}
+    >
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-[11px] text-text-secondary hover:text-text-primary transition-colors"
+      >
+        <ShieldCheck size={12} className="text-primary/70" />
+        <span className="font-medium">Repository Authentication</span>
+        <span className="text-text-muted text-[10px]">
+          {value ? '' : '(optional, for private repos)'}
+        </span>
+        <span className="ml-auto text-text-muted">
+          {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        </span>
+      </button>
+      {open && (
+        <div className="px-3 pb-3 pt-1 space-y-2 border-t border-border/20">
+          <p className="text-[10px] text-text-muted">
+            Choose a vault key that holds a Personal Access Token. The server
+            resolves it at clone time; the raw value never enters the YAML.
+          </p>
+          <div className="flex items-center gap-2">
+            {value ? (
+              <div className="flex-1 flex items-center justify-between gap-2 bg-background/60 border border-border/40 rounded-md px-2 py-1.5 text-[10px] font-mono text-text-primary">
+                <span className="truncate">{value}</span>
+                <button
+                  type="button"
+                  onClick={() => onChange(undefined)}
+                  className="text-text-muted hover:text-status-error transition-colors"
+                  aria-label="Clear vault selection"
+                >
+                  <X size={11} />
+                </button>
+              </div>
+            ) : (
+              <div className="flex-1 text-[10px] text-text-muted italic px-1">
+                No credential selected
+              </div>
+            )}
+            <SecretsPopover onSelect={onChange} />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/wizard/steps/SkillImportWizard.tsx
+++ b/web/src/components/wizard/steps/SkillImportWizard.tsx
@@ -12,7 +12,12 @@ import { Button } from '../../ui/Button';
 import { AddSourceStep } from './AddSourceStep';
 import { BrowseStep } from './BrowseStep';
 import { showToast } from '../../ui/Toast';
-import { addSkillSource, fetchRegistrySkills, fetchRegistryStatus } from '../../../lib/api';
+import {
+  addSkillSource,
+  fetchRegistrySkills,
+  fetchRegistryStatus,
+  type SkillAuth,
+} from '../../../lib/api';
 import { useRegistryStore } from '../../../stores/useRegistryStore';
 import type { SkillPreview } from '../../../types';
 
@@ -28,6 +33,7 @@ export function SkillImportWizard() {
   const [repoUrl, setRepoUrl] = useState('');
   const [ref, setRef] = useState('');
   const [path, setPath] = useState('');
+  const [auth, setAuth] = useState<SkillAuth | undefined>(undefined);
   const [previews, setPreviews] = useState<SkillPreview[]>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [configs, setConfigs] = useState<Map<string, SkillConfig>>(new Map());
@@ -43,25 +49,35 @@ export function SkillImportWizard() {
   const stepOrder: ImportStep[] = ['source', 'browse', 'configure', 'install'];
   const stepIdx = stepOrder.indexOf(step);
 
-  const handlePreviewLoaded = useCallback((skills: SkillPreview[], repo: string, refVal: string, pathVal: string) => {
-    setPreviews(skills);
-    setRepoUrl(repo);
-    setRef(refVal);
-    setPath(pathVal);
+  const handlePreviewLoaded = useCallback(
+    (
+      skills: SkillPreview[],
+      repo: string,
+      refVal: string,
+      pathVal: string,
+      authVal: SkillAuth | undefined,
+    ) => {
+      setPreviews(skills);
+      setRepoUrl(repo);
+      setRef(refVal);
+      setPath(pathVal);
+      setAuth(authVal);
 
-    // Auto-select valid skills that don't already exist
-    const autoSelected = new Set<string>();
-    const configMap = new Map<string, SkillConfig>();
-    for (const sk of skills) {
-      if (sk.valid && !sk.exists) {
-        autoSelected.add(sk.name);
+      // Auto-select valid skills that don't already exist
+      const autoSelected = new Set<string>();
+      const configMap = new Map<string, SkillConfig>();
+      for (const sk of skills) {
+        if (sk.valid && !sk.exists) {
+          autoSelected.add(sk.name);
+        }
+        configMap.set(sk.name, { name: sk.name, activate: true });
       }
-      configMap.set(sk.name, { name: sk.name, activate: true });
-    }
-    setSelected(autoSelected);
-    setConfigs(configMap);
-    setStep('browse');
-  }, []);
+      setSelected(autoSelected);
+      setConfigs(configMap);
+      setStep('browse');
+    },
+    [],
+  );
 
   const handleInstall = useCallback(async () => {
     setInstalling(true);
@@ -79,6 +95,7 @@ export function SkillImportWizard() {
         trust: hasFlagged,
         noActivate: false,
         selected: [...selected],
+        auth,
       });
 
       const imported = (result.imported ?? []).map((i) => i.name);
@@ -111,7 +128,7 @@ export function SkillImportWizard() {
       setInstalling(false);
       setStep('install');
     }
-  }, [repoUrl, ref, path, previews, selected]);
+  }, [repoUrl, ref, path, previews, selected, auth]);
 
   const canGoNext = () => {
     switch (step) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -14,6 +14,36 @@ export class AuthError extends Error {
   }
 }
 
+/**
+ * HTTPError carries the server response status alongside the error message
+ * so callers can branch on classified statuses (401/404/400) — e.g. the
+ * skill wizard auto-expanding its auth card on 401 or 404.
+ */
+export class HTTPError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.name = 'HTTPError';
+  }
+}
+
+/**
+ * Auth payload accepted by all /api/skills/sources/* endpoints. The raw
+ * Token is transient (used once, never persisted); CredentialRef is the
+ * "${vault:KEY}" reference that the server resolves against the live
+ * vault on every request and that gets recorded in lock/origin for
+ * subsequent updates.
+ */
+export type SkillAuthMethod = 'token' | 'ssh-agent' | 'ssh-key' | '';
+export interface SkillAuth {
+  method?: SkillAuthMethod;
+  token?: string;
+  credentialRef?: string;
+  sshUser?: string;
+  sshKeyPath?: string;
+}
+
 export function getStoredToken(): string | null {
   try {
     return localStorage.getItem(AUTH_STORAGE_KEY);
@@ -391,7 +421,10 @@ async function mutateJSON<T>(
 
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));
-    throw new Error(data.error || `${method} ${endpoint} failed: ${response.status}`);
+    throw new HTTPError(
+      response.status,
+      data.error || `${method} ${endpoint} failed: ${response.status}`,
+    );
   }
 
   // DELETE returns no body
@@ -803,6 +836,7 @@ export async function addSkillSource(source: {
   trust?: boolean;
   noActivate?: boolean;
   selected?: string[];
+  auth?: SkillAuth;
 }): Promise<ImportResult> {
   return mutateJSON<ImportResult>('/api/skills/sources', 'POST', source);
 }
@@ -841,20 +875,20 @@ export async function updateSkillSource(name: string): Promise<{ source: string;
 }
 
 /**
- * Preview skills in a source without importing
- * GET /api/skills/sources/{name}/preview
+ * Preview skills in a source without importing.
+ *
+ * Posts the request body (rather than query params) so optional auth
+ * credentials never surface in URLs, logs, or browser history.
+ * POST /api/skills/sources/{name}/preview
  */
 export async function previewSkillSource(
   name: string,
-  params?: { repo?: string; ref?: string; path?: string },
+  params?: { repo?: string; ref?: string; path?: string; auth?: SkillAuth },
 ): Promise<SkillPreviewResponse> {
-  const query = new URLSearchParams();
-  if (params?.repo) query.set('repo', params.repo);
-  if (params?.ref) query.set('ref', params.ref);
-  if (params?.path) query.set('path', params.path);
-  const qs = query.toString();
-  return fetchJSON<SkillPreviewResponse>(
-    `/api/skills/sources/${encodeURIComponent(name)}/preview${qs ? `?${qs}` : ''}`,
+  return mutateJSON<SkillPreviewResponse>(
+    `/api/skills/sources/${encodeURIComponent(name)}/preview`,
+    'POST',
+    params ?? {},
   );
 }
 

--- a/web/src/lib/yaml-builder.ts
+++ b/web/src/lib/yaml-builder.ts
@@ -21,6 +21,12 @@ export interface MCPServerFormData {
     ref?: string;
     path?: string;
     dockerfile?: string;
+    // Optional auth block for private git sources. Only accepts a vault
+    // reference (no raw tokens) since this block is persisted to YAML.
+    auth?: {
+      method?: 'token';
+      credentialRef?: string; // e.g. "${vault:GIT_TOKEN}"
+    };
   };
   // External
   url?: string;
@@ -169,6 +175,17 @@ function buildMCPServer(data: MCPServerFormData, indentLevel = 2): string {
         if (data.source.ref) lines.push(`${inner}  ref: ${data.source.ref}`);
         if (data.source.path) lines.push(`${inner}  path: ${data.source.path}`);
         if (data.source.dockerfile) lines.push(`${inner}  dockerfile: ${data.source.dockerfile}`);
+        // Auth block: persisted as a vault reference. The resolver runs
+        // server-side at clone time; no raw credentials ever hit YAML.
+        if (data.source.auth?.credentialRef) {
+          lines.push(`${inner}  auth:`);
+          if (data.source.auth.method) {
+            lines.push(`${inner}    method: ${data.source.auth.method}`);
+          }
+          lines.push(
+            `${inner}    credential_ref: ${yamlValue(data.source.auth.credentialRef)}`,
+          );
+        }
       }
       if (data.port) lines.push(`${inner}port: ${data.port}`);
       if (data.transport) lines.push(`${inner}transport: ${data.transport}`);


### PR DESCRIPTION
## Description

Adds the web UI surfaces for private-repo auth: an inline collapsible auth card in the skill import wizard (auto-opens on 401/404) and a matching repository-auth subsection in the MCP server source block. PR 4 of 5 for private-repo support.

Also closes a small gap in PR 3: the `/api/skills/sources/{name}/preview` route is now also reachable via POST so the wizard can send auth credentials in the body instead of query strings.

## Type of Change

- [x] New feature (additive, non-breaking)

## Changes Made

**Backend (gap fix)**
- `internal/api/api.go`: `POST /api/skills/sources/{name}/preview` added alongside the existing `GET`; handler is shared
- `internal/api/skills.go`: `handleSkillSourcePreview` now reads `repo`/`ref`/`path`/`auth` from a POST JSON body, falling back to query params for GET callers

**Frontend API layer**
- `web/src/lib/api.ts`: new `HTTPError` class (carries response `.status` so callers can branch on classified statuses), `SkillAuth` / `SkillAuthMethod` types, `addSkillSource` accepts optional `auth`, `previewSkillSource` now POSTs with a body so tokens never land in URLs/logs
- `web/src/lib/yaml-builder.ts`: `source.auth` type + YAML emission (`credential_ref` only, never a raw token; block omitted entirely when no ref)

**Skill wizard**
- `AddSourceStep.tsx`: inline collapsible auth card under URL/Ref/Path fields; collapsed by default; auto-opens with a banner when scan returns 401 or 404 (or the error message matches auth-class keywords); two modes — **Vault secret** (reuses `SecretsPopover` verbatim) and **Paste token** (password input, marked "not saved"); SSH URLs hide the token inputs and show a "using ssh-agent" hint; first-run tip line for new users
- `SkillImportWizard.tsx`: threads `SkillAuth` through the 4-step flow so the install POST carries the same creds

**MCP server form**
- `MCPServerForm.tsx`: new `SourceAuthField` component nested in the git-source block; **vault-only** (no paste-token path) because the form output is persisted to YAML — raw credentials can never leak
- Mirrors the same `SecretsPopover` pattern used elsewhere in the form

**Tests (9 new)**
- `AddSourceStep.test.tsx` (new): collapsed-by-default; expand toggle; 401 auto-opens with banner; 404 auto-opens with \"private repository\" banner; paste-token payload shape; SSH URL omits auth entirely
- `MCPServerForm.test.tsx`: `credential_ref` is emitted for git sources with auth; raw `token:` never appears in YAML; `auth` block is omitted when no `credentialRef` set

## Testing

- `go build ./...` / `go test -race ./internal/api/` — pass (aside from the pre-existing `TestHandleSkills_SourcesList_Empty` state-leak flake)
- `golangci-lint run ./...` — 0 issues
- `npm run build` — clean
- `npm test` — 384 passed (9 new)
- `npm run lint` — no new issues (43 pre-existing in unrelated files)
- No new npm dependencies; only bundled `lucide-react` icons used

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #500