### PR TITLE
feat: reactive autoscaling for MCP ReplicaSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to gridctl will be documented in this file.
 ### Features
 
 
+- **feat: reactive autoscaling for MCP ReplicaSet.** Replace static `replicas: N` with an `autoscale:` block (min/max/target_in_flight/scale_up_after/scale_down_after/warm_pool/idle_to_zero) and gridctl will spawn and reap replicas reactively based on median in-flight load. Supported on container, local-process, and SSH transports; rejected (with a precise YAML path) on external URL and OpenAPI. Adds a new `AUTOSCALE` column to `gridctl status --replicas`, an `autoscale` object to `/api/mcp-servers`, and structured log lines / trace spans per scaling decision. `autoscale` is mutually exclusive with `replicas`; servers without it behave identically to previous releases. See [docs/scaling.md](docs/scaling.md#autoscaling) and [examples/autoscale/](examples/autoscale/).
 - Graduate Podman runtime to stable ([#424](https://github.com/gridctl/gridctl/pull/424))
 - Expand OpenAPI auth to support OAuth2 CC, query-param keys, mTLS, and basic auth ([#427](https://github.com/gridctl/gridctl/pull/427))
 - Complete wizard spec for SSH advanced fields, OpenAPI auth types, mTLS, and pin_schemas ([#429](https://github.com/gridctl/gridctl/pull/429))

--- a/cmd/gridctl/status.go
+++ b/cmd/gridctl/status.go
@@ -189,6 +189,17 @@ type mcpServerAPI struct {
 	SSH          bool              `json:"ssh"`
 	OpenAPI      bool              `json:"openapi"`
 	Replicas     []mcpReplicaAPI   `json:"replicas,omitempty"`
+	Autoscale    *autoscaleAPI     `json:"autoscale,omitempty"`
+}
+
+// autoscaleAPI mirrors the subset of mcp.AutoscaleStatus the CLI renders in
+// the AUTOSCALE column.
+type autoscaleAPI struct {
+	Min            int `json:"min"`
+	Max            int `json:"max"`
+	Current        int `json:"current"`
+	Target         int `json:"target"`
+	TargetInFlight int `json:"targetInFlight"`
 }
 
 // mcpReplicaAPI is the per-replica slice of mcpServerAPI.
@@ -229,13 +240,21 @@ func buildMCPRollup(servers []mcpServerAPI) []output.MCPServerRollup {
 	now := time.Now()
 	for _, srv := range servers {
 		row := output.MCPServerRollup{
-			Name:     srv.Name,
-			Type:     mcpServerType(srv),
-			Replicas: "—",
-			State:    "healthy",
+			Name:      srv.Name,
+			Type:      mcpServerType(srv),
+			Replicas:  "—",
+			State:     "healthy",
+			Autoscale: formatAutoscaleCell(srv.Autoscale),
 		}
 		n := len(srv.Replicas)
 		if n == 0 {
+			// Autoscaled servers can legitimately report 0 replicas (scale-
+			// to-zero): show the autoscale stats but still label unknown.
+			if srv.Autoscale != nil {
+				row.State = "idle"
+				rows = append(rows, row)
+				continue
+			}
 			// No replica info (e.g. pre-phase-3 daemon, or external transport).
 			row.State = "unknown"
 			rows = append(rows, row)
@@ -267,19 +286,44 @@ func buildMCPRollup(servers []mcpServerAPI) []output.MCPServerRollup {
 	return rows
 }
 
+// formatAutoscaleCell produces the "min/current/max (target=N)" render used
+// in the AUTOSCALE column. Returns "" when the server is not autoscaled so
+// the column renderer can suppress it for static-only stacks.
+func formatAutoscaleCell(a *autoscaleAPI) string {
+	if a == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d/%d/%d (target=%d)", a.Min, a.Current, a.Max, a.TargetInFlight)
+}
+
 // buildReplicaDetails converts API statuses into the per-replica rows for
-// `gridctl status --replicas`. Servers with no replica data are skipped.
+// `gridctl status --replicas`. Autoscaled servers with zero replicas still
+// produce one synthetic row so scale-to-zero state is visible.
 func buildReplicaDetails(servers []mcpServerAPI) []output.ReplicaDetail {
 	var rows []output.ReplicaDetail
 	now := time.Now()
 	for _, srv := range servers {
+		autoCell := formatAutoscaleCell(srv.Autoscale)
+		if len(srv.Replicas) == 0 && srv.Autoscale != nil {
+			rows = append(rows, output.ReplicaDetail{
+				Server:    srv.Name,
+				Replica:   0,
+				Handle:    "—",
+				State:     "idle",
+				Uptime:    "—",
+				InFlight:  0,
+				Autoscale: autoCell,
+			})
+			continue
+		}
 		for _, r := range srv.Replicas {
 			row := output.ReplicaDetail{
-				Server:   srv.Name,
-				Replica:  r.ReplicaID,
-				Handle:   replicaHandle(r),
-				State:    r.State,
-				InFlight: r.InFlight,
+				Server:    srv.Name,
+				Replica:   r.ReplicaID,
+				Handle:    replicaHandle(r),
+				State:     r.State,
+				InFlight:  r.InFlight,
+				Autoscale: autoCell,
 			}
 			if r.Healthy && !r.StartedAt.IsZero() {
 				row.Uptime = formatUptime(now.Sub(r.StartedAt))

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -148,3 +148,127 @@ mcp-servers:
 ```
 
 Validation surfaces the exact path (`mcp-servers[N].replicas`) so CI can fail fast.
+
+---
+
+## Autoscaling
+
+A server can replace static `replicas: N` with an `autoscale` block that lets
+gridctl spawn and reap replicas reactively based on in-flight load. The same
+transport rules apply — autoscale is supported on container, local-process,
+and SSH servers, and rejected on external URL and OpenAPI transports.
+
+```yaml
+mcp-servers:
+  - name: junos
+    command:
+      - .venv/bin/python
+      - servers/junos-mcp-server/jmcp.py
+      - --transport
+      - stdio
+    replica_policy: least-connections
+    autoscale:
+      min: 1                    # >= 0; must be >= 1 unless idle_to_zero is true
+      max: 8                    # >= min; capped at 32
+      target_in_flight: 3       # per-replica in-flight the scaler tries to hold below
+      scale_up_after: 30s       # min 10s; default 30s
+      scale_down_after: 5m      # min 1m; default 5m
+      warm_pool: 0              # extra idle replicas kept above the load floor
+      idle_to_zero: false       # when true, min may be 0 (scale-to-zero)
+```
+
+`autoscale` and `replicas` are **mutually exclusive** on the same server.
+A server without an `autoscale` block behaves exactly as it did before; every
+new field is optional at the YAML layer.
+
+### Decision rules in plain prose
+
+Every 10s the scaler samples the median in-flight request count across the
+server's currently-healthy replicas, appends the sample to a rolling window
+at least 30s long, and decides:
+
+1. **Noop** — target is within the current set and no cooldown is pending.
+2. **Scale up** — target > current AND the rolling median has exceeded
+   `target_in_flight` for the full `scale_up_after` window. Spawns enough
+   replicas in one tick to reach target, clamped at `max`. Cooldown: no
+   further scale-up until `scale_up_after` has elapsed since the last one.
+   *Exception:* if `current < min + warm_pool`, the cooldown is skipped so
+   the warm pool recovers eagerly after a crash.
+3. **Scale down** — target < current AND the rolling median has been below
+   half the target for the full `scale_down_after` window. Reaps **at most
+   one replica per tick**, preferring the replica with the lowest in-flight
+   count (ties broken by oldest). Floored at `min + warm_pool`. Cooldown is
+   tracked separately from scale-up.
+4. **Idle-to-zero reap** — when `idle_to_zero: true` and `min: 0` and the
+   rolling window has been zero for the full `scale_down_after`, reap every
+   remaining replica through the same drain protocol.
+5. **Cold start** — a tool call that arrives while the set is at zero
+   replicas (`idle_to_zero: true` reaped everything) synchronously spawns
+   the first replica before returning. The tool call blocks on that spawn.
+
+Every decision emits exactly one structured log line with `direction`
+(up/down/noop), `current`, `target`, `median_in_flight`, and `reason`
+(`load` / `warm_pool` / `idle_to_zero` / `cooldown` / `cold_start`). Scale
+actions also produce trace spans (`mcp.autoscale.spawn` and `mcp.autoscale.reap`).
+
+Drain protocol: when a replica is picked for reap, it's removed from
+dispatch immediately, then the scaler waits up to 30s for its in-flight
+counter to reach zero before closing the client. Exceeding that deadline
+puts the replica back in rotation and aborts this tick's scale-down.
+
+### Operator trade-offs
+
+- **Memory cost scales with `max`.** Three Python replicas cost three
+  runtimes and three sets of imported libraries. Right-size `max` to your
+  peak-demand replica count; a very high `max` is almost always a config
+  error (the validator caps it at 32 as a sanity check).
+- **Cold-start latency.** When `idle_to_zero: true`, the first tool call
+  after an idle period pays the full transport-specific start cost (see the
+  Cold Start Penalty section below).
+- **WarmPool is an always-on buffer.** `min + warm_pool` is the floor the
+  scaler refuses to cross on scale-down. Useful to absorb brief spikes
+  without paying the scale-up cooldown every time.
+- **Shared upstream resources stay bottlenecked.** If the server pool shares
+  a single DB connection or API token, adding replicas distributes stdio
+  pipes but doesn't speed up serialisation at the bottleneck.
+
+### Cold Start Penalty
+
+`idle_to_zero: true, min: 0` reaps every replica after `scale_down_after`
+of zero traffic. The next tool call pays the full cold-start cost:
+
+| Transport | Rough cold-start cost |
+|-----------|-----------------------|
+| Local process | 100ms–1s |
+| SSH | 1–3s |
+| Container (stdio) | 2–10s |
+| Container (HTTP) | 5–30s (readiness poll) |
+
+**Configure client-side timeouts to tolerate this.** Most MCP clients
+(Claude Desktop, Cursor, Windsurf) default to 30–60s tool-call timeouts,
+which may be tight for container cold starts. When enabling `idle_to_zero`
+for a container-backed server, raise the client's tool-call timeout to at
+least **60s** or keep a permanent warm replica (`min: 0, warm_pool: 1`).
+
+### Hot reload
+
+- Changes *inside* an existing `autoscale` block are applied as a policy
+  update — the scaler swaps the policy atomically on the next tick and no
+  in-flight tool calls are disrupted.
+- Switching between `replicas: N` and `autoscale:` (or vice versa) is a
+  full server restart, same as any other structural change.
+
+### Observability
+
+- **Logs** — one `"autoscale decision"` line per tick per autoscaled server;
+  spawn/reap failures emit `autoscale spawn failed` / `autoscale reap failed`
+  at WARN with `server`, `direction`, `current`, `target`, `error` attrs.
+- **Traces** — `mcp.autoscale.spawn` / `mcp.autoscale.reap` spans with an
+  `mcp.autoscale.direction` attribute for UI filtering.
+- **CLI** — `gridctl status --replicas` shows an `AUTOSCALE` column rendering
+  `min/current/max (target=N)` for autoscaled servers; blank for static ones.
+- **REST** — `/api/mcp-servers` and the `/api/stack/health` payload include
+  an `autoscale` object per server: `{min, max, current, target, targetInFlight,
+  medianInFlight, lastDecision, lastScaleUpAt, lastScaleDownAt, warmPool,
+  idleToZero}`.
+

--- a/examples/autoscale/README.md
+++ b/examples/autoscale/README.md
@@ -1,0 +1,109 @@
+# Reactive autoscaling
+
+Gridctl can autoscale a local-process, SSH, or container-backed MCP server
+based on live in-flight load. Enable it by replacing `replicas: N` with an
+`autoscale` block on the server.
+
+```yaml
+mcp-servers:
+  - name: junos
+    command: [python, junos-server.py]
+    autoscale:
+      min: 1
+      max: 8
+      target_in_flight: 3
+      scale_up_after: 30s
+      scale_down_after: 5m
+```
+
+## What it does
+
+Every 10s the scaler samples the median in-flight request count across healthy
+replicas and decides:
+
+- **Scale up** — when the rolling median stays above `target_in_flight` for
+  the full `scale_up_after` window, spawn enough replicas to drive the median
+  back under target. Clamped at `max`.
+- **Scale down** — when the rolling median stays below half the target for
+  the full `scale_down_after` window, reap one replica per tick, floored at
+  `min + warm_pool`.
+- **Cold start** — a tool call that arrives while `current == 0` (only
+  possible under `idle_to_zero: true, min: 0`) synchronously spawns the first
+  replica before the call returns.
+
+Every decision emits one structured log line you can grep for:
+
+```
+level=INFO msg="autoscale decision" server=junos direction=up current=1 target=3 median_in_flight=9 reason=load
+```
+
+Scale actions also produce trace spans (`mcp.autoscale.spawn`, `mcp.autoscale.reap`)
+carrying a `mcp.autoscale.direction` attribute, so the traces UI can filter
+scale events.
+
+## Observability
+
+| Surface | What you'll see |
+|---------|-----------------|
+| `gridctl status --replicas` | New `AUTOSCALE` column: `min/current/max (target=N)` |
+| `/api/mcp-servers` | `autoscale` object per server with current / target / median |
+| Logs | One `"autoscale decision"` line per tick (INFO); spawn/reap failures at WARN |
+| Traces | Spans under `gridctl.autoscaler` and `mcp.autoscale.*` |
+
+## Operator trade-offs
+
+- **Memory cost scales with `max`.** Three Python replicas cost three Python
+  runtimes and three sets of imported libraries. Keep `max` close to the
+  peak-demand replica count; a very high `max` is rarely useful and makes
+  capacity planning harder.
+- **Cold-start latency.** When `idle_to_zero: true`, the first tool call
+  after an idle period pays the full transport-specific start cost (container
+  boot or process spawn + MCP handshake). See the "Cold start penalty" section
+  below; increase client timeouts when running cold.
+- **WarmPool is the always-on buffer.** `min + warm_pool` is the floor the
+  scaler refuses to cross on scale-down. Use it to absorb brief traffic
+  spikes without paying scale-up cooldown each time.
+
+## Cold start penalty
+
+`idle_to_zero: true` reaps every replica after `scale_down_after` of idle
+time. The first tool call after that adds:
+
+| Transport | Cold-start cost (rough) |
+|-----------|-------------------------|
+| Local process | ~100ms–1s (Go/Python interpreter + imports) |
+| SSH | ~1–3s (SSH handshake + process start) |
+| Container (stdio) | ~2–10s (container create + attach + init) |
+| Container (HTTP) | ~5–30s (container create + readiness poll) |
+
+**Configure client timeouts to tolerate this.** Claude Desktop, Cursor, and
+most MCP clients default to a 30–60s tool-call timeout; that's enough for
+local/SSH but may be tight for container cold starts. When you enable
+`idle_to_zero` for a container-backed server, raise the client's tool-call
+timeout to **60s minimum** (or disable idle-to-zero for that server).
+
+You can also use `warm_pool: 1` with `min: 0, idle_to_zero: true` to keep
+one replica permanently warm — trading a small amount of idle memory for a
+zero-cold-start guarantee.
+
+## Mutually exclusive with `replicas: N`
+
+A server can't have both `autoscale` and `replicas: N`. `gridctl validate`
+rejects that configuration up front:
+
+```
+mcp-servers[0]: cannot set both 'replicas' and 'autoscale' on the same server
+```
+
+Switching between `replicas: 3` and an `autoscale` block on the same server
+is a full restart at hot-reload time (different bookkeeping). Changes
+*inside* an existing `autoscale` block are applied as a policy update without
+dropping in-flight calls.
+
+## Not supported
+
+- External URL servers and OpenAPI servers — they're stateless from gridctl's
+  point of view; scale them at the HTTP tier.
+- Cross-daemon load balancing — decisions are local to one gridctl daemon.
+- Predictive pre-warm — policies are reactive to current load only. Use
+  `warm_pool` to keep a buffer above the load floor.

--- a/examples/autoscale/autoscale-basic.yaml
+++ b/examples/autoscale/autoscale-basic.yaml
@@ -1,0 +1,35 @@
+# Phase 1 reactive autoscaling example.
+#
+# The gateway keeps the median in-flight request count per replica at or below
+# `target_in_flight`. When demand rises, it spawns additional replicas of the
+# server up to `max`; when demand falls, it reaps replicas back down to `min`
+# after `scale_down_after` of sustained low load.
+#
+# `autoscale` and `replicas` are mutually exclusive. A server without an
+# `autoscale` block continues to behave exactly as it does today.
+#
+# Run with:
+#   gridctl validate examples/autoscale/autoscale-basic.yaml   # exits 0
+#   gridctl apply    examples/autoscale/autoscale-basic.yaml
+#   # In another terminal, burst traffic against it:
+#   gridctl status --replicas
+
+version: "1"
+name: autoscale-demo
+
+network:
+  name: autoscale-demo-net
+
+mcp-servers:
+  - name: junos
+    command:
+      - examples/_mock-servers/local-stdio-server/local-stdio-server
+    autoscale:
+      min: 1                    # always keep at least 1 replica healthy
+      max: 8                    # upper bound (sanity-capped at 32)
+      target_in_flight: 3       # scale out when median in-flight exceeds 3 per replica
+      scale_up_after: 30s       # wait 30s of sustained high load before spawning
+      scale_down_after: 5m      # wait 5m of sustained low load before reaping
+      warm_pool: 0              # keep 0 extra idle replicas above the load floor
+      idle_to_zero: false       # keep min healthy even during a complete lull
+    replica_policy: least-connections

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -425,7 +425,8 @@ type MCPServerStatus struct {
 	HealthError   string   `json:"healthError,omitempty"`
 	ToolWhitelist []string `json:"toolWhitelist,omitempty"`
 
-	Replicas []mcp.ReplicaStatus `json:"replicas,omitempty"`
+	Replicas  []mcp.ReplicaStatus  `json:"replicas,omitempty"`
+	Autoscale *mcp.AutoscaleStatus `json:"autoscale,omitempty"`
 }
 
 func (s *Server) getMCPServerStatuses() []MCPServerStatus {
@@ -450,6 +451,7 @@ func (s *Server) getMCPServerStatuses() []MCPServerStatus {
 			HealthError:   ms.HealthError,
 			ToolWhitelist: ms.ToolWhitelist,
 			Replicas:      ms.Replicas,
+			Autoscale:     ms.Autoscale,
 		}
 		if ms.LastCheck != nil {
 			ts := ms.LastCheck.Format(time.RFC3339)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -156,6 +156,61 @@ type MCPServer struct {
 	// ReplicaPolicy selects the dispatch policy when Replicas > 1.
 	// Valid values: "round-robin" (default), "least-connections".
 	ReplicaPolicy string `yaml:"replica_policy,omitempty" json:"replica_policy,omitempty"`
+
+	// Autoscale, when set, replaces the static Replicas count with reactive
+	// autoscaling bounded by Min and Max. Mutually exclusive with Replicas.
+	// Not supported on external URL or OpenAPI transports.
+	Autoscale *AutoscaleConfig `yaml:"autoscale,omitempty" json:"autoscale,omitempty"`
+}
+
+// AutoscaleConfig controls reactive autoscaling of a ReplicaSet. All fields are
+// optional at the YAML layer only in the sense that SetDefaults fills missing
+// timings; Min, Max, and TargetInFlight are required for the block to validate.
+type AutoscaleConfig struct {
+	// Min is the minimum number of healthy replicas to maintain.
+	// >= 0. Must be >= 1 when IdleToZero is false.
+	Min int `yaml:"min" json:"min"`
+	// Max is the upper bound on replica count. >= 1, >= Min, <= 32.
+	Max int `yaml:"max" json:"max"`
+	// TargetInFlight is the per-replica in-flight request count the scaler
+	// tries to hold the median at or below. >= 1.
+	TargetInFlight int `yaml:"target_in_flight" json:"target_in_flight"`
+	// ScaleUpAfter is how long the window median must exceed the target
+	// before spawning a replica. Default 30s. Minimum 10s.
+	ScaleUpAfter string `yaml:"scale_up_after,omitempty" json:"scale_up_after,omitempty"`
+	// ScaleDownAfter is how long the window median must be below the target
+	// before reaping a replica. Default 5m. Minimum 1m.
+	ScaleDownAfter string `yaml:"scale_down_after,omitempty" json:"scale_down_after,omitempty"`
+	// WarmPool keeps this many extra idle-ready replicas above the load-derived
+	// target at all times. Default 0. Must satisfy Min + WarmPool <= Max.
+	WarmPool int `yaml:"warm_pool,omitempty" json:"warm_pool,omitempty"`
+	// IdleToZero allows the scaler to reap every replica after a sustained
+	// idle. Min may be 0 only when IdleToZero is true. Default false.
+	IdleToZero bool `yaml:"idle_to_zero,omitempty" json:"idle_to_zero,omitempty"`
+}
+
+// ResolvedScaleUpAfter parses ScaleUpAfter; returns 30s when unset or invalid.
+func (a *AutoscaleConfig) ResolvedScaleUpAfter() time.Duration {
+	if a == nil || a.ScaleUpAfter == "" {
+		return 30 * time.Second
+	}
+	d, err := time.ParseDuration(a.ScaleUpAfter)
+	if err != nil || d <= 0 {
+		return 30 * time.Second
+	}
+	return d
+}
+
+// ResolvedScaleDownAfter parses ScaleDownAfter; returns 5m when unset or invalid.
+func (a *AutoscaleConfig) ResolvedScaleDownAfter() time.Duration {
+	if a == nil || a.ScaleDownAfter == "" {
+		return 5 * time.Minute
+	}
+	d, err := time.ParseDuration(a.ScaleDownAfter)
+	if err != nil || d <= 0 {
+		return 5 * time.Minute
+	}
+	return d
 }
 
 // ResolvedReadyTimeout parses ReadyTimeout; returns 0 when unset or invalid
@@ -366,7 +421,9 @@ func (s *Stack) SetDefaults() {
 				s.MCPServers[i].Source.Ref = "main"
 			}
 		}
-		if s.MCPServers[i].Replicas <= 0 {
+		// When autoscale is configured the scaler owns replica count — leave
+		// Replicas at 0 so downstream code can distinguish static from elastic.
+		if s.MCPServers[i].Autoscale == nil && s.MCPServers[i].Replicas <= 0 {
 			s.MCPServers[i].Replicas = 1
 		}
 		if s.MCPServers[i].ReplicaPolicy == "" {

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -379,6 +379,11 @@ func Validate(s *Stack) error {
 			errs = append(errs, ValidationError{prefix + ".replicas", "not supported for external URL or OpenAPI servers (already external/stateless — scale them at the HTTP tier)"})
 		}
 
+		// Autoscale validation.
+		if server.Autoscale != nil {
+			errs = append(errs, validateAutoscale(server, prefix)...)
+		}
+
 		// In simple mode, server.Network is ignored (per design decision)
 	}
 
@@ -416,6 +421,74 @@ func Validate(s *Stack) error {
 		return errs
 	}
 	return nil
+}
+
+// validateAutoscale validates the autoscale block on one MCP server. prefix is
+// the YAML path of the server entry (e.g. "mcp-servers[2]") so every error
+// surfaces the full dotted path for CI / --format json consumers.
+func validateAutoscale(server MCPServer, prefix string) ValidationErrors {
+	var errs ValidationErrors
+	a := server.Autoscale
+	asPrefix := prefix + ".autoscale"
+
+	// Mutually exclusive with replicas.
+	if server.Replicas > 0 {
+		errs = append(errs, ValidationError{prefix, "cannot set both 'replicas' and 'autoscale' on the same server"})
+	}
+
+	// Not supported on external / openapi, matching the existing replicas rule.
+	if server.IsExternal() || server.IsOpenAPI() {
+		errs = append(errs, ValidationError{asPrefix, "not supported for external URL or OpenAPI servers (already external/stateless — scale them at the HTTP tier)"})
+		return errs
+	}
+
+	// Bounds on required fields.
+	if a.Min < 0 {
+		errs = append(errs, ValidationError{asPrefix + ".min", "must be >= 0"})
+	}
+	if a.Max < 1 {
+		errs = append(errs, ValidationError{asPrefix + ".max", "must be >= 1"})
+	}
+	if a.Max > maxReplicas {
+		errs = append(errs, ValidationError{asPrefix + ".max", fmt.Sprintf("must be <= %d", maxReplicas)})
+	}
+	if a.Max >= 1 && a.Max < a.Min {
+		errs = append(errs, ValidationError{asPrefix + ".max", "must be >= min"})
+	}
+	if !a.IdleToZero && a.Min < 1 {
+		errs = append(errs, ValidationError{asPrefix + ".min", "must be >= 1 unless idle_to_zero is true"})
+	}
+	if a.TargetInFlight < 1 {
+		errs = append(errs, ValidationError{asPrefix + ".target_in_flight", "must be >= 1"})
+	}
+
+	// Timings.
+	if a.ScaleUpAfter != "" {
+		d, err := time.ParseDuration(a.ScaleUpAfter)
+		if err != nil {
+			errs = append(errs, ValidationError{asPrefix + ".scale_up_after", fmt.Sprintf("invalid duration %q (expected e.g. \"30s\")", a.ScaleUpAfter)})
+		} else if d < 10*time.Second {
+			errs = append(errs, ValidationError{asPrefix + ".scale_up_after", "must be >= 10s"})
+		}
+	}
+	if a.ScaleDownAfter != "" {
+		d, err := time.ParseDuration(a.ScaleDownAfter)
+		if err != nil {
+			errs = append(errs, ValidationError{asPrefix + ".scale_down_after", fmt.Sprintf("invalid duration %q (expected e.g. \"5m\")", a.ScaleDownAfter)})
+		} else if d < time.Minute {
+			errs = append(errs, ValidationError{asPrefix + ".scale_down_after", "must be >= 1m"})
+		}
+	}
+
+	// Warm pool constraints.
+	if a.WarmPool < 0 {
+		errs = append(errs, ValidationError{asPrefix + ".warm_pool", "must be >= 0"})
+	}
+	if a.Max >= 1 && a.Min+a.WarmPool > a.Max {
+		errs = append(errs, ValidationError{asPrefix + ".warm_pool", "min + warm_pool must be <= max"})
+	}
+
+	return errs
 }
 
 func validateSource(s *Source, prefix string) ValidationErrors {

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -1344,3 +1344,213 @@ func TestStack_SetDefaults_Replicas(t *testing.T) {
 		}
 	}
 }
+
+func TestValidate_Autoscale(t *testing.T) {
+	// Minimal valid autoscale block on a local-process server.
+	base := func(a *AutoscaleConfig) *Stack {
+		return &Stack{
+			Name:    "test",
+			Network: Network{Name: "n"},
+			MCPServers: []MCPServer{{
+				Name:      "junos",
+				Command:   []string{"python", "j.py"},
+				Autoscale: a,
+			}},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		stack   *Stack
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "minimal valid",
+			stack: base(&AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3}),
+		},
+		{
+			name:  "valid with all timings",
+			stack: base(&AutoscaleConfig{Min: 2, Max: 8, TargetInFlight: 3, ScaleUpAfter: "30s", ScaleDownAfter: "5m", WarmPool: 1}),
+		},
+		{
+			name:  "idle_to_zero allows min 0",
+			stack: base(&AutoscaleConfig{Min: 0, Max: 4, TargetInFlight: 3, IdleToZero: true}),
+		},
+		{
+			name:    "min 0 without idle_to_zero rejected",
+			stack:   base(&AutoscaleConfig{Min: 0, Max: 4, TargetInFlight: 3}),
+			wantErr: true,
+			errMsg:  "autoscale.min",
+		},
+		{
+			name:    "max < min rejected",
+			stack:   base(&AutoscaleConfig{Min: 5, Max: 3, TargetInFlight: 1}),
+			wantErr: true,
+			errMsg:  "must be >= min",
+		},
+		{
+			name:    "max 0 rejected",
+			stack:   base(&AutoscaleConfig{Min: 0, Max: 0, TargetInFlight: 1, IdleToZero: true}),
+			wantErr: true,
+			errMsg:  "autoscale.max",
+		},
+		{
+			name:    "max 33 rejected",
+			stack:   base(&AutoscaleConfig{Min: 1, Max: 33, TargetInFlight: 3}),
+			wantErr: true,
+			errMsg:  "<= 32",
+		},
+		{
+			name:    "target_in_flight 0 rejected",
+			stack:   base(&AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 0}),
+			wantErr: true,
+			errMsg:  "target_in_flight",
+		},
+		{
+			name:    "scale_up_after below 10s rejected",
+			stack:   base(&AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3, ScaleUpAfter: "5s"}),
+			wantErr: true,
+			errMsg:  "scale_up_after",
+		},
+		{
+			name:    "scale_down_after below 1m rejected",
+			stack:   base(&AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3, ScaleDownAfter: "30s"}),
+			wantErr: true,
+			errMsg:  "scale_down_after",
+		},
+		{
+			name:    "warm_pool push exceeds max",
+			stack:   base(&AutoscaleConfig{Min: 3, Max: 4, TargetInFlight: 3, WarmPool: 2}),
+			wantErr: true,
+			errMsg:  "warm_pool",
+		},
+		{
+			name:    "warm_pool negative rejected",
+			stack:   base(&AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3, WarmPool: -1}),
+			wantErr: true,
+			errMsg:  "warm_pool",
+		},
+		{
+			name:    "scale_up_after invalid duration rejected",
+			stack:   base(&AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3, ScaleUpAfter: "not-a-duration"}),
+			wantErr: true,
+			errMsg:  "invalid duration",
+		},
+		{
+			name: "autoscale with replicas set rejected",
+			stack: &Stack{
+				Name:    "test",
+				Network: Network{Name: "n"},
+				MCPServers: []MCPServer{{
+					Name:      "junos",
+					Command:   []string{"python", "j.py"},
+					Replicas:  3,
+					Autoscale: &AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3},
+				}},
+			},
+			wantErr: true,
+			errMsg:  "cannot set both",
+		},
+		{
+			name: "autoscale on external rejected",
+			stack: &Stack{
+				Name:    "test",
+				Network: Network{Name: "n"},
+				MCPServers: []MCPServer{{
+					Name:      "ext",
+					URL:       "https://example.com/mcp",
+					Autoscale: &AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3},
+				}},
+			},
+			wantErr: true,
+			errMsg:  "external",
+		},
+		{
+			name: "autoscale on openapi rejected",
+			stack: &Stack{
+				Name:    "test",
+				Network: Network{Name: "n"},
+				MCPServers: []MCPServer{{
+					Name:      "api",
+					OpenAPI:   &OpenAPIConfig{Spec: "spec.yaml"},
+					Autoscale: &AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3},
+				}},
+			},
+			wantErr: true,
+			errMsg:  "external URL or OpenAPI",
+		},
+		{
+			name: "autoscale on container valid",
+			stack: &Stack{
+				Name:    "test",
+				Network: Network{Name: "n"},
+				MCPServers: []MCPServer{{
+					Name:      "ctr",
+					Image:     "alpine",
+					Port:      3000,
+					Autoscale: &AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3},
+				}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.stack)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errMsg != "" && !strings.Contains(err.Error(), tc.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tc.errMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestAutoscaleConfig_Resolved(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        *AutoscaleConfig
+		wantUp     time.Duration
+		wantDown   time.Duration
+	}{
+		{name: "nil returns defaults", cfg: nil, wantUp: 30 * time.Second, wantDown: 5 * time.Minute},
+		{name: "empty returns defaults", cfg: &AutoscaleConfig{}, wantUp: 30 * time.Second, wantDown: 5 * time.Minute},
+		{name: "valid durations parsed", cfg: &AutoscaleConfig{ScaleUpAfter: "45s", ScaleDownAfter: "10m"}, wantUp: 45 * time.Second, wantDown: 10 * time.Minute},
+		{name: "garbage falls back", cfg: &AutoscaleConfig{ScaleUpAfter: "oops"}, wantUp: 30 * time.Second, wantDown: 5 * time.Minute},
+		{name: "negative falls back", cfg: &AutoscaleConfig{ScaleUpAfter: "-10s"}, wantUp: 30 * time.Second, wantDown: 5 * time.Minute},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.ResolvedScaleUpAfter(); got != tc.wantUp {
+				t.Errorf("ResolvedScaleUpAfter() = %v, want %v", got, tc.wantUp)
+			}
+			if got := tc.cfg.ResolvedScaleDownAfter(); got != tc.wantDown {
+				t.Errorf("ResolvedScaleDownAfter() = %v, want %v", got, tc.wantDown)
+			}
+		})
+	}
+}
+
+func TestStack_SetDefaults_AutoscaleKeepsReplicasZero(t *testing.T) {
+	s := &Stack{
+		Name:    "test",
+		Network: Network{Name: "n"},
+		MCPServers: []MCPServer{
+			{Name: "a", Image: "alpine", Port: 3000, Autoscale: &AutoscaleConfig{Min: 2, Max: 6, TargetInFlight: 3}},
+			{Name: "b", Image: "alpine", Port: 3000}, // static: Replicas → 1
+		},
+	}
+	s.SetDefaults()
+	if got := s.MCPServers[0].Replicas; got != 0 {
+		t.Errorf("autoscaled server: Replicas = %d, want 0 (scaler owns count)", got)
+	}
+	if got := s.MCPServers[1].Replicas; got != 1 {
+		t.Errorf("static server: Replicas = %d, want 1", got)
+	}
+}

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -239,10 +239,12 @@ func (b *GatewayBuilder) Run(ctx context.Context, inst *GatewayInstance, verbose
 	if b.rt != nil {
 		registrar.SetRuntime(b.rt.Runtime())
 	}
+	registrar.SetBasePort(b.config.BasePort)
 	registrar.RegisterAll(ctx, b.result, b.stack, b.stackPath)
 
-	// Start periodic health monitoring
+	// Start periodic health monitoring and autoscaler tick loop.
 	gateway.StartHealthMonitor(ctx, mcp.DefaultHealthCheckInterval)
+	gateway.StartAutoscaler(ctx, mcp.DefaultAutoscalerInterval)
 
 	// Start background skill update check (non-blocking)
 	skills.CheckUpdatesBackground(

--- a/pkg/controller/server_registrar.go
+++ b/pkg/controller/server_registrar.go
@@ -25,6 +25,12 @@ type ServerRegistrar struct {
 	// receive a CleanupOnReadyFailure closure that removes the workload if the
 	// gateway's readiness wait times out. nil disables cleanup (e.g. in tests).
 	runtime runtime.WorkloadRuntime
+
+	// basePort is the starting host port for new container replicas spawned
+	// at runtime by the autoscaler. Defaults to runtime.DefaultBasePort when
+	// the caller omits it; collisions with ports assigned during static
+	// bring-up are avoided by the allocator's monotonic counter.
+	basePort int
 }
 
 // NewServerRegistrar creates a ServerRegistrar.
@@ -50,17 +56,44 @@ func (r *ServerRegistrar) SetRuntime(rt runtime.WorkloadRuntime) {
 	r.runtime = rt
 }
 
+// SetBasePort sets the starting host port for dynamic container spawns by the
+// autoscaler. Picks up where the initial bring-up left off.
+func (r *ServerRegistrar) SetBasePort(p int) {
+	r.basePort = p
+}
+
 // RegisterAll registers all MCP servers from the UpResult with the gateway.
 // For each server it builds one MCPServerConfig per replica and registers
-// them as a single ReplicaSet under the server's logical name.
+// them as a single ReplicaSet under the server's logical name. Autoscaled
+// servers are routed through registerAutoscaled instead so the Spawner owns
+// replica provisioning.
 func (r *ServerRegistrar) RegisterAll(ctx context.Context, result *runtime.UpResult, stack *config.Stack, stackPath string) {
 	serverConfigs := make(map[string]config.MCPServer)
 	for _, s := range stack.MCPServers {
 		serverConfigs[s.Name] = s
 	}
 
+	// Container-based autoscaled servers need a post-bring-up port allocator
+	// that starts where the static containers left off.
+	nextHostPort := r.basePort
+	for _, s := range result.MCPServers {
+		for _, rep := range s.Replicas {
+			if rep.HostPort > nextHostPort {
+				nextHostPort = rep.HostPort
+			}
+		}
+	}
+
 	for _, server := range result.MCPServers {
 		serverCfg := serverConfigs[server.Name]
+
+		if serverCfg.Autoscale != nil {
+			if err := r.registerAutoscaled(ctx, serverCfg, stack, stackPath, nextHostPort); err != nil {
+				r.logger.Warn("failed to register autoscaled MCP server", "name", server.Name, "error", err)
+			}
+			continue
+		}
+
 		cfgs := r.buildReplicaConfigs(server, serverCfg, stackPath)
 		if len(cfgs) == 0 {
 			r.logger.Warn("no replica configs built", "name", server.Name)
@@ -92,6 +125,14 @@ type ReplicaRuntime struct {
 // zero-valued ReplicaRuntime entries of the desired length (or a single-entry
 // slice for the single-replica case).
 func (r *ServerRegistrar) RegisterOne(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error {
+	// Autoscaled servers ignore the caller's replica slice — the Spawner
+	// owns provisioning. This path runs for hot-reload adds of autoscaled
+	// servers; the reload handler passes placeholder runtimes it wouldn't
+	// normally provision for us.
+	if server.Autoscale != nil {
+		return r.registerAutoscaled(ctx, server, nil, stackPath, r.basePort)
+	}
+
 	if len(replicas) == 0 {
 		replicas = []ReplicaRuntime{{}}
 	}
@@ -104,6 +145,84 @@ func (r *ServerRegistrar) RegisterOne(ctx context.Context, server config.MCPServ
 		policy = mcp.ReplicaPolicyRoundRobin
 	}
 	return r.gateway.RegisterMCPReplicaSet(ctx, server.Name, policy, cfgs)
+}
+
+// registerAutoscaled wires up a Spawner for the server transport and calls
+// Gateway.RegisterAutoscaler. stack may be nil when called from the hot-reload
+// path; it's only needed for container-backed servers to derive the network
+// name and resolved image.
+func (r *ServerRegistrar) registerAutoscaled(ctx context.Context, server config.MCPServer, stack *config.Stack, stackPath string, hostPortBase int) error {
+	if server.Autoscale == nil {
+		return fmt.Errorf("registerAutoscaled: %s has no autoscale block", server.Name)
+	}
+
+	template := r.buildConfigFromMCPServer(server, 0, "", stackPath)
+	template.CleanupOnReadyFailure = nil // spawner's own cleanup takes over
+
+	var spawner mcp.Spawner
+	switch {
+	case server.IsLocalProcess():
+		spawner = NewProcessSpawner(r.gateway, template)
+	case server.IsSSH():
+		spawner = NewSSHSpawner(r.gateway, template)
+	case server.IsContainerBased():
+		var networkName, imageName string
+		if stack != nil {
+			networkName = stack.Network.Name
+			if len(stack.Networks) > 0 && server.Network != "" {
+				networkName = server.Network
+			}
+		}
+		imageName = server.Image
+		if server.Source != nil && stack != nil {
+			imageName = fmt.Sprintf("gridctl-%s-%s:latest", stack.Name, server.Name)
+		}
+		transport := server.Transport
+		if transport == "" {
+			transport = "http"
+		}
+		spawner = NewContainerSpawner(ContainerSpawnerOptions{
+			Builder:   r.gateway,
+			Runtime:   r.runtime,
+			Stack:     stackNameOrEmpty(stack),
+			Server:    server,
+			Network:   networkName,
+			Image:     imageName,
+			Transport: transport,
+			Ports:     NewAtomicPortAllocator(hostPortBase),
+			Logger:    r.logger,
+			InitialID: 0,
+		})
+	default:
+		return fmt.Errorf("autoscale not supported for %s transport", server.Name)
+	}
+
+	policy := server.ReplicaPolicy
+	if policy == "" {
+		policy = mcp.ReplicaPolicyRoundRobin
+	}
+	return r.gateway.RegisterAutoscaler(ctx, template, policy, spawner, toAutoscalePolicy(server.Autoscale))
+}
+
+func stackNameOrEmpty(s *config.Stack) string {
+	if s == nil {
+		return ""
+	}
+	return s.Name
+}
+
+// toAutoscalePolicy converts the YAML AutoscaleConfig into the runtime
+// AutoscalePolicy used by the scaler.
+func toAutoscalePolicy(a *config.AutoscaleConfig) mcp.AutoscalePolicy {
+	return mcp.AutoscalePolicy{
+		Min:            a.Min,
+		Max:            a.Max,
+		TargetInFlight: a.TargetInFlight,
+		ScaleUpAfter:   a.ResolvedScaleUpAfter(),
+		ScaleDownAfter: a.ResolvedScaleDownAfter(),
+		WarmPool:       a.WarmPool,
+		IdleToZero:     a.IdleToZero,
+	}
 }
 
 // buildReplicaConfigs fans out an UpResult's per-replica handles into one

--- a/pkg/controller/spawn_container.go
+++ b/pkg/controller/spawn_container.go
@@ -1,0 +1,229 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/logging"
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/runtime"
+)
+
+// PortAllocator hands out unique host ports for new container replicas.
+// Implementations must be safe to call from the autoscaler's goroutine.
+type PortAllocator interface {
+	Allocate() int
+}
+
+// atomicPortAllocator is a simple monotonic allocator starting at basePort.
+// Production deployments can swap this for one that tracks releases, but a
+// monotonic allocator matches the orchestrator's existing behaviour (host
+// ports are freed when the container exits; OS reclaims them eventually).
+type atomicPortAllocator struct {
+	next atomic.Int32
+}
+
+// NewAtomicPortAllocator returns a PortAllocator starting at base+1 on the
+// first call. base is typically the basePort handed to Orchestrator.Up plus
+// the number of ports already assigned during the initial bring-up.
+func NewAtomicPortAllocator(base int) PortAllocator {
+	p := &atomicPortAllocator{}
+	p.next.Store(int32(base))
+	return p
+}
+
+// Allocate returns the next host port, incrementing the internal counter
+// atomically. Safe to call from any goroutine.
+func (p *atomicPortAllocator) Allocate() int {
+	return int(p.next.Add(1))
+}
+
+// ContainerSpawner spawns container-backed MCP replicas (stdio or HTTP). Each
+// Spawn starts a new container named `<stack>-<server>-replica-<id>`, waits
+// for it via the same BuildAgentClient path the static bring-up uses, and
+// tracks the workload id so Reap can stop + remove the container.
+type ContainerSpawner struct {
+	builder   ClientBuilder
+	rt        runtime.WorkloadRuntime
+	stack     string
+	server    config.MCPServer
+	network   string
+	image     string
+	transport string
+	ports     PortAllocator
+	logger    *slog.Logger
+
+	idCounter atomic.Int64
+
+	mu       sync.Mutex
+	workloads map[mcp.AgentClient]runtime.WorkloadID // client -> container id, for Reap
+}
+
+// ContainerSpawnerOptions bundles everything a ContainerSpawner needs. Kept
+// as a struct so callers don't accumulate positional arguments.
+type ContainerSpawnerOptions struct {
+	Builder   ClientBuilder
+	Runtime   runtime.WorkloadRuntime
+	Stack     string             // stack.Name
+	Server    config.MCPServer   // full server config (command, env, port, etc.)
+	Network   string             // resolved network name
+	Image     string             // pre-built image (source-based workloads pre-tag as gridctl-<stack>-<server>:latest)
+	Transport string             // "http" | "stdio" | "sse"
+	Ports     PortAllocator
+	Logger    *slog.Logger
+	InitialID int // next replica id to assign (typically set.Size() at register time)
+}
+
+// NewContainerSpawner constructs a ContainerSpawner from explicit options.
+func NewContainerSpawner(opts ContainerSpawnerOptions) *ContainerSpawner {
+	logger := opts.Logger
+	if logger == nil {
+		logger = logging.NewDiscardLogger()
+	}
+	cs := &ContainerSpawner{
+		builder:   opts.Builder,
+		rt:        opts.Runtime,
+		stack:     opts.Stack,
+		server:    opts.Server,
+		network:   opts.Network,
+		image:     opts.Image,
+		transport: opts.Transport,
+		ports:     opts.Ports,
+		logger:    logger,
+		workloads: make(map[mcp.AgentClient]runtime.WorkloadID),
+	}
+	cs.idCounter.Store(int64(opts.InitialID))
+	return cs
+}
+
+// Spawn starts a new container and returns a ready-to-serve AgentClient.
+// On any failure after container start but before client initialisation,
+// the spawned container is stopped and removed so no orphan containers
+// linger. Matches the "defer cleanup()" requirement in the spec.
+func (c *ContainerSpawner) Spawn(ctx context.Context) (mcp.AgentClient, error) {
+	if c.rt == nil {
+		return nil, fmt.Errorf("container spawner %q: runtime unavailable", c.server.Name)
+	}
+	replicaID := int(c.idCounter.Add(1) - 1)
+	name := runtime.ReplicaContainerName(c.stack, c.server.Name, replicaID, 2) // >1 to force suffix
+	hostPort := c.ports.Allocate()
+
+	cfg := runtime.WorkloadConfig{
+		Name:        name,
+		Stack:       c.stack,
+		Type:        runtime.WorkloadTypeMCPServer,
+		Image:       c.image,
+		Command:     c.server.Command,
+		Env:         c.server.Env,
+		NetworkName: c.network,
+		ExposedPort: c.server.Port,
+		HostPort:    hostPort,
+		Transport:   c.transport,
+		Labels: map[string]string{
+			"gridctl.managed":    "true",
+			"gridctl.stack":      c.stack,
+			"gridctl.mcp-server": c.server.Name,
+		},
+	}
+
+	c.logger.Info("autoscale spawn: starting container",
+		"server", c.server.Name, "replica_id", replicaID, "container", name, "host_port", hostPort)
+
+	status, err := c.rt.Start(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("start container %s: %w", name, err)
+	}
+	actualHostPort := status.HostPort
+	if actualHostPort == 0 {
+		actualHostPort = hostPort
+	}
+
+	// Any failure from here on should tear down the container we just started.
+	cleaned := false
+	cleanup := func() {
+		if cleaned {
+			return
+		}
+		cleaned = true
+		if err := c.rt.Stop(context.Background(), status.ID); err != nil {
+			c.logger.Warn("autoscale spawn cleanup: stop failed", "container", name, "error", err)
+		}
+		if err := c.rt.Remove(context.Background(), status.ID); err != nil {
+			c.logger.Warn("autoscale spawn cleanup: remove failed", "container", name, "error", err)
+		}
+	}
+
+	client, err := c.builder.BuildAgentClient(ctx, c.buildClientConfig(actualHostPort, status.ID))
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("build client %s: %w", name, err)
+	}
+
+	// Track the container id so Reap can stop + remove it later.
+	c.mu.Lock()
+	c.workloads[client] = status.ID
+	c.mu.Unlock()
+	return client, nil
+}
+
+// Reap closes the client and removes the backing container. Callers pass the
+// full Replica (not the bare client) so the scaler can log per-replica id.
+func (c *ContainerSpawner) Reap(ctx context.Context, r *mcp.Replica) error {
+	if r == nil {
+		return nil
+	}
+	client := r.Client()
+	if closer, ok := client.(io.Closer); ok {
+		if err := closer.Close(); err != nil {
+			c.logger.Warn("autoscale reap: client close", "replica_id", r.ID(), "error", err)
+		}
+	}
+
+	c.mu.Lock()
+	id, ok := c.workloads[client]
+	if ok {
+		delete(c.workloads, client)
+	}
+	c.mu.Unlock()
+
+	if !ok || c.rt == nil {
+		return nil
+	}
+	var errs []error
+	if err := c.rt.Stop(ctx, id); err != nil {
+		c.logger.Warn("autoscale reap: stop failed", "replica_id", r.ID(), "container", id, "error", err)
+		errs = append(errs, fmt.Errorf("stop %s: %w", id, err))
+	}
+	if err := c.rt.Remove(ctx, id); err != nil {
+		errs = append(errs, fmt.Errorf("remove %s: %w", id, err))
+	}
+	return errors.Join(errs...)
+}
+
+// buildClientConfig assembles the MCPServerConfig passed to BuildAgentClient.
+// stdio containers consume containerID; http/sse consume the endpoint URL.
+func (c *ContainerSpawner) buildClientConfig(hostPort int, id runtime.WorkloadID) mcp.MCPServerConfig {
+	cfg := mcp.MCPServerConfig{
+		Name:         c.server.Name,
+		Transport:    mcp.Transport(c.transport),
+		Tools:        c.server.Tools,
+		OutputFormat: c.server.OutputFormat,
+		PinSchemas:   c.server.PinSchemas,
+		ReadyTimeout: c.server.ResolvedReadyTimeout(),
+	}
+	if cfg.Transport == "" {
+		cfg.Transport = mcp.TransportHTTP
+	}
+	if cfg.Transport == mcp.TransportStdio {
+		cfg.ContainerID = string(id)
+	} else {
+		cfg.Endpoint = fmt.Sprintf("http://localhost:%d/mcp", hostPort)
+	}
+	return cfg
+}

--- a/pkg/controller/spawn_process.go
+++ b/pkg/controller/spawn_process.go
@@ -1,0 +1,54 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// ClientBuilder abstracts the Gateway helper that constructs and initialises
+// an AgentClient from an MCPServerConfig. Kept as an interface so unit tests
+// can supply fakes without spinning up a full gateway.
+type ClientBuilder interface {
+	BuildAgentClient(ctx context.Context, cfg mcp.MCPServerConfig) (mcp.AgentClient, error)
+}
+
+// ProcessSpawner spawns local-process MCP replicas. Each Spawn clones the
+// template MCPServerConfig and delegates construction to the gateway's
+// BuildAgentClient so the same transport plumbing the static path uses
+// also services autoscaled spawns.
+type ProcessSpawner struct {
+	builder  ClientBuilder
+	template mcp.MCPServerConfig
+}
+
+// NewProcessSpawner returns a Spawner for LocalProcess (and SSH; see below)
+// replicas. template.Name is the logical server name; it's reused for every
+// replica and does not need per-replica uniqueness at this layer because the
+// ReplicaSet assigns monotonic ids on AddReplica.
+func NewProcessSpawner(builder ClientBuilder, template mcp.MCPServerConfig) *ProcessSpawner {
+	return &ProcessSpawner{builder: builder, template: template}
+}
+
+// Spawn constructs a new replica's AgentClient, initialises MCP, and returns
+// the ready-to-serve client. Callers (the Autoscaler) add the result to the
+// ReplicaSet via AddReplica.
+func (s *ProcessSpawner) Spawn(ctx context.Context) (mcp.AgentClient, error) {
+	if s.builder == nil {
+		return nil, fmt.Errorf("process spawner %q: nil client builder", s.template.Name)
+	}
+	return s.builder.BuildAgentClient(ctx, s.template)
+}
+
+// Reap closes the replica's client so its process exits.
+func (s *ProcessSpawner) Reap(_ context.Context, r *mcp.Replica) error {
+	if r == nil {
+		return nil
+	}
+	if closer, ok := r.Client().(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}

--- a/pkg/controller/spawn_ssh.go
+++ b/pkg/controller/spawn_ssh.go
@@ -1,0 +1,39 @@
+package controller
+
+import (
+	"context"
+	"io"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// SSHSpawner spawns SSH-transport MCP replicas. Each Spawn opens a fresh SSH
+// session via the gateway's transport switch (BuildAgentClient handles the
+// ssh command construction). The template carries SSHHost / SSHUser /
+// SSHPort / SSHIdentityFile etc. and is reused verbatim per replica: gridctl
+// already tolerates many concurrent ssh sessions to the same host.
+type SSHSpawner struct {
+	builder  ClientBuilder
+	template mcp.MCPServerConfig
+}
+
+// NewSSHSpawner returns a Spawner for SSH-transport replicas.
+func NewSSHSpawner(builder ClientBuilder, template mcp.MCPServerConfig) *SSHSpawner {
+	return &SSHSpawner{builder: builder, template: template}
+}
+
+// Spawn constructs and initialises a new SSH-backed AgentClient.
+func (s *SSHSpawner) Spawn(ctx context.Context) (mcp.AgentClient, error) {
+	return s.builder.BuildAgentClient(ctx, s.template)
+}
+
+// Reap closes the SSH stream so the remote process exits.
+func (s *SSHSpawner) Reap(_ context.Context, r *mcp.Replica) error {
+	if r == nil {
+		return nil
+	}
+	if closer, ok := r.Client().(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}

--- a/pkg/controller/spawn_test.go
+++ b/pkg/controller/spawn_test.go
@@ -1,0 +1,151 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// fakeAgentClient is a minimal AgentClient stub used only to give the Spawner
+// a non-nil return value. Spawners do not call any methods on the returned
+// client themselves, so the stub's methods are unlikely to execute.
+type fakeAgentClient struct {
+	name string
+}
+
+func (f *fakeAgentClient) Name() string                             { return f.name }
+func (f *fakeAgentClient) Initialize(context.Context) error         { return nil }
+func (f *fakeAgentClient) RefreshTools(context.Context) error       { return nil }
+func (f *fakeAgentClient) Tools() []mcp.Tool                         { return nil }
+func (f *fakeAgentClient) IsInitialized() bool                      { return true }
+func (f *fakeAgentClient) ServerInfo() mcp.ServerInfo                { return mcp.ServerInfo{Name: f.name} }
+func (f *fakeAgentClient) CallTool(context.Context, string, map[string]any) (*mcp.ToolCallResult, error) {
+	return &mcp.ToolCallResult{}, nil
+}
+
+// fakeBuilder is a minimal ClientBuilder that returns a pre-made AgentClient
+// and records every template it was called with, so tests can verify that
+// the Spawner passed through the expected transport configuration.
+type fakeBuilder struct {
+	lastCfg   mcp.MCPServerConfig
+	buildErr  error
+	callCount int
+}
+
+func (f *fakeBuilder) BuildAgentClient(_ context.Context, cfg mcp.MCPServerConfig) (mcp.AgentClient, error) {
+	f.callCount++
+	f.lastCfg = cfg
+	if f.buildErr != nil {
+		return nil, f.buildErr
+	}
+	return &fakeAgentClient{name: cfg.Name}, nil
+}
+
+func newFakeBuilder(_ *testing.T) *fakeBuilder { return &fakeBuilder{} }
+
+func TestProcessSpawner_Spawn_DelegatesToBuilder(t *testing.T) {
+	b := newFakeBuilder(t)
+	template := mcp.MCPServerConfig{
+		Name: "proc", LocalProcess: true, Command: []string{"/bin/true"},
+		Env: map[string]string{"K": "V"},
+	}
+	sp := NewProcessSpawner(b, template)
+
+	c, err := sp.Spawn(context.Background())
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if c == nil {
+		t.Fatal("Spawn returned nil client")
+	}
+	if b.callCount != 1 {
+		t.Errorf("builder called %d times, want 1", b.callCount)
+	}
+	if b.lastCfg.Name != "proc" || !b.lastCfg.LocalProcess {
+		t.Errorf("builder received wrong template: %+v", b.lastCfg)
+	}
+	if b.lastCfg.Env["K"] != "V" {
+		t.Errorf("env not propagated: %v", b.lastCfg.Env)
+	}
+}
+
+func TestProcessSpawner_Spawn_PropagatesBuildError(t *testing.T) {
+	b := newFakeBuilder(t)
+	b.buildErr = errors.New("kaboom")
+	sp := NewProcessSpawner(b, mcp.MCPServerConfig{Name: "x", LocalProcess: true})
+	if _, err := sp.Spawn(context.Background()); err == nil {
+		t.Fatal("expected error from builder to surface")
+	}
+}
+
+func TestProcessSpawner_Reap_NilReplicaIsNoop(t *testing.T) {
+	sp := NewProcessSpawner(newFakeBuilder(t), mcp.MCPServerConfig{Name: "x"})
+	if err := sp.Reap(context.Background(), nil); err != nil {
+		t.Errorf("Reap(nil) = %v, want nil", err)
+	}
+}
+
+func TestProcessSpawner_NilBuilder_RejectsSpawn(t *testing.T) {
+	sp := NewProcessSpawner(nil, mcp.MCPServerConfig{Name: "x", LocalProcess: true})
+	if _, err := sp.Spawn(context.Background()); err == nil {
+		t.Fatal("Spawn with nil builder should error")
+	}
+}
+
+func TestSSHSpawner_Spawn_PassesSSHTemplate(t *testing.T) {
+	b := newFakeBuilder(t)
+	template := mcp.MCPServerConfig{
+		Name: "remote", SSH: true,
+		SSHHost: "10.0.0.1", SSHUser: "mcp",
+		Command: []string{"/opt/mcp-server"},
+	}
+	sp := NewSSHSpawner(b, template)
+
+	if _, err := sp.Spawn(context.Background()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if !b.lastCfg.SSH || b.lastCfg.SSHHost != "10.0.0.1" {
+		t.Errorf("SSH template not forwarded: %+v", b.lastCfg)
+	}
+}
+
+func TestSSHSpawner_Reap_NilReplicaIsNoop(t *testing.T) {
+	sp := NewSSHSpawner(newFakeBuilder(t), mcp.MCPServerConfig{Name: "x"})
+	if err := sp.Reap(context.Background(), nil); err != nil {
+		t.Errorf("Reap(nil) = %v, want nil", err)
+	}
+}
+
+func TestAtomicPortAllocator_Monotonic(t *testing.T) {
+	p := NewAtomicPortAllocator(9000)
+	got := []int{p.Allocate(), p.Allocate(), p.Allocate()}
+	want := []int{9001, 9002, 9003}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("Allocate[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestAtomicPortAllocator_ConcurrentUniqueness(t *testing.T) {
+	p := NewAtomicPortAllocator(10000)
+	const workers, per = 16, 64
+	out := make(chan int, workers*per)
+	for i := 0; i < workers; i++ {
+		go func() {
+			for j := 0; j < per; j++ {
+				out <- p.Allocate()
+			}
+		}()
+	}
+	seen := make(map[int]bool, workers*per)
+	for i := 0; i < workers*per; i++ {
+		v := <-out
+		if seen[v] {
+			t.Fatalf("duplicate port %d from concurrent Allocate", v)
+		}
+		seen[v] = true
+	}
+}

--- a/pkg/controller/spawn_test.go
+++ b/pkg/controller/spawn_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/gridctl/gridctl/pkg/config"
 	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/runtime"
 )
 
 // fakeAgentClient is a minimal AgentClient stub used only to give the Spawner
@@ -147,5 +149,269 @@ func TestAtomicPortAllocator_ConcurrentUniqueness(t *testing.T) {
 			t.Fatalf("duplicate port %d from concurrent Allocate", v)
 		}
 		seen[v] = true
+	}
+}
+
+// closableFakeAgentClient lets tests exercise the Reap path where the client
+// implements io.Closer (the non-nil, non-closer branch is covered by the
+// stock fakeAgentClient).
+type closableFakeAgentClient struct {
+	fakeAgentClient
+	closed   bool
+	closeErr error
+}
+
+func (c *closableFakeAgentClient) Close() error {
+	c.closed = true
+	return c.closeErr
+}
+
+func TestProcessSpawner_Reap_ClosesCloserClient(t *testing.T) {
+	sp := NewProcessSpawner(newFakeBuilder(t), mcp.MCPServerConfig{Name: "p"})
+	c := &closableFakeAgentClient{fakeAgentClient: fakeAgentClient{name: "p"}}
+	set := mcp.NewReplicaSet("p", mcp.ReplicaPolicyRoundRobin, []mcp.AgentClient{c})
+	rep := set.Replicas()[0]
+
+	if err := sp.Reap(context.Background(), rep); err != nil {
+		t.Fatalf("Reap: %v", err)
+	}
+	if !c.closed {
+		t.Error("Close was not called on the replica client")
+	}
+}
+
+func TestSSHSpawner_Reap_ClosesCloserClient(t *testing.T) {
+	sp := NewSSHSpawner(newFakeBuilder(t), mcp.MCPServerConfig{Name: "s"})
+	c := &closableFakeAgentClient{fakeAgentClient: fakeAgentClient{name: "s"}}
+	set := mcp.NewReplicaSet("s", mcp.ReplicaPolicyRoundRobin, []mcp.AgentClient{c})
+	rep := set.Replicas()[0]
+
+	if err := sp.Reap(context.Background(), rep); err != nil {
+		t.Fatalf("Reap: %v", err)
+	}
+	if !c.closed {
+		t.Error("Close was not called on the replica client")
+	}
+}
+
+// stubContainerRuntime implements just enough of runtime.WorkloadRuntime to
+// drive ContainerSpawner through its Spawn/Reap paths. Unused methods inherit
+// from the embedded nil interface and will panic if called, which surfaces
+// accidental reliance on real runtime behaviour.
+type stubContainerRuntime struct {
+	runtime.WorkloadRuntime
+	startCalls  []runtime.WorkloadConfig
+	startStatus runtime.WorkloadStatus
+	startErr    error
+	stopCalls   []runtime.WorkloadID
+	stopErr     error
+	removeCalls []runtime.WorkloadID
+	removeErr   error
+}
+
+func (s *stubContainerRuntime) Start(_ context.Context, cfg runtime.WorkloadConfig) (*runtime.WorkloadStatus, error) {
+	s.startCalls = append(s.startCalls, cfg)
+	if s.startErr != nil {
+		return nil, s.startErr
+	}
+	status := s.startStatus
+	if status.Name == "" {
+		status.Name = cfg.Name
+	}
+	return &status, nil
+}
+
+func (s *stubContainerRuntime) Stop(_ context.Context, id runtime.WorkloadID) error {
+	s.stopCalls = append(s.stopCalls, id)
+	return s.stopErr
+}
+
+func (s *stubContainerRuntime) Remove(_ context.Context, id runtime.WorkloadID) error {
+	s.removeCalls = append(s.removeCalls, id)
+	return s.removeErr
+}
+
+func TestContainerSpawner_Spawn_NilRuntimeErrors(t *testing.T) {
+	sp := NewContainerSpawner(ContainerSpawnerOptions{
+		Builder:   newFakeBuilder(t),
+		Server:    config.MCPServer{Name: "x"},
+		Transport: "http",
+		Ports:     NewAtomicPortAllocator(9000),
+	})
+	if _, err := sp.Spawn(context.Background()); err == nil {
+		t.Fatal("expected error when runtime is nil")
+	}
+}
+
+func TestContainerSpawner_Spawn_HTTP_BuildsEndpointAndReaps(t *testing.T) {
+	rt := &stubContainerRuntime{startStatus: runtime.WorkloadStatus{ID: "c-1", HostPort: 9555}}
+	b := newFakeBuilder(t)
+	sp := NewContainerSpawner(ContainerSpawnerOptions{
+		Builder:   b,
+		Runtime:   rt,
+		Stack:     "demo",
+		Server:    config.MCPServer{Name: "svc", Port: 3000, Transport: "http"},
+		Network:   "demo-net",
+		Image:     "demo/svc:latest",
+		Transport: "http",
+		Ports:     NewAtomicPortAllocator(9000),
+	})
+
+	c, err := sp.Spawn(context.Background())
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if c == nil {
+		t.Fatal("Spawn returned nil client")
+	}
+	if len(rt.startCalls) != 1 {
+		t.Fatalf("Start calls = %d, want 1", len(rt.startCalls))
+	}
+	got := rt.startCalls[0]
+	if got.Stack != "demo" || got.NetworkName != "demo-net" || got.Image != "demo/svc:latest" {
+		t.Errorf("Start cfg missing fields: %+v", got)
+	}
+	if got.Labels["gridctl.mcp-server"] != "svc" || got.Labels["gridctl.stack"] != "demo" {
+		t.Errorf("labels wrong: %v", got.Labels)
+	}
+	if b.lastCfg.Transport != mcp.TransportHTTP {
+		t.Errorf("builder transport = %q, want http", b.lastCfg.Transport)
+	}
+	if b.lastCfg.Endpoint == "" {
+		t.Errorf("http replica missing endpoint: %+v", b.lastCfg)
+	}
+
+	set := mcp.NewReplicaSet("svc", mcp.ReplicaPolicyRoundRobin, []mcp.AgentClient{c})
+	if err := sp.Reap(context.Background(), set.Replicas()[0]); err != nil {
+		t.Fatalf("Reap: %v", err)
+	}
+	if len(rt.stopCalls) != 1 || rt.stopCalls[0] != "c-1" {
+		t.Errorf("stop calls = %v", rt.stopCalls)
+	}
+	if len(rt.removeCalls) != 1 || rt.removeCalls[0] != "c-1" {
+		t.Errorf("remove calls = %v", rt.removeCalls)
+	}
+}
+
+func TestContainerSpawner_Spawn_Stdio_UsesContainerID(t *testing.T) {
+	rt := &stubContainerRuntime{startStatus: runtime.WorkloadStatus{ID: "stdio-1"}}
+	b := newFakeBuilder(t)
+	sp := NewContainerSpawner(ContainerSpawnerOptions{
+		Builder:   b,
+		Runtime:   rt,
+		Server:    config.MCPServer{Name: "stdio-svc"},
+		Transport: "stdio",
+		Ports:     NewAtomicPortAllocator(9000),
+	})
+
+	if _, err := sp.Spawn(context.Background()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if b.lastCfg.Transport != mcp.TransportStdio {
+		t.Errorf("transport = %q, want stdio", b.lastCfg.Transport)
+	}
+	if b.lastCfg.ContainerID != "stdio-1" {
+		t.Errorf("ContainerID = %q, want stdio-1", b.lastCfg.ContainerID)
+	}
+	if b.lastCfg.Endpoint != "" {
+		t.Errorf("stdio replica should not set Endpoint, got %q", b.lastCfg.Endpoint)
+	}
+}
+
+func TestContainerSpawner_Spawn_StartError_NoWorkloadTracked(t *testing.T) {
+	rt := &stubContainerRuntime{startErr: errors.New("daemon down")}
+	sp := NewContainerSpawner(ContainerSpawnerOptions{
+		Builder:   newFakeBuilder(t),
+		Runtime:   rt,
+		Server:    config.MCPServer{Name: "svc"},
+		Transport: "http",
+		Ports:     NewAtomicPortAllocator(9000),
+	})
+	if _, err := sp.Spawn(context.Background()); err == nil {
+		t.Fatal("expected Spawn to surface runtime.Start error")
+	}
+}
+
+func TestContainerSpawner_Spawn_BuildError_CleansUpContainer(t *testing.T) {
+	rt := &stubContainerRuntime{startStatus: runtime.WorkloadStatus{ID: "c-2", HostPort: 9700}}
+	b := newFakeBuilder(t)
+	b.buildErr = errors.New("client build failed")
+	sp := NewContainerSpawner(ContainerSpawnerOptions{
+		Builder:   b,
+		Runtime:   rt,
+		Server:    config.MCPServer{Name: "svc"},
+		Transport: "http",
+		Ports:     NewAtomicPortAllocator(9000),
+	})
+
+	if _, err := sp.Spawn(context.Background()); err == nil {
+		t.Fatal("expected Spawn to surface build error")
+	}
+	if len(rt.stopCalls) != 1 || rt.stopCalls[0] != "c-2" {
+		t.Errorf("cleanup stop calls = %v", rt.stopCalls)
+	}
+	if len(rt.removeCalls) != 1 || rt.removeCalls[0] != "c-2" {
+		t.Errorf("cleanup remove calls = %v", rt.removeCalls)
+	}
+}
+
+func TestContainerSpawner_Reap_NilReplicaIsNoop(t *testing.T) {
+	sp := NewContainerSpawner(ContainerSpawnerOptions{
+		Builder:   newFakeBuilder(t),
+		Runtime:   &stubContainerRuntime{},
+		Server:    config.MCPServer{Name: "svc"},
+		Transport: "http",
+		Ports:     NewAtomicPortAllocator(9000),
+	})
+	if err := sp.Reap(context.Background(), nil); err != nil {
+		t.Errorf("Reap(nil) = %v, want nil", err)
+	}
+}
+
+func TestContainerSpawner_Reap_UntrackedClientIsNoop(t *testing.T) {
+	rt := &stubContainerRuntime{}
+	sp := NewContainerSpawner(ContainerSpawnerOptions{
+		Builder:   newFakeBuilder(t),
+		Runtime:   rt,
+		Server:    config.MCPServer{Name: "svc"},
+		Transport: "http",
+		Ports:     NewAtomicPortAllocator(9000),
+	})
+	set := mcp.NewReplicaSet("svc", mcp.ReplicaPolicyRoundRobin, []mcp.AgentClient{&fakeAgentClient{name: "svc"}})
+	if err := sp.Reap(context.Background(), set.Replicas()[0]); err != nil {
+		t.Errorf("Reap untracked = %v, want nil", err)
+	}
+	if len(rt.stopCalls) != 0 || len(rt.removeCalls) != 0 {
+		t.Errorf("untracked replica should not call runtime: stop=%v remove=%v", rt.stopCalls, rt.removeCalls)
+	}
+}
+
+func TestToAutoscalePolicy_MapsFieldsAndDefaults(t *testing.T) {
+	a := &config.AutoscaleConfig{
+		Min: 1, Max: 5, TargetInFlight: 2,
+		ScaleUpAfter: "45s", ScaleDownAfter: "3m",
+		WarmPool: 1, IdleToZero: true,
+	}
+	p := toAutoscalePolicy(a)
+	if p.Min != 1 || p.Max != 5 || p.TargetInFlight != 2 || p.WarmPool != 1 || !p.IdleToZero {
+		t.Errorf("field copy mismatch: %+v", p)
+	}
+	if p.ScaleUpAfter.String() != "45s" || p.ScaleDownAfter.String() != "3m0s" {
+		t.Errorf("resolved durations wrong: up=%v down=%v", p.ScaleUpAfter, p.ScaleDownAfter)
+	}
+
+	// Empty durations should fall back to the config defaults (30s / 5m).
+	bare := toAutoscalePolicy(&config.AutoscaleConfig{Min: 1, Max: 2, TargetInFlight: 1})
+	if bare.ScaleUpAfter.String() != "30s" || bare.ScaleDownAfter.String() != "5m0s" {
+		t.Errorf("default durations wrong: up=%v down=%v", bare.ScaleUpAfter, bare.ScaleDownAfter)
+	}
+}
+
+func TestStackNameOrEmpty(t *testing.T) {
+	if got := stackNameOrEmpty(nil); got != "" {
+		t.Errorf("nil stack: got %q, want empty string", got)
+	}
+	if got := stackNameOrEmpty(&config.Stack{Name: "prod"}); got != "prod" {
+		t.Errorf("named stack: got %q, want prod", got)
 	}
 }

--- a/pkg/mcp/autoscaler.go
+++ b/pkg/mcp/autoscaler.go
@@ -1,0 +1,717 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// AutoscalePolicy controls reactive autoscaling for a single ReplicaSet.
+// Values are a snapshot; use Autoscaler.UpdatePolicy to swap in a new one
+// without restarting the scaler loop.
+type AutoscalePolicy struct {
+	Min             int           // Minimum healthy replica count (>= 0; 0 only when IdleToZero).
+	Max             int           // Upper bound on replica count (>= 1).
+	TargetInFlight  int           // Per-replica in-flight request the scaler holds the median at or below.
+	ScaleUpAfter    time.Duration // Window median must exceed target for at least this long.
+	ScaleDownAfter  time.Duration // Window median must be below the target for at least this long.
+	WarmPool        int           // Extra replicas kept above the load-derived target.
+	IdleToZero      bool          // When true, Min may be 0; zero-scale reaps happen after ScaleDownAfter of no traffic.
+}
+
+// DefaultAutoscalerInterval is the tick cadence Gateway.StartAutoscaler uses
+// when callers pass 0. Kept short enough that reap/spawn latencies are
+// observable; the per-direction cooldowns (ScaleUpAfter / ScaleDownAfter)
+// gate actual actions so a 10s tick does not cause flapping.
+const DefaultAutoscalerInterval = 10 * time.Second
+
+// drainTimeout is the per-replica budget for graceful scale-down. Drain waits
+// for in-flight to reach zero before closing the client; past this the
+// scaler puts the replica back in rotation and aborts the reap.
+const drainTimeout = 30 * time.Second
+
+// drainPollInterval is how often Autoscaler.drainAndReap polls InFlight()
+// while waiting for requests to finish.
+const drainPollInterval = 100 * time.Millisecond
+
+// Decision is the coarse outcome of a scaler tick.
+type Decision int
+
+const (
+	DecisionNoop      Decision = iota // No action taken (includes cooldown-gated)
+	DecisionScaleUp                   // Spawned one or more replicas this tick
+	DecisionScaleDown                 // Reaped one replica this tick
+)
+
+// String returns the log-friendly label for a decision.
+func (d Decision) String() string {
+	switch d {
+	case DecisionScaleUp:
+		return "up"
+	case DecisionScaleDown:
+		return "down"
+	default:
+		return "noop"
+	}
+}
+
+// Spawner launches or reaps one replica for a named server. One implementation
+// per transport class lives in pkg/controller. The Gateway constructs the
+// right one at RegisterMCPReplicaSet time and hands it to NewAutoscaler.
+//
+// Spawn MUST return a ready-to-serve AgentClient: Connect/Initialize/RefreshTools
+// have completed before the returned value is added to the set, otherwise the
+// first tool call routed to the new replica would fail.
+// Reap is given the Replica (pre-removed from dispatch) and should close the
+// underlying client and free any resources owned by the spawner.
+type Spawner interface {
+	Spawn(ctx context.Context) (AgentClient, error)
+	Reap(ctx context.Context, r *Replica) error
+}
+
+// inFlightWindow is a fixed-size circular buffer of timestamped load samples.
+// The scaler consults it to answer "has median been above/below target for
+// the full cooldown window?" with O(n) scan over a bounded buffer.
+type inFlightWindow struct {
+	mu      sync.Mutex
+	samples []inFlightSample
+	size    time.Duration
+}
+
+type inFlightSample struct {
+	at     time.Time
+	median float64
+}
+
+// newInFlightWindow returns a rolling window whose retention is at least size.
+// Samples older than size are pruned from the head on every Add.
+func newInFlightWindow(size time.Duration) *inFlightWindow {
+	if size < 30*time.Second {
+		size = 30 * time.Second
+	}
+	return &inFlightWindow{size: size}
+}
+
+// Add inserts a sample and prunes entries older than the window.
+func (w *inFlightWindow) Add(at time.Time, median float64) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.samples = append(w.samples, inFlightSample{at: at, median: median})
+	cutoff := at.Add(-w.size)
+	drop := 0
+	for _, s := range w.samples {
+		if s.at.Before(cutoff) {
+			drop++
+			continue
+		}
+		break
+	}
+	if drop > 0 {
+		w.samples = append([]inFlightSample(nil), w.samples[drop:]...)
+	}
+}
+
+// Latest returns the most recently added sample value, or 0 if empty.
+func (w *inFlightWindow) Latest() float64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.samples) == 0 {
+		return 0
+	}
+	return w.samples[len(w.samples)-1].median
+}
+
+// Size returns the configured window duration.
+func (w *inFlightWindow) Size() time.Duration {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.size
+}
+
+// Resize updates the retention without dropping existing samples; the next
+// Add call prunes to the new size.
+func (w *inFlightWindow) Resize(size time.Duration) {
+	if size < 30*time.Second {
+		size = 30 * time.Second
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.size = size
+}
+
+// sampleMedian returns the median of every sample in the window since from
+// (inclusive). Returns 0 when the window has no qualifying samples.
+func (w *inFlightWindow) sampleMedian(from time.Time) float64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	vals := make([]float64, 0, len(w.samples))
+	for _, s := range w.samples {
+		if s.at.Before(from) {
+			continue
+		}
+		vals = append(vals, s.median)
+	}
+	if len(vals) == 0 {
+		return 0
+	}
+	sort.Float64s(vals)
+	mid := len(vals) / 2
+	if len(vals)%2 == 1 {
+		return vals[mid]
+	}
+	return (vals[mid-1] + vals[mid]) / 2
+}
+
+// allSamplesZeroSince reports whether every sample at or after from has
+// median == 0. Returns false if the window has no samples since from.
+func (w *inFlightWindow) allSamplesZeroSince(from time.Time) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	sawAny := false
+	for _, s := range w.samples {
+		if s.at.Before(from) {
+			continue
+		}
+		sawAny = true
+		if s.median > 0 {
+			return false
+		}
+	}
+	return sawAny
+}
+
+// oldestAt returns the timestamp of the oldest retained sample, or the zero
+// value when the window is empty.
+func (w *inFlightWindow) oldestAt() time.Time {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.samples) == 0 {
+		return time.Time{}
+	}
+	return w.samples[0].at
+}
+
+// Autoscaler runs the scale-up / scale-down decision loop for one ReplicaSet.
+// The ReplicaSet and Spawner are both injected so the decision logic can be
+// tested against in-memory fakes.
+type Autoscaler struct {
+	name    string
+	set     *ReplicaSet
+	spawner Spawner
+	policy  atomic.Pointer[AutoscalePolicy] // swapped atomically on hot reload
+	logger  *slog.Logger
+
+	mu              sync.Mutex
+	lastScaleUpAt   time.Time
+	lastScaleDownAt time.Time
+	lastDecision    Decision
+
+	window *inFlightWindow
+
+	// spawnMu serialises every Spawn call for this scaler — cold-start from
+	// HandleToolsCall, periodic ticks, and warm-pool catch-up all take it.
+	// Without this the cold-start path and a concurrent tick could both call
+	// spawner.Spawn on an empty set and produce double the intended replicas.
+	spawnMu sync.Mutex
+}
+
+// NewAutoscaler builds an Autoscaler bound to a ReplicaSet and Spawner. The
+// policy is applied immediately; subsequent UpdatePolicy calls swap it
+// atomically. The initial rolling window is max(30s, ScaleUpAfter/2).
+func NewAutoscaler(name string, set *ReplicaSet, spawner Spawner, policy AutoscalePolicy, logger *slog.Logger) *Autoscaler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	a := &Autoscaler{
+		name:    name,
+		set:     set,
+		spawner: spawner,
+		logger:  logger,
+		window:  newInFlightWindow(windowSizeFor(policy.ScaleUpAfter)),
+	}
+	p := policy
+	a.policy.Store(&p)
+	return a
+}
+
+// Name returns the logical server name this scaler manages.
+func (a *Autoscaler) Name() string { return a.name }
+
+// Set returns the managed ReplicaSet.
+func (a *Autoscaler) Set() *ReplicaSet { return a.set }
+
+// Policy returns the current policy snapshot.
+func (a *Autoscaler) Policy() AutoscalePolicy {
+	return *a.policy.Load()
+}
+
+// UpdatePolicy swaps the active policy atomically and resizes the rolling
+// window to match the new ScaleUpAfter. Called by the reload handler on
+// policy-only changes so the next tick applies the new shape.
+func (a *Autoscaler) UpdatePolicy(p AutoscalePolicy) {
+	a.policy.Store(&p)
+	a.window.Resize(windowSizeFor(p.ScaleUpAfter))
+	a.logger.Info("autoscale policy updated",
+		"server", a.name,
+		"min", p.Min, "max", p.Max,
+		"target_in_flight", p.TargetInFlight,
+		"warm_pool", p.WarmPool,
+		"idle_to_zero", p.IdleToZero,
+	)
+}
+
+// Status returns a snapshot of scaler state for the /api/stack/health payload.
+// Returns zeroed timestamps until the corresponding action has occurred.
+func (a *Autoscaler) Status() AutoscaleStatus {
+	p := a.Policy()
+	a.mu.Lock()
+	lastUp, lastDown, lastDecision := a.lastScaleUpAt, a.lastScaleDownAt, a.lastDecision
+	a.mu.Unlock()
+
+	current := a.set.HealthyCount()
+	median := a.set.MedianInFlight()
+	target := a.computeTarget(current, median, p)
+
+	st := AutoscaleStatus{
+		Min:            p.Min,
+		Max:            p.Max,
+		Current:        current,
+		Target:         target,
+		TargetInFlight: p.TargetInFlight,
+		MedianInFlight: int64(math.Round(median)),
+		LastDecision:   lastDecision.String(),
+		WarmPool:       p.WarmPool,
+		IdleToZero:     p.IdleToZero,
+	}
+	if !lastUp.IsZero() {
+		t := lastUp
+		st.LastScaleUpAt = &t
+	}
+	if !lastDown.IsZero() {
+		t := lastDown
+		st.LastScaleDownAt = &t
+	}
+	return st
+}
+
+// windowSizeFor returns the rolling-window retention for a given
+// ScaleUpAfter: max(30s, ScaleUpAfter/2). The /2 gives the scaler enough
+// history to distinguish a sustained spike from a single noisy sample.
+func windowSizeFor(scaleUpAfter time.Duration) time.Duration {
+	half := scaleUpAfter / 2
+	if half < 30*time.Second {
+		return 30 * time.Second
+	}
+	return half
+}
+
+// Tick runs one evaluation cycle. Safe to call concurrently with tool dispatch.
+// Returns the decision and any spawn/reap error. Errors are also logged at
+// WARN so operators see them in the structured log stream.
+func (a *Autoscaler) Tick(ctx context.Context, now time.Time) (Decision, error) {
+	p := a.Policy()
+
+	// 1. Sample median in-flight and feed the rolling window.
+	median := a.set.MedianInFlight()
+	a.window.Add(now, median)
+
+	current := a.set.HealthyCount()
+
+	// 2. Determine raw target and apply warm pool + clamps.
+	target := a.computeTarget(current, median, p)
+
+	// 3. Handle idle-to-zero path first: aggressive reap only after
+	//    ScaleDownAfter of sustained zero-traffic windows.
+	if p.IdleToZero && p.Min == 0 && current > 0 {
+		sinceWindow := now.Add(-p.ScaleDownAfter)
+		// Require the rolling window to cover the full cooldown — otherwise
+		// a freshly-started scaler would scale to zero on its first tick.
+		if oldest := a.window.oldestAt(); !oldest.IsZero() && !oldest.After(sinceWindow) && a.window.allSamplesZeroSince(sinceWindow) {
+			return a.scaleDown(ctx, now, current, target, p, "idle_to_zero")
+		}
+	}
+
+	switch {
+	case target > current:
+		return a.scaleUp(ctx, now, current, target, p, median)
+	case target < current:
+		return a.scaleDown(ctx, now, current, target, p, "load")
+	default:
+		return a.noop(now, current, target, median, "load")
+	}
+}
+
+// TriggerColdStart spawns the first replica synchronously. Used by
+// HandleToolsCall when a tool call arrives while the set is at zero replicas
+// under an idle-to-zero policy. Returns nil once at least one replica has
+// been added (including concurrently by another caller that won the race).
+// Holds a.spawnMu so a racing periodic Tick cannot spawn in parallel.
+func (a *Autoscaler) TriggerColdStart(ctx context.Context) error {
+	a.spawnMu.Lock()
+	defer a.spawnMu.Unlock()
+
+	if a.set.HealthyCount() > 0 {
+		return nil
+	}
+	p := a.Policy()
+	if p.Max < 1 {
+		return errors.New("autoscale policy max < 1; cold start refused")
+	}
+
+	tracer := otel.Tracer("gridctl.autoscaler")
+	ctx, span := tracer.Start(ctx, "mcp.autoscale.cold_start")
+	span.SetAttributes(
+		attribute.String("server.name", a.name),
+		attribute.String("mcp.autoscale.direction", "up"),
+		attribute.String("mcp.autoscale.reason", "cold_start"),
+	)
+	defer span.End()
+
+	client, err := a.spawner.Spawn(ctx)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		a.logger.Warn("autoscale cold-start spawn failed",
+			"server", a.name, "direction", "up", "error", err,
+		)
+		return fmt.Errorf("cold start %s: %w", a.name, err)
+	}
+	// Record the cooldown timestamp BEFORE adding the replica so a concurrent
+	// tick that observes current==1 right after AddReplica cannot decide to
+	// spawn again (its cooldown check now sees lastScaleUpAt populated).
+	a.mu.Lock()
+	a.lastScaleUpAt = time.Now()
+	a.lastDecision = DecisionScaleUp
+	a.mu.Unlock()
+	id := a.set.AddReplica(client)
+	a.logger.Info("autoscale decision",
+		"server", a.name,
+		"direction", "up",
+		"current", a.set.HealthyCount(),
+		"target", 1,
+		"median_in_flight", float64(0),
+		"reason", "cold_start",
+		"replica_id", id,
+	)
+	return nil
+}
+
+// computeTarget returns the clamped replica target for the current sample.
+// The load-derived figure is floored at Min, then WarmPool is added on top
+// so the warm pool always sits above the load floor (not merely above Min).
+// current == 0 under idle-to-zero bypasses load-derived math (the scaler is
+// driven by the cold-start trigger in that state).
+func (a *Autoscaler) computeTarget(current int, median float64, p AutoscalePolicy) int {
+	loadTarget := 0
+	if current > 0 && p.TargetInFlight > 0 {
+		loadTarget = int(math.Ceil(float64(current) * median / float64(p.TargetInFlight)))
+	}
+	if loadTarget < p.Min {
+		loadTarget = p.Min
+	}
+	target := loadTarget + p.WarmPool
+	if target > p.Max {
+		target = p.Max
+	}
+	if target < 0 {
+		target = 0
+	}
+	return target
+}
+
+// scaleUp spawns up to target-current replicas. Cooldown applies unless
+// current < Min + WarmPool (the pool is eager). On any spawn failure the
+// lastScaleUpAt timestamp is NOT updated so the next tick retries.
+func (a *Autoscaler) scaleUp(ctx context.Context, now time.Time, current, target int, p AutoscalePolicy, median float64) (Decision, error) {
+	a.mu.Lock()
+	lastUp := a.lastScaleUpAt
+	a.mu.Unlock()
+
+	poolFloor := p.Min + p.WarmPool
+	eager := current < poolFloor
+	if !eager && !lastUp.IsZero() && now.Sub(lastUp) < p.ScaleUpAfter {
+		a.logDecision("up-noop", current, target, median, "cooldown")
+		return a.recordDecision(DecisionNoop)
+	}
+
+	// Only require the sustained-signal condition on ordinary load-driven
+	// scale-ups; warm-pool catch-up is eager.
+	if !eager {
+		sinceWindow := now.Add(-p.ScaleUpAfter)
+		if a.window.sampleMedian(sinceWindow) < float64(p.TargetInFlight) {
+			a.logDecision("up-noop", current, target, median, "insufficient_signal")
+			return a.recordDecision(DecisionNoop)
+		}
+	}
+
+	need := target - current
+	if need <= 0 {
+		return a.noop(now, current, target, median, "load")
+	}
+
+	// Spawn each replica under its own span so a slow spawn doesn't stall the
+	// rest of the tick. spawnMu is shared with TriggerColdStart so a concurrent
+	// cold-start caller cannot double-spawn on a near-empty set.
+	a.spawnMu.Lock()
+	defer a.spawnMu.Unlock()
+
+	tracer := otel.Tracer("gridctl.autoscaler")
+	reason := "load"
+	if eager {
+		reason = "warm_pool"
+	}
+	var spawnErr error
+	added := 0
+	for i := 0; i < need; i++ {
+		ctx, span := tracer.Start(ctx, "mcp.autoscale.spawn")
+		span.SetAttributes(
+			attribute.String("server.name", a.name),
+			attribute.String("mcp.autoscale.direction", "up"),
+			attribute.String("mcp.autoscale.reason", reason),
+		)
+
+		client, err := a.spawner.Spawn(ctx)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			span.End()
+			spawnErr = err
+			a.logger.Warn("autoscale spawn failed",
+				"server", a.name,
+				"direction", "up",
+				"current", current+added,
+				"target", target,
+				"error", err,
+			)
+			break
+		}
+		id := a.set.AddReplica(client)
+		added++
+		span.SetAttributes(attribute.Int("mcp.replica.id", id))
+		span.End()
+	}
+
+	if added > 0 {
+		a.mu.Lock()
+		a.lastScaleUpAt = now
+		a.lastDecision = DecisionScaleUp
+		a.mu.Unlock()
+	}
+
+	// Use a representative reason for the rollup log. The per-spawn warnings
+	// above already carry error detail.
+	a.logger.Info("autoscale decision",
+		"server", a.name,
+		"direction", "up",
+		"current", current+added,
+		"target", target,
+		"median_in_flight", median,
+		"reason", reason,
+		"spawned", added,
+	)
+
+	if spawnErr != nil {
+		return DecisionScaleUp, spawnErr
+	}
+	return DecisionScaleUp, nil
+}
+
+// scaleDown reaps at most one replica per tick, picking the replica with
+// lowest in-flight (tie-broken by oldest). Cooldown is tracked per-direction
+// so a burst that just scaled up does not block a later scale-down.
+func (a *Autoscaler) scaleDown(ctx context.Context, now time.Time, current, target int, p AutoscalePolicy, reason string) (Decision, error) {
+	a.mu.Lock()
+	lastDown := a.lastScaleDownAt
+	a.mu.Unlock()
+
+	median := a.window.Latest()
+
+	// Refuse to cross floor even if target says we should.
+	floor := p.Min + p.WarmPool
+	if p.IdleToZero && reason == "idle_to_zero" {
+		floor = 0
+	}
+	if current <= floor {
+		a.logDecision("down-noop", current, target, median, "at_floor")
+		return a.recordDecision(DecisionNoop)
+	}
+
+	if !lastDown.IsZero() && now.Sub(lastDown) < p.ScaleDownAfter {
+		a.logDecision("down-noop", current, target, median, "cooldown")
+		return a.recordDecision(DecisionNoop)
+	}
+
+	// Only require the sustained-below signal on ordinary load-driven
+	// downs; the idle_to_zero path was already gated by allSamplesZeroSince.
+	if reason == "load" {
+		sinceWindow := now.Add(-p.ScaleDownAfter)
+		if threshold := float64(p.TargetInFlight) / 2; a.window.sampleMedian(sinceWindow) > threshold {
+			a.logDecision("down-noop", current, target, median, "insufficient_signal")
+			return a.recordDecision(DecisionNoop)
+		}
+	}
+
+	victim := a.pickReapTarget()
+	if victim == nil {
+		a.logDecision("down-noop", current, target, median, "no_candidate")
+		return a.recordDecision(DecisionNoop)
+	}
+
+	tracer := otel.Tracer("gridctl.autoscaler")
+	ctx, span := tracer.Start(ctx, "mcp.autoscale.reap")
+	span.SetAttributes(
+		attribute.String("server.name", a.name),
+		attribute.String("mcp.autoscale.direction", "down"),
+		attribute.String("mcp.autoscale.reason", reason),
+		attribute.Int("mcp.replica.id", victim.ID()),
+	)
+	defer span.End()
+
+	if err := a.drainAndReap(ctx, victim); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		a.logger.Warn("autoscale reap failed; re-adding replica",
+			"server", a.name,
+			"direction", "down",
+			"replica_id", victim.ID(),
+			"current", current,
+			"target", target,
+			"error", err,
+		)
+		// On any drain failure — deadline exceeded or ctx cancelled — put
+		// the original *Replica pointer back so in-flight counters and
+		// restart bookkeeping stay consistent. Next tick may retry.
+		a.set.ReinsertReplica(victim)
+		// Do not update lastScaleDownAt on failure — next tick may retry.
+		return DecisionScaleDown, err
+	}
+
+	a.mu.Lock()
+	a.lastScaleDownAt = now
+	a.lastDecision = DecisionScaleDown
+	a.mu.Unlock()
+	a.logger.Info("autoscale decision",
+		"server", a.name,
+		"direction", "down",
+		"current", a.set.HealthyCount(),
+		"target", target,
+		"median_in_flight", median,
+		"reason", reason,
+		"replica_id", victim.ID(),
+	)
+	return DecisionScaleDown, nil
+}
+
+// noop logs a single-line decision and records it without taking any action.
+func (a *Autoscaler) noop(_ time.Time, current, target int, median float64, reason string) (Decision, error) {
+	a.logDecision("noop", current, target, median, reason)
+	a.mu.Lock()
+	a.lastDecision = DecisionNoop
+	a.mu.Unlock()
+	return DecisionNoop, nil
+}
+
+// logDecision emits the single structured log line the spec mandates.
+func (a *Autoscaler) logDecision(direction string, current, target int, median float64, reason string) {
+	a.logger.Info("autoscale decision",
+		"server", a.name,
+		"direction", direction,
+		"current", current,
+		"target", target,
+		"median_in_flight", median,
+		"reason", reason,
+	)
+}
+
+// recordDecision stores the last decision label for Status() and returns.
+func (a *Autoscaler) recordDecision(d Decision) (Decision, error) {
+	a.mu.Lock()
+	a.lastDecision = d
+	a.mu.Unlock()
+	return d, nil
+}
+
+// pickReapTarget selects the replica to reap: lowest in-flight, oldest on tie.
+// Returns nil if the set is empty.
+func (a *Autoscaler) pickReapTarget() *Replica {
+	replicas := a.set.Replicas()
+	if len(replicas) == 0 {
+		return nil
+	}
+	chosen := replicas[0]
+	for _, r := range replicas[1:] {
+		cInFlight := chosen.InFlight()
+		rInFlight := r.InFlight()
+		switch {
+		case rInFlight < cInFlight:
+			chosen = r
+		case rInFlight == cInFlight && r.StartedAt().Before(chosen.StartedAt()):
+			chosen = r
+		}
+	}
+	return chosen
+}
+
+// errDrainTimeout signals that a reap's drain deadline was exceeded so the
+// scaler can put the replica back in rotation.
+var errDrainTimeout = errors.New("drain deadline exceeded")
+
+// drainAndReap removes the replica from dispatch immediately, waits up to
+// drainTimeout for its in-flight counter to reach 0, then asks the spawner
+// to close the underlying client. When the drain deadline is exceeded the
+// replica is NOT closed so the caller can put it back in rotation.
+//
+// An unconditional grace poll runs before checking InFlight so that a
+// concurrent Pick caller who already resolved the replica but has not yet
+// called IncInFlight has time to do so. Without this window, a drain could
+// see InFlight==0 immediately after RemoveReplica and close a client that a
+// racing tool call is about to use.
+func (a *Autoscaler) drainAndReap(ctx context.Context, r *Replica) error {
+	if _, err := a.set.RemoveReplica(r.ID()); err != nil {
+		return fmt.Errorf("remove replica %d: %w", r.ID(), err)
+	}
+
+	deadline := time.Now().Add(drainTimeout)
+	for {
+		// Pick-vs-reap grace window: wait one poll before declaring idle.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(drainPollInterval):
+		}
+		if r.InFlight() == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			return errDrainTimeout
+		}
+	}
+	return a.spawner.Reap(ctx, r)
+}
+
+// AutoscaleStatus is the serialisable snapshot included in MCPServerStatus
+// when a server has autoscale configured. Fields mirror the spec in
+// new_feature.md § "Observability surface".
+type AutoscaleStatus struct {
+	Min             int        `json:"min"`
+	Max             int        `json:"max"`
+	Current         int        `json:"current"`
+	Target          int        `json:"target"`
+	TargetInFlight  int        `json:"targetInFlight"`
+	MedianInFlight  int64      `json:"medianInFlight"`
+	LastScaleUpAt   *time.Time `json:"lastScaleUpAt,omitempty"`
+	LastScaleDownAt *time.Time `json:"lastScaleDownAt,omitempty"`
+	LastDecision    string     `json:"lastDecision"`
+	WarmPool        int        `json:"warmPool,omitempty"`
+	IdleToZero      bool       `json:"idleToZero,omitempty"`
+}

--- a/pkg/mcp/autoscaler_test.go
+++ b/pkg/mcp/autoscaler_test.go
@@ -1,0 +1,598 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+)
+
+// fakeSpawner records Spawn / Reap calls and returns pre-seeded clients. Tests
+// construct one per autoscaler and inspect CountSpawn / CountReap afterwards.
+type fakeSpawner struct {
+	mu           sync.Mutex
+	spawned      int32
+	reaped       int32
+	spawnErr     error
+	errOnce      bool // if true, spawnErr is cleared after first failure
+	spawnErrFor  int  // number of spawn attempts that fail before succeeding (0 = none)
+	newClient    func(id int) AgentClient
+	nextClientID atomic.Int32
+}
+
+func newFakeSpawner(t *testing.T) *fakeSpawner {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	return &fakeSpawner{
+		newClient: func(id int) AgentClient {
+			name := "replica-" + itoa(id)
+			return setupMockAgentClient(ctrl, name, []Tool{{Name: "echo"}})
+		},
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := "0123456789"
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var out []byte
+	for n > 0 {
+		out = append([]byte{digits[n%10]}, out...)
+		n /= 10
+	}
+	if neg {
+		out = append([]byte{'-'}, out...)
+	}
+	return string(out)
+}
+
+func (f *fakeSpawner) Spawn(_ context.Context) (AgentClient, error) {
+	atomic.AddInt32(&f.spawned, 1)
+
+	f.mu.Lock()
+	err := f.spawnErr
+	switch {
+	case f.spawnErrFor > 0:
+		// Scheduled failure budget — fail and decrement. Clear the error
+		// once the budget is exhausted so later ticks succeed.
+		f.spawnErrFor--
+		if f.spawnErrFor == 0 {
+			f.spawnErr = nil
+		}
+		f.mu.Unlock()
+		return nil, err
+	case f.errOnce && err != nil:
+		f.spawnErr = nil
+		f.mu.Unlock()
+		return nil, err
+	case err != nil:
+		f.mu.Unlock()
+		return nil, err
+	}
+	f.mu.Unlock()
+
+	id := int(f.nextClientID.Add(1) - 1)
+	return f.newClient(id), nil
+}
+
+func (f *fakeSpawner) Reap(_ context.Context, _ *Replica) error {
+	atomic.AddInt32(&f.reaped, 1)
+	return nil
+}
+
+func (f *fakeSpawner) CountSpawn() int { return int(atomic.LoadInt32(&f.spawned)) }
+func (f *fakeSpawner) CountReap() int  { return int(atomic.LoadInt32(&f.reaped)) }
+
+// setInitialReplicas seeds a fresh set with N healthy replicas via AddReplica,
+// matching how a warm scaler would have done it. Returns the replica ids.
+func setInitialReplicas(t *testing.T, set *ReplicaSet, sp *fakeSpawner, n int) []int {
+	t.Helper()
+	ids := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		client, err := sp.Spawn(context.Background())
+		if err != nil {
+			t.Fatalf("seed spawn: %v", err)
+		}
+		ids = append(ids, set.AddReplica(client))
+	}
+	return ids
+}
+
+// newTestAutoscaler returns an Autoscaler wired to an empty ReplicaSet + the
+// given policy. Initial replicas are pre-seeded via setInitialReplicas.
+func newTestAutoscaler(t *testing.T, policy AutoscalePolicy, initial int) (*Autoscaler, *ReplicaSet, *fakeSpawner) {
+	t.Helper()
+	set := NewReplicaSet("junos", ReplicaPolicyRoundRobin, nil)
+	sp := newFakeSpawner(t)
+	setInitialReplicas(t, set, sp, initial)
+	logger := slog.New(slog.NewTextHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	a := NewAutoscaler("junos", set, sp, policy, logger)
+	return a, set, sp
+}
+
+// discardWriter silences slog output in tests.
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestAutoscaler_Noop_MedianBelowTarget(t *testing.T) {
+	policy := AutoscalePolicy{Min: 2, Max: 6, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 5 * time.Minute}
+	a, set, sp := newTestAutoscaler(t, policy, 2)
+
+	// Median 1 with target 3 → ceil(2*1/3) = 1 + warm 0 = 1, clamped to Min 2. target == current: noop.
+	set.Replicas()[0].inFlight.Store(1)
+	set.Replicas()[1].inFlight.Store(1)
+	d, err := a.Tick(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if d != DecisionNoop {
+		t.Errorf("decision = %v, want Noop", d)
+	}
+	if sp.CountSpawn() != 2 {
+		t.Errorf("spawn count = %d, want 2 (seed only)", sp.CountSpawn())
+	}
+}
+
+func TestAutoscaler_ScaleUp_AfterSustainedHighLoad(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 4, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 5 * time.Minute}
+	a, set, sp := newTestAutoscaler(t, policy, 1)
+
+	// Median 9 vs target 3 → ceil(1*9/3) = 3. Warm+0 = 3. Clamped Min 1, Max 4 = 3.
+	set.Replicas()[0].inFlight.Store(9)
+
+	// Feed a window's worth of high-load samples so scale-up passes the
+	// sustained-signal gate.
+	now := time.Now()
+	for offset := 60 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 9)
+	}
+
+	d, err := a.Tick(context.Background(), now)
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if d != DecisionScaleUp {
+		t.Fatalf("decision = %v, want ScaleUp", d)
+	}
+	if got := set.Size(); got != 3 {
+		t.Errorf("replica count = %d, want 3", got)
+	}
+	if sp.CountSpawn() != 3 { // 1 seed + 2 scale-up (target 3 from current 1 = spawn 2)
+		t.Errorf("spawn count = %d, want 3", sp.CountSpawn())
+	}
+}
+
+func TestAutoscaler_ScaleUp_ClampedAtMax(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 3, TargetInFlight: 2, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 5 * time.Minute}
+	a, set, sp := newTestAutoscaler(t, policy, 1)
+
+	set.Replicas()[0].inFlight.Store(50) // absurd pressure
+	now := time.Now()
+	for offset := 60 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 50)
+	}
+
+	if _, err := a.Tick(context.Background(), now); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if got := set.Size(); got != policy.Max {
+		t.Errorf("replica count = %d, want Max %d", got, policy.Max)
+	}
+	_ = sp
+}
+
+func TestAutoscaler_ScaleUp_CooldownBlocksSecondTick(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 6, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 5 * time.Minute}
+	a, set, _ := newTestAutoscaler(t, policy, 1)
+
+	set.Replicas()[0].inFlight.Store(9)
+	now := time.Now()
+	for offset := 60 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 9)
+	}
+
+	// First tick scales up.
+	if _, err := a.Tick(context.Background(), now); err != nil {
+		t.Fatalf("tick 1: %v", err)
+	}
+	size1 := set.Size()
+
+	// Second tick 5s later is within ScaleUpAfter cooldown → must be a noop.
+	d, err := a.Tick(context.Background(), now.Add(5*time.Second))
+	if err != nil {
+		t.Fatalf("tick 2: %v", err)
+	}
+	if d != DecisionNoop {
+		t.Errorf("tick 2 decision = %v, want Noop", d)
+	}
+	if set.Size() != size1 {
+		t.Errorf("tick 2 added replicas despite cooldown (size %d → %d)", size1, set.Size())
+	}
+}
+
+func TestAutoscaler_WarmPool_SkipsCooldown(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 6, WarmPool: 2, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 5 * time.Minute}
+	a, _, _ := newTestAutoscaler(t, policy, 1)
+
+	// Record a recent lastScaleUpAt so the cooldown would normally block.
+	a.mu.Lock()
+	a.lastScaleUpAt = time.Now().Add(-1 * time.Second)
+	a.mu.Unlock()
+
+	// current (1) < Min+WarmPool (3) triggers eager scale-up ignoring cooldown.
+	d, err := a.Tick(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if d != DecisionScaleUp {
+		t.Errorf("decision = %v, want ScaleUp (warm-pool catch-up)", d)
+	}
+}
+
+func TestAutoscaler_ScaleDown_AfterSustainedIdle(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 4, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second}
+	a, set, _ := newTestAutoscaler(t, policy, 3)
+
+	// No load: all replicas idle, median 0.
+	now := time.Now()
+	for offset := 120 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 0)
+	}
+
+	d, err := a.Tick(context.Background(), now)
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if d != DecisionScaleDown {
+		t.Fatalf("decision = %v, want ScaleDown", d)
+	}
+	if got := set.Size(); got != 2 {
+		t.Errorf("replica count = %d, want 2 (one reaped per tick)", got)
+	}
+}
+
+func TestAutoscaler_ScaleDown_FlooredByMin(t *testing.T) {
+	policy := AutoscalePolicy{Min: 2, Max: 4, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second}
+	a, set, _ := newTestAutoscaler(t, policy, 2) // exactly at Min
+
+	now := time.Now()
+	for offset := 120 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 0)
+	}
+
+	d, _ := a.Tick(context.Background(), now)
+	if d != DecisionNoop {
+		t.Errorf("decision = %v, want Noop (at Min floor)", d)
+	}
+	if got := set.Size(); got != 2 {
+		t.Errorf("replica count = %d, want 2 (Min floor)", got)
+	}
+}
+
+func TestAutoscaler_ScaleDown_FlooredByWarmPool(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 4, WarmPool: 1, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second}
+	a, _, _ := newTestAutoscaler(t, policy, 2) // Min 1 + WarmPool 1 floor
+
+	now := time.Now()
+	for offset := 120 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 0)
+	}
+
+	d, _ := a.Tick(context.Background(), now)
+	if d != DecisionNoop {
+		t.Errorf("decision = %v, want Noop (warm-pool floor)", d)
+	}
+}
+
+func TestAutoscaler_ScaleDown_CooldownBlocksSecondTick(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 4, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second}
+	a, set, _ := newTestAutoscaler(t, policy, 3)
+
+	now := time.Now()
+	for offset := 120 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 0)
+	}
+	// First reap.
+	if _, err := a.Tick(context.Background(), now); err != nil {
+		t.Fatalf("tick 1: %v", err)
+	}
+	if set.Size() != 2 {
+		t.Fatalf("after tick 1: size = %d, want 2", set.Size())
+	}
+
+	// Immediate second tick is inside the cooldown.
+	d, _ := a.Tick(context.Background(), now.Add(5*time.Second))
+	if d != DecisionNoop {
+		t.Errorf("tick 2 decision = %v, want Noop", d)
+	}
+	if set.Size() != 2 {
+		t.Errorf("tick 2 reaped despite cooldown: size = %d, want 2", set.Size())
+	}
+}
+
+func TestAutoscaler_ScaleDown_OnePerTick(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 10, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second}
+	a, set, _ := newTestAutoscaler(t, policy, 6)
+
+	now := time.Now()
+	for offset := 120 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 0)
+	}
+
+	// Even if the load-derived target is 1 (big drop), a single tick reaps at most one.
+	if _, err := a.Tick(context.Background(), now); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if got := set.Size(); got != 5 {
+		t.Errorf("size after one tick = %d, want 5 (one-per-tick)", got)
+	}
+}
+
+func TestAutoscaler_WarmPool_KeepsAboveLoadTarget(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 6, WarmPool: 2, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second}
+	a, set, _ := newTestAutoscaler(t, policy, 1)
+
+	// Tick immediately: warm-pool catch-up should scale eagerly to 1+2=3.
+	d, err := a.Tick(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if d != DecisionScaleUp {
+		t.Errorf("decision = %v, want ScaleUp", d)
+	}
+	if got := set.Size(); got != 3 {
+		t.Errorf("size = %d, want 3 (Min 1 + WarmPool 2)", got)
+	}
+}
+
+func TestAutoscaler_IdleToZero_ReapsToZero(t *testing.T) {
+	policy := AutoscalePolicy{Min: 0, Max: 2, TargetInFlight: 3, IdleToZero: true, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second}
+	a, set, sp := newTestAutoscaler(t, policy, 1)
+
+	// Sustained idle across the full ScaleDownAfter window.
+	now := time.Now()
+	for offset := 120 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 0)
+	}
+
+	// First tick reaps one (the only remaining replica). The idle_to_zero path
+	// drains aggressively past the normal warm-pool floor.
+	d, err := a.Tick(context.Background(), now)
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if d != DecisionScaleDown {
+		t.Fatalf("decision = %v, want ScaleDown", d)
+	}
+	if set.Size() != 0 {
+		t.Errorf("size = %d, want 0 after idle-to-zero reap", set.Size())
+	}
+	if sp.CountReap() != 1 {
+		t.Errorf("reap count = %d, want 1", sp.CountReap())
+	}
+}
+
+func TestAutoscaler_SpawnFailure_NoCooldownUpdate(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 4, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second}
+	a, set, sp := newTestAutoscaler(t, policy, 1)
+
+	// One failing spawn, then success. scaleUp needs 2 spawns to reach target
+	// 3 from current 1 — the first fails (loop breaks), the tick records no
+	// cooldown. Tick 2 retries both spawns successfully.
+	sp.mu.Lock()
+	sp.spawnErr = errors.New("kaboom")
+	sp.spawnErrFor = 1
+	sp.mu.Unlock()
+
+	set.Replicas()[0].inFlight.Store(9)
+	now := time.Now()
+	for offset := 60 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 9)
+	}
+
+	// Tick 1: every spawn fails -> warm scale-up fails, lastScaleUpAt stays zero.
+	if _, err := a.Tick(context.Background(), now); err == nil {
+		t.Fatal("expected spawn error on tick 1")
+	}
+	a.mu.Lock()
+	lastUp := a.lastScaleUpAt
+	a.mu.Unlock()
+	if !lastUp.IsZero() {
+		t.Errorf("lastScaleUpAt updated after failed spawn: %v", lastUp)
+	}
+
+	// Tick 2: spawns succeed; lastScaleUpAt now moves.
+	if _, err := a.Tick(context.Background(), now.Add(1*time.Second)); err != nil {
+		t.Fatalf("tick 2 unexpected error: %v", err)
+	}
+	a.mu.Lock()
+	lastUp = a.lastScaleUpAt
+	a.mu.Unlock()
+	if lastUp.IsZero() {
+		t.Error("lastScaleUpAt still zero after successful scale-up")
+	}
+}
+
+func TestAutoscaler_ReapDrainTimeout_RestoresReplica(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 4, TargetInFlight: 3, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second}
+	a, set, _ := newTestAutoscaler(t, policy, 3)
+
+	// Peg every replica above zero so whichever the scaler picks as victim,
+	// its drain cannot complete.
+	for _, r := range set.Replicas() {
+		r.inFlight.Store(1)
+	}
+
+	now := time.Now()
+	for offset := 120 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 0)
+	}
+
+	// Use a fast-deadline context to force the drain to fail without waiting 30s.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := a.Tick(ctx, now)
+	if err == nil {
+		t.Fatal("expected drain/context error")
+	}
+	// Replica count should be unchanged (victim re-added after the failure).
+	if got := set.Size(); got != 3 {
+		t.Errorf("size = %d, want 3 (reap aborted)", got)
+	}
+	// lastScaleDownAt must NOT be updated on failure.
+	a.mu.Lock()
+	lastDown := a.lastScaleDownAt
+	a.mu.Unlock()
+	if !lastDown.IsZero() {
+		t.Errorf("lastScaleDownAt updated after failed reap: %v", lastDown)
+	}
+}
+
+func TestAutoscaler_UpdatePolicy_AppliesOnNextTick(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 4, TargetInFlight: 5, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second}
+	a, set, _ := newTestAutoscaler(t, policy, 1)
+
+	set.Replicas()[0].inFlight.Store(5)
+	now := time.Now()
+	for offset := 60 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		a.window.Add(now.Add(-offset), 5)
+	}
+
+	// Under target=5, current-target math = ceil(1*5/5) = 1 → noop.
+	d, _ := a.Tick(context.Background(), now)
+	if d != DecisionNoop {
+		t.Fatalf("pre-update decision = %v, want Noop", d)
+	}
+
+	// Tighten target to 2 → ceil(1*5/2)=3 replicas.
+	a.UpdatePolicy(AutoscalePolicy{Min: 1, Max: 4, TargetInFlight: 2, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second})
+
+	d, _ = a.Tick(context.Background(), now.Add(1*time.Second))
+	if d != DecisionScaleUp {
+		t.Errorf("post-update decision = %v, want ScaleUp", d)
+	}
+	if set.Size() < 3 {
+		t.Errorf("size after tighter policy = %d, want >= 3", set.Size())
+	}
+}
+
+func TestAutoscaler_ColdStart_SpawnsOnZeroReplicas(t *testing.T) {
+	policy := AutoscalePolicy{Min: 0, Max: 3, TargetInFlight: 3, IdleToZero: true}
+	a, set, sp := newTestAutoscaler(t, policy, 0)
+
+	if set.Size() != 0 {
+		t.Fatalf("precondition: expected empty set, got size %d", set.Size())
+	}
+
+	if err := a.TriggerColdStart(context.Background()); err != nil {
+		t.Fatalf("cold start: %v", err)
+	}
+	if set.Size() != 1 {
+		t.Errorf("size after cold start = %d, want 1", set.Size())
+	}
+	if sp.CountSpawn() != 1 {
+		t.Errorf("spawn count = %d, want 1", sp.CountSpawn())
+	}
+}
+
+func TestAutoscaler_ColdStart_NoopWhenReplicasExist(t *testing.T) {
+	policy := AutoscalePolicy{Min: 0, Max: 3, TargetInFlight: 3, IdleToZero: true}
+	a, set, sp := newTestAutoscaler(t, policy, 1)
+
+	before := sp.CountSpawn()
+	if err := a.TriggerColdStart(context.Background()); err != nil {
+		t.Fatalf("cold start: %v", err)
+	}
+	if sp.CountSpawn() != before {
+		t.Errorf("spawn count changed: before %d, after %d", before, sp.CountSpawn())
+	}
+	if set.Size() != 1 {
+		t.Errorf("size = %d, want 1 (no new spawn)", set.Size())
+	}
+}
+
+func TestAutoscaler_Status_ReflectsState(t *testing.T) {
+	policy := AutoscalePolicy{Min: 1, Max: 4, TargetInFlight: 3, WarmPool: 1, IdleToZero: false, ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second}
+	a, set, _ := newTestAutoscaler(t, policy, 2)
+
+	set.Replicas()[0].inFlight.Store(2)
+	set.Replicas()[1].inFlight.Store(4)
+
+	st := a.Status()
+	if st.Min != 1 || st.Max != 4 || st.TargetInFlight != 3 {
+		t.Errorf("status bounds = {Min:%d Max:%d Target:%d}, want {1 4 3}", st.Min, st.Max, st.TargetInFlight)
+	}
+	if st.Current != 2 {
+		t.Errorf("current = %d, want 2", st.Current)
+	}
+	if st.MedianInFlight != 3 { // median of [2,4] = 3
+		t.Errorf("median = %d, want 3", st.MedianInFlight)
+	}
+	if st.WarmPool != 1 {
+		t.Errorf("warm pool = %d, want 1", st.WarmPool)
+	}
+	if st.LastDecision != "noop" {
+		t.Errorf("last decision = %q, want noop", st.LastDecision)
+	}
+}
+
+func TestInFlightWindow_PrunesOldSamples(t *testing.T) {
+	w := newInFlightWindow(30 * time.Second)
+	now := time.Now()
+	w.Add(now.Add(-2*time.Minute), 5)
+	w.Add(now.Add(-45*time.Second), 7)
+	w.Add(now.Add(-5*time.Second), 3)
+	// The trigger pruning happens on the next Add.
+	w.Add(now, 1)
+
+	// Oldest retained must be within size (30s + jitter on Add timing).
+	if oldest := w.oldestAt(); oldest.Before(now.Add(-30 * time.Second)) {
+		t.Errorf("oldest sample at %v, should be within 30s of now (%v)", oldest, now)
+	}
+}
+
+func TestInFlightWindow_Median(t *testing.T) {
+	w := newInFlightWindow(60 * time.Second)
+	now := time.Now()
+	w.Add(now.Add(-30*time.Second), 1)
+	w.Add(now.Add(-20*time.Second), 5)
+	w.Add(now.Add(-10*time.Second), 9)
+	// Odd length: median=5.
+	if got := w.sampleMedian(now.Add(-60 * time.Second)); got != 5 {
+		t.Errorf("odd median = %v, want 5", got)
+	}
+	// Narrow the cutoff: only 9 qualifies → median=9.
+	if got := w.sampleMedian(now.Add(-15 * time.Second)); got != 9 {
+		t.Errorf("narrow median = %v, want 9", got)
+	}
+}
+
+func TestInFlightWindow_AllZeroSince(t *testing.T) {
+	w := newInFlightWindow(60 * time.Second)
+	now := time.Now()
+	// Seed the window with recent zero samples only.
+	for offset := 60 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		w.Add(now.Add(-offset), 0)
+	}
+	from := now.Add(-30 * time.Second)
+	if !w.allSamplesZeroSince(from) {
+		t.Error("expected allSamplesZeroSince(true) for all-idle window")
+	}
+
+	w.Add(now, 2) // one non-zero sample
+	if w.allSamplesZeroSince(from) {
+		t.Error("expected allSamplesZeroSince(false) after a non-zero sample")
+	}
+}

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -999,6 +999,9 @@ func (g *Gateway) UnregisterMCPServer(name string) {
 	g.router.RemoveClient(name)
 	g.router.RefreshTools()
 	g.unregisterAutoscaler(name)
+	g.mu.Lock()
+	delete(g.serverMeta, name)
+	g.mu.Unlock()
 }
 
 // RestartMCPServer restarts an individual MCP server by name.

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -142,6 +142,9 @@ type Gateway struct {
 	pinAction      string           // "warn" | "block" on drift (default "warn")
 	blockedMu      sync.RWMutex
 	blockedServers map[string]bool  // servers blocked due to unacknowledged schema drift
+
+	autoMu      sync.RWMutex
+	autoscalers map[string]*Autoscaler // name -> scaler for autoscaled replica sets
 }
 
 // NewGateway creates a new MCP gateway.
@@ -158,6 +161,7 @@ func NewGateway() *Gateway {
 		health:         make(map[string]*HealthStatus),
 		replicaHealth:  make(map[string]map[int]*HealthStatus),
 		blockedServers: make(map[string]bool),
+		autoscalers:    make(map[string]*Autoscaler),
 	}
 }
 
@@ -680,6 +684,131 @@ func (g *Gateway) RegisterMCPServer(ctx context.Context, cfg MCPServerConfig) er
 	return g.RegisterMCPReplicaSet(ctx, cfg.Name, ReplicaPolicyRoundRobin, []MCPServerConfig{cfg})
 }
 
+// RegisterAutoscaler registers an autoscaled replica set for an MCP server.
+// The Spawner owns replica provisioning; the gateway only stores metadata and
+// wires the scaler into the router. One synchronous Tick is executed before
+// returning so Min (and WarmPool) replicas are available before the caller's
+// first tool call — except when IdleToZero=true and Min=0, in which case the
+// first tool call triggers a cold-start spawn instead.
+func (g *Gateway) RegisterAutoscaler(ctx context.Context, template MCPServerConfig, policy string, spawner Spawner, autoscale AutoscalePolicy) error {
+	if template.Name == "" {
+		return fmt.Errorf("register autoscaler: empty name")
+	}
+	if spawner == nil {
+		return fmt.Errorf("register autoscaler %s: nil spawner", template.Name)
+	}
+	if autoscale.Max < 1 {
+		return fmt.Errorf("register autoscaler %s: invalid policy (max=%d)", template.Name, autoscale.Max)
+	}
+	if policy == "" {
+		policy = ReplicaPolicyRoundRobin
+	}
+
+	// Register metadata up front so pinningEnabledForServer and health
+	// check iteration both recognise this as an MCP server.
+	func() {
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		g.serverMeta[template.Name] = template
+	}()
+
+	set := NewReplicaSet(template.Name, policy, nil)
+	g.router.AddReplicaSet(set)
+
+	scaler := NewAutoscaler(template.Name, set, spawner, autoscale, g.logger)
+	g.autoMu.Lock()
+	g.autoscalers[template.Name] = scaler
+	g.autoMu.Unlock()
+
+	// Seed initial replicas synchronously so the set is warm before the
+	// first incoming tool call. Idle-to-zero with Min=0 and no warm pool
+	// intentionally stays cold until a tool call triggers the cold-start spawn.
+	skipInitialTick := autoscale.IdleToZero && autoscale.Min == 0 && autoscale.WarmPool == 0
+	if !skipInitialTick {
+		if _, err := scaler.Tick(ctx, time.Now()); err != nil {
+			g.logger.Warn("initial autoscaler tick failed",
+				"server", template.Name, "error", err)
+			// Do not fail the whole registration — the next periodic tick
+			// will retry; warm_pool ensures the cooldown doesn't block us.
+		}
+	}
+
+	g.logger.Info("registered autoscaled MCP server",
+		"name", template.Name,
+		"min", autoscale.Min,
+		"max", autoscale.Max,
+		"target_in_flight", autoscale.TargetInFlight,
+		"warm_pool", autoscale.WarmPool,
+		"idle_to_zero", autoscale.IdleToZero,
+	)
+	return nil
+}
+
+// GetAutoscaler returns the autoscaler registered for serverName, or nil if
+// the server is not autoscaled.
+func (g *Gateway) GetAutoscaler(serverName string) *Autoscaler {
+	g.autoMu.RLock()
+	defer g.autoMu.RUnlock()
+	return g.autoscalers[serverName]
+}
+
+// Autoscalers returns a snapshot slice of every registered autoscaler, sorted
+// by server name for deterministic iteration in the tick loop.
+func (g *Gateway) Autoscalers() []*Autoscaler {
+	g.autoMu.RLock()
+	names := make([]string, 0, len(g.autoscalers))
+	for n := range g.autoscalers {
+		names = append(names, n)
+	}
+	g.autoMu.RUnlock()
+	sort.Strings(names)
+
+	g.autoMu.RLock()
+	defer g.autoMu.RUnlock()
+	out := make([]*Autoscaler, 0, len(names))
+	for _, n := range names {
+		if s, ok := g.autoscalers[n]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// unregisterAutoscaler drops the autoscaler for a server (used during hot
+// reload when switching from autoscale back to static replicas, or when the
+// server is removed from the stack).
+func (g *Gateway) unregisterAutoscaler(serverName string) {
+	g.autoMu.Lock()
+	defer g.autoMu.Unlock()
+	delete(g.autoscalers, serverName)
+}
+
+// StartAutoscaler launches a background goroutine that ticks every registered
+// autoscaler on the given interval. Cancelling ctx stops the loop. Safe to
+// call alongside StartHealthMonitor and StartCleanup.
+func (g *Gateway) StartAutoscaler(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = DefaultAutoscalerInterval
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case now := <-ticker.C:
+				for _, a := range g.Autoscalers() {
+					if _, err := a.Tick(ctx, now); err != nil {
+						g.logger.Debug("autoscaler tick error",
+							"server", a.Name(), "error", err)
+					}
+				}
+			}
+		}
+	}()
+}
+
 // RegisterMCPReplicaSet initializes one AgentClient per config and registers
 // them as a single replica set under the given server name. All configs must
 // be for the same logical server (same Name, same transport, same tool list);
@@ -742,6 +871,14 @@ func (g *Gateway) RegisterMCPReplicaSet(ctx context.Context, name, policy string
 
 	g.logger.Info("registered MCP server", "name", name, "transport", cfgs[0].Transport, "replicas", len(clients), "tools", len(clients[0].Tools()), "duration", time.Since(start))
 	return nil
+}
+
+// BuildAgentClient creates, connects, and initializes an AgentClient from a
+// single MCPServerConfig. It does NOT touch serverMeta, pins, health, or the
+// router — callers compose that separately. Exported so Spawner implementations
+// in pkg/controller can reuse the transport switch rather than duplicating it.
+func (g *Gateway) BuildAgentClient(ctx context.Context, cfg MCPServerConfig) (AgentClient, error) {
+	return g.buildAgentClient(ctx, cfg)
 }
 
 // buildAgentClient creates, connects, and initializes an AgentClient from a
@@ -861,6 +998,7 @@ func (g *Gateway) SetServerMeta(cfg MCPServerConfig) {
 func (g *Gateway) UnregisterMCPServer(name string) {
 	g.router.RemoveClient(name)
 	g.router.RefreshTools()
+	g.unregisterAutoscaler(name)
 }
 
 // RestartMCPServer restarts an individual MCP server by name.
@@ -1095,12 +1233,27 @@ func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*
 	routeSpan.SetAttributes(attribute.String("tool.name", params.Name))
 	replica, toolName, err := g.router.RouteToolCallReplica(params.Name)
 	if err != nil {
-		routeSpan.SetStatus(codes.Error, err.Error())
-		routeSpan.End()
-		return &ToolCallResult{
-			Content: []Content{NewTextContent(fmt.Sprintf("Error: %v", err))},
-			IsError: true,
-		}, nil
+		// Cold-start trigger: if the target server is autoscaled and currently
+		// at zero healthy replicas, synchronously spawn one before retrying.
+		// Bounded here by the caller's context (tool-call timeout) rather than
+		// by a hard-coded deadline so long-spin containers can complete.
+		if agentName, _, parseErr := ParsePrefixedTool(params.Name); parseErr == nil {
+			if scaler := g.GetAutoscaler(agentName); scaler != nil {
+				if cs := scaler.TriggerColdStart(ctx); cs == nil {
+					replica, toolName, err = g.router.RouteToolCallReplica(params.Name)
+				} else if err == nil {
+					err = cs
+				}
+			}
+		}
+		if err != nil {
+			routeSpan.SetStatus(codes.Error, err.Error())
+			routeSpan.End()
+			return &ToolCallResult{
+				Content: []Content{NewTextContent(fmt.Sprintf("Error: %v", err))},
+				IsError: true,
+			}, nil
+		}
 	}
 	client := replica.Client()
 	replicaID := replica.ID()
@@ -1484,6 +1637,11 @@ type MCPServerStatus struct {
 	ToolWhitelist []string `json:"toolWhitelist,omitempty"`
 
 	Replicas []ReplicaStatus `json:"replicas,omitempty"` // Per-replica status; always populated
+
+	// Autoscale is non-nil only for servers with an autoscale block in
+	// their stack YAML. Reports current min/max/target/median and the
+	// last scaler decision so operators can reason about scale events.
+	Autoscale *AutoscaleStatus `json:"autoscale,omitempty"`
 }
 
 // ReplicaStatus reports the live state of a single replica within a
@@ -1584,25 +1742,58 @@ func allToolsOf(client AgentClient) []Tool {
 // Note: This only returns actual MCP servers, not A2A adapters or other
 // clients added directly to the router.
 func (g *Gateway) Status() []MCPServerStatus {
-	clients := g.router.Clients()
-	statuses := make([]MCPServerStatus, 0, len(clients))
-
+	// Gather names from both the router (live replica sets) and the serverMeta
+	// map so autoscaled servers without any live replicas still appear.
 	g.mu.RLock()
-	defer g.mu.RUnlock()
+	metaSnapshot := make(map[string]MCPServerConfig, len(g.serverMeta))
+	for k, v := range g.serverMeta {
+		metaSnapshot[k] = v
+	}
+	defaultFormat := g.defaultOutputFormat
+	g.mu.RUnlock()
 
-	for _, client := range clients {
-		// Only include clients that were registered as MCP servers
-		// (have metadata). This filters out A2A adapters which are
-		// internal plumbing and shouldn't appear as MCP servers.
-		meta, isMCPServer := g.serverMeta[client.Name()]
-		if !isMCPServer {
+	// Build a name set combining router-registered clients and autoscaled
+	// metadata entries (which may have empty ReplicaSets at scale-to-zero).
+	routerClients := g.router.Clients()
+	seen := make(map[string]bool, len(routerClients)+len(metaSnapshot))
+	namesOrder := make([]string, 0, len(routerClients)+len(metaSnapshot))
+	clientByName := make(map[string]AgentClient, len(routerClients))
+	for _, c := range routerClients {
+		name := c.Name()
+		if _, ok := metaSnapshot[name]; !ok {
 			continue
 		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		namesOrder = append(namesOrder, name)
+		clientByName[name] = c
+	}
+	for name := range metaSnapshot {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		namesOrder = append(namesOrder, name)
+	}
 
-		// Report every tool the downstream server advertises, not just the
-		// currently-whitelisted subset. The UI tool editor needs the full
-		// set so operators can widen a curated whitelist.
-		tools := allToolsOf(client)
+	statuses := make([]MCPServerStatus, 0, len(namesOrder))
+
+	for _, name := range namesOrder {
+		meta := metaSnapshot[name]
+		client := clientByName[name] // may be nil for autoscaled servers at zero replicas
+
+		// Report every tool the downstream server advertises. When every
+		// replica has been reaped (scale-to-zero), client is nil and we
+		// fall back to the set's tool cache so the Status surface keeps
+		// its shape.
+		var tools []Tool
+		if client != nil {
+			tools = allToolsOf(client)
+		} else if set := g.router.GetReplicaSet(name); set != nil {
+			tools = set.CachedTools()
+		}
 		toolNames := make([]string, len(tools))
 		for i, t := range tools {
 			toolNames[i] = t.Name
@@ -1610,16 +1801,16 @@ func (g *Gateway) Status() []MCPServerStatus {
 
 		// Resolve effective output format: server override > gateway default
 		outputFormat := meta.OutputFormat
-		if outputFormat == "" && g.defaultOutputFormat != "" {
-			outputFormat = g.defaultOutputFormat
+		if outputFormat == "" && defaultFormat != "" {
+			outputFormat = defaultFormat
 		}
 
 		status := MCPServerStatus{
-			Name:          client.Name(),
+			Name:          name,
 			Transport:     meta.Transport,
 			Endpoint:      meta.Endpoint,
 			ContainerID:   meta.ContainerID,
-			Initialized:   client.IsInitialized(),
+			Initialized:   client != nil && client.IsInitialized(),
 			ToolCount:     len(tools),
 			Tools:         toolNames,
 			External:      meta.External,
@@ -1636,14 +1827,19 @@ func (g *Gateway) Status() []MCPServerStatus {
 
 		// Include health status if available
 		g.healthMu.RLock()
-		if hs, ok := g.health[client.Name()]; ok {
+		if hs, ok := g.health[name]; ok {
 			status.Healthy = &hs.Healthy
 			status.LastCheck = &hs.LastCheck
 			status.HealthError = hs.Error
 		}
 		g.healthMu.RUnlock()
 
-		status.Replicas = g.ReplicaStatuses(client.Name())
+		status.Replicas = g.ReplicaStatuses(name)
+
+		if scaler := g.GetAutoscaler(name); scaler != nil {
+			st := scaler.Status()
+			status.Autoscale = &st
+		}
 
 		statuses = append(statuses, status)
 	}

--- a/pkg/mcp/gateway_autoscale_test.go
+++ b/pkg/mcp/gateway_autoscale_test.go
@@ -1,0 +1,239 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+)
+
+// gatewayFakeSpawner is the minimum Spawner implementation the gateway-level
+// tests need: it returns a pre-seeded AgentClient and tracks Spawn/Reap
+// invocations, with optional failure injection.
+type gatewayFakeSpawner struct {
+	ctrl    *gomock.Controller
+	spawns  atomic.Int32
+	reaps   atomic.Int32
+	failErr error
+}
+
+func (f *gatewayFakeSpawner) Spawn(_ context.Context) (AgentClient, error) {
+	f.spawns.Add(1)
+	if f.failErr != nil {
+		return nil, f.failErr
+	}
+	tools := []Tool{{Name: "echo", InputSchema: json.RawMessage(`{"type":"object"}`)}}
+	m := setupMockAgentClient(f.ctrl, "replica", tools)
+	m.EXPECT().CallTool(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&ToolCallResult{Content: []Content{NewTextContent("ok")}}, nil).
+		AnyTimes()
+	return m, nil
+}
+func (f *gatewayFakeSpawner) Reap(_ context.Context, _ *Replica) error {
+	f.reaps.Add(1)
+	return nil
+}
+
+func newGatewayFakeSpawner(t *testing.T) *gatewayFakeSpawner {
+	return &gatewayFakeSpawner{ctrl: gomock.NewController(t)}
+}
+
+func TestGateway_RegisterAutoscaler_StoresMetadataAndScaler(t *testing.T) {
+	gw := NewGateway()
+	t.Cleanup(gw.Close)
+	gw.SetLogger(slog.New(slog.NewTextHandler(discardWriter{}, nil)))
+
+	template := MCPServerConfig{Name: "svc", LocalProcess: true, Command: []string{"irrelevant"}}
+	sp := newGatewayFakeSpawner(t)
+	policy := AutoscalePolicy{Min: 1, Max: 3, TargetInFlight: 3}
+
+	if err := gw.RegisterAutoscaler(context.Background(), template, ReplicaPolicyRoundRobin, sp, policy); err != nil {
+		t.Fatalf("RegisterAutoscaler: %v", err)
+	}
+
+	if got := gw.GetAutoscaler("svc"); got == nil {
+		t.Error("GetAutoscaler returned nil for registered server")
+	}
+	if got := gw.Autoscalers(); len(got) != 1 || got[0].Name() != "svc" {
+		t.Errorf("Autoscalers = %v, want [svc]", got)
+	}
+	if got := sp.spawns.Load(); got != 1 {
+		t.Errorf("initial tick spawned %d replicas, want 1 (Min=1)", got)
+	}
+}
+
+func TestGateway_RegisterAutoscaler_Rejects_NilSpawner(t *testing.T) {
+	gw := NewGateway()
+	t.Cleanup(gw.Close)
+	err := gw.RegisterAutoscaler(context.Background(),
+		MCPServerConfig{Name: "svc"}, ReplicaPolicyRoundRobin, nil,
+		AutoscalePolicy{Max: 1})
+	if err == nil {
+		t.Fatal("expected error for nil spawner")
+	}
+}
+
+func TestGateway_RegisterAutoscaler_Rejects_EmptyName(t *testing.T) {
+	gw := NewGateway()
+	t.Cleanup(gw.Close)
+	err := gw.RegisterAutoscaler(context.Background(),
+		MCPServerConfig{Name: ""}, ReplicaPolicyRoundRobin,
+		newGatewayFakeSpawner(t), AutoscalePolicy{Max: 1})
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestGateway_RegisterAutoscaler_Rejects_MaxZero(t *testing.T) {
+	gw := NewGateway()
+	t.Cleanup(gw.Close)
+	err := gw.RegisterAutoscaler(context.Background(),
+		MCPServerConfig{Name: "svc"}, ReplicaPolicyRoundRobin,
+		newGatewayFakeSpawner(t), AutoscalePolicy{Max: 0})
+	if err == nil {
+		t.Fatal("expected error for Max=0 policy")
+	}
+}
+
+func TestGateway_RegisterAutoscaler_IdleToZero_SkipsInitialSpawn(t *testing.T) {
+	gw := NewGateway()
+	t.Cleanup(gw.Close)
+	gw.SetLogger(slog.New(slog.NewTextHandler(discardWriter{}, nil)))
+
+	sp := newGatewayFakeSpawner(t)
+	policy := AutoscalePolicy{Min: 0, Max: 2, TargetInFlight: 3, IdleToZero: true}
+	if err := gw.RegisterAutoscaler(context.Background(),
+		MCPServerConfig{Name: "svc", LocalProcess: true, Command: []string{"x"}},
+		ReplicaPolicyRoundRobin, sp, policy); err != nil {
+		t.Fatalf("RegisterAutoscaler: %v", err)
+	}
+	if got := sp.spawns.Load(); got != 0 {
+		t.Errorf("idle_to_zero + Min=0 + WarmPool=0 spawned %d replicas, want 0", got)
+	}
+}
+
+func TestGateway_HandleToolsCall_ColdStartViaAutoscaler(t *testing.T) {
+	gw := NewGateway()
+	t.Cleanup(gw.Close)
+	gw.SetLogger(slog.New(slog.NewTextHandler(discardWriter{}, nil)))
+
+	sp := newGatewayFakeSpawner(t)
+	policy := AutoscalePolicy{Min: 0, Max: 2, TargetInFlight: 3, IdleToZero: true}
+	if err := gw.RegisterAutoscaler(context.Background(),
+		MCPServerConfig{Name: "svc", LocalProcess: true, Command: []string{"x"}},
+		ReplicaPolicyRoundRobin, sp, policy); err != nil {
+		t.Fatalf("RegisterAutoscaler: %v", err)
+	}
+	if got := gw.Router().GetReplicaSet("svc").Size(); got != 0 {
+		t.Fatalf("precondition: size = %d, want 0", got)
+	}
+
+	result, err := gw.HandleToolsCall(context.Background(), ToolCallParams{
+		Name:      PrefixTool("svc", "echo"),
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("HandleToolsCall: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool call returned IsError; content=%v", result.Content)
+	}
+	if got := sp.spawns.Load(); got != 1 {
+		t.Errorf("cold start spawn count = %d, want 1", got)
+	}
+}
+
+func TestGateway_StartAutoscaler_TicksPeriodically(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping time-based test in short mode")
+	}
+	gw := NewGateway()
+	t.Cleanup(gw.Close)
+	gw.SetLogger(slog.New(slog.NewTextHandler(discardWriter{}, nil)))
+
+	sp := newGatewayFakeSpawner(t)
+	policy := AutoscalePolicy{Min: 1, Max: 2, TargetInFlight: 3}
+	if err := gw.RegisterAutoscaler(context.Background(),
+		MCPServerConfig{Name: "svc", LocalProcess: true, Command: []string{"x"}},
+		ReplicaPolicyRoundRobin, sp, policy); err != nil {
+		t.Fatalf("RegisterAutoscaler: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	gw.StartAutoscaler(ctx, 100*time.Millisecond)
+
+	// After a few tick windows the scaler has run at least once beyond the
+	// initial synchronous tick in RegisterAutoscaler.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if sp.spawns.Load() >= 1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if sp.spawns.Load() < 1 {
+		t.Errorf("tick loop did not run: spawns = %d, want >= 1", sp.spawns.Load())
+	}
+}
+
+func TestGateway_UnregisterAutoscaler_ViaUnregisterMCPServer(t *testing.T) {
+	gw := NewGateway()
+	t.Cleanup(gw.Close)
+
+	sp := newGatewayFakeSpawner(t)
+	if err := gw.RegisterAutoscaler(context.Background(),
+		MCPServerConfig{Name: "svc", LocalProcess: true, Command: []string{"x"}},
+		ReplicaPolicyRoundRobin, sp,
+		AutoscalePolicy{Min: 1, Max: 2, TargetInFlight: 3}); err != nil {
+		t.Fatalf("RegisterAutoscaler: %v", err)
+	}
+	if gw.GetAutoscaler("svc") == nil {
+		t.Fatal("precondition: scaler should be registered")
+	}
+	gw.UnregisterMCPServer("svc")
+	if gw.GetAutoscaler("svc") != nil {
+		t.Error("UnregisterMCPServer did not drop the scaler")
+	}
+}
+
+func TestGateway_RegisterAutoscaler_InitialTickError_DoesNotFailRegistration(t *testing.T) {
+	gw := NewGateway()
+	t.Cleanup(gw.Close)
+	gw.SetLogger(slog.New(slog.NewTextHandler(discardWriter{}, nil)))
+
+	sp := &gatewayFakeSpawner{ctrl: gomock.NewController(t), failErr: errors.New("kaboom")}
+	err := gw.RegisterAutoscaler(context.Background(),
+		MCPServerConfig{Name: "svc", LocalProcess: true, Command: []string{"x"}},
+		ReplicaPolicyRoundRobin, sp,
+		AutoscalePolicy{Min: 1, Max: 2, TargetInFlight: 3})
+	if err != nil {
+		t.Fatalf("RegisterAutoscaler should succeed even when initial tick fails: %v", err)
+	}
+	if gw.GetAutoscaler("svc") == nil {
+		t.Error("scaler not registered despite initial tick failure")
+	}
+}
+
+func TestGateway_BuildAgentClient_LocalProcess(t *testing.T) {
+	// BuildAgentClient is exported so Spawner implementations in pkg/controller
+	// can reuse the transport switch. With LocalProcess + an invalid command
+	// it must surface the connection error rather than panic.
+	gw := NewGateway()
+	t.Cleanup(gw.Close)
+	gw.SetLogger(slog.New(slog.NewTextHandler(discardWriter{}, nil)))
+
+	_, err := gw.BuildAgentClient(context.Background(), MCPServerConfig{
+		Name:         "svc",
+		LocalProcess: true,
+		Command:      []string{"/this/command/does/not/exist"},
+	})
+	if err == nil {
+		t.Fatal("expected error from BuildAgentClient with invalid command")
+	}
+}

--- a/pkg/mcp/replica_set.go
+++ b/pkg/mcp/replica_set.go
@@ -2,7 +2,9 @@ package mcp
 
 import (
 	"errors"
+	"fmt"
 	"math/rand/v2"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -165,11 +167,25 @@ type ReplicaSet struct {
 	mu       sync.RWMutex
 	replicas []*Replica
 	rrCursor atomic.Int64
+
+	// nextID is the next replica id to hand out. Monotonically increasing;
+	// ids are never reused, so removal never invalidates a stored id.
+	// Seeded to len(clients) by NewReplicaSet so existing static ids (0..n-1)
+	// remain untouched and dynamic adds pick up from n.
+	nextID atomic.Int64
+
+	// toolCache caches the last known tool surface (keyed by the canonical
+	// server name) so Router.AggregatedTools can still advertise tools when
+	// every replica has been reaped (e.g. scale-to-zero). A nil or empty
+	// value means the cache is cold.
+	toolCacheMu sync.RWMutex
+	toolCache   []Tool
 }
 
 // NewReplicaSet builds a ReplicaSet from an ordered slice of AgentClients. The
 // first client becomes replica-0, and so on. All replicas start healthy. An
-// unknown policy falls back to round-robin.
+// unknown policy falls back to round-robin. The id counter is seeded to
+// len(clients) so dynamic adds never collide with static ids.
 func NewReplicaSet(name, policy string, clients []AgentClient) *ReplicaSet {
 	if policy != ReplicaPolicyRoundRobin && policy != ReplicaPolicyLeastConnections {
 		policy = ReplicaPolicyRoundRobin
@@ -189,6 +205,12 @@ func NewReplicaSet(name, policy string, clients []AgentClient) *ReplicaSet {
 		}
 		r.healthy.Store(true)
 		set.replicas = append(set.replicas, r)
+	}
+	set.nextID.Store(int64(len(clients)))
+	// Seed the tool cache from replica-0 so even an immediate scale-to-zero
+	// preserves the tool surface advertised to clients.
+	if len(clients) > 0 {
+		set.SetToolCache(clients[0].Tools())
 	}
 	return set
 }
@@ -270,7 +292,8 @@ func (s *ReplicaSet) pickLeastConnectionsLocked() (*Replica, error) {
 			continue
 		}
 		inFlight := r.InFlight()
-		if chosen == nil || inFlight < chosenInFlight {
+		if chosen == nil || inFlight < chosenInFlight ||
+			(inFlight == chosenInFlight && r.id < chosen.id) {
 			chosen = r
 			chosenInFlight = inFlight
 		}
@@ -279,4 +302,131 @@ func (s *ReplicaSet) pickLeastConnectionsLocked() (*Replica, error) {
 		return nil, ErrNoHealthyReplicas
 	}
 	return chosen, nil
+}
+
+// AddReplica appends a new replica with a monotonically increasing id and
+// marks it healthy. Returns the new replica's id. Ids are never reused so
+// handles stored by observers (health monitor, status endpoints) remain
+// stable across scale events.
+func (s *ReplicaSet) AddReplica(client AgentClient) int {
+	s.mu.Lock()
+	id := int(s.nextID.Add(1) - 1)
+	r := &Replica{
+		id:        id,
+		client:    client,
+		restart:   &backoffState{},
+		startedAt: time.Now(),
+	}
+	r.healthy.Store(true)
+	s.replicas = append(s.replicas, r)
+	s.mu.Unlock()
+
+	// Keep the tool-definition cache warm for scale-to-zero. Done outside
+	// s.mu so client.Tools() (which may refresh under its own lock) does
+	// not block Pick / Replicas / HealthyCount callers on this replica.
+	if client != nil {
+		s.SetToolCache(client.Tools())
+	}
+	return id
+}
+
+// RemoveReplica removes the replica with the given id and returns it so the
+// caller can close its client. Returns an error if the id is not present.
+// The caller is responsible for policy checks (min floor, warm pool, etc.);
+// this method only enforces that the replica exists.
+func (s *ReplicaSet) RemoveReplica(id int) (*Replica, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, r := range s.replicas {
+		if r.id != id {
+			continue
+		}
+		s.replicas = append(s.replicas[:i], s.replicas[i+1:]...)
+		return r, nil
+	}
+	return nil, fmt.Errorf("replica %d not in set %q", id, s.name)
+}
+
+// ReinsertReplica puts a previously-removed replica back into the set
+// without minting a new id. Used by the autoscaler when a drain fails so
+// the in-flight counters and restart state the caller accumulated while
+// the replica was detached are preserved. Idempotent: if a replica with
+// the same id is already present, this is a no-op.
+func (s *ReplicaSet) ReinsertReplica(r *Replica) {
+	if r == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, existing := range s.replicas {
+		if existing.id == r.id {
+			return
+		}
+	}
+	r.SetHealthy(true)
+	s.replicas = append(s.replicas, r)
+}
+
+// HealthyCount returns the number of replicas currently marked healthy.
+func (s *ReplicaSet) HealthyCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	n := 0
+	for _, r := range s.replicas {
+		if r.Healthy() {
+			n++
+		}
+	}
+	return n
+}
+
+// MedianInFlight returns the median of in-flight counters across currently
+// healthy replicas. Returns 0 when no replica is healthy. Returns float64
+// for precision in small-scale clusters where one request can tilt the mean
+// noticeably.
+func (s *ReplicaSet) MedianInFlight() float64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	samples := make([]int64, 0, len(s.replicas))
+	for _, r := range s.replicas {
+		if r.Healthy() {
+			samples = append(samples, r.InFlight())
+		}
+	}
+	if len(samples) == 0 {
+		return 0
+	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	mid := len(samples) / 2
+	if len(samples)%2 == 1 {
+		return float64(samples[mid])
+	}
+	return float64(samples[mid-1]+samples[mid]) / 2
+}
+
+// SetToolCache replaces the tool-definition cache. Callers set this after
+// every successful refresh so Router.AggregatedTools can fall back to the
+// cached surface when every replica is currently reaped.
+func (s *ReplicaSet) SetToolCache(tools []Tool) {
+	if len(tools) == 0 {
+		return
+	}
+	s.toolCacheMu.Lock()
+	defer s.toolCacheMu.Unlock()
+	out := make([]Tool, len(tools))
+	copy(out, tools)
+	s.toolCache = out
+}
+
+// CachedTools returns a copy of the cached tool surface. Returns an empty
+// slice when the cache has not been primed.
+func (s *ReplicaSet) CachedTools() []Tool {
+	s.toolCacheMu.RLock()
+	defer s.toolCacheMu.RUnlock()
+	if len(s.toolCache) == 0 {
+		return nil
+	}
+	out := make([]Tool, len(s.toolCache))
+	copy(out, s.toolCache)
+	return out
 }

--- a/pkg/mcp/replica_set_test.go
+++ b/pkg/mcp/replica_set_test.go
@@ -273,6 +273,171 @@ func TestReplicaSet_ClientIdentity(t *testing.T) {
 	}
 }
 
+func TestReplicaSet_AddReplica_MonotonicIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin,
+		[]AgentClient{setupMockAgentClient(ctrl, "r0", nil), setupMockAgentClient(ctrl, "r1", nil)})
+
+	if got := set.Replicas()[0].ID(); got != 0 {
+		t.Fatalf("replica-0 id = %d, want 0", got)
+	}
+	if got := set.Replicas()[1].ID(); got != 1 {
+		t.Fatalf("replica-1 id = %d, want 1", got)
+	}
+
+	// First AddReplica must hand out id=2.
+	id := set.AddReplica(setupMockAgentClient(ctrl, "added", nil))
+	if id != 2 {
+		t.Errorf("first AddReplica returned id %d, want 2", id)
+	}
+	id = set.AddReplica(setupMockAgentClient(ctrl, "added2", nil))
+	if id != 3 {
+		t.Errorf("second AddReplica returned id %d, want 3", id)
+	}
+	if got := set.Size(); got != 4 {
+		t.Errorf("Size() = %d, want 4", got)
+	}
+}
+
+func TestReplicaSet_RemoveReplica_IDsNeverReused(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin,
+		[]AgentClient{setupMockAgentClient(ctrl, "r0", nil), setupMockAgentClient(ctrl, "r1", nil)})
+
+	// Remove id=0.
+	r, err := set.RemoveReplica(0)
+	if err != nil {
+		t.Fatalf("RemoveReplica(0): %v", err)
+	}
+	if r.ID() != 0 {
+		t.Fatalf("removed replica id = %d, want 0", r.ID())
+	}
+
+	// Add a new replica — must NOT reuse id=0.
+	id := set.AddReplica(setupMockAgentClient(ctrl, "new", nil))
+	if id != 2 {
+		t.Errorf("after removal, new replica id = %d, want 2 (monotonic)", id)
+	}
+
+	// Remove unknown id returns an error.
+	if _, err := set.RemoveReplica(99); err == nil {
+		t.Error("RemoveReplica(99) returned nil error; want 'not in set'")
+	}
+}
+
+func TestReplicaSet_RemoveReplica_PreservesOthers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin,
+		[]AgentClient{
+			setupMockAgentClient(ctrl, "r0", nil),
+			setupMockAgentClient(ctrl, "r1", nil),
+			setupMockAgentClient(ctrl, "r2", nil),
+		})
+	if _, err := set.RemoveReplica(1); err != nil {
+		t.Fatalf("RemoveReplica(1): %v", err)
+	}
+	ids := make([]int, 0, 2)
+	for _, r := range set.Replicas() {
+		ids = append(ids, r.ID())
+	}
+	if len(ids) != 2 || ids[0] != 0 || ids[1] != 2 {
+		t.Errorf("after removing id=1, remaining ids = %v, want [0 2]", ids)
+	}
+}
+
+func TestReplicaSet_MedianInFlight(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin,
+		[]AgentClient{
+			setupMockAgentClient(ctrl, "r0", nil),
+			setupMockAgentClient(ctrl, "r1", nil),
+			setupMockAgentClient(ctrl, "r2", nil),
+			setupMockAgentClient(ctrl, "r3", nil),
+		})
+	reps := set.Replicas()
+	reps[0].inFlight.Store(1)
+	reps[1].inFlight.Store(3)
+	reps[2].inFlight.Store(5)
+	reps[3].inFlight.Store(7)
+
+	// Even length: average of middle two = (3+5)/2 = 4.
+	if got := set.MedianInFlight(); got != 4 {
+		t.Errorf("even median = %v, want 4", got)
+	}
+
+	// Odd length: drop one; median of {1,3,7} = 3.
+	reps[2].SetHealthy(false)
+	if got := set.MedianInFlight(); got != 3 {
+		t.Errorf("odd median = %v, want 3", got)
+	}
+
+	// All unhealthy — median = 0.
+	for _, r := range reps {
+		r.SetHealthy(false)
+	}
+	if got := set.MedianInFlight(); got != 0 {
+		t.Errorf("no healthy: median = %v, want 0", got)
+	}
+}
+
+func TestReplicaSet_ToolCache_WarmOnInit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	tools := []Tool{{Name: "t0"}, {Name: "t1"}}
+	client := setupMockAgentClient(ctrl, "r0", tools)
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin, []AgentClient{client})
+
+	cached := set.CachedTools()
+	if len(cached) != 2 || cached[0].Name != "t0" {
+		t.Errorf("cached tools = %v, want [{t0} {t1}]", cached)
+	}
+
+	// After reaping every replica, the cache still serves the tool surface.
+	if _, err := set.RemoveReplica(0); err != nil {
+		t.Fatalf("RemoveReplica: %v", err)
+	}
+	stillCached := set.CachedTools()
+	if len(stillCached) != 2 {
+		t.Errorf("after scale-to-zero: cached tools len = %d, want 2", len(stillCached))
+	}
+}
+
+func TestReplicaSet_ToolCache_SetIgnoresEmpty(t *testing.T) {
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin, nil)
+	set.SetToolCache([]Tool{{Name: "keep"}})
+	set.SetToolCache(nil) // must not clear
+	if got := set.CachedTools(); len(got) != 1 || got[0].Name != "keep" {
+		t.Errorf("empty set call cleared cache; got %v", got)
+	}
+}
+
+func TestReplicaSet_AddReplica_ConcurrentIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	set := NewReplicaSet("svc", ReplicaPolicyRoundRobin, nil)
+
+	var wg sync.WaitGroup
+	ids := make(chan int, 64)
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ids <- set.AddReplica(setupMockAgentClient(ctrl, "x", nil))
+		}()
+	}
+	wg.Wait()
+	close(ids)
+
+	seen := make(map[int]bool, 64)
+	for id := range ids {
+		if seen[id] {
+			t.Fatalf("duplicate id %d returned from concurrent AddReplica", id)
+		}
+		seen[id] = true
+	}
+	if len(seen) != 64 {
+		t.Errorf("got %d distinct ids, want 64", len(seen))
+	}
+}
+
 func TestReplica_InFlightCounters(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	set := NewReplicaSet("svc", ReplicaPolicyLeastConnections,

--- a/pkg/mcp/router.go
+++ b/pkg/mcp/router.go
@@ -116,13 +116,21 @@ func (r *Router) ReplicaSets() []*ReplicaSet {
 }
 
 // toolsOf returns the Tools list to advertise for a set. All replicas share
-// the same tool surface, so reading from replica-0 is sufficient.
+// the same tool surface, so reading from replica-0 is sufficient. When every
+// replica has been reaped (e.g. scale-to-zero), falls back to the set's tool
+// cache so clients still see the tool surface and can trigger a cold-start.
 func toolsOf(set *ReplicaSet) []Tool {
 	reps := set.Replicas()
 	if len(reps) == 0 {
-		return nil
+		return set.CachedTools()
 	}
-	return reps[0].Client().Tools()
+	tools := reps[0].Client().Tools()
+	// Opportunistically refresh the cache on every successful read so a
+	// subsequent scale-to-zero serves the most recent tool surface.
+	if len(tools) > 0 {
+		set.SetToolCache(tools)
+	}
+	return tools
 }
 
 // RefreshTools updates the tool registry from all agents.

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -30,20 +30,22 @@ type GatewaySummary struct {
 // `gridctl status`. A server with a single replica uses "—" in the Replicas
 // column to match the UX spec.
 type MCPServerRollup struct {
-	Name     string
-	Type     string // transport label: local-process, container, ssh, external, openapi
-	Replicas string // "N/M" for sets with replicas > 1, "—" for single-replica servers
-	State    string // "healthy", "degraded (replica-N restarting, next in 4s)", "unhealthy"
+	Name      string
+	Type      string // transport label: local-process, container, ssh, external, openapi
+	Replicas  string // "N/M" for sets with replicas > 1, "—" for single-replica servers
+	State     string // "healthy", "degraded (replica-N restarting, next in 4s)", "unhealthy"
+	Autoscale string // "min/current/max (target=N)" for autoscaled servers, empty for static
 }
 
 // ReplicaDetail is one row of the expanded `gridctl status --replicas` view.
 type ReplicaDetail struct {
-	Server   string
-	Replica  int
-	Handle   string // PID for local-process, container id prefix for container-backed
-	State    string
-	Uptime   string
-	InFlight int64
+	Server    string
+	Replica   int
+	Handle    string // PID for local-process, container id prefix for container-backed
+	State     string
+	Uptime    string
+	InFlight  int64
+	Autoscale string // "min/current/max (target=N)" — repeated per replica row for server-level info, empty for static servers
 }
 
 // ContainerSummary contains data for the container status table.
@@ -191,7 +193,9 @@ func (p *Printer) Containers(containers []ContainerSummary) {
 	p.Println()
 }
 
-// MCPServers prints the rolled-up MCP-server status table.
+// MCPServers prints the rolled-up MCP-server status table. The AUTOSCALE column
+// is shown only when at least one row has autoscale configured, so static-only
+// stacks see an unchanged table.
 func (p *Printer) MCPServers(rows []MCPServerRollup) {
 	if len(rows) == 0 {
 		return
@@ -203,19 +207,36 @@ func (p *Printer) MCPServers(rows []MCPServerRollup) {
 	t.SetOutputMirror(p.out)
 	t.SetStyle(p.tableStyle())
 
-	t.AppendHeader(table.Row{"Name", "Type", "Replicas", "State"})
+	hasAutoscale := false
+	for _, r := range rows {
+		if r.Autoscale != "" {
+			hasAutoscale = true
+			break
+		}
+	}
+
+	if hasAutoscale {
+		t.AppendHeader(table.Row{"Name", "Type", "Replicas", "Autoscale", "State"})
+	} else {
+		t.AppendHeader(table.Row{"Name", "Type", "Replicas", "State"})
+	}
 	for _, r := range rows {
 		state := r.State
 		if p.isTTY {
 			state = colorReplicaState(r.State)
 		}
-		t.AppendRow(table.Row{r.Name, r.Type, r.Replicas, state})
+		if hasAutoscale {
+			t.AppendRow(table.Row{r.Name, r.Type, r.Replicas, r.Autoscale, state})
+		} else {
+			t.AppendRow(table.Row{r.Name, r.Type, r.Replicas, state})
+		}
 	}
 	t.Render()
 	p.Println()
 }
 
 // Replicas prints the per-replica detail table used by `gridctl status --replicas`.
+// The AUTOSCALE column only appears when at least one row populates it.
 func (p *Printer) Replicas(rows []ReplicaDetail) {
 	if len(rows) == 0 {
 		return
@@ -227,13 +248,29 @@ func (p *Printer) Replicas(rows []ReplicaDetail) {
 	t.SetOutputMirror(p.out)
 	t.SetStyle(p.tableStyle())
 
-	t.AppendHeader(table.Row{"Server", "Replica", "PID/Container", "State", "Uptime", "In-Flight"})
+	hasAutoscale := false
+	for _, r := range rows {
+		if r.Autoscale != "" {
+			hasAutoscale = true
+			break
+		}
+	}
+
+	if hasAutoscale {
+		t.AppendHeader(table.Row{"Server", "Replica", "PID/Container", "State", "Uptime", "In-Flight", "Autoscale"})
+	} else {
+		t.AppendHeader(table.Row{"Server", "Replica", "PID/Container", "State", "Uptime", "In-Flight"})
+	}
 	for _, r := range rows {
 		state := r.State
 		if p.isTTY {
 			state = colorReplicaState(r.State)
 		}
-		t.AppendRow(table.Row{r.Server, fmt.Sprintf("%d", r.Replica), r.Handle, state, r.Uptime, r.InFlight})
+		if hasAutoscale {
+			t.AppendRow(table.Row{r.Server, fmt.Sprintf("%d", r.Replica), r.Handle, state, r.Uptime, r.InFlight, r.Autoscale})
+		} else {
+			t.AppendRow(table.Row{r.Server, fmt.Sprintf("%d", r.Replica), r.Handle, state, r.Uptime, r.InFlight})
+		}
 	}
 	t.Render()
 	p.Println()

--- a/pkg/reload/diff.go
+++ b/pkg/reload/diff.go
@@ -17,6 +17,10 @@ type MCPServerDiff struct {
 	Added    []config.MCPServer
 	Removed  []config.MCPServer
 	Modified []MCPServerChange
+	// AutoscalePolicyChanges lists servers whose autoscale block fields
+	// changed but whose other config is stable. The reload handler applies
+	// these via Autoscaler.UpdatePolicy without restarting the server.
+	AutoscalePolicyChanges []MCPServerChange
 }
 
 // MCPServerChange represents a modification to an existing MCP server.
@@ -45,6 +49,7 @@ func (d *ConfigDiff) IsEmpty() bool {
 	return len(d.MCPServers.Added) == 0 &&
 		len(d.MCPServers.Removed) == 0 &&
 		len(d.MCPServers.Modified) == 0 &&
+		len(d.MCPServers.AutoscalePolicyChanges) == 0 &&
 		len(d.Resources.Added) == 0 &&
 		len(d.Resources.Removed) == 0 &&
 		len(d.Resources.Modified) == 0 &&
@@ -111,13 +116,27 @@ func diffMCPServers(oldServers, newServers []config.MCPServer) MCPServerDiff {
 		oldServer, exists := oldMap[newServer.Name]
 		if !exists {
 			diff.Added = append(diff.Added, newServer)
-		} else if !mcpServerEqual(oldServer, newServer) {
-			diff.Modified = append(diff.Modified, MCPServerChange{
+			continue
+		}
+		if mcpServerEqual(oldServer, newServer) {
+			continue
+		}
+		// Autoscale-only policy updates are applied in-place without
+		// restarting the server so in-flight tool calls are not disrupted.
+		// Switching between autoscale and static replicas is a full restart.
+		if isAutoscalePolicyOnlyChange(oldServer, newServer) {
+			diff.AutoscalePolicyChanges = append(diff.AutoscalePolicyChanges, MCPServerChange{
 				Name: newServer.Name,
 				Old:  oldServer,
 				New:  newServer,
 			})
+			continue
 		}
+		diff.Modified = append(diff.Modified, MCPServerChange{
+			Name: newServer.Name,
+			Old:  oldServer,
+			New:  newServer,
+		})
 	}
 
 	// Find removed
@@ -128,6 +147,45 @@ func diffMCPServers(oldServers, newServers []config.MCPServer) MCPServerDiff {
 	}
 
 	return diff
+}
+
+// isAutoscalePolicyOnlyChange reports whether the only difference between two
+// server configs is inside the autoscale block. Transitions between static
+// replicas and autoscale always return false so those are restarted cleanly.
+func isAutoscalePolicyOnlyChange(oldServer, newServer config.MCPServer) bool {
+	// Both must already be autoscaled; switching in/out is a restart.
+	if oldServer.Autoscale == nil || newServer.Autoscale == nil {
+		return false
+	}
+	// Ignore autoscale deltas while comparing everything else.
+	oldCopy := oldServer
+	newCopy := newServer
+	oldCopy.Autoscale = nil
+	newCopy.Autoscale = nil
+	if !mcpServerEqual(oldCopy, newCopy) {
+		return false
+	}
+	// Only an autoscale change remains — and we already know the configs
+	// differ overall, so the autoscale block must carry the diff.
+	return !autoscaleEqual(oldServer.Autoscale, newServer.Autoscale)
+}
+
+func autoscaleEqual(a, b *config.AutoscaleConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	// Compare resolved durations so YAML strings that parse to the same
+	// duration ("30s" vs "30000ms") don't trigger a spurious policy update.
+	return a.Min == b.Min &&
+		a.Max == b.Max &&
+		a.TargetInFlight == b.TargetInFlight &&
+		a.ResolvedScaleUpAfter() == b.ResolvedScaleUpAfter() &&
+		a.ResolvedScaleDownAfter() == b.ResolvedScaleDownAfter() &&
+		a.WarmPool == b.WarmPool &&
+		a.IdleToZero == b.IdleToZero
 }
 
 func diffResources(oldResources, newResources []config.Resource) ResourceDiff {
@@ -172,6 +230,13 @@ func mcpServerEqual(a, b config.MCPServer) bool {
 	// Compare basic fields
 	if a.Name != b.Name || a.Image != b.Image || a.Port != b.Port ||
 		a.Transport != b.Transport || a.URL != b.URL || a.Network != b.Network {
+		return false
+	}
+	// Compare the autoscale block so transitions between static replicas and
+	// autoscale (or field changes inside an existing autoscale block) surface
+	// here. Static replicas count / policy are intentionally NOT compared to
+	// preserve pre-existing hot-reload behavior.
+	if !autoscaleEqual(a.Autoscale, b.Autoscale) {
 		return false
 	}
 

--- a/pkg/reload/diff_test.go
+++ b/pkg/reload/diff_test.go
@@ -230,3 +230,73 @@ func TestMCPServerEqual_ToolsChanges(t *testing.T) {
 	}
 }
 
+func TestComputeDiff_AutoscalePolicyOnlyChange(t *testing.T) {
+	base := config.MCPServer{
+		Name:      "junos",
+		Command:   []string{"python", "j.py"},
+		Autoscale: &config.AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3},
+	}
+	updated := base
+	updated.Autoscale = &config.AutoscaleConfig{Min: 1, Max: 8, TargetInFlight: 2}
+
+	diff := ComputeDiff(
+		&config.Stack{MCPServers: []config.MCPServer{base}},
+		&config.Stack{MCPServers: []config.MCPServer{updated}},
+	)
+
+	if len(diff.MCPServers.AutoscalePolicyChanges) != 1 {
+		t.Fatalf("AutoscalePolicyChanges = %d, want 1", len(diff.MCPServers.AutoscalePolicyChanges))
+	}
+	if len(diff.MCPServers.Modified) != 0 {
+		t.Errorf("Modified = %d, want 0 (policy-only should not restart)", len(diff.MCPServers.Modified))
+	}
+}
+
+func TestComputeDiff_StaticToAutoscaleIsRestart(t *testing.T) {
+	oldS := config.MCPServer{Name: "junos", Command: []string{"python", "j.py"}, Replicas: 3}
+	newS := config.MCPServer{Name: "junos", Command: []string{"python", "j.py"},
+		Autoscale: &config.AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3}}
+
+	diff := ComputeDiff(
+		&config.Stack{MCPServers: []config.MCPServer{oldS}},
+		&config.Stack{MCPServers: []config.MCPServer{newS}},
+	)
+	if len(diff.MCPServers.Modified) != 1 {
+		t.Errorf("static->autoscale should restart: Modified = %d, want 1", len(diff.MCPServers.Modified))
+	}
+	if len(diff.MCPServers.AutoscalePolicyChanges) != 0 {
+		t.Errorf("static->autoscale must not be a policy update: AutoscalePolicyChanges = %d, want 0",
+			len(diff.MCPServers.AutoscalePolicyChanges))
+	}
+}
+
+func TestComputeDiff_AutoscaleToStaticIsRestart(t *testing.T) {
+	oldS := config.MCPServer{Name: "junos", Command: []string{"python", "j.py"},
+		Autoscale: &config.AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3}}
+	newS := config.MCPServer{Name: "junos", Command: []string{"python", "j.py"}, Replicas: 2}
+
+	diff := ComputeDiff(
+		&config.Stack{MCPServers: []config.MCPServer{oldS}},
+		&config.Stack{MCPServers: []config.MCPServer{newS}},
+	)
+	if len(diff.MCPServers.Modified) != 1 {
+		t.Errorf("autoscale->static should restart: Modified = %d, want 1", len(diff.MCPServers.Modified))
+	}
+}
+
+func TestComputeDiff_AutoscaleWithUnrelatedChangeIsRestart(t *testing.T) {
+	oldS := config.MCPServer{Name: "junos", Command: []string{"python", "j.py"},
+		Autoscale: &config.AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3}}
+	newS := config.MCPServer{Name: "junos", Command: []string{"python", "j_v2.py"},
+		Autoscale: &config.AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3}}
+
+	diff := ComputeDiff(
+		&config.Stack{MCPServers: []config.MCPServer{oldS}},
+		&config.Stack{MCPServers: []config.MCPServer{newS}},
+	)
+	if len(diff.MCPServers.Modified) != 1 {
+		t.Errorf("command change mixed with autoscale should restart: Modified = %d, want 1",
+			len(diff.MCPServers.Modified))
+	}
+}
+

--- a/pkg/reload/reload.go
+++ b/pkg/reload/reload.go
@@ -175,6 +175,9 @@ func (h *Handler) Reload(ctx context.Context) (*ReloadResult, error) {
 		return result, nil
 	}
 
+	// Apply autoscale policy-only updates in place — no restart required.
+	h.applyAutoscalePolicyUpdates(diff.MCPServers, result)
+
 	// Apply resource changes
 	if err := h.applyResourceChanges(ctx, diff.Resources, newCfg, result); err != nil {
 		result.Success = false
@@ -211,6 +214,31 @@ func (h *Handler) Reload(ctx context.Context) (*ReloadResult, error) {
 	}
 
 	return result, nil
+}
+
+// applyAutoscalePolicyUpdates swaps the live scaler policy for each affected
+// server without restarting. In-flight tool calls are not disrupted.
+func (h *Handler) applyAutoscalePolicyUpdates(diff MCPServerDiff, result *ReloadResult) {
+	for _, change := range diff.AutoscalePolicyChanges {
+		h.logger.Info("updating autoscale policy", "name", change.Name)
+		scaler := h.gateway.GetAutoscaler(change.Name)
+		if scaler == nil || change.New.Autoscale == nil {
+			h.logger.Warn("autoscale policy change requested but no scaler registered",
+				"name", change.Name)
+			result.Errors = append(result.Errors, fmt.Sprintf("no autoscaler for %s", change.Name))
+			continue
+		}
+		scaler.UpdatePolicy(mcp.AutoscalePolicy{
+			Min:            change.New.Autoscale.Min,
+			Max:            change.New.Autoscale.Max,
+			TargetInFlight: change.New.Autoscale.TargetInFlight,
+			ScaleUpAfter:   change.New.Autoscale.ResolvedScaleUpAfter(),
+			ScaleDownAfter: change.New.Autoscale.ResolvedScaleDownAfter(),
+			WarmPool:       change.New.Autoscale.WarmPool,
+			IdleToZero:     change.New.Autoscale.IdleToZero,
+		})
+		result.Modified = append(result.Modified, "mcp-server:"+change.Name+" (autoscale policy)")
+	}
 }
 
 func (h *Handler) applyMCPServerChanges(ctx context.Context, diff MCPServerDiff, newCfg *config.Stack, result *ReloadResult) error {

--- a/pkg/reload/reload_test.go
+++ b/pkg/reload/reload_test.go
@@ -734,3 +734,139 @@ func assertContains(t *testing.T, items []string, expected string) {
 	}
 	t.Errorf("expected %q in %v", expected, items)
 }
+
+// fakeAutoscaleSpawner is a no-op Spawner the reload tests use to register an
+// autoscaler without touching real processes. Spawn always returns an error
+// so the initial tick skips — RegisterAutoscaler tolerates this.
+type fakeAutoscaleSpawner struct{}
+
+func (f *fakeAutoscaleSpawner) Spawn(context.Context) (mcp.AgentClient, error) {
+	return nil, fmt.Errorf("no-op spawner")
+}
+func (f *fakeAutoscaleSpawner) Reap(context.Context, *mcp.Replica) error { return nil }
+
+// TestHandler_Reload_AutoscalePolicyOnlyUpdate verifies that a change inside
+// an existing autoscale block is classified as a policy update (not a
+// restart) and is applied via Autoscaler.UpdatePolicy. No servers are
+// added/removed/modified in the restart sense.
+func TestHandler_Reload_AutoscalePolicyOnlyUpdate(t *testing.T) {
+	content := `
+name: test
+network:
+  name: test-net
+mcp-servers:
+  - name: junos
+    command: [/bin/true]
+    autoscale:
+      min: 1
+      max: 8
+      target_in_flight: 2
+`
+	stackPath := writeStackFile(t, content)
+
+	// Initial config matches the stack file.
+	initialCfg := &config.Stack{
+		Name:    "test",
+		Network: config.Network{Name: "test-net", Driver: "bridge"},
+		MCPServers: []config.MCPServer{{
+			Name:      "junos",
+			Command:   []string{"/bin/true"},
+			Autoscale: &config.AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3},
+		}},
+	}
+
+	h, _ := setupHandler(t, stackPath, initialCfg)
+
+	// Pre-register an autoscaler on the gateway so the policy update has a
+	// live scaler to target. Initial tick fails (no-op spawner) but the
+	// scaler is still registered.
+	if err := h.gateway.RegisterAutoscaler(context.Background(),
+		mcp.MCPServerConfig{Name: "junos", LocalProcess: true, Command: []string{"/bin/true"}},
+		mcp.ReplicaPolicyRoundRobin, &fakeAutoscaleSpawner{},
+		mcp.AutoscalePolicy{Min: 1, Max: 4, TargetInFlight: 3}); err != nil {
+		t.Fatalf("pre-register: %v", err)
+	}
+	before := h.gateway.GetAutoscaler("junos").Policy()
+	if before.Max != 4 || before.TargetInFlight != 3 {
+		t.Fatalf("pre-reload policy = %+v", before)
+	}
+
+	result, err := h.Reload(context.Background())
+	if err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Reload.Success=false: %s (errors=%v)", result.Message, result.Errors)
+	}
+
+	// Autoscaler.Policy() must reflect the new YAML.
+	after := h.gateway.GetAutoscaler("junos").Policy()
+	if after.Max != 8 || after.TargetInFlight != 2 {
+		t.Errorf("post-reload policy = %+v, want Max=8 TargetInFlight=2", after)
+	}
+
+	// The reload result must report this as a modification annotated with
+	// "(autoscale policy)" — not an Added/Removed entry.
+	found := false
+	for _, m := range result.Modified {
+		if m == "mcp-server:junos (autoscale policy)" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected modified entry for autoscale policy update; got %v", result.Modified)
+	}
+}
+
+// TestHandler_Reload_AutoscalePolicyUpdate_MissingScaler records an error
+// when the YAML asks for a policy update but no scaler is registered (e.g.
+// the autoscaler failed to register on first apply).
+func TestHandler_Reload_AutoscalePolicyUpdate_MissingScaler(t *testing.T) {
+	content := `
+name: test
+network:
+  name: test-net
+mcp-servers:
+  - name: junos
+    command: [/bin/true]
+    autoscale:
+      min: 1
+      max: 8
+      target_in_flight: 2
+`
+	stackPath := writeStackFile(t, content)
+
+	initialCfg := &config.Stack{
+		Name:    "test",
+		Network: config.Network{Name: "test-net", Driver: "bridge"},
+		MCPServers: []config.MCPServer{{
+			Name:      "junos",
+			Command:   []string{"/bin/true"},
+			Autoscale: &config.AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3},
+		}},
+	}
+
+	h, _ := setupHandler(t, stackPath, initialCfg)
+	// Intentionally do NOT call RegisterAutoscaler — simulates a scaler that
+	// failed to come up.
+
+	result, err := h.Reload(context.Background())
+	if err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	// Success=false because per-item errors were collected.
+	if result.Success {
+		t.Error("expected Reload.Success=false when scaler is missing")
+	}
+	found := false
+	for _, e := range result.Errors {
+		if e == "no autoscaler for junos" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'no autoscaler for junos' in Errors; got %v", result.Errors)
+	}
+}

--- a/pkg/runtime/orchestrator.go
+++ b/pkg/runtime/orchestrator.go
@@ -191,6 +191,26 @@ func (o *Orchestrator) Up(ctx context.Context, stack *config.Stack, opts UpOptio
 	for _, server := range stack.MCPServers {
 		replicas := replicaCount(&server)
 
+		// Autoscaled servers defer all replica provisioning to the Spawner.
+		// Emit a placeholder result entry so the registrar sees the server
+		// and routes it through RegisterAutoscaler.
+		if server.Autoscale != nil {
+			o.logger.Info("registering autoscaled MCP server",
+				"name", server.Name,
+				"min", server.Autoscale.Min,
+				"max", server.Autoscale.Max,
+				"target_in_flight", server.Autoscale.TargetInFlight,
+			)
+			result.MCPServers = append(result.MCPServers, MCPServerResult{
+				Name:         server.Name,
+				External:     server.IsExternal(),
+				LocalProcess: server.IsLocalProcess(),
+				SSH:          server.IsSSH(),
+				OpenAPI:      server.IsOpenAPI(),
+			})
+			continue
+		}
+
 		// Skip container creation for external servers
 		if server.IsExternal() {
 			o.logger.Info("registering external MCP server", "name", server.Name, "url", server.URL)

--- a/tests/integration/autoscaler_test.go
+++ b/tests/integration/autoscaler_test.go
@@ -1,0 +1,397 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/controller"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// newProcessTemplate builds an MCPServerConfig template the ProcessSpawner
+// will clone every time it spawns a replica. Uses the mock stdio binary
+// built by TestMain so autoscaler integration tests don't need a full
+// container runtime.
+func newProcessTemplate(name string) mcp.MCPServerConfig {
+	return mcp.MCPServerConfig{
+		Name:         name,
+		LocalProcess: true,
+		Command:      []string{mockStdioBin},
+	}
+}
+
+// waitFor polls cond every 50ms until it returns true or deadline expires.
+// Returns the final value of cond() so callers can fail with context.
+func waitFor(t *testing.T, deadline time.Duration, cond func() bool) bool {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if cond() {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return cond()
+}
+
+// TestAutoscaler_ColdStart_IdleToZero verifies that a server registered with
+// `min: 0, idle_to_zero: true` starts with zero replicas, then a tool call
+// synchronously spawns the first one.
+func TestAutoscaler_ColdStart_IdleToZero(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if mockStdioBin == "" {
+		t.Skip("mock stdio server binary not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	gw := mcp.NewGateway()
+	t.Cleanup(gw.Close)
+
+	template := newProcessTemplate("test-autoscale-cold")
+	spawner := controller.NewProcessSpawner(gw, template)
+	policy := mcp.AutoscalePolicy{
+		Min: 0, Max: 2, TargetInFlight: 3, IdleToZero: true,
+		ScaleUpAfter: 30 * time.Second, ScaleDownAfter: 60 * time.Second,
+	}
+	if err := gw.RegisterAutoscaler(ctx, template, mcp.ReplicaPolicyRoundRobin, spawner, policy); err != nil {
+		t.Fatalf("RegisterAutoscaler: %v", err)
+	}
+
+	set := gw.Router().GetReplicaSet(template.Name)
+	if set == nil {
+		t.Fatal("no replica set registered")
+	}
+	if got := set.Size(); got != 0 {
+		t.Fatalf("initial size = %d, want 0 (idle_to_zero, min 0, warm_pool 0)", got)
+	}
+
+	// A tool call against an empty set should trigger a synchronous cold start.
+	result, err := gw.HandleToolsCall(ctx, mcp.ToolCallParams{
+		Name:      mcp.PrefixTool(template.Name, "echo"),
+		Arguments: map[string]any{"message": "wake up"},
+	})
+	if err != nil {
+		t.Fatalf("tool call: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool call returned IsError; content=%v", result.Content)
+	}
+	if got := set.Size(); got != 1 {
+		t.Errorf("after cold start: size = %d, want 1", got)
+	}
+	t.Cleanup(func() {
+		// Reap whatever the scaler spawned so we don't leak processes.
+		for _, r := range set.Replicas() {
+			if _, err := set.RemoveReplica(r.ID()); err == nil {
+				_ = spawner.Reap(context.Background(), r)
+			}
+		}
+	})
+}
+
+// TestAutoscaler_TickScalesUp_SustainedLoad verifies that when the rolling
+// window shows sustained high median in-flight, Tick spawns replicas up to
+// target. We drive the window manually to avoid depending on the mock
+// server's request latency.
+func TestAutoscaler_TickScalesUp_SustainedLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if mockStdioBin == "" {
+		t.Skip("mock stdio server binary not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	gw := mcp.NewGateway()
+	t.Cleanup(gw.Close)
+
+	template := newProcessTemplate("test-autoscale-up")
+	spawner := controller.NewProcessSpawner(gw, template)
+	policy := mcp.AutoscalePolicy{
+		Min: 1, Max: 4, TargetInFlight: 3,
+		ScaleUpAfter:   10 * time.Second,
+		ScaleDownAfter: 1 * time.Minute,
+	}
+	if err := gw.RegisterAutoscaler(ctx, template, mcp.ReplicaPolicyRoundRobin, spawner, policy); err != nil {
+		t.Fatalf("RegisterAutoscaler: %v", err)
+	}
+
+	set := gw.Router().GetReplicaSet(template.Name)
+	t.Cleanup(func() {
+		for _, r := range set.Replicas() {
+			if _, err := set.RemoveReplica(r.ID()); err == nil {
+				_ = spawner.Reap(context.Background(), r)
+			}
+		}
+	})
+
+	// Wait for the initial tick's spawn (Min=1) to complete.
+	if !waitFor(t, 10*time.Second, func() bool { return set.Size() >= 1 }) {
+		t.Fatalf("initial replica not spawned: size = %d", set.Size())
+	}
+
+	// Pin high in-flight on replica-0 so the scaler sees sustained load.
+	scaler := gw.GetAutoscaler(template.Name)
+	if scaler == nil {
+		t.Fatal("no scaler registered")
+	}
+	for i := 0; i < 9; i++ {
+		set.Replicas()[0].IncInFlight()
+	}
+
+	// Jump logical time far past the initial-tick cooldown window, then feed
+	// a sample immediately before "now" so the sustained-signal check passes.
+	now := time.Now().Add(1 * time.Hour)
+	if _, err := scaler.Tick(ctx, now.Add(-5*time.Second)); err != nil {
+		t.Fatalf("priming Tick: %v", err)
+	}
+	if _, err := scaler.Tick(ctx, now); err != nil {
+		t.Fatalf("scale-up Tick: %v", err)
+	}
+
+	if !waitFor(t, 10*time.Second, func() bool { return set.Size() >= 2 }) {
+		t.Fatalf("scale-up did not add replicas: size = %d, want >= 2 (policy target ~3)", set.Size())
+	}
+	if got := set.Size(); got > policy.Max {
+		t.Errorf("size = %d, exceeds Max %d", got, policy.Max)
+	}
+}
+
+// TestAutoscaler_TickScalesDown_IdleShrinksToMin verifies that after a
+// sustained-idle window, Tick reaps replicas back toward Min.
+func TestAutoscaler_TickScalesDown_IdleShrinksToMin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if mockStdioBin == "" {
+		t.Skip("mock stdio server binary not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	gw := mcp.NewGateway()
+	t.Cleanup(gw.Close)
+
+	template := newProcessTemplate("test-autoscale-down")
+	spawner := controller.NewProcessSpawner(gw, template)
+	policy := mcp.AutoscalePolicy{
+		Min: 1, Max: 4, TargetInFlight: 3,
+		ScaleUpAfter:   10 * time.Second,
+		ScaleDownAfter: 1 * time.Minute,
+	}
+	if err := gw.RegisterAutoscaler(ctx, template, mcp.ReplicaPolicyRoundRobin, spawner, policy); err != nil {
+		t.Fatalf("RegisterAutoscaler: %v", err)
+	}
+	set := gw.Router().GetReplicaSet(template.Name)
+	t.Cleanup(func() {
+		for _, r := range set.Replicas() {
+			if _, err := set.RemoveReplica(r.ID()); err == nil {
+				_ = spawner.Reap(context.Background(), r)
+			}
+		}
+	})
+
+	if !waitFor(t, 10*time.Second, func() bool { return set.Size() >= 1 }) {
+		t.Fatalf("initial replica not spawned: size = %d", set.Size())
+	}
+
+	// Manually seed 3 replicas so we have something to reap.
+	for i := 0; i < 2; i++ {
+		client, err := spawner.Spawn(ctx)
+		if err != nil {
+			t.Fatalf("seed spawn %d: %v", i, err)
+		}
+		set.AddReplica(client)
+	}
+	if set.Size() < 3 {
+		t.Fatalf("seed failed: size = %d, want 3", set.Size())
+	}
+
+	scaler := gw.GetAutoscaler(template.Name)
+	// Zero in-flight on all replicas; feed an idle window.
+	now := time.Now()
+	for offset := 120 * time.Second; offset >= 0; offset -= 5 * time.Second {
+		if _, err := scaler.Tick(ctx, now.Add(-offset)); err != nil {
+			t.Fatalf("Tick(offset=%v): %v", offset, err)
+		}
+	}
+
+	if !waitFor(t, 5*time.Second, func() bool { return set.Size() < 3 }) {
+		t.Errorf("scale-down did not reap any replica after sustained idle; size = %d", set.Size())
+	}
+}
+
+// TestAutoscaler_UpdatePolicy_TakesEffectOnNextTick verifies that a hot
+// policy update is applied without restarting the scaler.
+func TestAutoscaler_UpdatePolicy_TakesEffectOnNextTick(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if mockStdioBin == "" {
+		t.Skip("mock stdio server binary not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	gw := mcp.NewGateway()
+	t.Cleanup(gw.Close)
+
+	template := newProcessTemplate("test-autoscale-reload")
+	spawner := controller.NewProcessSpawner(gw, template)
+	policy := mcp.AutoscalePolicy{
+		Min: 1, Max: 4, TargetInFlight: 10, // high target -> no scale-up under normal load
+		ScaleUpAfter:   10 * time.Second,
+		ScaleDownAfter: 1 * time.Minute,
+	}
+	if err := gw.RegisterAutoscaler(ctx, template, mcp.ReplicaPolicyRoundRobin, spawner, policy); err != nil {
+		t.Fatalf("RegisterAutoscaler: %v", err)
+	}
+	set := gw.Router().GetReplicaSet(template.Name)
+	t.Cleanup(func() {
+		for _, r := range set.Replicas() {
+			if _, err := set.RemoveReplica(r.ID()); err == nil {
+				_ = spawner.Reap(context.Background(), r)
+			}
+		}
+	})
+
+	if !waitFor(t, 10*time.Second, func() bool { return set.Size() >= 1 }) {
+		t.Fatalf("initial replica not spawned: size = %d", set.Size())
+	}
+	scaler := gw.GetAutoscaler(template.Name)
+
+	// Pin in-flight at 5; with target=10 that's not enough to scale.
+	for i := 0; i < 5; i++ {
+		set.Replicas()[0].IncInFlight()
+	}
+	// Logical time far past the initial-tick cooldown.
+	now := time.Now().Add(1 * time.Hour)
+	if _, err := scaler.Tick(ctx, now); err != nil {
+		t.Fatalf("pre-reload Tick: %v", err)
+	}
+	if set.Size() != 1 {
+		t.Errorf("pre-reload: size = %d, want 1 (target too high)", set.Size())
+	}
+
+	// Tighten the target.
+	scaler.UpdatePolicy(mcp.AutoscalePolicy{
+		Min: 1, Max: 4, TargetInFlight: 1, // very low target
+		ScaleUpAfter:   10 * time.Second,
+		ScaleDownAfter: 1 * time.Minute,
+	})
+
+	// Advance time past the cooldown and tick again — new policy takes effect.
+	newNow := now.Add(30 * time.Second)
+	if _, err := scaler.Tick(ctx, newNow.Add(-5*time.Second)); err != nil {
+		t.Fatalf("priming Tick: %v", err)
+	}
+	if _, err := scaler.Tick(ctx, newNow); err != nil {
+		t.Fatalf("post-update Tick: %v", err)
+	}
+
+	if !waitFor(t, 10*time.Second, func() bool { return set.Size() >= 2 }) {
+		t.Errorf("post-reload: size = %d, want >= 2 after tightening target", set.Size())
+	}
+}
+
+// faultySpawner wraps a Spawner and fails the first N Spawn calls before
+// delegating. Used to verify the error path does not panic and eventually
+// recovers.
+type faultySpawner struct {
+	inner     mcp.Spawner
+	failsLeft atomic.Int32
+	mu        sync.Mutex
+	spawns    int
+	reaps     int
+}
+
+func (f *faultySpawner) Spawn(ctx context.Context) (mcp.AgentClient, error) {
+	f.mu.Lock()
+	f.spawns++
+	f.mu.Unlock()
+	if f.failsLeft.Add(-1) >= 0 {
+		return nil, errors.New("synthetic spawn failure")
+	}
+	return f.inner.Spawn(ctx)
+}
+func (f *faultySpawner) Reap(ctx context.Context, r *mcp.Replica) error {
+	f.mu.Lock()
+	f.reaps++
+	f.mu.Unlock()
+	return f.inner.Reap(ctx, r)
+}
+
+// TestAutoscaler_SpawnerError_Recovers verifies that a spawner that fails
+// its first N calls does not crash the scaler, logs WARN, and eventually
+// succeeds without the cooldown blocking it.
+func TestAutoscaler_SpawnerError_Recovers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if mockStdioBin == "" {
+		t.Skip("mock stdio server binary not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	gw := mcp.NewGateway()
+	t.Cleanup(gw.Close)
+
+	template := newProcessTemplate("test-autoscale-err")
+	real := controller.NewProcessSpawner(gw, template)
+	fs := &faultySpawner{inner: real}
+	fs.failsLeft.Store(2) // first two spawns fail
+
+	policy := mcp.AutoscalePolicy{
+		Min: 1, Max: 2, TargetInFlight: 3,
+		ScaleUpAfter:   10 * time.Second,
+		ScaleDownAfter: 1 * time.Minute,
+	}
+	// Register; the synchronous initial Tick in RegisterAutoscaler will
+	// trigger the first failing spawn but not propagate (best-effort).
+	if err := gw.RegisterAutoscaler(ctx, template, mcp.ReplicaPolicyRoundRobin, fs, policy); err != nil {
+		t.Fatalf("RegisterAutoscaler: %v", err)
+	}
+
+	set := gw.Router().GetReplicaSet(template.Name)
+	t.Cleanup(func() {
+		for _, r := range set.Replicas() {
+			if _, err := set.RemoveReplica(r.ID()); err == nil {
+				_ = fs.Reap(context.Background(), r)
+			}
+		}
+	})
+	scaler := gw.GetAutoscaler(template.Name)
+
+	// After the failures budget is exhausted, further ticks should succeed.
+	// Warm-pool catch-up means cooldown does not apply until Min is met.
+	if !waitFor(t, 10*time.Second, func() bool {
+		_, _ = scaler.Tick(ctx, time.Now())
+		return set.Size() >= 1
+	}) {
+		t.Errorf("scaler never recovered from spawn failures: size = %d, spawns attempted = %d",
+			set.Size(), fs.spawns)
+	}
+	if fs.spawns < 3 {
+		t.Errorf("expected at least 3 spawn attempts (2 fails + 1 success), got %d", fs.spawns)
+	}
+}
+
+// dummy so the file compiles cleanly when -short is used everywhere.
+var _ = fmt.Sprintf


### PR DESCRIPTION
## Description

Replace static `replicas: N` with a reactive `autoscale:` block that spawns and reaps MCP replicas based on median in-flight load. Supports container, local-process, and SSH transports.

## Type of Change

- [x] New feature

## Changes Made

- Add `autoscale` config block (`min`, `max`, `target_in_flight`, `scale_up_after`, `scale_down_after`, `warm_pool`, `idle_to_zero`) with validation; mutually exclusive with `replicas`
- Implement `pkg/mcp/autoscaler` with per-replica-set controller driving scale decisions from in-flight samples
- Wire autoscaler into gateway, replica set, router, orchestrator, and reload/diff flows
- Add per-transport replica spawners (container, local process, SSH); reject `autoscale` on external URL and OpenAPI with precise YAML-path errors
- Surface autoscale state via `/api/mcp-servers` and a new `AUTOSCALE` column in `gridctl status --replicas`
- Emit structured log lines / trace spans per scaling decision
- Add `docs/scaling.md#autoscaling` and `examples/autoscale/` walkthrough
- Servers without `autoscale` behave identically to prior releases

## Testing

- Unit tests: autoscaler, replica set, config validation, reload diff/apply, spawners, output table
- Gateway autoscale tests and `tests/integration/autoscaler_test.go` integration suite
- `make test` and `make build`; manual smoke via `examples/autoscale/autoscale-basic.yaml`

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed