### PR TITLE
refactor: polish registry dialogs, typography, and layout

### DIFF
--- a/web/src/__tests__/ConfirmDialog.test.tsx
+++ b/web/src/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { useState } from 'react';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { ConfirmDialog } from '../components/ui/ConfirmDialog';
+
+beforeEach(() => {
+  cleanup();
+  Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    configurable: true,
+    get() {
+      return this.parentNode;
+    },
+  });
+});
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function Harness({
+  onConfirm,
+  onClose,
+  variant = 'danger',
+}: {
+  onConfirm?: () => void;
+  onClose?: () => void;
+  variant?: 'default' | 'danger';
+}) {
+  const [open, setOpen] = useState(true);
+  return (
+    <ConfirmDialog
+      isOpen={open}
+      onClose={() => {
+        setOpen(false);
+        onClose?.();
+      }}
+      onConfirm={() => {
+        onConfirm?.();
+        setOpen(false);
+      }}
+      title="Delete skill"
+      message={
+        <p>
+          Delete <span data-testid="name">my-skill</span>?
+        </p>
+      }
+      confirmLabel={`Delete "my-skill"`}
+      variant={variant}
+    />
+  );
+}
+
+describe('ConfirmDialog', () => {
+  it('renders with alertdialog semantics and autofocuses Cancel', async () => {
+    render(<Harness />);
+    await act(async () => {
+      await nextFrame();
+    });
+
+    const dialog = screen.getByRole('alertdialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+    expect(dialog).toHaveAttribute('aria-describedby');
+    expect(screen.getByText('Cancel')).toHaveFocus();
+  });
+
+  it('closes on Escape', async () => {
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} />);
+    await act(async () => {
+      await nextFrame();
+    });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onConfirm when the destructive button is activated', async () => {
+    const onConfirm = vi.fn();
+    render(<Harness onConfirm={onConfirm} />);
+    await act(async () => {
+      await nextFrame();
+    });
+
+    fireEvent.click(screen.getByText(/Delete "my-skill"/));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the destructive label with the echoed name', async () => {
+    render(<Harness />);
+    await act(async () => {
+      await nextFrame();
+    });
+    expect(screen.getByText(/Delete "my-skill"/)).toBeInTheDocument();
+  });
+
+  it('returns null when closed', () => {
+    function ClosedHarness() {
+      return (
+        <ConfirmDialog
+          isOpen={false}
+          onClose={() => {}}
+          onConfirm={() => {}}
+          title="x"
+          message="x"
+          confirmLabel="x"
+        />
+      );
+    }
+    const { container } = render(<ClosedHarness />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/web/src/__tests__/useFocusTrap.test.tsx
+++ b/web/src/__tests__/useFocusTrap.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { useRef, useState } from 'react';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+
+// jsdom doesn't implement layout, so offsetParent is null for everything by
+// default. Patch it to return the parent element so our visibility check works.
+beforeEach(() => {
+  cleanup();
+  Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    configurable: true,
+    get() {
+      return this.parentNode;
+    },
+  });
+});
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function TestHarness({ initiallyOpen = false }: { initiallyOpen?: boolean }) {
+  const [open, setOpen] = useState(initiallyOpen);
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+  const containerRef = useFocusTrap<HTMLDivElement>({
+    active: open,
+    initialFocusRef: cancelRef,
+  });
+
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(true)}>
+        open
+      </button>
+      {open && (
+        <div ref={containerRef} data-testid="trap">
+          <button type="button" ref={cancelRef}>
+            cancel
+          </button>
+          <button type="button">confirm</button>
+          <button type="button" onClick={() => setOpen(false)}>
+            close
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+describe('useFocusTrap', () => {
+  it('focuses the initial ref when activated', async () => {
+    render(<TestHarness />);
+    fireEvent.click(screen.getByText('open'));
+    await act(async () => {
+      await nextFrame();
+    });
+
+    expect(screen.getByText('cancel')).toHaveFocus();
+  });
+
+  it('wraps Tab from last element back to first', async () => {
+    render(<TestHarness />);
+    fireEvent.click(screen.getByText('open'));
+    await act(async () => {
+      await nextFrame();
+    });
+
+    const cancel = screen.getByText('cancel');
+    const confirm = screen.getByText('confirm');
+    const close = screen.getByText('close');
+
+    expect(cancel).toHaveFocus();
+
+    // Move focus to the last element, then Tab: should wrap to first.
+    close.focus();
+    expect(close).toHaveFocus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(cancel).toHaveFocus();
+
+    // Confirm Shift+Tab from first wraps to last.
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(close).toHaveFocus();
+
+    void confirm;
+  });
+
+  it('restores focus to the trigger when trap deactivates', async () => {
+    render(<TestHarness />);
+    const trigger = screen.getByText('open');
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    fireEvent.click(trigger);
+    await act(async () => {
+      await nextFrame();
+    });
+    expect(screen.getByText('cancel')).toHaveFocus();
+
+    fireEvent.click(screen.getByText('close'));
+    expect(trigger).toHaveFocus();
+  });
+
+  it('does not trap when inactive', () => {
+    function Inactive() {
+      const ref = useFocusTrap<HTMLDivElement>({ active: false });
+      return (
+        <div ref={ref}>
+          <button type="button">outside-ok</button>
+        </div>
+      );
+    }
+    render(
+      <div>
+        <button type="button">sibling</button>
+        <Inactive />
+      </div>,
+    );
+    const sibling = screen.getByText('sibling');
+    sibling.focus();
+    expect(sibling).toHaveFocus();
+    // Pressing Tab should not be intercepted; we just verify no error is thrown
+    // and focus does not move away from sibling to the trap container.
+    fireEvent.keyDown(document, { key: 'Tab' });
+    // jsdom doesn't actually move focus on keydown, but we can at least verify
+    // the handler isn't active (focus stays where JS left it).
+    expect(document.activeElement).toBe(sibling);
+  });
+});

--- a/web/src/components/registry/RegistrySidebar.tsx
+++ b/web/src/components/registry/RegistrySidebar.tsx
@@ -27,6 +27,7 @@ import { useUIStore } from '../../stores/useUIStore';
 import { useWindowManager } from '../../hooks/useWindowManager';
 import { useFuzzySearch } from '../../hooks/useFuzzySearch';
 import { PopoutButton } from '../ui/PopoutButton';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { SkillEditor } from './SkillEditor';
 import { showToast } from '../ui/Toast';
 import {
@@ -196,21 +197,21 @@ export function RegistrySidebar({ embedded = false }: { embedded?: boolean } = {
           </span>
           {(updateSummary?.available ?? 0) > 0 && (
             <>
-              <span className="text-[8px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary font-medium flex items-center gap-0.5 animate-fade-in-scale">
-                <ArrowUpCircle size={8} />
+              <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary font-medium flex items-center gap-1 animate-fade-in-scale">
+                <ArrowUpCircle size={10} />
                 {updateSummary?.available} update{(updateSummary?.available ?? 0) !== 1 ? 's' : ''}
               </span>
               <button
                 onClick={handleUpdateAll}
                 disabled={updatingAll}
                 className={cn(
-                  'text-[8px] px-1.5 py-0.5 rounded-full font-medium flex items-center gap-0.5 transition-colors',
+                  'text-[10px] px-1.5 py-0.5 rounded-full font-medium flex items-center gap-1 transition-colors',
                   updatingAll
                     ? 'bg-text-muted/10 text-text-muted cursor-wait'
                     : 'bg-secondary/10 text-secondary hover:bg-secondary/20',
                 )}
               >
-                <ArrowUpCircle size={8} />
+                <ArrowUpCircle size={10} />
                 {updatingAll ? 'Updating...' : 'Update All'}
               </button>
             </>
@@ -276,31 +277,27 @@ export function RegistrySidebar({ embedded = false }: { embedded?: boolean } = {
         </div>
       )}
 
-      {/* Delete confirmation overlay */}
-      {confirmDelete && (
-        <div className="absolute inset-0 bg-background/80 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="glass-panel-elevated rounded-xl p-5 max-w-xs mx-4 space-y-3">
-            <p className="text-sm text-text-primary">
+      {/* Delete confirmation */}
+      <ConfirmDialog
+        isOpen={confirmDelete !== null}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete skill"
+        message={
+          <>
+            <p>
               Delete <span className="font-mono text-primary">{confirmDelete}</span>?
             </p>
-            <p className="text-xs text-text-muted">This action cannot be undone.</p>
-            <div className="flex justify-end gap-2 pt-2">
-              <button
-                onClick={() => setConfirmDelete(null)}
-                className="px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary bg-surface-elevated rounded-lg transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleDeleteConfirm}
-                className="px-3 py-1.5 text-xs font-medium rounded-lg bg-status-error text-white hover:bg-status-error/90 transition-colors"
-              >
-                Delete
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+            <p>This action cannot be undone.</p>
+          </>
+        }
+        confirmLabel={
+          <span>
+            Delete <span className="font-mono">"{confirmDelete}"</span>
+          </span>
+        }
+        variant="danger"
+      />
 
       {/* Editor modal */}
       <SkillEditor
@@ -347,7 +344,7 @@ function SkillsList({
           {isFiltered ? 'No matching skills' : 'No skills registered'}
         </p>
         {!isFiltered && (
-          <p className="text-text-muted/60 text-[10px] mt-1">
+          <p className="text-text-muted text-[10px] mt-1">
             Create a SKILL.md to get started
           </p>
         )}
@@ -459,12 +456,12 @@ function SkillItem({
           {/* Metadata badges */}
           <div className="flex gap-1 mt-2 flex-wrap">
             {skill.license && (
-              <span className="text-[9px] px-1.5 py-0.5 rounded bg-surface-highlight text-text-muted">
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-highlight text-text-muted">
                 {skill.license}
               </span>
             )}
             {skill.compatibility && (
-              <span className="text-[9px] px-1.5 py-0.5 rounded bg-surface-highlight text-text-muted">
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-highlight text-text-muted">
                 {skill.compatibility}
               </span>
             )}
@@ -495,12 +492,12 @@ function SkillItem({
                       {r.criterion}
                     </p>
                     {!r.passed && !r.skipped && r.actual && (
-                      <p className="text-[9px] text-status-error mt-0.5 font-mono truncate">
+                      <p className="text-[10px] text-status-error mt-0.5 font-mono truncate">
                         actual: {r.actual}
                       </p>
                     )}
                     {r.skipped && r.skipReason && (
-                      <p className="text-[9px] text-text-muted/50 mt-0.5 italic">
+                      <p className="text-[10px] text-text-muted mt-0.5 italic">
                         {r.skipReason}
                       </p>
                     )}
@@ -532,7 +529,7 @@ function SkillItem({
             </button>
             <button
               onClick={(e) => { e.stopPropagation(); onDelete(skill.name); }}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-semibold bg-gradient-to-r from-status-error to-rose-600 text-white shadow-[0_1px_8px_rgba(244,63,94,0.2)] hover:shadow-[0_2px_12px_rgba(244,63,94,0.3)] hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200"
+              className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-semibold bg-status-error text-white hover:bg-status-error/90 focus:outline-none focus:ring-2 focus:ring-status-error/40 focus:ring-offset-2 focus:ring-offset-background transition-colors duration-150"
             >
               <Trash2 size={10} /> Delete
             </button>
@@ -550,10 +547,10 @@ function TestStatusBadge({ result, onClick }: { result: SkillTestResult | null; 
     return (
       <button
         onClick={(e) => { e.stopPropagation(); onClick(); }}
-        className="flex items-center gap-1 text-[9px] text-text-muted/60 hover:text-text-muted transition-colors"
+        className="flex items-center gap-1 text-[10px] text-text-muted hover:text-text-primary transition-colors"
         title="No test run yet"
       >
-        <MinusCircle size={9} />
+        <MinusCircle size={10} />
         <span>— untested</span>
       </button>
     );
@@ -565,7 +562,7 @@ function TestStatusBadge({ result, onClick }: { result: SkillTestResult | null; 
     <button
       onClick={(e) => { e.stopPropagation(); onClick(); }}
       className={cn(
-        'flex items-center gap-1 text-[9px] transition-colors',
+        'flex items-center gap-1 text-[10px] transition-colors',
         allPassed
           ? 'text-status-running hover:text-status-running/80'
           : 'text-status-error hover:text-status-error/80',
@@ -574,16 +571,16 @@ function TestStatusBadge({ result, onClick }: { result: SkillTestResult | null; 
     >
       {allPassed ? (
         <>
-          <CheckCircle2 size={9} />
+          <CheckCircle2 size={10} />
           <span>✓ tested</span>
         </>
       ) : (
         <>
-          <XCircle size={9} />
+          <XCircle size={10} />
           <span>✗ failing</span>
         </>
       )}
-      <FlaskConical size={8} className="opacity-40 ml-0.5" />
+      <FlaskConical size={10} className="opacity-40 ml-0.5" />
     </button>
   );
 }
@@ -598,7 +595,7 @@ function StateBadge({ state }: { state: ItemState }) {
   };
 
   return (
-    <span className={cn('text-[9px] px-1.5 py-0.5 rounded font-mono', styles[state] ?? styles.draft)}>
+    <span className={cn('text-[10px] px-1.5 py-0.5 rounded font-mono', styles[state] ?? styles.draft)}>
       {state}
     </span>
   );

--- a/web/src/components/registry/SkillCard.tsx
+++ b/web/src/components/registry/SkillCard.tsx
@@ -21,6 +21,7 @@ export interface SkillCardProps {
   onEdit: (skill: AgentSkill) => void;
   onDelete: (skill: AgentSkill) => void;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 function StateBadge({ state }: { state: ItemState }) {
@@ -31,7 +32,7 @@ function StateBadge({ state }: { state: ItemState }) {
   };
 
   return (
-    <span className={cn('text-[9px] px-1.5 py-0.5 rounded font-mono flex-shrink-0', styles[state] ?? styles.draft)}>
+    <span className={cn('text-[10px] px-1.5 py-0.5 rounded font-mono flex-shrink-0', styles[state] ?? styles.draft)}>
       {state}
     </span>
   );
@@ -72,9 +73,11 @@ export const SkillCard = memo(({
   onEdit,
   onDelete,
   className,
+  style,
 }: SkillCardProps) => {
   return (
     <div
+      style={style}
       className={cn(
         'relative rounded-xl overflow-hidden flex flex-col',
         'backdrop-blur-xl border transition-all duration-200 ease-out',

--- a/web/src/components/registry/SkillEditor.tsx
+++ b/web/src/components/registry/SkillEditor.tsx
@@ -199,7 +199,7 @@ function MetadataEditor({
         </button>
       </div>
       {(entries ?? []).length === 0 && (
-        <p className="text-xs text-text-muted/50 italic">No metadata entries</p>
+        <p className="text-xs text-text-muted italic">No metadata entries</p>
       )}
       <div className="space-y-2">
         {(entries ?? []).map((entry) => (
@@ -255,13 +255,13 @@ function AcceptanceCriteriaEditor({
         </button>
       </div>
       {(entries ?? []).length === 0 && (
-        <p className="text-xs text-text-muted/50 italic">No acceptance criteria defined</p>
+        <p className="text-xs text-text-muted italic">No acceptance criteria defined</p>
       )}
       <div className="space-y-3">
         {(entries ?? []).map((entry) => (
           <div key={entry.id} className="rounded-lg border border-border/30 bg-background/40 p-3 space-y-2">
             <div className="flex items-start gap-2">
-              <span className="text-[10px] text-text-muted/60 uppercase tracking-wider w-12 pt-2.5 flex-shrink-0 font-mono">
+              <span className="text-[10px] text-text-muted uppercase tracking-wider w-12 pt-2.5 flex-shrink-0 font-mono">
                 GIVEN
               </span>
               <input
@@ -278,7 +278,7 @@ function AcceptanceCriteriaEditor({
               </button>
             </div>
             <div className="flex items-start gap-2">
-              <span className="text-[10px] text-text-muted/60 uppercase tracking-wider w-12 pt-2.5 flex-shrink-0 font-mono">
+              <span className="text-[10px] text-text-muted uppercase tracking-wider w-12 pt-2.5 flex-shrink-0 font-mono">
                 WHEN
               </span>
               <input
@@ -290,7 +290,7 @@ function AcceptanceCriteriaEditor({
               <div className="w-6 flex-shrink-0" />
             </div>
             <div className="flex items-start gap-2">
-              <span className="text-[10px] text-text-muted/60 uppercase tracking-wider w-12 pt-2.5 flex-shrink-0 font-mono">
+              <span className="text-[10px] text-text-muted uppercase tracking-wider w-12 pt-2.5 flex-shrink-0 font-mono">
                 THEN
               </span>
               <input
@@ -798,7 +798,7 @@ export function SkillEditor({
                 <div>
                   <label className="text-xs text-text-muted uppercase tracking-wider block mb-1.5">
                     Description
-                    <span className="ml-2 text-text-muted/60 normal-case">{description.length}/1024</span>
+                    <span className="ml-2 text-text-muted normal-case">{description.length}/1024</span>
                   </label>
                   <textarea
                     value={description}

--- a/web/src/components/registry/SkillFileTree.tsx
+++ b/web/src/components/registry/SkillFileTree.tsx
@@ -108,7 +108,7 @@ export function SkillFileTree({ skillName, onSelectFile }: SkillFileTreeProps) {
 
       {/* File list */}
       {(files ?? []).length === 0 ? (
-        <p className="text-[10px] text-text-muted/50 px-3 pb-2 italic">No supporting files</p>
+        <p className="text-[10px] text-text-muted px-3 pb-2 italic">No supporting files</p>
       ) : (
         <div className="px-2 pb-2 space-y-0.5">
           {Object.entries(grouped).map(([dir, dirFiles]) => (
@@ -136,7 +136,7 @@ export function SkillFileTree({ skillName, onSelectFile }: SkillFileTreeProps) {
                       >
                         {file.path.split('/').pop()}
                       </button>
-                      <span className="text-[9px] text-text-muted font-mono">
+                      <span className="text-[10px] text-text-muted font-mono">
                         {formatFileSize(file.size)}
                       </span>
                       <button

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useId, useRef, type ReactNode } from 'react';
+import { cn } from '../../lib/cn';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+
+type Variant = 'default' | 'danger';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  message: ReactNode;
+  confirmLabel: ReactNode;
+  cancelLabel?: string;
+  variant?: Variant;
+  /** Which button to focus on open. Defaults to 'cancel' for safety. */
+  autoFocus?: 'cancel' | 'confirm';
+}
+
+export function ConfirmDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  variant = 'default',
+  autoFocus = 'cancel',
+}: ConfirmDialogProps) {
+  const titleId = useId();
+  const descId = useId();
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+  const confirmRef = useRef<HTMLButtonElement | null>(null);
+  const initialFocusRef = autoFocus === 'confirm' ? confirmRef : cancelRef;
+  const panelRef = useFocusTrap<HTMLDivElement>({
+    active: isOpen,
+    initialFocusRef,
+  });
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, handleKeyDown]);
+
+  if (!isOpen) return null;
+
+  const confirmClasses =
+    variant === 'danger'
+      ? cn(
+          'bg-status-error text-white',
+          'hover:bg-status-error/90',
+          'focus:outline-none focus:ring-2 focus:ring-status-error/40 focus:ring-offset-2 focus:ring-offset-background',
+        )
+      : cn(
+          'bg-primary text-background',
+          'hover:bg-primary-light',
+          'focus:outline-none focus:ring-2 focus:ring-primary/40 focus:ring-offset-2 focus:ring-offset-background',
+        );
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 z-[60] animate-fade-in-scale',
+        'bg-background/80 backdrop-blur-sm flex items-center justify-center',
+      )}
+    >
+      <div className="absolute inset-0" onClick={onClose} />
+
+      <div
+        ref={panelRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        className={cn(
+          'relative glass-panel-elevated rounded-xl p-5 max-w-sm w-full mx-4 space-y-3 shadow-lg',
+        )}
+      >
+        <h2
+          id={titleId}
+          className="text-sm font-semibold text-text-primary"
+        >
+          {title}
+        </h2>
+        <div id={descId} className="text-xs text-text-muted space-y-2">
+          {message}
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onClose}
+            className={cn(
+              'px-3 py-1.5 text-xs rounded-lg transition-colors',
+              'text-text-secondary hover:text-text-primary bg-surface-elevated hover:bg-surface-highlight',
+              'focus:outline-none focus:ring-2 focus:ring-primary/30 focus:ring-offset-2 focus:ring-offset-background',
+            )}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            onClick={() => {
+              onConfirm();
+            }}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium rounded-lg transition-colors',
+              confirmClasses,
+            )}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback, type ReactNode } from 'react';
+import { useState, useEffect, useCallback, useId, type ReactNode } from 'react';
 import { X, Maximize2, Minimize2, ExternalLink } from 'lucide-react';
 import { cn } from '../../lib/cn';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 type ModalSize = 'default' | 'wide' | 'full';
 
@@ -39,6 +40,8 @@ export function Modal({
   flush,
 }: ModalProps) {
   const [expanded, setExpanded] = useState(false);
+  const titleId = useId();
+  const panelRef = useFocusTrap<HTMLDivElement>({ active: isOpen });
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -84,6 +87,10 @@ export function Modal({
 
       {/* Panel */}
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         className={cn(
           'relative flex flex-col',
           flush
@@ -97,7 +104,7 @@ export function Modal({
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border/30 flex-shrink-0">
-          <h2 className="text-sm font-medium text-text-primary">{title}</h2>
+          <h2 id={titleId} className="text-sm font-medium text-text-primary">{title}</h2>
           <div className="flex items-center gap-1">
             {expandable && (
               <button

--- a/web/src/components/vault/VaultPanel.tsx
+++ b/web/src/components/vault/VaultPanel.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { Button } from '../ui/Button';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { ResizeHandle } from '../ui/ResizeHandle';
 import { PopoutButton } from '../ui/PopoutButton';
 import { useVaultStore } from '../../stores/useVaultStore';
@@ -724,28 +725,27 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
         </>
       )}
 
-      {/* Delete confirmation overlay */}
-      {confirmDelete && (
-        <div className="absolute inset-0 bg-background/80 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="glass-panel-elevated rounded-xl p-5 max-w-xs mx-4 space-y-3">
-            <p className="text-sm text-text-primary">
+      {/* Delete confirmation */}
+      <ConfirmDialog
+        isOpen={confirmDelete !== null}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete secret"
+        message={
+          <>
+            <p>
               Delete <span className="font-mono text-primary">{confirmDelete}</span>?
             </p>
-            <p className="text-xs text-text-muted">This action cannot be undone.</p>
-            <div className="flex justify-end gap-2 pt-2">
-              <button
-                onClick={() => setConfirmDelete(null)}
-                className="px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary bg-surface-elevated rounded-lg transition-colors"
-              >
-                Cancel
-              </button>
-              <Button variant="danger" size="sm" onClick={handleDeleteConfirm}>
-                Delete
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+            <p>This action cannot be undone.</p>
+          </>
+        }
+        confirmLabel={
+          <span>
+            Delete <span className="font-mono">"{confirmDelete}"</span>
+          </span>
+        }
+        variant="danger"
+      />
       </div>{/* end content column */}
     </div>,
     document.body,

--- a/web/src/hooks/useFocusTrap.ts
+++ b/web/src/hooks/useFocusTrap.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'button:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex^="-"])',
+].join(',');
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) => !el.hasAttribute('aria-hidden') && el.offsetParent !== null,
+  );
+}
+
+interface UseFocusTrapOptions {
+  /** Whether the trap is currently active. */
+  active: boolean;
+  /** Optional ref to the element that should receive initial focus. If omitted, focuses the first focusable element. */
+  initialFocusRef?: React.RefObject<HTMLElement | null>;
+  /** If true, restores focus to the previously focused element when the trap deactivates. Defaults to true. */
+  restoreFocus?: boolean;
+}
+
+/**
+ * Traps keyboard focus within a container while active, and (by default) restores
+ * focus to the previously focused element when the trap deactivates. Intended for
+ * modal dialogs.
+ */
+export function useFocusTrap<T extends HTMLElement = HTMLElement>({
+  active,
+  initialFocusRef,
+  restoreFocus = true,
+}: UseFocusTrapOptions): React.RefObject<T | null> {
+  const containerRef = useRef<T | null>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+
+    // Defer initial focus one frame so the container is fully in the DOM/layout
+    // and any autofocus attributes have settled.
+    const rafId = requestAnimationFrame(() => {
+      const target =
+        initialFocusRef?.current ??
+        getFocusable(container)[0] ??
+        container;
+      if (target && !container.contains(document.activeElement)) {
+        if (!target.hasAttribute('tabindex') && target === container) {
+          target.setAttribute('tabindex', '-1');
+        }
+        target.focus();
+      }
+    });
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const focusable = getFocusable(container);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        container.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const activeEl = document.activeElement as HTMLElement | null;
+
+      if (e.shiftKey) {
+        if (activeEl === first || !container.contains(activeEl)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (activeEl === last || !container.contains(activeEl)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      document.removeEventListener('keydown', handleKeyDown);
+      if (restoreFocus) {
+        const previous = previouslyFocusedRef.current;
+        if (previous && document.contains(previous)) {
+          previous.focus();
+        }
+      }
+    };
+  }, [active, initialFocusRef, restoreFocus]);
+
+  return containerRef;
+}

--- a/web/src/pages/DetachedEditorPage.tsx
+++ b/web/src/pages/DetachedEditorPage.tsx
@@ -170,7 +170,7 @@ function DetachedEditorContent() {
           {itemName ? `Editing: ${itemName}` : 'New skill'}
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
+          <span className="w-1.5 h-1.5 rounded-full bg-text-muted animate-pulse" />
           Detached Editor
         </span>
       </div>

--- a/web/src/pages/DetachedLogsPage.tsx
+++ b/web/src/pages/DetachedLogsPage.tsx
@@ -538,7 +538,7 @@ function DetachedLogsPageContent() {
           {filteredLogs.length} / {(logs ?? []).length} entries {isPaused ? '(paused)' : ''}
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
+          <span className="w-1.5 h-1.5 rounded-full bg-text-muted animate-pulse" />
           Detached Window
         </span>
       </footer>

--- a/web/src/pages/DetachedMetricsPage.tsx
+++ b/web/src/pages/DetachedMetricsPage.tsx
@@ -442,7 +442,7 @@ function DetachedMetricsPageContent() {
           {isPaused ? ' (paused)' : ''}
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
+          <span className="w-1.5 h-1.5 rounded-full bg-text-muted animate-pulse" />
           Detached Window
         </span>
       </footer>

--- a/web/src/pages/DetachedRegistryPage.tsx
+++ b/web/src/pages/DetachedRegistryPage.tsx
@@ -14,6 +14,7 @@ import { ZoomControls } from '../components/log/ZoomControls';
 import { SkillEditor } from '../components/registry/SkillEditor';
 import { SkillCard } from '../components/registry/SkillCard';
 import { SkillCardSkeleton } from '../components/registry/SkillCardSkeleton';
+import { ConfirmDialog } from '../components/ui/ConfirmDialog';
 import { ToastContainer, showToast } from '../components/ui/Toast';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
 import { useLogFontSize } from '../hooks/useLogFontSize';
@@ -109,13 +110,36 @@ interface GroupedSkillGridProps {
 
 function GroupedSkillGrid({ skills, hasSearch, onEnable, onDisable, onEdit, onDelete }: GroupedSkillGridProps) {
   const groups = groupSkills(skills);
-  const showHeaders = groups.size > 1;
+  // Only group when the structure is meaningful: 2+ groups AND at least one
+  // group has 2+ skills. Otherwise the full-width section headers just waste
+  // horizontal space (every skill becomes its own "group of one").
+  const hasMeaningfulGrouping =
+    groups.size > 1 && Array.from(groups.values()).some((g) => g.length > 1);
 
   const gridStyle: React.CSSProperties = {
     display: 'grid',
     gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
     gap: '12px',
   };
+
+  if (!hasMeaningfulGrouping) {
+    return (
+      <div className="p-4" style={gridStyle}>
+        {skills.map((skill, i) => (
+          <SkillCard
+            key={skill.name}
+            skill={skill}
+            className={cn('motion-safe:animate-fade-in-scale', skill.metadata?.colspan === '2' ? 'col-span-2' : undefined)}
+            style={{ animationDelay: `${Math.min(i, 10) * 30}ms` }}
+            onEnable={onEnable}
+            onDisable={onDisable}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div className="p-4" style={gridStyle}>
@@ -124,7 +148,7 @@ function GroupedSkillGrid({ skills, hasSearch, onEnable, onDisable, onEdit, onDe
           key={key || '__ungrouped__'}
           groupKey={key}
           skills={groupSkillList}
-          showHeader={showHeaders}
+          showHeader
           hasSearch={hasSearch}
           onEnable={onEnable}
           onDisable={onDisable}
@@ -163,11 +187,12 @@ function GroupSection({ groupKey, skills, showHeader, hasSearch, onEnable, onDis
           <div className="border-b border-border/30" />
         </div>
       )}
-      {skills.map((skill) => (
+      {skills.map((skill, i) => (
         <SkillCard
           key={skill.name}
           skill={skill}
-          className={cn('animate-fade-in-scale', skill.metadata?.colspan === '2' ? 'col-span-2' : undefined)}
+          className={cn('motion-safe:animate-fade-in-scale', skill.metadata?.colspan === '2' ? 'col-span-2' : undefined)}
+          style={{ animationDelay: `${Math.min(i, 10) * 30}ms` }}
           onEnable={onEnable}
           onDisable={onDisable}
           onEdit={onEdit}
@@ -398,7 +423,7 @@ function DetachedRegistryContent() {
               <BookOpen size={32} className="text-text-muted/50" />
             </div>
             <span className="text-sm">No skills registered</span>
-            <span className="text-[10px] text-text-muted/60">Create a SKILL.md to get started</span>
+            <span className="text-[10px] text-text-muted">Create a SKILL.md to get started</span>
           </div>
         )}
 
@@ -443,36 +468,32 @@ function DetachedRegistryContent() {
           <span className="text-status-running">{status?.activeSkills ?? 0} active</span>
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
+          <span className="w-1.5 h-1.5 rounded-full bg-text-muted animate-pulse" />
           Detached Window
         </span>
       </footer>
 
-      {/* Delete confirmation overlay */}
-      {confirmDelete && (
-        <div className="absolute inset-0 bg-background/80 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="glass-panel-elevated rounded-xl p-5 max-w-xs mx-4 space-y-3">
-            <p className="text-sm text-text-primary">
+      {/* Delete confirmation */}
+      <ConfirmDialog
+        isOpen={confirmDelete !== null}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete skill"
+        message={
+          <>
+            <p>
               Delete <span className="font-mono text-primary">{confirmDelete}</span>?
             </p>
-            <p className="text-xs text-text-muted">This action cannot be undone.</p>
-            <div className="flex justify-end gap-2 pt-2">
-              <button
-                onClick={() => setConfirmDelete(null)}
-                className="px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary bg-surface-elevated rounded-lg transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleDeleteConfirm}
-                className="px-3 py-1.5 text-xs font-medium rounded-lg bg-status-error text-white hover:bg-status-error/90 transition-colors"
-              >
-                Delete
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+            <p>This action cannot be undone.</p>
+          </>
+        }
+        confirmLabel={
+          <span>
+            Delete <span className="font-mono">"{confirmDelete}"</span>
+          </span>
+        }
+        variant="danger"
+      />
 
       {/* Editor modal */}
       <SkillEditor

--- a/web/src/pages/DetachedSidebarPage.tsx
+++ b/web/src/pages/DetachedSidebarPage.tsx
@@ -273,7 +273,7 @@ function DetachedSidebarPageContent() {
           {selectedData?.type === 'mcp-server' ? 'MCP Server' : selectedData?.type === 'resource' ? 'Resource' : ''}
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
+          <span className="w-1.5 h-1.5 rounded-full bg-text-muted animate-pulse" />
           Detached Window
         </span>
       </footer>

--- a/web/src/pages/DetachedTracesPage.tsx
+++ b/web/src/pages/DetachedTracesPage.tsx
@@ -388,7 +388,7 @@ function DetachedTracesPageContent() {
       <footer className="h-6 flex-shrink-0 bg-surface/90 backdrop-blur-xl border-t border-border/50 flex items-center justify-between px-4 text-[10px] text-text-muted">
         <span>{traces.length > 0 ? `${traces.length} trace${traces.length !== 1 ? 's' : ''}` : 'No data'}</span>
         <span className="flex items-center gap-1">
-          <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
+          <span className="w-1.5 h-1.5 rounded-full bg-text-muted animate-pulse" />
           Detached Window
         </span>
       </footer>

--- a/web/src/pages/DetachedVaultPage.tsx
+++ b/web/src/pages/DetachedVaultPage.tsx
@@ -22,6 +22,7 @@ import {
 import { cn } from '../lib/cn';
 import { IconButton } from '../components/ui/IconButton';
 import { Button } from '../components/ui/Button';
+import { ConfirmDialog } from '../components/ui/ConfirmDialog';
 import { ZoomControls } from '../components/log/ZoomControls';
 import { VaultLockPrompt } from '../components/vault/VaultLockPrompt';
 import { ToastContainer, showToast } from '../components/ui/Toast';
@@ -735,34 +736,33 @@ function DetachedVaultContent() {
             {locked ? 'Vault locked' : ''}
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
+            <span className="w-1.5 h-1.5 rounded-full bg-text-muted animate-pulse" />
             Detached Window
           </span>
         </div>
       </footer>
 
-      {/* Delete confirmation overlay */}
-      {confirmDelete && (
-        <div className="absolute inset-0 bg-background/80 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="glass-panel-elevated rounded-xl p-5 max-w-xs mx-4 space-y-3">
-            <p className="text-sm text-text-primary">
+      {/* Delete confirmation */}
+      <ConfirmDialog
+        isOpen={confirmDelete !== null}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete secret"
+        message={
+          <>
+            <p>
               Delete <span className="font-mono text-primary">{confirmDelete}</span>?
             </p>
-            <p className="text-xs text-text-muted">This action cannot be undone.</p>
-            <div className="flex justify-end gap-2 pt-2">
-              <button
-                onClick={() => setConfirmDelete(null)}
-                className="px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary bg-surface-elevated rounded-lg transition-colors"
-              >
-                Cancel
-              </button>
-              <Button variant="danger" size="sm" onClick={handleDeleteConfirm}>
-                Delete
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+            <p>This action cannot be undone.</p>
+          </>
+        }
+        confirmLabel={
+          <span>
+            Delete <span className="font-mono">"{confirmDelete}"</span>
+          </span>
+        }
+        variant="danger"
+      />
 
       <ToastContainer />
     </div>

--- a/web/src/pages/DetachedWorkflowPage.tsx
+++ b/web/src/pages/DetachedWorkflowPage.tsx
@@ -303,7 +303,7 @@ function DetachedWorkflowContent() {
             1/2/3 modes &middot; f follow &middot; &thinsp;run &middot; t toolbox &middot; i inspector
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
+            <span className="w-1.5 h-1.5 rounded-full bg-text-muted animate-pulse" />
             Detached
           </span>
         </span>


### PR DESCRIPTION
## Description

Curated UX polish for the Skills Registry based on an external review. Adds WCAG 2.2 AA compliant modals and confirm dialogs, kills sub-10px typography, unifies the destructive-button treatment, and fixes the detached grid's single-card-per-row layout.

## Type of Change

- [x] Refactor / enhancement (non-breaking)

## Changes Made

**New primitives**
- `useFocusTrap` hook — traps Tab cycling, restores focus on close
- `ConfirmDialog` component — `role="alertdialog"`, autofocuses Cancel, echoes the skill/secret name in the destructive button

**Modal a11y upgrade**
- Adds `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, and focus trap to the shared `Modal`. Benefits `SkillEditor`, wizard, and every future modal consumer

**Dialog migration**
- Replaces four ad-hoc inline delete confirmations (registry sidebar, detached registry, vault panel, detached vault) with the new `ConfirmDialog`

**Registry polish**
- Removes every `text-[8px]` and `text-[9px]` in the registry scope; 10px floor
- Replaces `text-text-muted/50` and `/60` opacity-stacked hints with full-opacity `text-muted` (4.92:1, passes AA)
- Re-skins `SkillItem`'s delete button from gradient+glow to solid `bg-status-error`

**Detached registry layout**
- `GroupedSkillGrid` now checks for meaningful grouping (2+ groups AND at least one with 2+ skills). Flat skill directories no longer render as one-card-per-full-width-row — the grid packs 4–5 cards per row. Grouping still appears when there's real directory structure
- Card animations now stagger via `animation-delay` (capped at 10 × 30ms) and gate behind `motion-safe:`

**Detached footers**
- Eight detached-window footer dots (registry, vault, editor, logs, metrics, sidebar, traces, workflow) swap `bg-status-running` → `bg-text-muted` to resolve the collision with the global 'running' status semantic. Live-data indicators that legitimately signal 'running' are preserved

## Testing

- New Vitest coverage for `useFocusTrap` (4 tests) and `ConfirmDialog` (5 tests)
- Full test suite: 393/393 passing
- `npm run build` green
- Manual keyboard walkthrough of delete flow confirmed: autofocus lands on Cancel, Tab wraps within dialog, Escape closes, focus returns to opener

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed