### PR TITLE
docs: sync autoscale coverage across docs and AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -666,6 +666,8 @@ When the vault is locked, all endpoints except `status`, `unlock`, and `lock` re
 
 **Replica sets:** Each registered server is a `ReplicaSet` in the router — a pool of 1..N `AgentClient` replicas sharing one server name and one tool namespace. Set `replicas: N` (and optionally `replica_policy: round-robin | least-connections`) in `mcp-servers[]` to spawn N independent processes. Validation caps at 32 and rejects replicas on `external` / `openapi` transports. Per-replica health monitor pings each replica independently, excludes failures from dispatch, and reconnects with exponential backoff (1s → 30s cap, ±25% jitter, reset on success). When every replica is unhealthy, tool calls fail with `no healthy replicas: <server>`. Every log line and trace span on the tool-call path carries a `replica_id`; `gridctl status --replicas` and `/api/stack/health` expose the per-replica breakdown. See [docs/scaling.md](docs/scaling.md).
 
+**Autoscale:** A server can replace static `replicas: N` with a reactive `autoscale:` block — same transport rules, same replica-set plumbing, but with a per-set controller in `pkg/mcp/autoscaler` that spawns/reaps replicas based on rolling-median in-flight load (`min`, `max`, `target_in_flight`, `scale_up_after`, `scale_down_after`, `warm_pool`, `idle_to_zero`). `autoscale` and `replicas` are mutually exclusive on the same server. Live snapshots are published on `/api/status` and `/api/mcp-servers` as `autoscale?: AutoscaleStatus` (current, target, median, lastDecision, lastScaleUp/DownAt); `gridctl status --replicas` surfaces the same via an `AUTOSCALE` column. See [docs/scaling.md#autoscaling](docs/scaling.md#autoscaling).
+
 ## Stack YAML Schema
 
 Gridctl supports two network modes:

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Restart Claude Desktop after editing. All tools from your stack are now availabl
 
 - [Configuration Reference](docs/config-schema.md) — every field in `stack.yaml`
 - [REST API Reference](docs/api-reference.md) — all gateway endpoints
-- [Scaling stdio servers](docs/scaling.md) — run multiple replicas with policies and trade-offs
+- [Scaling](docs/scaling.md) — static replicas, reactive autoscaling, and the trade-offs
 - [Troubleshooting](docs/troubleshooting.md) — common issues and resolutions
 
 ## 🤝 Contributing

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -89,7 +89,17 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/status
       "openapiSpec": "",
       "healthy": true,
       "lastCheck": "2025-01-15T10:30:00Z",
-      "healthError": ""
+      "healthError": "",
+      "autoscale": {
+        "min": 1,
+        "max": 8,
+        "current": 2,
+        "target": 3,
+        "targetInFlight": 3,
+        "medianInFlight": 9,
+        "lastScaleUpAt": "2025-01-15T10:29:12Z",
+        "lastDecision": "up"
+      }
     }
   ],
   "agents": [
@@ -165,17 +175,33 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/status
 | `per_server` | map | Token counts keyed by server name |
 | `format_savings` | object | Savings from output format conversion (`original_tokens`, `formatted_tokens`, `saved_tokens`, `savings_percent`) |
 
-**MCP server status** includes `outputFormat` (string, omitted when unset) showing the configured output format for each server.
+**MCP server status** includes `outputFormat` (string, omitted when unset) showing the configured output format for each server, and `autoscale` (object, omitted when the server has no autoscale block) described under [`/api/mcp-servers`](#get-apimcp-servers).
 
 #### `GET /api/mcp-servers`
 
-Returns MCP server status details.
+Returns MCP server status details. Response fields match the `mcp-servers[]` entries under [`/api/status`](#get-apistatus).
 
 **Auth:** Yes
 
 ```bash
 curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/mcp-servers
 ```
+
+**Autoscale fields** — servers configured with an `autoscale` block (see [config-schema.md#autoscale](config-schema.md#autoscale)) include an `autoscale` object in their status:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `min` | int | Configured floor |
+| `max` | int | Configured ceiling |
+| `current` | int | Running replica count at the last controller tick |
+| `target` | int | Desired replica count at the last controller tick |
+| `targetInFlight` | int | Configured per-replica in-flight target |
+| `medianInFlight` | int | Rolling median in-flight request count across healthy replicas |
+| `lastScaleUpAt` | string | RFC3339 timestamp of the most recent scale-up (omitted when none) |
+| `lastScaleDownAt` | string | RFC3339 timestamp of the most recent scale-down (omitted when none) |
+| `lastDecision` | string | `"up"`, `"down"`, or `"noop"` — what the controller just decided |
+| `warmPool` | int | Configured warm-pool (omitted when 0) |
+| `idleToZero` | bool | Configured scale-to-zero (omitted when false) |
 
 #### `GET /api/tools`
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -322,8 +322,9 @@ mcp-servers:
 | `output_format` | string | No | — | Output format override: `"json"`, `"toon"`, `"csv"`, or `"text"`. Overrides `gateway.output_format` for this server |
 | `pin_schemas` | bool | No | — | Override schema pinning for this server. `false` disables pinning regardless of gateway setting. Omit to inherit from `gateway.security.schema_pinning.enabled` |
 | `ready_timeout` | duration | No | `30s` | Readiness wait for container-based HTTP/SSE servers. Accepts any `time.Duration` string (e.g. `"60s"`, `"2m"`). When a container does not become ready within this window, the container is stopped and removed so a retry starts clean. Ignored for stdio, external, local process, SSH, and OpenAPI servers |
-| `replicas` | int | No | `1` | Number of independent processes to spawn for this server. Values >1 load-balance JSON-RPC tool calls across replicas using `replica_policy`. Range: 1–32. Not supported for external URL or OpenAPI transports. See [Scaling stdio servers](scaling.md) |
-| `replica_policy` | string | No | `"round-robin"` | Dispatch policy when `replicas > 1`: `"round-robin"` or `"least-connections"` |
+| `replicas` | int | No | `1` | Number of independent processes to spawn for this server. Values >1 load-balance JSON-RPC tool calls across replicas using `replica_policy`. Range: 1–32. Not supported for external URL or OpenAPI transports. Mutually exclusive with `autoscale`. See [Scaling](scaling.md) |
+| `replica_policy` | string | No | `"round-robin"` | Dispatch policy when `replicas > 1` or `autoscale` is set: `"round-robin"` or `"least-connections"` |
+| `autoscale` | object | No | — | Reactive autoscaling block. Mutually exclusive with `replicas`. Not supported for external URL or OpenAPI transports. See [Autoscale](#autoscale) |
 
 **Type determination rules:**
 - Must have exactly one of: `image`, `source`, `url`, `command` (alone), `ssh` + `command`, or `openapi`
@@ -410,6 +411,37 @@ Transport-layer TLS configuration. Can be combined with any `auth` type.
 | `exclude` | []string | No | — | Operation IDs to exclude (blacklist) |
 
 Cannot use both `include` and `exclude`.
+
+### Autoscale
+
+Reactive autoscaling block — replaces the static `replicas: N` field with a policy that spawns and reaps replicas based on live in-flight load. Supported on container, local-process, and SSH servers. Rejected on external URL and OpenAPI transports with a precise YAML-path validation error. `autoscale` and `replicas` are mutually exclusive on the same server.
+
+```yaml
+mcp-servers:
+  - name: junos
+    command: [.venv/bin/python, servers/junos-mcp-server/jmcp.py, --transport, stdio]
+    replica_policy: least-connections
+    autoscale:
+      min: 1
+      max: 8
+      target_in_flight: 3
+      scale_up_after: 30s
+      scale_down_after: 5m
+      warm_pool: 0
+      idle_to_zero: false
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `min` | int | **Yes** | — | Floor on the replica count. Must be `>= 0`; must be `>= 1` unless `idle_to_zero` is true |
+| `max` | int | **Yes** | — | Ceiling on the replica count. Must be `>= 1`, `<= 32`, and `>= min` |
+| `target_in_flight` | int | **Yes** | — | Target per-replica in-flight request count. The scaler holds the rolling median at or below this. Must be `>= 1` |
+| `scale_up_after` | duration | No | `30s` | Window the rolling median must stay above `target_in_flight` before spawning. Minimum `10s` |
+| `scale_down_after` | duration | No | `5m` | Window the rolling median must stay below half the target before reaping. Minimum `1m` |
+| `warm_pool` | int | No | `0` | Extra idle replicas kept above the load-derived target. `min + warm_pool` is the scale-down floor. `min + warm_pool <= max` |
+| `idle_to_zero` | bool | No | `false` | When true, allows `min: 0` and reaps every replica after sustained idle. The first tool call after idle pays a cold-start penalty (see [docs/scaling.md#cold-start-penalty](scaling.md#cold-start-penalty)) |
+
+Full decision-rule walkthrough, cold-start trade-offs, and observability details live in [docs/scaling.md#autoscaling](scaling.md#autoscaling). Live state is exposed via `/api/status` and `/api/mcp-servers` (see [api-reference.md](api-reference.md#get-apistatus)) and the `AUTOSCALE` column of `gridctl status --replicas`.
 
 ---
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -107,6 +107,8 @@ Implementation in `src/lib/graph/` (butterfly.ts, edges.ts, nodes.ts, transform.
 *   **Color:** Violet accents for all MCP server types (unified theme)
 *   **Content:** Name, transport type, endpoint/container ID, tool count, status
 *   **Format Badge:** Teal badge next to transport badge, shown only when `outputFormat` is non-default (not `json`). Displays format name (TOON, CSV, text).
+*   **Scale Badge:** Inline mono badge in the header row. When `data.autoscale` is present the badge renders `×<current>/<target>` (e.g. `×2/3`); otherwise, when `replicaCount > 1`, it falls back to `×N`; otherwise nothing. Autoscale takes precedence over static replicas.
+*   **Decision Ring:** Subtle inset ring driven by `data.autoscale.lastDecision`. `"up"` → amber `animate-pulse-glow`; `"down"` → `ring-secondary/40`; `"noop"` → no extra ring. The ring is inset (`ring-inset`) so it layers below the selection ring without fighting it.
 *   **Token Heat Overlay:** Amber glow proportional to relative token usage when heat map is enabled via Flame button in canvas controls.
 *   **Type Indicators:** Gray bordered badge next to status badge indicating server type:
     *   **Container:** Terminal icon + "Container" (for container-based servers)
@@ -151,6 +153,19 @@ Shows per-server token counts, sparkline trend chart, and conditional format sav
     *   `SparkChart` — Minimal Recharts-based sparkline (no axes, legends, or tooltips)
 *   **Visibility:** Only renders when token data exists for the selected server
 *   **Format Savings:** Conditional bar showing original vs formatted tokens and savings percentage
+
+### Scaling Section (Autoscaled MCP Servers Only)
+Live view of reactive-autoscale state. Renders whenever the selected server's `MCPServerStatus.autoscale` is populated.
+
+*   **Location:** Below Token Usage, above Actions (MCP server nodes only)
+*   **Icon:** Activity (Lucide), `defaultOpen`
+*   **Component:** `AutoscalePanel` (`web/src/components/status/AutoscalePanel.tsx`)
+*   **Layout (top-down):**
+    *   Headline: `Current <c> / Target <t> · Range <min>–<max>` (mono, violet emphasis)
+    *   Dwell phrase keyed off `lastDecision` (e.g. `Scaling up · median in-flight 14, target 10`; `Stable · …`; `Idle · scaled to zero`)
+    *   Inline-SVG sparkline — `current` solid violet, `target` dashed violet at 50%, min/max as faint horizontal guide lines at 15%. No chart library; path data memoized.
+    *   Collapsible **Recent Decisions** feed (closed by default) — last ≤10 client-derived entries with `HH:MM:SS · kind chip · from→to`
+*   **Derivation:** The decision feed is **not** streamed by the backend; it's reconstructed in the store by diffing `lastScaleUpAt` / `lastScaleDownAt` between polls. Two scale events within one 3s polling window can coalesce — accepted trade-off.
 
 ### Access Section (Agents Only)
 Shows the MCP server dependencies for an agent with tool-level access visualization.
@@ -609,7 +624,7 @@ The creation wizard is a multi-step modal for adding MCP servers, resources, sta
 - **RecipePicker**: First step — resource type selection cards (Stack, MCP Server, Resource, Agent, Skill)
 - **BrowseStep**: Registry browser for importing skills
 - **AddSourceStep**: Transport/source configuration for MCP servers
-- **MCPServerForm**: MCP server detail form
+- **MCPServerForm**: MCP server detail form. Advanced section includes a segmented **Scaling** control (Static replicas | Autoscale). The two branches share no state — toggling clears the opposite field group so the emitted YAML carries at most one of `replicas:` or `autoscale:`. Hidden on `external` and `openapi` server types (backend rejects both).
 - **ResourceForm**: Resource (non-MCP container) form
 - **StackForm**: Stack spec builder
 - **ReviewStep**: Final review and deploy step (all resource types); for stacks, shows **Save & Load** instead of Deploy


### PR DESCRIPTION
## Description

Fill the documentation gaps left by PRs #512 (backend), #514 (wizard UI), and #515 (status observability). The `autoscale:` config block and `AutoscaleStatus` API field were live but weren't reflected in the config schema, API reference, root `AGENTS.md`, `web/AGENTS.md`, or the README link label.

## Type of Change

- [x] Documentation update

## Changes Made

- `docs/config-schema.md`: added `autoscale` to the All MCP Server Fields table; new **Autoscale** subsection with the 7 fields, transport constraints, mutual exclusivity with `replicas`, and cross-links to `scaling.md#autoscaling`.
- `docs/api-reference.md`: added `autoscale` to the `/api/status` response example; documented the full `AutoscaleStatus` schema under `/api/mcp-servers`.
- `web/AGENTS.md`: extended §7 (MCP Server Node) with the ×current/target badge and decision-ring rules; added §8 "Scaling Section" covering `AutoscalePanel`; added a Scaling-control note on `MCPServerForm` in §18.
- `AGENTS.md` (root): extended the Replica sets paragraph with an **Autoscale** paragraph pointing to `pkg/mcp/autoscaler`, the config block, and `/api/status` / `/api/mcp-servers` surfaces.
- `README.md`: refreshed the scaling-doc label to cover both static replicas and reactive autoscale.

## Testing

- `grep`-audited every cross-link target (`#autoscale`, `#autoscaling`, `#cold-start-penalty`, `#get-apistatus`, `#get-apimcp-servers`) against the corresponding heading.
- No code changes; no test runs required.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed