### PR TITLE
fix: restore chart axis contrast on dark theme

### DIFF
--- a/web/src/components/chart/AreaChart.tsx
+++ b/web/src/components/chart/AreaChart.tsx
@@ -385,11 +385,9 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
             hide={!showXAxis}
             dataKey={index}
             interval={startEndOnly ? "preserveStartEnd" : intervalType}
-            tick={{ transform: "translate(0, 6)" }}
+            tick={{ transform: "translate(0, 6)", fill: "var(--color-text-primary)" }}
             ticks={startEndOnly ? [data[0][index], data[data.length - 1][index]] : undefined}
-            fill=""
-            stroke=""
-            className="text-xs fill-text-secondary"
+            className="text-xs"
             tickLine={false}
             axisLine={false}
             minTickGap={tickGap}
@@ -407,10 +405,8 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
             tickLine={false}
             type="number"
             domain={yAxisDomain as AxisDomain}
-            tick={{ transform: "translate(-3, 0)" }}
-            fill=""
-            stroke=""
-            className="text-xs fill-text-secondary"
+            tick={{ transform: "translate(-3, 0)", fill: "var(--color-text-primary)" }}
+            className="text-xs"
             tickFormatter={type === "percent" ? valueToPercent : valueFormatter}
             allowDecimals={allowDecimals}
           >
@@ -430,7 +426,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
             wrapperStyle={{ outline: "none" }}
             isAnimationActive={true}
             animationDuration={100}
-            cursor={{ stroke: "#27272a", strokeWidth: 1 }}
+            cursor={{ stroke: "var(--color-text-muted)", strokeWidth: 1, strokeDasharray: "3 3" }}
             offset={20}
             position={{ y: 0 }}
             content={({ active, payload, label: rawLabel }) => {

--- a/web/src/components/playground/ReasoningWaterfall.tsx
+++ b/web/src/components/playground/ReasoningWaterfall.tsx
@@ -96,7 +96,7 @@ function WaterfallRow({ entry }: { entry: WaterfallEntry }) {
               <p className="text-[9px] text-text-muted/40 uppercase tracking-wider mb-0.5 font-medium">
                 Input
               </p>
-              <pre className="text-[9px] font-mono text-text-muted/70 bg-background/60 border border-border/20 rounded p-2 overflow-x-auto whitespace-pre-wrap break-words max-h-28 scrollbar-dark">
+              <pre className="text-[9px] font-mono text-text-secondary bg-background/60 border border-border/20 rounded p-2 overflow-x-auto whitespace-pre-wrap break-words max-h-28 scrollbar-dark">
                 {JSON.stringify(entry.input, null, 2)}
               </pre>
             </div>
@@ -106,7 +106,7 @@ function WaterfallRow({ entry }: { entry: WaterfallEntry }) {
               <p className="text-[9px] text-text-muted/40 uppercase tracking-wider mb-0.5 font-medium">
                 Output
               </p>
-              <pre className="text-[9px] font-mono text-text-muted/70 bg-background/60 border border-border/20 rounded p-2 overflow-x-auto whitespace-pre-wrap break-words max-h-32 scrollbar-dark">
+              <pre className="text-[9px] font-mono text-text-secondary bg-background/60 border border-border/20 rounded p-2 overflow-x-auto whitespace-pre-wrap break-words max-h-32 scrollbar-dark">
                 {JSON.stringify(entry.output, null, 2)}
               </pre>
             </div>

--- a/web/src/components/workflow/DesignerGraph.tsx
+++ b/web/src/components/workflow/DesignerGraph.tsx
@@ -69,7 +69,7 @@ function stepsToFlow(
           source: depId,
           target: step.id,
           type: 'smoothstep',
-          style: { stroke: '#27272a', strokeWidth: 1.5 },
+          style: { stroke: '#3f3f46', strokeWidth: 1.5 },
         });
       });
     });
@@ -160,7 +160,7 @@ export function DesignerGraph({
         return s;
       });
       onStepsChange(updatedSteps);
-      setEdges((eds) => addEdge({ ...connection, type: 'smoothstep', style: { stroke: '#27272a', strokeWidth: 1.5 } }, eds));
+      setEdges((eds) => addEdge({ ...connection, type: 'smoothstep', style: { stroke: '#3f3f46', strokeWidth: 1.5 } }, eds));
     },
     [steps, onStepsChange, setEdges],
   );
@@ -269,7 +269,7 @@ export function DesignerGraph({
         nodesDraggable={true}
         nodesConnectable={true}
       >
-        <Background color="#27272a" gap={20} size={1} />
+        <Background color="#3f3f46" gap={20} size={1} />
         <Controls
           showInteractive={false}
           className="!bg-surface-elevated/80 !border-border/40 !rounded-lg !shadow-node"

--- a/web/src/components/workflow/WorkflowGraph.tsx
+++ b/web/src/components/workflow/WorkflowGraph.tsx
@@ -70,7 +70,7 @@ function buildFlowElements(
             stroke:
               depStatus === 'success' ? '#10b981' :
               depStatus === 'failed' ? '#f43f5e' :
-              '#27272a',
+              '#3f3f46',
             strokeWidth: 1.5,
             ...(isActive && { strokeDasharray: '5 5' }),
           },
@@ -137,7 +137,7 @@ export function WorkflowGraph() {
         nodesDraggable={false}
         nodesConnectable={false}
       >
-        <Background color="#27272a" gap={20} size={1} />
+        <Background color="#3f3f46" gap={20} size={1} />
         <Controls
           showInteractive={false}
           className="!bg-surface-elevated/80 !border-border/40 !rounded-lg !shadow-node"


### PR DESCRIPTION
## Description

Chart axis labels on the MCP server detail **Metrics** tab were rendering in near-black on the dark theme background (~1.1:1 contrast), making them unreadable. Same defect affected the detached metrics window. This PR also bundles a small low-contrast audit sweep across the rest of the web UI (hover cursor, workflow canvas edges/grid, reasoning waterfall code blocks).

**Root cause:** `AreaChart.tsx` passed `fill=""` and `stroke=""` to Recharts `<XAxis>` / `<YAxis>`. Those empty-string SVG attributes override the `fill-text-secondary` Tailwind class via inline-attribute precedence, so tick `<text>` elements fell back to the browser default `fill: black`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `chart/AreaChart.tsx`: drop `fill=""` / `stroke=""` / `fill-text-secondary` on X and Y axes; set `tick={{ ...existing, fill: "var(--color-text-primary)" }}`. Tooltip cursor stroke upgraded from `#27272a` to `var(--color-text-muted)` with a dashed pattern.
- `workflow/WorkflowGraph.tsx` and `workflow/DesignerGraph.tsx`: idle/pending edge stroke and React Flow `<Background>` grid bumped from `#27272a` (border token) to `#3f3f46` so edges and canvas dots are perceptible. Active edge colors (success `#10b981`, failed `#f43f5e`) untouched.
- `playground/ReasoningWaterfall.tsx`: Input/Output code blocks switched from `text-text-muted/70` (~2:1) to `text-text-secondary` so expanded tool-call payloads are readable.

## Testing

Manual visual check:
1. `cd web && npm run dev`
2. MCP server detail → **Metrics** tab — confirm Y-axis (`120k / 60k / 0`) and X-axis time labels are legible.
3. Hover over the chart — confirm the vertical cursor line is visible.
4. Open the detached metrics window — confirm same legibility.
5. Workflow / designer page with multi-node graph — confirm idle edges between nodes and canvas grid dots are perceptible.
6. Playground reasoning waterfall — expand a tool-call row and confirm Input/Output JSON is readable.

Automated:
- `npm run build` passes
- `npm run test` passes (463 tests, 36 files)
- `npm run lint` has 38 pre-existing errors on `main` (React hooks violations in `DetachedWorkflowPage.tsx` etc.) — none in files touched by this PR

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #519