### PR TITLE
feat: wizard UI for reactive autoscaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@ All notable changes to gridctl will be documented in this file.
 - Add MCP replicas schema and router (phase 1 of #470) ([#477](https://github.com/gridctl/gridctl/pull/477))
 - Wire MCP replicas runtime and health (phase 2 of #470) ([#478](https://github.com/gridctl/gridctl/pull/478))
 - Replicas observability, status, and API (phase 3 of #470) ([#479](https://github.com/gridctl/gridctl/pull/479))
-- Replicas wizard input and canvas badge (phase 4 of #470) ([#480](https://github.com/gridctl/gridctl/pull/480))## [0.1.0-beta.5] - 2026-04-08
+- Replicas wizard input and canvas badge (phase 4 of #470) ([#480](https://github.com/gridctl/gridctl/pull/480))
+- Wizard UI for reactive autoscaling. A new segmented "Scaling" control in the MCP server form lets users pick between static `replicas` and the `autoscale:` block shipped in [#512](https://github.com/gridctl/gridctl/pull/512); toggling between modes clears the opposite field group so the output YAML carries at most one. Defaults (min=1, max=5, target=10, scale_up=30s, scale_down=5m) keep the form valid on first view. Backend validation errors surface inline at apply time at the `mcp-servers[i].autoscale.*` paths.
+
+## [0.1.0-beta.5] - 2026-04-08
 
 
 ### Bug Fixes

--- a/web/src/__tests__/MCPServerForm.test.tsx
+++ b/web/src/__tests__/MCPServerForm.test.tsx
@@ -717,3 +717,267 @@ describe('MCPServerForm — replicas UI', () => {
     expect(screen.getByText('Replica Policy')).toBeInTheDocument();
   });
 });
+
+describe('MCPServerForm — scaling segmented control', () => {
+  it('renders the Scaling segmented control for supported types', () => {
+    render(
+      <MCPServerForm
+        data={defaultData({ serverType: 'container', image: 'test:latest' })}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText('Advanced'));
+    expect(screen.getByRole('radiogroup', { name: 'Scaling mode' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Static replicas' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: 'Autoscale' })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('does not render the scaling control for external/openapi types', () => {
+    const { rerender } = render(
+      <MCPServerForm
+        data={defaultData({ serverType: 'external', url: 'http://x' })}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText('Advanced'));
+    expect(screen.queryByRole('radiogroup', { name: 'Scaling mode' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Replicas')).not.toBeInTheDocument();
+
+    rerender(
+      <MCPServerForm
+        data={defaultData({ serverType: 'openapi', openapi: { spec: 'https://x/y.yaml' } })}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.queryByRole('radiogroup', { name: 'Scaling mode' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Replicas')).not.toBeInTheDocument();
+  });
+
+  it('selecting Autoscale clears replicas/replicaPolicy and seeds defaults', () => {
+    const onChange = vi.fn();
+    render(
+      <MCPServerForm
+        data={defaultData({ serverType: 'container', image: 'test:latest', replicas: 3, replicaPolicy: 'least-connections' })}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('Advanced'));
+    fireEvent.click(screen.getByRole('radio', { name: 'Autoscale' }));
+    expect(onChange).toHaveBeenCalledWith({
+      replicas: undefined,
+      replicaPolicy: undefined,
+      autoscale: { min: 1, max: 5, targetInFlight: 10, scaleUpAfter: '30s', scaleDownAfter: '5m' },
+    });
+  });
+
+  it('selecting Static clears autoscale', () => {
+    const onChange = vi.fn();
+    render(
+      <MCPServerForm
+        data={defaultData({
+          serverType: 'container',
+          image: 'test:latest',
+          autoscale: { min: 1, max: 5, targetInFlight: 10 },
+        })}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('Advanced'));
+    fireEvent.click(screen.getByRole('radio', { name: 'Static replicas' }));
+    expect(onChange).toHaveBeenCalledWith({ autoscale: undefined });
+  });
+
+  it('in Autoscale mode renders six inputs, checkbox, and summary line', () => {
+    render(
+      <MCPServerForm
+        data={defaultData({
+          serverType: 'container',
+          image: 'test:latest',
+          autoscale: { min: 1, max: 5, targetInFlight: 10, scaleUpAfter: '30s', scaleDownAfter: '5m' },
+        })}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText('Advanced'));
+    expect(screen.getByLabelText('Min replicas')).toHaveValue(1);
+    expect(screen.getByLabelText('Max replicas')).toHaveValue(5);
+    expect(screen.getByLabelText('Target concurrent requests per replica')).toHaveValue(10);
+    expect(screen.getByLabelText('Scale up after')).toHaveValue('30s');
+    expect(screen.getByLabelText('Scale down after')).toHaveValue('5m');
+    expect(screen.getByLabelText('Warm pool')).toHaveValue(0);
+    expect(screen.getByLabelText('Scale to zero when idle')).not.toBeChecked();
+    expect(
+      screen.getByText('Autoscale 1–5 replicas · 10 concurrent/replica'),
+    ).toBeInTheDocument();
+  });
+
+  it('clamps min/max to known-valid ranges', () => {
+    const onChange = vi.fn();
+    render(
+      <MCPServerForm
+        data={defaultData({
+          serverType: 'container',
+          image: 'test:latest',
+          autoscale: { min: 1, max: 5, targetInFlight: 10 },
+        })}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('Advanced'));
+    const maxInput = screen.getByLabelText('Max replicas') as HTMLInputElement;
+    fireEvent.change(maxInput, { target: { value: '99' } });
+    expect(onChange).toHaveBeenLastCalledWith({
+      autoscale: { min: 1, max: 32, targetInFlight: 10 },
+    });
+  });
+});
+
+describe('YAML serialization — autoscale', () => {
+  it('emits an autoscale block with required fields only when optionals are unset', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'junos',
+        serverType: 'local',
+        command: ['python', 'srv.py'],
+        autoscale: { min: 1, max: 5, targetInFlight: 10 },
+      },
+    });
+    expect(yaml).toContain('autoscale:');
+    expect(yaml).toContain('min: 1');
+    expect(yaml).toContain('max: 5');
+    expect(yaml).toContain('target_in_flight: 10');
+    expect(yaml).not.toContain('scale_up_after');
+    expect(yaml).not.toContain('scale_down_after');
+    expect(yaml).not.toContain('warm_pool');
+    expect(yaml).not.toContain('idle_to_zero');
+  });
+
+  it('emits optional fields when they are set', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'junos',
+        serverType: 'container',
+        image: 'test:latest',
+        autoscale: {
+          min: 1,
+          max: 8,
+          targetInFlight: 20,
+          scaleUpAfter: '45s',
+          scaleDownAfter: '2m',
+          warmPool: 2,
+          idleToZero: true,
+        },
+      },
+    });
+    expect(yaml).toContain('scale_up_after: 45s');
+    expect(yaml).toContain('scale_down_after: 2m');
+    expect(yaml).toContain('warm_pool: 2');
+    expect(yaml).toContain('idle_to_zero: true');
+  });
+
+  it('mirrors Go omitempty: skips warm_pool: 0 and idle_to_zero: false', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'junos',
+        serverType: 'container',
+        image: 'test:latest',
+        autoscale: {
+          min: 1,
+          max: 5,
+          targetInFlight: 10,
+          warmPool: 0,
+          idleToZero: false,
+        },
+      },
+    });
+    expect(yaml).not.toContain('warm_pool');
+    expect(yaml).not.toContain('idle_to_zero');
+  });
+
+  it('never emits both replicas and autoscale in the same entry', () => {
+    // When autoscale is present, the builder ignores replicas/replicaPolicy.
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'junos',
+        serverType: 'container',
+        image: 'test:latest',
+        replicas: 3,
+        replicaPolicy: 'least-connections',
+        autoscale: { min: 1, max: 5, targetInFlight: 10 },
+      },
+    });
+    expect(yaml).toContain('autoscale:');
+    expect(yaml).not.toMatch(/^\s*replicas:/m);
+    expect(yaml).not.toMatch(/^\s*replica_policy:/m);
+  });
+
+  it('parseYAMLToForm recognizes autoscale and leaves replicas undefined', () => {
+    const yaml = buildYAML({
+      type: 'mcp-server',
+      data: {
+        name: 'junos',
+        serverType: 'container',
+        image: 'test:latest',
+        autoscale: {
+          min: 2,
+          max: 8,
+          targetInFlight: 15,
+          scaleUpAfter: '45s',
+          scaleDownAfter: '2m',
+          warmPool: 1,
+          idleToZero: true,
+        },
+      },
+    });
+    const parsed = parseYAMLToForm(yaml, 'mcp-server');
+    expect('error' in parsed).toBe(false);
+    if ('error' in parsed) return;
+    const d = parsed.data as MCPServerFormData;
+    expect(d.autoscale).toEqual({
+      min: 2,
+      max: 8,
+      targetInFlight: 15,
+      scaleUpAfter: '45s',
+      scaleDownAfter: '2m',
+      warmPool: 1,
+      idleToZero: true,
+    });
+    expect(d.replicas).toBeUndefined();
+    expect(d.replicaPolicy).toBeUndefined();
+  });
+
+  it('round-trips an autoscaled server YAML byte-identically', () => {
+    const data: MCPServerFormData = {
+      name: 'junos',
+      serverType: 'container',
+      image: 'test:latest',
+      autoscale: {
+        min: 1,
+        max: 5,
+        targetInFlight: 10,
+        scaleUpAfter: '30s',
+        scaleDownAfter: '5m',
+      },
+    };
+    const yaml = buildYAML({ type: 'mcp-server', data });
+    const parsed = parseYAMLToForm(yaml, 'mcp-server');
+    expect('error' in parsed).toBe(false);
+    if ('error' in parsed) return;
+    const rebuilt = buildYAML({
+      type: 'mcp-server',
+      data: {
+        ...(parsed.data as MCPServerFormData),
+        // parseYAMLToForm hard-codes serverType: 'container' and does not
+        // recover the image line; patch back so the rebuild matches what we
+        // started with.
+        serverType: 'container',
+        image: 'test:latest',
+      },
+    });
+    expect(rebuilt).toBe(yaml);
+  });
+});

--- a/web/src/components/wizard/steps/MCPServerForm.tsx
+++ b/web/src/components/wizard/steps/MCPServerForm.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '../../../lib/cn';
-import type { MCPServerFormData, ServerType } from '../../../lib/yaml-builder';
+import type { AutoscaleFormData, MCPServerFormData, ServerType } from '../../../lib/yaml-builder';
 import type { ProbeServerConfig } from '../../../lib/api';
 import { SecretsPopover } from '../SecretsPopover';
 import { TransportAdvisor } from '../TransportAdvisor';
@@ -120,22 +120,23 @@ interface FieldVisibility {
   buildArgs: boolean;
   network: boolean;
   replicas: boolean;
+  autoscale: boolean;
 }
 
 function getFieldVisibility(serverType: ServerType): FieldVisibility {
   switch (serverType) {
     case 'container':
-      return { image: true, port: true, transport: true, command: true, source: false, url: false, ssh: false, openapi: false, buildArgs: false, network: true, replicas: true };
+      return { image: true, port: true, transport: true, command: true, source: false, url: false, ssh: false, openapi: false, buildArgs: false, network: true, replicas: true, autoscale: true };
     case 'source':
-      return { image: false, port: true, transport: true, command: false, source: true, url: false, ssh: false, openapi: false, buildArgs: true, network: true, replicas: true };
+      return { image: false, port: true, transport: true, command: false, source: true, url: false, ssh: false, openapi: false, buildArgs: true, network: true, replicas: true, autoscale: true };
     case 'external':
-      return { image: false, port: false, transport: true, command: false, source: false, url: true, ssh: false, openapi: false, buildArgs: false, network: false, replicas: false };
+      return { image: false, port: false, transport: true, command: false, source: false, url: true, ssh: false, openapi: false, buildArgs: false, network: false, replicas: false, autoscale: false };
     case 'local':
-      return { image: false, port: false, transport: false, command: true, source: false, url: false, ssh: false, openapi: false, buildArgs: false, network: false, replicas: true };
+      return { image: false, port: false, transport: false, command: true, source: false, url: false, ssh: false, openapi: false, buildArgs: false, network: false, replicas: true, autoscale: true };
     case 'ssh':
-      return { image: false, port: false, transport: false, command: true, source: false, url: false, ssh: true, openapi: false, buildArgs: false, network: false, replicas: true };
+      return { image: false, port: false, transport: false, command: true, source: false, url: false, ssh: true, openapi: false, buildArgs: false, network: false, replicas: true, autoscale: true };
     case 'openapi':
-      return { image: false, port: false, transport: false, command: false, source: false, url: false, ssh: false, openapi: true, buildArgs: false, network: false, replicas: false };
+      return { image: false, port: false, transport: false, command: false, source: false, url: false, ssh: false, openapi: true, buildArgs: false, network: false, replicas: false, autoscale: false };
   }
 }
 
@@ -445,7 +446,8 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
     (data.buildArgs ? Object.keys(data.buildArgs).length : 0) +
     (data.network ? 1 : 0) +
     (data.pinSchemas !== undefined ? 1 : 0) +
-    (data.replicas !== undefined && data.replicas !== 1 ? 1 : 0);
+    (data.replicas !== undefined && data.replicas !== 1 ? 1 : 0) +
+    (data.autoscale ? 1 : 0);
 
   return (
     <div className="space-y-3">
@@ -1408,47 +1410,291 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
           <p className="text-[10px] text-text-muted mt-1">Override the gateway-level schema pinning setting for this server</p>
         </div>
 
-        {visibility.replicas && (
-          <div>
-            <label className={labelClass}>Replicas</label>
-            <input
-              type="number"
-              aria-label="Replicas"
-              value={data.replicas ?? 1}
-              onChange={(e) => {
-                const n = Number(e.target.value);
-                if (!Number.isFinite(n)) return;
-                const clamped = Math.max(1, Math.min(32, Math.trunc(n)));
-                onChange({ replicas: clamped === 1 ? undefined : clamped });
-              }}
-              placeholder="1"
-              min={1}
-              max={32}
-              className={cn(inputClass, errors?.replicas && 'border-status-error/50')}
-            />
-            <FieldError error={errors?.replicas} />
-            <p className="text-[10px] text-text-muted mt-1">Number of parallel instances to run (1–32). Supported for container, local-process, and SSH transports.</p>
-            {data.replicas !== undefined && data.replicas > 1 && (
-              <div className="mt-3">
-                <label className={labelClass}>Replica Policy</label>
-                <select
-                  aria-label="Replica Policy"
-                  value={data.replicaPolicy ?? 'round-robin'}
-                  onChange={(e) => {
-                    const v = e.target.value as 'round-robin' | 'least-connections';
-                    onChange({ replicaPolicy: v === 'round-robin' ? undefined : v });
-                  }}
-                  className={inputClass}
-                >
-                  <option value="round-robin">Round-robin</option>
-                  <option value="least-connections">Least connections</option>
-                </select>
-                <p className="text-[10px] text-text-muted mt-1">How tool calls are distributed across replicas</p>
-              </div>
-            )}
-          </div>
+        {visibility.autoscale && (
+          <ScalingControl data={data} onChange={onChange} errors={errors} />
         )}
       </Section>
+    </div>
+  );
+}
+
+// --- Scaling control (Static replicas | Autoscale) ---
+
+const AUTOSCALE_DEFAULTS: AutoscaleFormData = {
+  min: 1,
+  max: 5,
+  targetInFlight: 10,
+  scaleUpAfter: '30s',
+  scaleDownAfter: '5m',
+};
+
+function clampInt(raw: number, min: number, max: number): number {
+  if (!Number.isFinite(raw)) return min;
+  return Math.max(min, Math.min(max, Math.trunc(raw)));
+}
+
+function ScalingControl({
+  data,
+  onChange,
+  errors,
+}: {
+  data: MCPServerFormData;
+  onChange: (data: Partial<MCPServerFormData>) => void;
+  errors?: Record<string, string>;
+}) {
+  const mode: 'static' | 'autoscale' = data.autoscale ? 'autoscale' : 'static';
+
+  const setMode = useCallback(
+    (next: 'static' | 'autoscale') => {
+      if (next === mode) return;
+      if (next === 'autoscale') {
+        onChange({
+          replicas: undefined,
+          replicaPolicy: undefined,
+          autoscale: { ...AUTOSCALE_DEFAULTS },
+        });
+      } else {
+        onChange({ autoscale: undefined });
+      }
+    },
+    [mode, onChange],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight' || e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      setMode(mode === 'static' ? 'autoscale' : 'static');
+    }
+  };
+
+  const updateAutoscale = (patch: Partial<AutoscaleFormData>) => {
+    onChange({ autoscale: { ...(data.autoscale as AutoscaleFormData), ...patch } });
+  };
+
+  return (
+    <div>
+      <label className={labelClass}>Scaling</label>
+      <div
+        role="radiogroup"
+        aria-label="Scaling mode"
+        onKeyDown={handleKeyDown}
+        className="inline-flex items-center rounded-lg border border-border/40 bg-background/60 p-0.5 mb-3"
+      >
+        {(['static', 'autoscale'] as const).map((m) => (
+          <button
+            key={m}
+            type="button"
+            role="radio"
+            aria-checked={mode === m}
+            tabIndex={mode === m ? 0 : -1}
+            onClick={() => setMode(m)}
+            className={cn(
+              'px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors',
+              mode === m
+                ? 'bg-primary/15 text-primary'
+                : 'text-text-muted hover:text-text-secondary',
+            )}
+          >
+            {m === 'static' ? 'Static replicas' : 'Autoscale'}
+          </button>
+        ))}
+      </div>
+
+      {mode === 'static' ? (
+        <div>
+          <label className={labelClass}>Replicas</label>
+          <input
+            type="number"
+            aria-label="Replicas"
+            value={data.replicas ?? 1}
+            onChange={(e) => {
+              const n = Number(e.target.value);
+              if (!Number.isFinite(n)) return;
+              const clamped = Math.max(1, Math.min(32, Math.trunc(n)));
+              onChange({ replicas: clamped === 1 ? undefined : clamped });
+            }}
+            placeholder="1"
+            min={1}
+            max={32}
+            className={cn(inputClass, errors?.replicas && 'border-status-error/50')}
+          />
+          <FieldError error={errors?.replicas} />
+          <p className="text-[10px] text-text-muted mt-1">Number of parallel instances to run (1–32). Supported for container, local-process, and SSH transports.</p>
+          {data.replicas !== undefined && data.replicas > 1 && (
+            <div className="mt-3">
+              <label className={labelClass}>Replica Policy</label>
+              <select
+                aria-label="Replica Policy"
+                value={data.replicaPolicy ?? 'round-robin'}
+                onChange={(e) => {
+                  const v = e.target.value as 'round-robin' | 'least-connections';
+                  onChange({ replicaPolicy: v === 'round-robin' ? undefined : v });
+                }}
+                className={inputClass}
+              >
+                <option value="round-robin">Round-robin</option>
+                <option value="least-connections">Least connections</option>
+              </select>
+              <p className="text-[10px] text-text-muted mt-1">How tool calls are distributed across replicas</p>
+            </div>
+          )}
+        </div>
+      ) : (
+        <AutoscaleFields
+          data={data.autoscale ?? AUTOSCALE_DEFAULTS}
+          onChange={updateAutoscale}
+          errors={errors}
+        />
+      )}
+    </div>
+  );
+}
+
+function AutoscaleFields({
+  data,
+  onChange,
+  errors,
+}: {
+  data: AutoscaleFormData;
+  onChange: (patch: Partial<AutoscaleFormData>) => void;
+  errors?: Record<string, string>;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className={labelClass}>Min replicas</label>
+          <input
+            type="number"
+            aria-label="Min replicas"
+            value={data.min}
+            onChange={(e) => {
+              const n = Number(e.target.value);
+              if (!Number.isFinite(n)) return;
+              onChange({ min: clampInt(n, 0, 32) });
+            }}
+            min={0}
+            max={32}
+            className={cn(inputClass, errors?.['autoscale.min'] && 'border-status-error/50')}
+          />
+          <FieldError error={errors?.['autoscale.min']} />
+        </div>
+        <div>
+          <label className={labelClass}>Max replicas</label>
+          <input
+            type="number"
+            aria-label="Max replicas"
+            value={data.max}
+            onChange={(e) => {
+              const n = Number(e.target.value);
+              if (!Number.isFinite(n)) return;
+              onChange({ max: clampInt(n, 1, 32) });
+            }}
+            min={1}
+            max={32}
+            className={cn(inputClass, errors?.['autoscale.max'] && 'border-status-error/50')}
+          />
+          <FieldError error={errors?.['autoscale.max']} />
+        </div>
+      </div>
+
+      <div>
+        <label className={labelClass}>Target concurrent requests per replica</label>
+        <input
+          type="number"
+          aria-label="Target concurrent requests per replica"
+          value={data.targetInFlight}
+          onChange={(e) => {
+            const n = Number(e.target.value);
+            if (!Number.isFinite(n)) return;
+            onChange({ targetInFlight: clampInt(n, 1, 10000) });
+          }}
+          min={1}
+          max={10000}
+          className={cn(inputClass, errors?.['autoscale.target_in_flight'] && 'border-status-error/50')}
+        />
+        <FieldError error={errors?.['autoscale.target_in_flight']} />
+        <p className="text-[10px] text-text-muted mt-1">
+          gridctl adds replicas when the average in-flight request count exceeds this.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className={labelClass}>Scale up after</label>
+          <input
+            type="text"
+            aria-label="Scale up after"
+            value={data.scaleUpAfter ?? ''}
+            onChange={(e) => onChange({ scaleUpAfter: e.target.value || undefined })}
+            placeholder="30s"
+            className={cn(inputClass, 'font-mono', errors?.['autoscale.scale_up_after'] && 'border-status-error/50')}
+          />
+          <FieldError error={errors?.['autoscale.scale_up_after']} />
+          <p className="text-[10px] text-text-muted mt-1">
+            Wait this long while above target before spawning a replica (min 10s).
+          </p>
+        </div>
+        <div>
+          <label className={labelClass}>Scale down after</label>
+          <input
+            type="text"
+            aria-label="Scale down after"
+            value={data.scaleDownAfter ?? ''}
+            onChange={(e) => onChange({ scaleDownAfter: e.target.value || undefined })}
+            placeholder="5m"
+            className={cn(inputClass, 'font-mono', errors?.['autoscale.scale_down_after'] && 'border-status-error/50')}
+          />
+          <FieldError error={errors?.['autoscale.scale_down_after']} />
+          <p className="text-[10px] text-text-muted mt-1">
+            Wait this long while below target before reaping a replica (min 1m).
+          </p>
+        </div>
+      </div>
+
+      <div>
+        <label className={labelClass}>Warm pool</label>
+        <input
+          type="number"
+          aria-label="Warm pool"
+          value={data.warmPool ?? 0}
+          onChange={(e) => {
+            const n = Number(e.target.value);
+            if (!Number.isFinite(n)) return;
+            const clamped = clampInt(n, 0, 32);
+            onChange({ warmPool: clamped === 0 ? undefined : clamped });
+          }}
+          min={0}
+          max={32}
+          className={cn(inputClass, errors?.['autoscale.warm_pool'] && 'border-status-error/50')}
+        />
+        <FieldError error={errors?.['autoscale.warm_pool']} />
+        <p className="text-[10px] text-text-muted mt-1">
+          Extra idle replicas kept above the load-derived target.
+        </p>
+      </div>
+
+      <div className="flex items-start gap-3">
+        <input
+          type="checkbox"
+          id="autoscale-idle-to-zero"
+          checked={data.idleToZero ?? false}
+          onChange={(e) => onChange({ idleToZero: e.target.checked ? true : undefined })}
+          className="mt-0.5 accent-primary"
+        />
+        <div>
+          <label htmlFor="autoscale-idle-to-zero" className="text-xs text-text-secondary cursor-pointer">
+            Scale to zero when idle
+          </label>
+          <p className="text-[10px] text-text-muted mt-0.5">
+            Allow reaping every replica after sustained idle. First request after idle may be slower.
+          </p>
+        </div>
+      </div>
+
+      <p className="text-[11px] text-text-secondary border-t border-border/20 pt-2 font-mono">
+        Autoscale {data.min}–{data.max} replicas · {data.targetInFlight} concurrent/replica
+      </p>
     </div>
   );
 }

--- a/web/src/lib/yaml-builder.ts
+++ b/web/src/lib/yaml-builder.ts
@@ -74,9 +74,24 @@ export interface MCPServerFormData {
   outputFormat?: string;
   network?: string;
   pinSchemas?: boolean;
-  // Replicas
+  // Replicas (mutually exclusive with autoscale)
   replicas?: number;
   replicaPolicy?: 'round-robin' | 'least-connections';
+  // Autoscale (mutually exclusive with replicas)
+  autoscale?: AutoscaleFormData;
+}
+
+// AutoscaleFormData mirrors pkg/config.AutoscaleConfig. UI labels are
+// vocabulary-swapped (target_in_flight → "Target concurrent requests per
+// replica") but YAML keys match the backend exactly.
+export interface AutoscaleFormData {
+  min: number;
+  max: number;
+  targetInFlight: number;
+  scaleUpAfter?: string;
+  scaleDownAfter?: string;
+  warmPool?: number;
+  idleToZero?: boolean;
 }
 
 export interface ResourceFormData {
@@ -269,13 +284,27 @@ function buildMCPServer(data: MCPServerFormData, indentLevel = 2): string {
   if (data.network) lines.push(`${inner}network: ${data.network}`);
   if (data.pinSchemas !== undefined) lines.push(`${inner}pin_schemas: ${data.pinSchemas}`);
 
-  // Replicas: mirror Go's omitempty semantics — skip the default (1) and the
-  // default policy (round-robin) so single-replica specs stay byte-identical.
-  if (data.replicas && data.replicas !== 1) {
-    lines.push(`${inner}replicas: ${data.replicas}`);
-  }
-  if (data.replicaPolicy && data.replicaPolicy !== 'round-robin') {
-    lines.push(`${inner}replica_policy: ${data.replicaPolicy}`);
+  // Scaling: autoscale and replicas are mutually exclusive on the backend.
+  // Prefer autoscale if present; otherwise fall through to the static replicas
+  // block, mirroring Go's omitempty semantics (skip replicas:1 and the default
+  // round-robin policy so single-replica specs stay byte-identical).
+  if (data.autoscale) {
+    const a = data.autoscale;
+    lines.push(`${inner}autoscale:`);
+    lines.push(`${inner}  min: ${a.min}`);
+    lines.push(`${inner}  max: ${a.max}`);
+    lines.push(`${inner}  target_in_flight: ${a.targetInFlight}`);
+    if (a.scaleUpAfter) lines.push(`${inner}  scale_up_after: ${a.scaleUpAfter}`);
+    if (a.scaleDownAfter) lines.push(`${inner}  scale_down_after: ${a.scaleDownAfter}`);
+    if (a.warmPool && a.warmPool > 0) lines.push(`${inner}  warm_pool: ${a.warmPool}`);
+    if (a.idleToZero) lines.push(`${inner}  idle_to_zero: true`);
+  } else {
+    if (data.replicas && data.replicas !== 1) {
+      lines.push(`${inner}replicas: ${data.replicas}`);
+    }
+    if (data.replicaPolicy && data.replicaPolicy !== 'round-robin') {
+      lines.push(`${inner}replica_policy: ${data.replicaPolicy}`);
+    }
   }
 
   return lines.join('\n');
@@ -418,19 +447,63 @@ export function parseYAMLToForm(yaml: string, resourceType: ResourceType): Wizar
     const lines = yaml.split('\n');
     const result: Record<string, unknown> = {};
 
+    // Collect the `autoscale:` sub-block separately so nested keys (min, max,
+    // target_in_flight, ...) do not collide with top-level keys of the same
+    // name on other resources. Everything else stays flat — a pre-existing
+    // limitation of this best-effort parser.
+    let autoscaleIndent: number | null = null;
+    let autoscaleBlock: Record<string, string> | null = null;
+
     for (const line of lines) {
       const match = line.match(/^(\s*)(\w[\w-]*):\s*(.*)/);
-      if (match) {
-        const [, , key, value] = match;
-        if (value) {
-          result[key] = value.replace(/^["']|["']$/g, '');
+      if (!match) continue;
+      const [, indentStr, key, value] = match;
+      const indent = indentStr.length;
+
+      if (autoscaleBlock !== null && autoscaleIndent !== null) {
+        if (indent > autoscaleIndent) {
+          if (value) autoscaleBlock[key] = value.replace(/^["']|["']$/g, '');
+          continue;
         }
+        // Outer-level key again — commit the block and resume flat parsing.
+        result.__autoscale = autoscaleBlock;
+        autoscaleBlock = null;
+        autoscaleIndent = null;
       }
+
+      if (key === 'autoscale') {
+        autoscaleBlock = {};
+        autoscaleIndent = indent;
+        continue;
+      }
+
+      if (value) {
+        result[key] = value.replace(/^["']|["']$/g, '');
+      }
+    }
+    if (autoscaleBlock !== null) {
+      result.__autoscale = autoscaleBlock;
     }
 
     // Return minimal parsed data based on type
     switch (resourceType) {
       case 'mcp-server': {
+        const autoRaw = result.__autoscale as Record<string, string> | undefined;
+        const autoscale: AutoscaleFormData | undefined = autoRaw
+          ? {
+              min: Number(autoRaw.min ?? 1),
+              max: Number(autoRaw.max ?? 5),
+              targetInFlight: Number(autoRaw.target_in_flight ?? 10),
+              scaleUpAfter: autoRaw.scale_up_after,
+              scaleDownAfter: autoRaw.scale_down_after,
+              warmPool:
+                autoRaw.warm_pool !== undefined && Number(autoRaw.warm_pool) > 0
+                  ? Number(autoRaw.warm_pool)
+                  : undefined,
+              idleToZero: autoRaw.idle_to_zero === 'true' ? true : undefined,
+            }
+          : undefined;
+
         const parsedReplicas = Number(result.replicas);
         const rawPolicy = result.replica_policy as string | undefined;
         const replicaPolicy =
@@ -444,8 +517,15 @@ export function parseYAMLToForm(yaml: string, resourceType: ResourceType): Wizar
             serverType: 'container',
             image: result.image as string,
             transport: result.transport as string,
-            replicas: Number.isFinite(parsedReplicas) && parsedReplicas > 0 ? parsedReplicas : undefined,
-            replicaPolicy,
+            // autoscale and replicas are mutually exclusive at the backend —
+            // don't surface stale replica fields if autoscale is present.
+            replicas: autoscale
+              ? undefined
+              : Number.isFinite(parsedReplicas) && parsedReplicas > 0
+                ? parsedReplicas
+                : undefined,
+            replicaPolicy: autoscale ? undefined : replicaPolicy,
+            autoscale,
           },
         };
       }


### PR DESCRIPTION
## Description

Slice A of the MCP autoscale UI: a segmented "Scaling" control in the MCP server wizard that lets users pick between static `replicas` and the `autoscale:` block shipped in #512. Defaults (min=1, max=5, target=10, scale_up=30s, scale_down=5m) keep the form valid on first view; toggling between modes clears the opposite field group so the output YAML carries at most one.

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

- **`web/src/lib/yaml-builder.ts`**: new `AutoscaleFormData` type on `MCPServerFormData`; `buildMCPServer()` emits an `autoscale:` block with the same omitempty semantics as `AutoscaleConfig` (skip `scale_up_after`/`scale_down_after` when unset, `warm_pool` when 0, `idle_to_zero` when false). `parseYAMLToForm()` now tracks indent for the `autoscale:` sub-block so nested keys do not collide with top-level ones.
- **`web/src/components/wizard/steps/MCPServerForm.tsx`**: `FieldVisibility.autoscale` added (true for container/source/local/ssh, false for external/openapi). New `ScalingControl` segmented radiogroup with arrow-key nav and roving tabindex. Six autoscale inputs with client-side clamping to the same bounds the backend validates, plus a "Scale to zero when idle" checkbox and a live summary line (`Autoscale 1–5 replicas · 10 concurrent/replica`). Toggling clears the opposite field group so `data.autoscale` is `undefined` (not `{}`) after returning to Static.
- **`web/src/__tests__/MCPServerForm.test.tsx`**: coverage for segmented control rendering, external/openapi hiding, toggle clearing, default field values, clamping, YAML emission with omitempty, parser recognition, and byte-identical round-trip.
- **`CHANGELOG.md`**: unreleased Features entry.

Slice B (live observability in the canvas badge and Sidebar) ships as a follow-up PR.

## Testing

- `cd web && npm test` — 435 tests pass, including the new 10 autoscale tests.
- `cd web && npm run build` — clean.
- `make build` — clean.
- `golangci-lint run ./...` — 0 issues.
- Manual: open the wizard, pick a container/source/local/ssh type, expand Advanced, toggle Scaling between Static and Autoscale; verify defaults, summary line, mutual-exclusivity, and that the YAML preview in ReviewStep carries only the active block.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #513