### PR TITLE
docs: document private git auth + add clone integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,9 +134,15 @@ gridctl/
 │   ├── builder/          # Image building
 │   │   ├── types.go      # BuildOptions, BuildResult
 │   │   ├── cache.go      # ~/.gridctl/cache management
-│   │   ├── git.go        # Git clone/update
+│   │   ├── git.go        # Git clone/update (thin wrapper over pkg/git)
 │   │   ├── docker.go     # Docker build
 │   │   └── builder.go    # Main builder
+│   ├── git/              # Shared git helpers for skills + builder
+│   │   ├── clone.go      # Clone, Fetch, Checkout, ResolveRef, HeadCommit, ListTags
+│   │   ├── auth.go       # Auther interface: NoAuth, HTTPSTokenAuth, SSHAgentAuth, SSHKeyFileAuth
+│   │   ├── detect.go     # DetectProtocol (Protocol: HTTPS, SSH, Local, Unknown)
+│   │   ├── errors.go     # Sentinel errors + ClassifyError (maps go-git errors to ErrAuth*, ErrNotFound, ErrHostKeyMismatch, etc.)
+│   │   └── redact.go     # RedactURL, RedactString, RedactError — scrubs PATs and embedded userinfo
 │   ├── output/           # CLI output formatting
 │   │   ├── output.go     # Printer, banner display, and progress helpers
 │   │   ├── styles.go     # Color schemes
@@ -178,12 +184,12 @@ gridctl/
 │   │   ├── codemode_sandbox.go # goja JavaScript sandbox
 │   │   └── codemode_transpile.go # esbuild ES2020+ → ES2015 transpilation
 │   ├── skills/           # Remote skill management (import, update, lockfile)
-│   │   ├── config.go     # Skill source configuration
+│   │   ├── config.go     # Skill source configuration (+ SourceAuth declarative block)
 │   │   ├── fingerprint.go # Content fingerprinting for change detection
-│   │   ├── importer.go   # Remote skill import (git clone/pull)
-│   │   ├── lockfile.go   # Lock file for pinned skill refs
-│   │   ├── origin.go     # Origin tracking per skill
-│   │   ├── remote.go     # Remote git operations
+│   │   ├── importer.go   # Remote skill import (git clone/pull) + AuthConfig + CredentialResolver
+│   │   ├── lockfile.go   # Lock file for pinned skill refs (+ CredentialRef per source)
+│   │   ├── origin.go     # Origin tracking per skill (+ CredentialRef sidecar field)
+│   │   ├── remote.go     # Remote git operations (CloneAndDiscover, FetchAndCompare)
 │   │   ├── scanner.go    # Registry directory scanner
 │   │   └── updater.go    # Skill update orchestration
 │   ├── format/           # Output format converters
@@ -242,6 +248,49 @@ gridctl/
         ├── replica_stackless_mode_test.go # Multi-replica register in stackless mode
         └── replica_mixed_counts_test.go   # 1-replica + 3-replica server in one gateway
 ```
+
+## Private Git Auth
+
+Gridctl clones private git repositories in two places — skill imports (`pkg/skills`) and MCP server source builds (`pkg/builder`). Both go through the shared `pkg/git` package.
+
+**Layering:**
+
+```
+cmd/gridctl/skill.go              internal/api/skills.go
+    │ --auth-token / --vault-key       │ { "auth": { method, token, credentialRef, ... } }
+    └──────────────┬───────────────────┘
+                   │ skills.AuthConfig
+                   ▼
+            pkg/skills/importer.go          pkg/builder/git.go
+                   │ BuildAuther()                 │
+                   ▼                               ▼
+                                  pkg/git/auth.go (Auther interface)
+                                  ├── NoAuth                (public / ambient)
+                                  ├── HTTPSTokenAuth        (PAT → http.BasicAuth)
+                                  ├── SSHAgentAuth          (ambient SSH_AUTH_SOCK)
+                                  └── SSHKeyFileAuth        (on-disk key)
+                                           │
+                                           ▼
+                              go-git transport.AuthMethod → clone/fetch
+```
+
+**Auther interface.** `pkg/git.Auther.AuthFor(url)` returns the `transport.AuthMethod` go-git uses. Each implementation validates its own inputs eagerly (`ErrEmptyToken`, `ErrProtocolMismatch`, `ErrSSHAgentMissing`) so a misconfigured auth fails fast rather than falling through to an unauthenticated clone that returns a cryptic "not found". `pkg/git.DetectProtocol(url)` classifies URLs as `HTTPS`, `SSH`, `Local`, or `Unknown`; implementations reject URLs whose protocol doesn't match their mechanism.
+
+**Resolver threading — `${vault:KEY}` is resolved once, at the boundary.**
+
+- The **CLI** (`cmd/gridctl/skill.go`) resolves `--vault-key GIT_TOKEN` into a raw token in `buildAuthConfigFromFlags` before calling `Importer.Import`. It also registers a `skills.CredentialResolver` on the importer so `skill update` can re-resolve stored references automatically.
+- The **API** (`internal/api/skills.go`) does the same inside `AuthRequest.toAuthConfig`, consulting the live `vault.Store` on every request so rotated secrets take effect immediately.
+- `skills.AuthConfig` carries both the transient `Token` and the opaque `CredentialRef` (e.g. `${vault:GIT_TOKEN}`). The importer passes `CredentialRef` through to `Origin.CredentialRef` and `LockedSource.CredentialRef`; the `Token` never leaves the request/command lifecycle.
+
+**Credential-never-persisted-raw invariant.** Raw tokens and SSH passphrases live in exactly one place on disk: the encrypted vault (`pkg/vault`). Nothing else writes them.
+
+- `Origin.CredentialRef` and `LockedSource.CredentialRef` store only the reference string.
+- `skills.yaml` (`SourceAuth.CredentialRef`) stores only the reference string.
+- Error paths go through `git.RedactError` before reaching logs, API responses, or CLI stderr. `git.RedactString` scrubs known PAT patterns (`ghp_…`, `github_pat_…`, `glpat-…`) and embedded URL userinfo; `git.RedactURL` strips userinfo from a bare URL. Callers should prefer `credential_ref` + vault over embedding tokens in URLs, since redaction is a defense-in-depth layer, not a substitute for structured credential handling.
+
+**Error classification.** `git.ClassifyError` maps raw go-git errors into sentinels (`ErrAuthRequired`, `ErrAuthFailed`, `ErrNotFound`, `ErrHostKeyMismatch`, `ErrSSHAgentMissing`). The CLI turns these into human hints via `printSkillAuthHint`; the API maps them to HTTP status codes via `gitErrorStatus` (401, 404, 400, 500).
+
+**Scope.** v1 ships HTTPS PAT (via vault or ephemeral flag / env) and SSH-via-agent; SSH key-file auth is wired but lacks a stricter host-key policy — `SSHKeyFileAuth.KnownHostsPath` is reserved for follow-up work. Out of scope for v1: OAuth device flow, GitHub App tokens, OS keychain, 1Password/Bitwarden passthrough, credential templates, Git LFS auth.
 
 ## Build Commands
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,35 @@ output:
 
 Steps without dependencies run in parallel. Template expressions reference inputs (`{{ inputs.x }}`) and prior step results (`{{ steps.id.result }}`). Each step supports retry policies, timeouts, conditional execution, and configurable error handling (`fail` / `skip` / `continue`). The Web UI includes a visual workflow designer with Code, Visual, and Test modes. See [`examples/registry/`](examples/registry/) for working examples.
 
+### Private Repositories
+
+Both `gridctl skill add` and MCP server `source` blocks can clone private git repositories. Credentials come from one of three places, in priority order:
+
+1. **Vault reference** _(recommended)_ — the raw token stays in the encrypted vault; only a `${vault:KEY}` reference is persisted to the skill origin / lock file.
+2. **Ephemeral flag** — `--auth-token <PAT>` for one-shot CI use; never written to disk.
+3. **Ambient environment** — SSH URLs use ssh-agent + `~/.ssh/known_hosts`; HTTPS URLs fall back to `GITHUB_TOKEN` if set.
+
+```bash
+# Public repo (unchanged)
+gridctl skill add https://github.com/acme/public-skills
+
+# Private HTTPS with a vault-stored PAT (re-resolved on every update)
+gridctl vault set GIT_TOKEN ghp_xxxxxxxxxxxxxxxxxxxx
+gridctl skill add https://github.com/acme/private-skills --vault-key GIT_TOKEN
+
+# Private HTTPS with an ephemeral PAT (CI use; not persisted)
+gridctl skill add https://github.com/acme/private-skills --auth-token "$GIT_TOKEN"
+
+# Private SSH via ambient ssh-agent (no flags)
+gridctl skill add git@github.com:acme/private-skills.git
+```
+
+`--auth-token` and `--vault-key` are mutually exclusive. Both flags also work on `gridctl skill try`. `gridctl skill update` automatically re-resolves any stored `${vault:KEY}` reference.
+
+In the web wizard, the "Add skill source" step has an inline, collapsible **Authentication** card. It stays collapsed for public repos and auto-expands when a scan returns an auth-class error, offering two modes: pick an existing vault secret or paste a one-shot token. The same subsection is available in the MCP server form when the source type is `git`.
+
+Raw tokens are never written outside the encrypted vault — neither to the skill origin nor the lock file. Error and log paths strip embedded URL userinfo (`https://TOKEN@host/...`) and known PAT patterns (`ghp_…`, `github_pat_…`, `glpat-…`) before they reach the API or CLI.
+
 ### Distributed Tracing
 
 Every tool call through the gateway is captured as an OpenTelemetry trace. Spans record transport type, server name, duration, and error state. The last 1000 traces are kept in a ring buffer and are queryable via CLI or the Web UI.
@@ -341,6 +370,9 @@ gridctl vault lock / unlock          # Lock or unlock the vault
 gridctl vault change-passphrase      # Change the vault encryption passphrase
 gridctl skill list                   # List skills in the registry
 gridctl skill add <repo-url>         # Import skills from a remote git repository
+gridctl skill add <repo-url> --auth-token <pat>  # ...with ephemeral HTTPS PAT (CI; not persisted)
+gridctl skill add <repo-url> --vault-key <key>   # ...with a PAT resolved from ${vault:KEY}
+gridctl skill add <repo-url> --ssh-key <path>    # ...with an on-disk SSH private key
 gridctl skill update [name]          # Update imported skills (all if no name given)
 gridctl skill remove <name>          # Remove an imported skill
 gridctl skill pin <name> <ref>       # Pin a skill to a specific git ref

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -582,6 +582,80 @@ a2a-agents:
 
 ---
 
+## Skill Sources
+
+Skill sources are declared in `~/.gridctl/skills.yaml`. Each source points at a git repository that gridctl clones to discover `SKILL.md` files. Sources may be public or authenticated.
+
+```yaml
+defaults:
+  auto_update: true
+  update_interval: 24h
+
+sources:
+  - name: public-skills
+    repo: https://github.com/acme/public-skills
+    ref: main
+
+  - name: private-skills
+    repo: https://github.com/acme/private-skills
+    ref: v1.2.0
+    auth:
+      method: token
+      credential_ref: "${vault:GIT_TOKEN}"
+
+  - name: private-ssh
+    repo: git@github.com:acme/private-skills.git
+    auth:
+      method: ssh-agent
+```
+
+### All Skill Source Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | No | Derived from repo URL | Unique source name |
+| `repo` | string | **Yes** | — | Git repository URL (HTTPS or SSH) |
+| `ref` | string | No | Default branch | Branch, tag, or semver constraint (e.g. `^1.2`) |
+| `path` | string | No | — | Subdirectory containing `SKILL.md` files |
+| `auto_update` | bool | No | Inherits `defaults.auto_update` | Enable background updates for this source |
+| `update_interval` | duration | No | Inherits `defaults.update_interval` | Poll interval (e.g. `1h`, `24h`) |
+| `auth` | object | No | — | Authentication block for private repos (see [Auth](#skill-source-auth)) |
+
+### Skill Source Auth
+
+Declares how gridctl authenticates when cloning or fetching this repository. Raw tokens must **never** appear in `skills.yaml` — use `credential_ref` to point at a vault key.
+
+```yaml
+auth:
+  method: token
+  credential_ref: "${vault:GIT_TOKEN}"
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `method` | string | **Yes** | — | One of `"token"`, `"ssh-agent"`, `"ssh-key"`, or `"none"` |
+| `credential_ref` | string | Conditional | — | `${vault:KEY}` reference resolved at clone/fetch time. Required for `"token"` |
+| `ssh_user` | string | No | `git` | SSH username used with `"ssh-agent"` or `"ssh-key"` |
+| `ssh_key_path` | string | Conditional | — | Path to a private key file. Required for `"ssh-key"` |
+
+**Method behavior:**
+
+| Method | Transport | Credential source | Persisted |
+|--------|-----------|-------------------|-----------|
+| `token` | HTTPS | `credential_ref` (vault) — resolved on every clone/fetch | Reference only |
+| `ssh-agent` | SSH | Ambient `SSH_AUTH_SOCK` | None |
+| `ssh-key` | SSH | `ssh_key_path` on disk (optionally decrypted with `GRIDCTL_SSH_KEY_PASSPHRASE`) | Path only |
+| `none` / omitted | HTTPS or SSH | Ambient `GITHUB_TOKEN` env for HTTPS; `SSH_AUTH_SOCK` for SSH | None |
+
+**Security rules:**
+
+- Raw PAT or SSH key material must never appear in `skills.yaml`, the lock file, or origin sidecars.
+- `credential_ref` is the only credential field persisted; the live vault is consulted on every remote operation so rotating a secret takes effect immediately.
+- Prefer `credential_ref` over embedding credentials in the `repo` URL (`https://TOKEN@host/...`). Any userinfo or known PAT patterns that do leak into errors and logs are scrubbed by the redaction layer, but vault references keep them out of on-disk state entirely.
+- The CLI equivalents are `--auth-token <pat>` (ephemeral), `--vault-key <key>` (persisted as `credential_ref`), and `--ssh-key <path>` on `skill add` / `skill try`.
+
+---
+
 ## Variable Expansion
 
 String values in the configuration support variable expansion:

--- a/tests/integration/skills_private_git_test.go
+++ b/tests/integration/skills_private_git_test.go
@@ -1,0 +1,237 @@
+//go:build integration
+
+package integration
+
+import (
+	"errors"
+	"net/http"
+	"net/http/cgi" //nolint:gosec // G504: CVE-2016-5386 (Httpoxy) fixed in Go 1.6.3; used only against httptest.Server in this integration test
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
+	"github.com/gridctl/gridctl/pkg/logging"
+	"github.com/gridctl/gridctl/pkg/skills"
+)
+
+const (
+	privateRepoValidToken = "correct-horse-battery-staple"
+	privateRepoSkillName  = "private-test"
+)
+
+// initPrivateBareRepo creates a bare repo containing a single SKILL.md file
+// and returns the on-disk bare path plus the name of the repository on disk
+// (e.g. "repo.git"), which is exposed verbatim in the server URL path.
+func initPrivateBareRepo(t *testing.T) (bareParent, bareName string) {
+	t.Helper()
+
+	workDir := t.TempDir()
+	repo, err := gogit.PlainInit(workDir, false)
+	if err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	skillDir := filepath.Join(workDir, privateRepoSkillName)
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	skillMD := []byte("---\nname: private-test\ndescription: integration fixture\n---\n\nBody.\n")
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), skillMD, 0644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if _, err := wt.Add(privateRepoSkillName + "/SKILL.md"); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	sig := &object.Signature{Name: "it", Email: "it@test"}
+	if _, err := wt.Commit("initial commit", &gogit.CommitOptions{Author: sig}); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+
+	bareParent = t.TempDir()
+	bareName = "repo.git"
+	barePath := filepath.Join(bareParent, bareName)
+	if _, err := gogit.PlainClone(barePath, true, &gogit.CloneOptions{URL: workDir}); err != nil {
+		t.Fatalf("clone to bare: %v", err)
+	}
+	return bareParent, bareName
+}
+
+// startAuthedGitHTTPServer wraps a bare repository with httptest + the system
+// `git http-backend` CGI, gated by HTTP basic auth. The test is skipped when
+// the `git` binary is not available.
+//
+// Auth behavior (intentional):
+//
+//	no Authorization header    → 401 (→ ErrAuthRequired)
+//	wrong Authorization header → 403 (→ ErrAuthFailed)
+//	correct Authorization      → served by git-http-backend
+func startAuthedGitHTTPServer(t *testing.T, bareParent, validToken string) *httptest.Server {
+	t.Helper()
+
+	gitBin, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git binary not found; skipping http-backend integration")
+	}
+
+	cgiHandler := &cgi.Handler{
+		Path: gitBin,
+		Args: []string{"http-backend"},
+		Env: []string{
+			"GIT_PROJECT_ROOT=" + bareParent,
+			"GIT_HTTP_EXPORT_ALL=1",
+		},
+	}
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, _, ok := r.BasicAuth()
+		switch {
+		case !ok:
+			w.Header().Set("WWW-Authenticate", `Basic realm="gridctl-it"`)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		case user != validToken:
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		cgiHandler.ServeHTTP(w, r)
+	})
+
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// isolateGridctlHome points $HOME at a temp dir so clone caches under
+// ~/.gridctl/cache/repos don't leak between tests or into the user's home.
+func isolateGridctlHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+}
+
+func TestSkills_PrivateHTTPS_NoAuth_ReturnsAuthRequired(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	isolateGridctlHome(t)
+
+	bareParent, bareName := initPrivateBareRepo(t)
+	srv := startAuthedGitHTTPServer(t, bareParent, privateRepoValidToken)
+
+	repoURL := srv.URL + "/" + bareName
+
+	_, err := skills.CloneAndDiscover(repoURL, "", "", skills.AuthConfig{}, logging.NewDiscardLogger())
+	if err == nil {
+		t.Fatal("expected error cloning private repo without credentials")
+	}
+	classified := gitpkg.ClassifyError(err)
+	if !errors.Is(classified, gitpkg.ErrAuthRequired) {
+		t.Errorf("expected ErrAuthRequired after classification, got %v", classified)
+	}
+}
+
+func TestSkills_PrivateHTTPS_WrongToken_ReturnsAuthFailed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	isolateGridctlHome(t)
+
+	bareParent, bareName := initPrivateBareRepo(t)
+	srv := startAuthedGitHTTPServer(t, bareParent, privateRepoValidToken)
+
+	repoURL := srv.URL + "/" + bareName
+	cfg := skills.AuthConfig{Method: "token", Token: "not-the-right-token"}
+
+	_, err := skills.CloneAndDiscover(repoURL, "", "", cfg, logging.NewDiscardLogger())
+	if err == nil {
+		t.Fatal("expected error cloning with a wrong token")
+	}
+	classified := gitpkg.ClassifyError(err)
+	if !errors.Is(classified, gitpkg.ErrAuthFailed) {
+		t.Errorf("expected ErrAuthFailed after classification, got %v", classified)
+	}
+}
+
+func TestSkills_PrivateHTTPS_ValidToken_Succeeds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	isolateGridctlHome(t)
+
+	bareParent, bareName := initPrivateBareRepo(t)
+	srv := startAuthedGitHTTPServer(t, bareParent, privateRepoValidToken)
+
+	repoURL := srv.URL + "/" + bareName
+	cfg := skills.AuthConfig{Method: "token", Token: privateRepoValidToken}
+
+	result, err := skills.CloneAndDiscover(repoURL, "", "", cfg, logging.NewDiscardLogger())
+	if err != nil {
+		t.Fatalf("clone with valid token: %v", err)
+	}
+	if len(result.Skills) != 1 || result.Skills[0].Name != privateRepoSkillName {
+		t.Errorf("expected 1 discovered skill %q, got %+v", privateRepoSkillName, result.Skills)
+	}
+	if result.CommitSHA == "" {
+		t.Error("expected CommitSHA to be populated after successful clone")
+	}
+}
+
+func TestSkills_PrivateHTTPS_ErrorRedactsToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	isolateGridctlHome(t)
+
+	bareParent, bareName := initPrivateBareRepo(t)
+	srv := startAuthedGitHTTPServer(t, bareParent, privateRepoValidToken)
+
+	// A GitHub-classic-PAT-shaped string intentionally embedded in the URL
+	// userinfo. RedactString must scrub both the PAT pattern and the
+	// userinfo component before the error surfaces.
+	fakePAT := "ghp_" + strings.Repeat("a", 40)
+	repoURL := strings.Replace(srv.URL, "http://", "http://"+fakePAT+"@", 1) + "/" + bareName
+
+	_, err := skills.CloneAndDiscover(repoURL, "", "", skills.AuthConfig{}, logging.NewDiscardLogger())
+	if err == nil {
+		t.Fatal("expected error cloning with bogus embedded token")
+	}
+	if strings.Contains(err.Error(), fakePAT) {
+		t.Errorf("error message leaked embedded PAT: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "ghp_") {
+		t.Errorf("error message still contains ghp_ prefix: %q", err.Error())
+	}
+}
+
+func TestSkills_PrivateSSH_Optional(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	// SSH end-to-end requires a reachable SSH remote + a populated ssh-agent.
+	// Opt in via GRIDCTL_IT_SSH_URL (e.g. "git@github.com:acme/private.git");
+	// otherwise skip cleanly so this suite stays hermetic in CI.
+	repoURL := os.Getenv("GRIDCTL_IT_SSH_URL")
+	if repoURL == "" {
+		t.Skip("GRIDCTL_IT_SSH_URL not set; skipping SSH end-to-end test")
+	}
+	if os.Getenv("SSH_AUTH_SOCK") == "" {
+		t.Skip("SSH_AUTH_SOCK not set; skipping SSH end-to-end test")
+	}
+	isolateGridctlHome(t)
+
+	cfg := skills.AuthConfig{Method: "ssh-agent"}
+	if _, err := skills.CloneAndDiscover(repoURL, "", "", cfg, logging.NewDiscardLogger()); err != nil {
+		t.Fatalf("ssh-agent clone: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Final phase of the private-git-auth feature. Adds user-facing docs for the new auth flows and end-to-end integration tests that exercise the shared `pkg/git` auth layer against a real `git http-backend` CGI.

## Type of Change

- [x] Documentation
- [x] Tests

## Changes Made

- README: new **Private Repositories** subsection (vault / ephemeral / ambient precedence, CLI quickstart for HTTPS PAT and SSH) plus `skill add` auth flag variants in the CLI reference.
- `docs/config-schema.md`: new **Skill Sources** section documenting `~/.gridctl/skills.yaml` and the **Skill Source Auth** block (`method`, `credential_ref`, `ssh_user`, `ssh_key_path`) with a method-behavior matrix.
- `AGENTS.md`: added `pkg/git/` to the directory tree, annotated `pkg/skills/` and `pkg/builder/git.go` entries with their new auth responsibilities, and added a **Private Git Auth** design section covering layering, resolver threading, credential-never-persisted-raw invariant, and error classification.
- New `tests/integration/skills_private_git_test.go` (`//go:build integration`) — starts a real `git http-backend` behind httptest + basic auth, covering: no auth → `ErrAuthRequired` (401), correct token → clone + skill discovery succeeds, wrong token → `ErrAuthFailed` (403), embedded PAT → error redaction scrubs `ghp_…`. SSH end-to-end opt-in via `GRIDCTL_IT_SSH_URL`, skipped otherwise.

## Testing

- `go test ./pkg/git/... ./pkg/skills/... ./pkg/builder/...` — all pass
- `go test -tags=integration -run TestSkills_Private ./tests/integration/...` — 4 pass, SSH skipped
- `make build` — binary produced
- `golangci-lint run --build-tags=integration ./pkg/git/... ./pkg/skills/...` — 0 issues; new test file lints clean (`G504` silenced with documented rationale)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #500