### PR TITLE
feat: autoscale status observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to gridctl will be documented in this file.
 - Replicas observability, status, and API (phase 3 of #470) ([#479](https://github.com/gridctl/gridctl/pull/479))
 - Replicas wizard input and canvas badge (phase 4 of #470) ([#480](https://github.com/gridctl/gridctl/pull/480))
 - Wizard UI for reactive autoscaling. A new segmented "Scaling" control in the MCP server form lets users pick between static `replicas` and the `autoscale:` block shipped in [#512](https://github.com/gridctl/gridctl/pull/512); toggling between modes clears the opposite field group so the output YAML carries at most one. Defaults (min=1, max=5, target=10, scale_up=30s, scale_down=5m) keep the form valid on first view. Backend validation errors surface inline at apply time at the `mcp-servers[i].autoscale.*` paths.
+- Status observability for autoscaled MCP servers. Canvas nodes now render `×current/target` with an amber pulse ring while scaling up and a teal ring while scaling down. Selecting an autoscaled server reveals a Sidebar "Scaling" section with a live headline, dwell phrase, inline-SVG sparkline (current solid vs. target dashed), and a collapsible decision feed derived client-side from polling snapshots.
 
 ## [0.1.0-beta.5] - 2026-04-08
 

--- a/web/src/__tests__/AutoscalePanel.test.tsx
+++ b/web/src/__tests__/AutoscalePanel.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { AutoscalePanel, dwellPhrase } from '../components/status/AutoscalePanel';
+import type { AutoscaleStatus } from '../types';
+import type { AutoscaleSample, AutoscaleDecision } from '../stores/useStackStore';
+
+function makeStatus(overrides: Partial<AutoscaleStatus> = {}): AutoscaleStatus {
+  return {
+    min: 1,
+    max: 5,
+    current: 2,
+    target: 3,
+    targetInFlight: 10,
+    medianInFlight: 14,
+    lastDecision: 'up',
+    ...overrides,
+  };
+}
+
+function makeHistory(values: Array<Pick<AutoscaleSample, 'current' | 'target' | 'medianInFlight'>>): AutoscaleSample[] {
+  const base = 1_700_000_000_000;
+  return values.map((v, i) => ({ t: base + i * 3000, ...v }));
+}
+
+describe('AutoscalePanel', () => {
+  it('renders the headline with current, target, and range', () => {
+    render(<AutoscalePanel status={makeStatus()} history={[]} decisions={[]} />);
+    expect(screen.getByText('Current')).toBeInTheDocument();
+    expect(screen.getByText('/ Target')).toBeInTheDocument();
+    expect(screen.getByText('· Range')).toBeInTheDocument();
+    expect(screen.getByText('1–5')).toBeInTheDocument();
+  });
+
+  it('renders the scaling-up dwell phrase', () => {
+    render(<AutoscalePanel status={makeStatus({ lastDecision: 'up' })} history={[]} decisions={[]} />);
+    expect(screen.getByTestId('autoscale-dwell')).toHaveTextContent(
+      'Scaling up · median in-flight 14, target 10',
+    );
+  });
+
+  it('renders the scaling-down dwell phrase', () => {
+    render(
+      <AutoscalePanel
+        status={makeStatus({ lastDecision: 'down', medianInFlight: 2 })}
+        history={[]}
+        decisions={[]}
+      />,
+    );
+    expect(screen.getByTestId('autoscale-dwell')).toHaveTextContent(
+      'Scaling down · median in-flight 2 below target 10',
+    );
+  });
+
+  it('renders the stable dwell phrase when noop and current==target', () => {
+    render(
+      <AutoscalePanel
+        status={makeStatus({ lastDecision: 'noop', current: 3, target: 3, medianInFlight: 8 })}
+        history={[]}
+        decisions={[]}
+      />,
+    );
+    expect(screen.getByTestId('autoscale-dwell')).toHaveTextContent(
+      'Stable · median in-flight 8, target 10',
+    );
+  });
+
+  it('renders the idle-to-zero dwell phrase', () => {
+    render(
+      <AutoscalePanel
+        status={makeStatus({ lastDecision: 'noop', current: 0, target: 0, idleToZero: true })}
+        history={[]}
+        decisions={[]}
+      />,
+    );
+    expect(screen.getByTestId('autoscale-dwell')).toHaveTextContent('Idle · scaled to zero');
+  });
+
+  it('renders a placeholder when no history is available', () => {
+    render(<AutoscalePanel status={makeStatus()} history={[]} decisions={[]} />);
+    expect(screen.getByText('Collecting samples…')).toBeInTheDocument();
+  });
+
+  it('renders sparkline paths with correct M/L shape for current and target', () => {
+    const history = makeHistory([
+      { current: 1, target: 2, medianInFlight: 3 },
+      { current: 2, target: 3, medianInFlight: 8 },
+      { current: 3, target: 3, medianInFlight: 9 },
+    ]);
+    render(<AutoscalePanel status={makeStatus()} history={history} decisions={[]} />);
+    const svg = screen.getByTestId('autoscale-sparkline');
+    expect(svg).toBeInTheDocument();
+    const currentPath = screen.getByTestId('autoscale-sparkline-current');
+    const d = currentPath.getAttribute('d') ?? '';
+    // Three samples → one M and two L commands.
+    expect(d).toMatch(/^M /);
+    expect(d.split('L').length - 1).toBe(2);
+  });
+
+  it('decision feed opens on click and renders entries', () => {
+    const decisions: AutoscaleDecision[] = [
+      { t: 1_700_000_000_000, kind: 'up', from: 1, to: 2, reason: 'test' },
+      { t: 1_700_000_010_000, kind: 'down', from: 2, to: 1, reason: 'test' },
+    ];
+    render(<AutoscalePanel status={makeStatus()} history={[]} decisions={decisions} />);
+    const toggle = screen.getByRole('button', { name: /Recent Decisions/i });
+    fireEvent.click(toggle);
+    const feed = screen.getByTestId('autoscale-decision-feed');
+    expect(feed).toBeInTheDocument();
+    expect(feed.textContent).toMatch(/1→2/);
+    expect(feed.textContent).toMatch(/2→1/);
+  });
+
+  it('decision feed is collapsed by default', () => {
+    render(<AutoscalePanel status={makeStatus()} history={[]} decisions={[]} />);
+    expect(screen.queryByTestId('autoscale-decision-feed')).not.toBeInTheDocument();
+  });
+});
+
+describe('dwellPhrase', () => {
+  it('returns holding copy when current and target diverge on noop', () => {
+    const s = makeStatus({ lastDecision: 'noop', current: 1, target: 3 });
+    expect(dwellPhrase(s)).toBe('Holding · current 1, target 3');
+  });
+});

--- a/web/src/__tests__/CustomNode.test.tsx
+++ b/web/src/__tests__/CustomNode.test.tsx
@@ -131,4 +131,54 @@ describe('CustomNode', () => {
     expect(screen.queryByText('toon')).not.toBeInTheDocument();
     expect(screen.queryByText('csv')).not.toBeInTheDocument();
   });
+
+  it('renders ×current/target badge when autoscale is present', () => {
+    render(
+      <CustomNode
+        data={makeServerData({
+          autoscale: {
+            min: 1,
+            max: 5,
+            current: 2,
+            target: 3,
+            targetInFlight: 10,
+            medianInFlight: 14,
+            lastDecision: 'up',
+          },
+        })}
+      />,
+    );
+    expect(screen.getByText('×2/3')).toBeInTheDocument();
+  });
+
+  it('autoscale badge takes precedence over replicaCount badge', () => {
+    render(
+      <CustomNode
+        data={makeServerData({
+          replicaCount: 3,
+          autoscale: {
+            min: 1,
+            max: 5,
+            current: 2,
+            target: 3,
+            targetInFlight: 10,
+            medianInFlight: 14,
+            lastDecision: 'noop',
+          },
+        })}
+      />,
+    );
+    expect(screen.getByText('×2/3')).toBeInTheDocument();
+    expect(screen.queryByText('×3')).not.toBeInTheDocument();
+  });
+
+  it('falls back to ×N when only replicaCount is set', () => {
+    render(<CustomNode data={makeServerData({ replicaCount: 4 })} />);
+    expect(screen.getByText('×4')).toBeInTheDocument();
+  });
+
+  it('renders no scale badge when neither autoscale nor replicaCount > 1', () => {
+    render(<CustomNode data={makeServerData()} />);
+    expect(screen.queryByText(/^×/)).not.toBeInTheDocument();
+  });
 });

--- a/web/src/__tests__/useStackStore.test.ts
+++ b/web/src/__tests__/useStackStore.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+  updateAutoscaleObservability,
+  AUTOSCALE_HISTORY_CAP,
+  AUTOSCALE_DECISIONS_CAP,
+  type AutoscaleSample,
+  type AutoscaleDecision,
+} from '../stores/useStackStore';
+import type { MCPServerStatus, AutoscaleStatus } from '../types';
+
+function makeServer(overrides: Partial<MCPServerStatus> = {}, autoscale?: AutoscaleStatus): MCPServerStatus {
+  return {
+    name: 'srv-a',
+    transport: 'http',
+    initialized: true,
+    toolCount: 0,
+    tools: [],
+    autoscale,
+    ...overrides,
+  };
+}
+
+function as(overrides: Partial<AutoscaleStatus> = {}): AutoscaleStatus {
+  return {
+    min: 1,
+    max: 5,
+    current: 1,
+    target: 1,
+    targetInFlight: 10,
+    medianInFlight: 5,
+    lastDecision: 'noop',
+    ...overrides,
+  };
+}
+
+describe('updateAutoscaleObservability — ring buffer', () => {
+  it('appends a sample per server on each poll', () => {
+    const server = makeServer({}, as({ current: 2, target: 3, medianInFlight: 7 }));
+    const { history } = updateAutoscaleObservability([server], {}, {}, {});
+    expect(history['srv-a']).toHaveLength(1);
+    expect(history['srv-a'][0]).toMatchObject({ current: 2, target: 3, medianInFlight: 7 });
+  });
+
+  it('caps the ring buffer at AUTOSCALE_HISTORY_CAP and evicts oldest', () => {
+    let history: Record<string, AutoscaleSample[]> = {};
+    const lastSeen: Record<string, { upAt?: string; downAt?: string }> = {};
+
+    for (let i = 0; i < AUTOSCALE_HISTORY_CAP; i++) {
+      const server = makeServer({}, as({ current: i, target: 1 }));
+      ({ history } = updateAutoscaleObservability([server], history, {}, lastSeen));
+    }
+    expect(history['srv-a']).toHaveLength(AUTOSCALE_HISTORY_CAP);
+    expect(history['srv-a'][0].current).toBe(0); // oldest
+
+    // One more poll — 121st sample should evict the first (current=0).
+    const server = makeServer({}, as({ current: 999, target: 1 }));
+    ({ history } = updateAutoscaleObservability([server], history, {}, lastSeen));
+    expect(history['srv-a']).toHaveLength(AUTOSCALE_HISTORY_CAP);
+    expect(history['srv-a'][0].current).toBe(1); // first evicted
+    expect(history['srv-a'][AUTOSCALE_HISTORY_CAP - 1].current).toBe(999);
+  });
+
+  it('does not append samples for servers without autoscale', () => {
+    const server = makeServer();
+    const { history } = updateAutoscaleObservability([server], {}, {}, {});
+    expect(history['srv-a']).toBeUndefined();
+  });
+});
+
+describe('updateAutoscaleObservability — decision feed', () => {
+  it('records nothing on first observation (establishes baseline)', () => {
+    const server = makeServer({}, as({ lastScaleUpAt: '2026-04-22T12:00:00Z' }));
+    const { decisions, lastSeen } = updateAutoscaleObservability([server], {}, {}, {});
+    expect(decisions['srv-a']).toBeUndefined();
+    expect(lastSeen['srv-a']).toEqual({ upAt: '2026-04-22T12:00:00Z', downAt: undefined });
+  });
+
+  it('prepends a decision entry on lastScaleUpAt change', () => {
+    const first = makeServer({}, as({ current: 1, lastScaleUpAt: '2026-04-22T12:00:00Z' }));
+    const step1 = updateAutoscaleObservability([first], {}, {}, {});
+
+    const second = makeServer(
+      {},
+      as({
+        current: 2,
+        medianInFlight: 18,
+        targetInFlight: 10,
+        lastScaleUpAt: '2026-04-22T12:00:03Z',
+      }),
+    );
+    const step2 = updateAutoscaleObservability([second], step1.history, step1.decisions, step1.lastSeen);
+
+    expect(step2.decisions['srv-a']).toHaveLength(1);
+    expect(step2.decisions['srv-a'][0]).toMatchObject({
+      kind: 'up',
+      from: 1,
+      to: 2,
+    });
+    expect(step2.decisions['srv-a'][0].reason).toMatch(/18/);
+  });
+
+  it('prepends a decision entry on lastScaleDownAt change', () => {
+    const first = makeServer({}, as({ current: 3, lastScaleDownAt: '2026-04-22T12:00:00Z' }));
+    const step1 = updateAutoscaleObservability([first], {}, {}, {});
+
+    const second = makeServer(
+      {},
+      as({
+        current: 2,
+        medianInFlight: 2,
+        targetInFlight: 10,
+        lastScaleDownAt: '2026-04-22T12:00:03Z',
+      }),
+    );
+    const step2 = updateAutoscaleObservability([second], step1.history, step1.decisions, step1.lastSeen);
+    expect(step2.decisions['srv-a']).toHaveLength(1);
+    expect(step2.decisions['srv-a'][0]).toMatchObject({ kind: 'down', from: 3, to: 2 });
+  });
+
+  it('caps the decision feed at AUTOSCALE_DECISIONS_CAP per server', () => {
+    let history: Record<string, AutoscaleSample[]> = {};
+    let decisions: Record<string, AutoscaleDecision[]> = {};
+    let lastSeen: Record<string, { upAt?: string; downAt?: string }> = {};
+
+    // First poll establishes baseline; subsequent polls each advance the
+    // timestamp and record one decision. Need CAP + 3 advancing polls after
+    // the baseline to overflow the feed.
+    const totalPolls = AUTOSCALE_DECISIONS_CAP + 4;
+    for (let i = 0; i < totalPolls; i++) {
+      const server = makeServer(
+        {},
+        as({
+          current: i + 1,
+          lastScaleUpAt: `2026-04-22T12:00:${String(i).padStart(2, '0')}Z`,
+        }),
+      );
+      ({ history, decisions, lastSeen } = updateAutoscaleObservability(
+        [server],
+        history,
+        decisions,
+        lastSeen,
+      ));
+    }
+    expect(decisions['srv-a']).toHaveLength(AUTOSCALE_DECISIONS_CAP);
+  });
+
+  it('does not append duplicate decisions when lastScaleUpAt is unchanged', () => {
+    const server = makeServer({}, as({ current: 2, lastScaleUpAt: '2026-04-22T12:00:00Z' }));
+    const step1 = updateAutoscaleObservability([server], {}, {}, {});
+    const step2 = updateAutoscaleObservability([server], step1.history, step1.decisions, step1.lastSeen);
+    expect(step2.decisions['srv-a']).toBeUndefined();
+  });
+});

--- a/web/src/components/graph/CustomNode.tsx
+++ b/web/src/components/graph/CustomNode.tsx
@@ -34,7 +34,9 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
   const TransportIcon = getTransportIcon(transport);
   const toolCount = isServer ? (data as MCPServerNodeData).toolCount : null;
   const replicaCount = isServer ? (data as MCPServerNodeData).replicaCount ?? 1 : 1;
-  const hasReplicas = isServer && replicaCount > 1;
+  const autoscale = isServer ? (data as MCPServerNodeData).autoscale : undefined;
+  // Autoscale badge takes precedence over the static ×N badge.
+  const hasReplicas = isServer && !autoscale && replicaCount > 1;
 
   // Get endpoint/containerId for MCP servers
   const endpoint = isServer ? (data as MCPServerNodeData).endpoint : null;
@@ -56,6 +58,9 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
           : 'bg-gradient-to-br from-surface/95 to-secondary/[0.02] border-border/50',
         selected && isServer && 'border-violet-500 shadow-[0_0_15px_rgba(139,92,246,0.3)] ring-1 ring-violet-500/30',
         selected && !isServer && 'border-secondary shadow-glow-secondary ring-1 ring-secondary/30',
+        // Autoscale decision ring: inset so it does not fight selection highlighting.
+        autoscale?.lastDecision === 'up' && 'ring-2 ring-inset ring-primary/40 animate-pulse-glow',
+        autoscale?.lastDecision === 'down' && 'ring-2 ring-inset ring-secondary/40',
         !selected && 'hover:shadow-node-hover hover:border-text-muted/30'
       )}
       style={{
@@ -109,6 +114,17 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
               <span className="w-1.5 h-1.5 rounded-full bg-cyan-400 animate-pulse" />
               <span className="text-[9px] text-cyan-400 font-medium">active</span>
             </div>
+          )}
+          {/* Autoscale live count: current/target. Takes precedence over the
+              static ×N badge so operators see reactive scale at a glance. */}
+          {isServer && autoscale && (
+            <span
+              className="text-[10px] text-violet-300/80 font-mono tracking-tight"
+              title={`Autoscale · current ${autoscale.current} / target ${autoscale.target}`}
+              aria-label={`Autoscale current ${autoscale.current} of target ${autoscale.target}`}
+            >
+              ×{autoscale.current}/{autoscale.target}
+            </span>
           )}
           {/* Inline replica count when > 1. Shown in both compact and full modes
               so horizontal-scale servers are recognisable at a glance. */}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Monitor,
   Gauge,
   FileOutput,
+  Activity,
 } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { Badge } from '../ui/Badge';
@@ -24,6 +25,7 @@ import { PopoutButton } from '../ui/PopoutButton';
 import { GatewaySidebar } from '../gateway/GatewaySidebar';
 import { TokenUsageSection } from '../sidebar/TokenUsageSection';
 import { ToolsEditor } from '../sidebar/ToolsEditor';
+import { AutoscalePanel } from '../status/AutoscalePanel';
 import { getTransportIcon, getTransportColorClasses } from '../../lib/transport';
 import { useStackStore, useSelectedNodeData } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
@@ -37,6 +39,8 @@ export function Sidebar() {
   const setBottomPanelOpen = useUIStore((s) => s.setBottomPanelOpen);
   const sidebarDetached = useUIStore((s) => s.sidebarDetached);
   const selectNode = useStackStore((s) => s.selectNode);
+  const autoscaleHistory = useStackStore((s) => s.autoscaleHistory);
+  const autoscaleDecisions = useStackStore((s) => s.autoscaleDecisions);
   const { openDetachedWindow } = useWindowManager();
 
   const handleClose = () => {
@@ -335,6 +339,17 @@ export function Sidebar() {
         {isServer && (
           <Section title="Token Usage" icon={Gauge}>
             <TokenUsageSection serverName={data.name} />
+          </Section>
+        )}
+
+        {/* Scaling Section (MCP servers with autoscale only) */}
+        {isServer && serverData?.autoscale && (
+          <Section title="Scaling" icon={Activity} defaultOpen>
+            <AutoscalePanel
+              status={serverData.autoscale}
+              history={autoscaleHistory[data.name] ?? []}
+              decisions={autoscaleDecisions[data.name] ?? []}
+            />
           </Section>
         )}
 

--- a/web/src/components/status/AutoscalePanel.tsx
+++ b/web/src/components/status/AutoscalePanel.tsx
@@ -1,0 +1,211 @@
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import type { AutoscaleStatus } from '../../types';
+import type { AutoscaleSample, AutoscaleDecision } from '../../stores/useStackStore';
+
+interface AutoscalePanelProps {
+  status: AutoscaleStatus;
+  history: AutoscaleSample[];
+  decisions: AutoscaleDecision[];
+}
+
+export function AutoscalePanel({ status, history, decisions }: AutoscalePanelProps) {
+  return (
+    <div className="space-y-3">
+      <Headline status={status} />
+      <DwellPhrase status={status} />
+      <Sparkline history={history} max={status.max} />
+      <DecisionFeed decisions={decisions} />
+    </div>
+  );
+}
+
+function Headline({ status }: { status: AutoscaleStatus }) {
+  return (
+    <div className="flex items-baseline gap-2 text-sm text-text-primary font-mono tracking-tight">
+      <span className="text-text-muted">Current</span>
+      <span className="text-violet-300 font-semibold">{status.current}</span>
+      <span className="text-text-muted">/ Target</span>
+      <span className="text-violet-300 font-semibold">{status.target}</span>
+      <span className="text-text-muted">· Range</span>
+      <span className="text-text-secondary">
+        {status.min}–{status.max}
+      </span>
+    </div>
+  );
+}
+
+function DwellPhrase({ status }: { status: AutoscaleStatus }) {
+  const phrase = dwellPhrase(status);
+  return (
+    <p className="text-xs text-text-secondary leading-relaxed" data-testid="autoscale-dwell">
+      {phrase}
+    </p>
+  );
+}
+
+export function dwellPhrase(status: AutoscaleStatus): string {
+  if (status.idleToZero && status.current === 0) {
+    return 'Idle · scaled to zero';
+  }
+  if (status.lastDecision === 'up') {
+    return `Scaling up · median in-flight ${status.medianInFlight}, target ${status.targetInFlight}`;
+  }
+  if (status.lastDecision === 'down') {
+    return `Scaling down · median in-flight ${status.medianInFlight} below target ${status.targetInFlight}`;
+  }
+  // noop
+  if (status.current === status.target) {
+    return `Stable · median in-flight ${status.medianInFlight}, target ${status.targetInFlight}`;
+  }
+  return `Holding · current ${status.current}, target ${status.target}`;
+}
+
+interface SparklineProps {
+  history: AutoscaleSample[];
+  max: number;
+}
+
+// Inline SVG sparkline — no chart library. Width fills container via
+// viewBox; container sets fixed ~40px height. Memoized so the only work
+// per render is bookkeeping when history/max are unchanged.
+function Sparkline({ history, max }: SparklineProps) {
+  const W = 200;
+  const H = 40;
+
+  const geom = useMemo(() => {
+    if (history.length === 0) return null;
+    const maxSeen = Math.max(
+      max,
+      ...history.map((s) => s.current),
+      ...history.map((s) => s.target),
+    );
+    const yMax = Math.max(1, maxSeen * 1.1);
+    const n = history.length;
+    const xFor = (i: number) => (n <= 1 ? 0 : (i / (n - 1)) * W);
+    const yFor = (v: number) => H - (v / yMax) * H;
+    const toPath = (values: number[]) =>
+      values.map((v, i) => `${i === 0 ? 'M' : 'L'} ${xFor(i).toFixed(2)} ${yFor(v).toFixed(2)}`).join(' ');
+    const observedMin = Math.min(...history.map((s) => s.current));
+    return {
+      currentPath: toPath(history.map((s) => s.current)),
+      targetPath: toPath(history.map((s) => s.target)),
+      points: history.map((s, i) => ({ cx: xFor(i), cy: yFor(s.current), sample: s })),
+      minY: yFor(observedMin),
+      maxY: yFor(maxSeen),
+    };
+  }, [history, max]);
+
+  if (!geom) {
+    return (
+      <div className="h-10 rounded-md bg-background/40 border border-border/30 flex items-center justify-center">
+        <span className="text-[10px] text-text-muted">Collecting samples…</span>
+      </div>
+    );
+  }
+
+  return (
+    <svg
+      data-testid="autoscale-sparkline"
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      className="w-full h-10 block"
+      role="img"
+      aria-label="Autoscale current vs target over time"
+    >
+      {/* Min/max guide bands */}
+      <line x1={0} x2={W} y1={geom.minY} y2={geom.minY} stroke="rgb(139 92 246)" strokeOpacity={0.15} strokeWidth={1} />
+      <line x1={0} x2={W} y1={geom.maxY} y2={geom.maxY} stroke="rgb(139 92 246)" strokeOpacity={0.15} strokeWidth={1} />
+      {/* Target (dashed, 50% opacity) */}
+      <path
+        d={geom.targetPath}
+        fill="none"
+        stroke="rgb(139 92 246)"
+        strokeOpacity={0.5}
+        strokeWidth={1.5}
+        strokeDasharray="3 3"
+        vectorEffect="non-scaling-stroke"
+      />
+      {/* Current (solid 1.5px violet) */}
+      <path
+        data-testid="autoscale-sparkline-current"
+        d={geom.currentPath}
+        fill="none"
+        stroke="rgb(139 92 246)"
+        strokeWidth={1.5}
+        vectorEffect="non-scaling-stroke"
+      />
+      {/* Minimal tooltip points: <title> on each current-sample anchor */}
+      {geom.points.map((p) => (
+        <circle key={p.sample.t} cx={p.cx} cy={p.cy} r={1.5} fill="rgb(139 92 246)">
+          <title>{`current ${p.sample.current} · target ${p.sample.target} · median in-flight ${p.sample.medianInFlight}`}</title>
+        </circle>
+      ))}
+    </svg>
+  );
+}
+
+function DecisionFeed({ decisions }: { decisions: AutoscaleDecision[] }) {
+  const [open, setOpen] = useState(false);
+  const count = decisions.length;
+
+  return (
+    <div className="border border-border/30 rounded-md bg-background/30">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-2.5 py-1.5 hover:bg-surface-highlight/40 transition-colors rounded-md"
+        aria-expanded={open}
+      >
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] uppercase tracking-widest text-text-muted font-medium">
+            Recent Decisions
+          </span>
+          <span className="text-[10px] text-text-muted bg-surface-elevated px-1.5 py-0.5 rounded-md font-mono">
+            {count}
+          </span>
+        </div>
+        {open ? (
+          <ChevronDown size={12} className="text-text-muted" />
+        ) : (
+          <ChevronRight size={12} className="text-text-muted" />
+        )}
+      </button>
+      {open && (
+        <ul className="px-2.5 py-2 space-y-1" data-testid="autoscale-decision-feed">
+          {count === 0 && (
+            <li className="text-[11px] text-text-muted italic">No scale events yet</li>
+          )}
+          {decisions.map((d) => (
+            <DecisionRow key={`${d.t}-${d.kind}`} decision={d} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function DecisionRow({ decision }: { decision: AutoscaleDecision }) {
+  const Icon = decision.kind === 'up' ? TrendingUp : decision.kind === 'down' ? TrendingDown : Minus;
+  const color =
+    decision.kind === 'up' ? 'text-primary' : decision.kind === 'down' ? 'text-secondary' : 'text-text-muted';
+  return (
+    <li className="flex items-center gap-2 text-[11px] font-mono">
+      <span className="text-text-muted">{formatTime(decision.t)}</span>
+      <span className={cn('inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md', color)}>
+        <Icon size={10} />
+        <span className="uppercase tracking-wider">{decision.kind}</span>
+      </span>
+      <span className="text-text-secondary truncate">
+        {decision.from}→{decision.to}
+      </span>
+    </li>
+  );
+}
+
+function formatTime(t: number): string {
+  const d = new Date(t);
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}

--- a/web/src/lib/graph/nodes.ts
+++ b/web/src/lib/graph/nodes.ts
@@ -96,6 +96,7 @@ export function createMCPServerNodes(mcpServers: MCPServerStatus[]): Node[] {
       outputFormat: server.outputFormat,
       replicaCount: server.replicas?.length,
       toolWhitelist: server.toolWhitelist,
+      autoscale: server.autoscale,
     },
     draggable: true,
   }));

--- a/web/src/stores/useStackStore.ts
+++ b/web/src/stores/useStackStore.ts
@@ -11,11 +11,36 @@ import type {
   Tool,
   TokenUsage,
   ConnectionStatus,
+  AutoscaleDecisionKind,
 } from '../types';
 import { transformToNodesAndEdges } from '../lib/transform';
 import { useRegistryStore } from './useRegistryStore';
 import { useUIStore } from './useUIStore';
 import { usePinsStore } from './usePinsStore';
+
+// Per-server autoscale sample. Populated every poll cycle; capped at
+// AUTOSCALE_HISTORY_CAP entries so the ring buffer stays O(1) in memory.
+export interface AutoscaleSample {
+  t: number;              // ms since epoch (client-local)
+  current: number;
+  target: number;
+  medianInFlight: number;
+}
+
+// Client-derived scale event. The backend exposes only the last-decision
+// snapshot (lastScaleUpAt/lastScaleDownAt), not an event stream, so we
+// diff consecutive polls. Two scale events within one polling window
+// (3s) can be coalesced — that's a known limitation, not a bug.
+export interface AutoscaleDecision {
+  t: number;              // ms since epoch (client-local observation time)
+  kind: Exclude<AutoscaleDecisionKind, 'noop'>;
+  from: number;
+  to: number;
+  reason: string;
+}
+
+export const AUTOSCALE_HISTORY_CAP = 120; // 6 minutes at 3s polling
+export const AUTOSCALE_DECISIONS_CAP = 10;
 
 interface StackState {
   // === Raw API Data ===
@@ -33,6 +58,12 @@ interface StackState {
   nodes: Node[];
   edges: Edge[];
   draggedPositions: Map<string, { x: number; y: number }>;  // User-dragged node positions
+
+  // === Autoscale observability (client-derived from polling) ===
+  autoscaleHistory: Record<string, AutoscaleSample[]>;
+  autoscaleDecisions: Record<string, AutoscaleDecision[]>;
+  // Last-seen raw timestamps, used to diff polls and detect new scale events.
+  autoscaleLastSeen: Record<string, { upAt?: string; downAt?: string }>;
 
   // === UI State ===
   selectedNodeId: string | null;
@@ -72,6 +103,9 @@ export const useStackStore = create<StackState>()(
     nodes: [],
     edges: [],
     draggedPositions: new Map(),
+    autoscaleHistory: {},
+    autoscaleDecisions: {},
+    autoscaleLastSeen: {},
     selectedNodeId: null,
     connectionStatus: 'disconnected',
     lastUpdated: null,
@@ -80,14 +114,25 @@ export const useStackStore = create<StackState>()(
 
     // Actions
     setGatewayStatus: (status) => {
+      const mcpServers = status['mcp-servers'] || [];
+      const { autoscaleHistory, autoscaleDecisions, autoscaleLastSeen } = get();
+      const folded = updateAutoscaleObservability(
+        mcpServers,
+        autoscaleHistory,
+        autoscaleDecisions,
+        autoscaleLastSeen,
+      );
       set({
         gatewayInfo: status.gateway,
-        mcpServers: status['mcp-servers'] || [],
+        mcpServers,
         resources: status.resources || [],
         sessions: status.sessions ?? 0,
         codeMode: status.code_mode || null,
         tokenUsage: status.token_usage ?? null,
         stackName: status.stack_name || '',
+        autoscaleHistory: folded.history,
+        autoscaleDecisions: folded.decisions,
+        autoscaleLastSeen: folded.lastSeen,
         lastUpdated: new Date(),
         isLoading: false,
         error: null,
@@ -209,3 +254,79 @@ export const useSelectedNodeData = () => {
   const node = useSelectedNode();
   return node?.data as Record<string, unknown> | undefined;
 };
+
+// Fold the latest poll into the autoscale ring buffer and derived decision
+// feed. Exported for unit-testing; not intended for direct use from components.
+export function updateAutoscaleObservability(
+  mcpServers: MCPServerStatus[],
+  prevHistory: Record<string, AutoscaleSample[]>,
+  prevDecisions: Record<string, AutoscaleDecision[]>,
+  prevLastSeen: Record<string, { upAt?: string; downAt?: string }>,
+): {
+  history: Record<string, AutoscaleSample[]>;
+  decisions: Record<string, AutoscaleDecision[]>;
+  lastSeen: Record<string, { upAt?: string; downAt?: string }>;
+} {
+  const now = Date.now();
+  const history: Record<string, AutoscaleSample[]> = { ...prevHistory };
+  const decisions: Record<string, AutoscaleDecision[]> = { ...prevDecisions };
+  const lastSeen: Record<string, { upAt?: string; downAt?: string }> = { ...prevLastSeen };
+
+  for (const server of mcpServers) {
+    const as = server.autoscale;
+    if (!as) continue;
+
+    const prevSamples = history[server.name] ?? [];
+    const lastSample = prevSamples[prevSamples.length - 1];
+    const nextSample: AutoscaleSample = {
+      t: now,
+      current: as.current,
+      target: as.target,
+      medianInFlight: as.medianInFlight,
+    };
+    const nextSamples =
+      prevSamples.length >= AUTOSCALE_HISTORY_CAP
+        ? [...prevSamples.slice(prevSamples.length - AUTOSCALE_HISTORY_CAP + 1), nextSample]
+        : [...prevSamples, nextSample];
+    history[server.name] = nextSamples;
+
+    // Derive a decision entry when lastScaleUpAt/lastScaleDownAt advances vs.
+    // the last observation. First-sight values establish a baseline only —
+    // recording them would flood the feed with stale events on a page refresh.
+    // Two scale events inside one 3s polling window can coalesce — accepted
+    // limitation of snapshot-diff observation.
+    const seenBefore = server.name in prevLastSeen;
+    const seen = prevLastSeen[server.name] ?? {};
+    const newDecisions: AutoscaleDecision[] = [];
+    if (seenBefore && as.lastScaleUpAt && as.lastScaleUpAt !== seen.upAt) {
+      newDecisions.push({
+        t: Date.parse(as.lastScaleUpAt) || now,
+        kind: 'up',
+        from: lastSample?.current ?? as.current,
+        to: as.current,
+        reason: `median in-flight ${as.medianInFlight} ≥ target ${as.targetInFlight}`,
+      });
+    }
+    if (seenBefore && as.lastScaleDownAt && as.lastScaleDownAt !== seen.downAt) {
+      newDecisions.push({
+        t: Date.parse(as.lastScaleDownAt) || now,
+        kind: 'down',
+        from: lastSample?.current ?? as.current,
+        to: as.current,
+        reason: `median in-flight ${as.medianInFlight} below target ${as.targetInFlight}`,
+      });
+    }
+    if (newDecisions.length > 0) {
+      const prevServerDecisions = prevDecisions[server.name] ?? [];
+      // Newest first within this tick; then prepend to prior feed; cap.
+      newDecisions.sort((a, b) => b.t - a.t);
+      decisions[server.name] = [...newDecisions, ...prevServerDecisions].slice(0, AUTOSCALE_DECISIONS_CAP);
+    }
+    lastSeen[server.name] = {
+      upAt: as.lastScaleUpAt,
+      downAt: as.lastScaleDownAt,
+    };
+  }
+
+  return { history, decisions, lastSeen };
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -33,6 +33,25 @@ export interface ReplicaStatus {
   containerId?: string;
 }
 
+// Controller decision at the last autoscale tick.
+export type AutoscaleDecisionKind = 'up' | 'down' | 'noop';
+
+// Live autoscale snapshot matching mcp.AutoscaleStatus on the Go side.
+// Present only when a server has autoscale configured.
+export interface AutoscaleStatus {
+  min: number;
+  max: number;
+  current: number;
+  target: number;
+  targetInFlight: number;
+  medianInFlight: number;
+  lastScaleUpAt?: string;   // RFC3339
+  lastScaleDownAt?: string; // RFC3339
+  lastDecision: AutoscaleDecisionKind;
+  warmPool?: number;
+  idleToZero?: boolean;
+}
+
 // MCP Server status matching mcp.MCPServerStatus
 export interface MCPServerStatus {
   name: string;
@@ -57,6 +76,7 @@ export interface MCPServerStatus {
   // means the operator has curated a subset.
   toolWhitelist?: string[];
   replicas?: ReplicaStatus[]; // Per-replica runtime status
+  autoscale?: AutoscaleStatus; // Live autoscale snapshot (absent when not configured)
 }
 
 // Resource status for non-MCP containers
@@ -192,6 +212,9 @@ export interface MCPServerNodeData extends NodeDataBase {
   // Tool whitelist from the stack YAML — present when the operator has
   // curated a subset of the server's tools. Drives the canvas "curated" badge.
   toolWhitelist?: string[];
+  // Live autoscale snapshot — drives the ×current/target badge and decision ring
+  // on the canvas node, and powers the Sidebar Scaling section.
+  autoscale?: AutoscaleStatus;
 }
 
 export interface ResourceNodeData extends NodeDataBase {


### PR DESCRIPTION
## Description

Slice B of the MCP autoscale UI. Makes live autoscale state visible on the canvas and in the Sidebar by consuming the `autoscale` field already emitted by `/api/status`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `AutoscaleStatus` type mirroring the Go struct; threaded `autoscale` through `MCPServerStatus` → `MCPServerNodeData` → graph nodes.
- Canvas node now renders `×<current>/<target>` (replacing the static `×N`) with a subtle inset ring: amber pulse on `lastDecision === "up"`, teal on `"down"`, none on `"noop"`. Layered under the selection ring so the two don't fight.
- `useStackStore` grew an `autoscaleHistory` ring buffer (cap 120) and a client-derived `autoscaleDecisions` feed (cap 10). Decisions are diffed from consecutive `lastScaleUpAt` / `lastScaleDownAt` snapshots; first-sight timestamps establish a baseline instead of flooding the feed on page refresh.
- New `AutoscalePanel` component: headline (`Current X / Target Y · Range min–max`), dwell phrase keyed off the last decision, inline-SVG sparkline (current solid violet, target dashed, min/max guide bands), collapsible decision feed. No new dependencies.
- Sidebar renders a new Scaling section (default open) whenever the selected server has an `autoscale` snapshot.
- Test coverage: new `AutoscalePanel.test.tsx` and `useStackStore.test.ts`, plus badge-variant extensions to `CustomNode.test.tsx`.

## Testing

- `cd web && npm test` — 457/457 pass.
- `cd web && npm run build` — clean typecheck + bundle.
- `golangci-lint run ./...` — 0 issues.
- `make build` — clean.
- Manual: deploy an autoscaled server (`examples/autoscale/autoscale-basic.yaml`), drive some load, watch the canvas badge + Sidebar Scaling section update every 3s.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #513