### PR TITLE
fix: redact URL userinfo in clone log line

### DIFF
--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -38,7 +38,7 @@ type FetchOptions struct {
 // a subsequent Checkout when they need to land on a non-branch ref (tag,
 // commit, remote branch) after the full-clone fallback.
 func Clone(destPath string, opts CloneOptions, logger *slog.Logger) (*gogit.Repository, error) {
-	logger.Info("cloning repository", "url", opts.URL)
+	logger.Info("cloning repository", "url", RedactURL(opts.URL))
 
 	cloneOpts := &gogit.CloneOptions{
 		URL:   opts.URL,

--- a/pkg/git/clone_test.go
+++ b/pkg/git/clone_test.go
@@ -1,9 +1,11 @@
 package git
 
 import (
+	"bytes"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	gogit "github.com/go-git/go-git/v5"
@@ -14,6 +16,14 @@ import (
 
 func testLogger() *slog.Logger {
 	return logging.NewDiscardLogger()
+}
+
+// captureLogger returns a slog.Logger whose handler writes JSON records into
+// the returned buffer, for tests that assert on emitted log content.
+func captureLogger() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(h), &buf
 }
 
 // initBareRepo creates a bare repo with one commit on master and one annotated
@@ -115,6 +125,31 @@ func TestClone_InvalidURL(t *testing.T) {
 	_, err := Clone(dest, CloneOptions{URL: "/nonexistent/path"}, testLogger())
 	if err == nil {
 		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestClone_RedactsURLUserinfoInLog(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	logger, buf := captureLogger()
+	dest := filepath.Join(t.TempDir(), "clone")
+	url := "https://ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@127.0.0.1:1/does-not-exist"
+
+	// Error is expected — we're only asserting on the log line the Clone
+	// helper emits before attempting the clone.
+	_, _ = Clone(dest, CloneOptions{URL: url}, logger)
+
+	got := buf.String()
+	if strings.Contains(got, "ghp_") {
+		t.Errorf("log leaked PAT userinfo: %s", got)
+	}
+	if strings.Contains(got, "@127.0.0.1") {
+		t.Errorf("log retained userinfo@host: %s", got)
+	}
+	if !strings.Contains(got, "https://127.0.0.1:1/does-not-exist") {
+		t.Errorf("expected redacted URL in log, got: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Description

`pkg/git.Clone` logged `opts.URL` via `slog.Info` without routing through the redaction layer. When a caller passed a URL with embedded userinfo (e.g. `https://TOKEN@host/...`), the raw userinfo landed in structured logs — even though `RedactError` already covered the error return path. Wraps the URL argument in `RedactURL` at the log site so the library never emits unredacted URLs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `pkg/git/clone.go`: route `opts.URL` through `RedactURL` in the "cloning repository" log line.
- `pkg/git/clone_test.go`: add `captureLogger()` helper and `TestClone_RedactsURLUserinfoInLog` regression test that asserts no PAT pattern or `userinfo@host` appears in the emitted log record.

## Testing

- `go test ./pkg/git/...` — all pass, including the new regression test
- `golangci-lint run ./pkg/git/...` — 0 issues
- `make build` — clean

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed