### PR TITLE
fix: wire compare-to-running button to diff modal

### DIFF
--- a/web/src/__tests__/SpecComponents.test.tsx
+++ b/web/src/__tests__/SpecComponents.test.tsx
@@ -18,6 +18,7 @@ describe('useSpecStore', () => {
       plan: null,
       compareActive: false,
       diffModalOpen: false,
+      diffModalMode: 'apply',
       pendingSpec: null,
     });
   });
@@ -111,6 +112,7 @@ describe('useSpecStore', () => {
     useSpecStore.getState().openDiffModal('name: updated');
     expect(useSpecStore.getState().diffModalOpen).toBe(true);
     expect(useSpecStore.getState().pendingSpec).toBe('name: updated');
+    expect(useSpecStore.getState().diffModalMode).toBe('apply');
   });
 
   it('closes diff modal and clears pending spec', () => {
@@ -118,6 +120,20 @@ describe('useSpecStore', () => {
     useSpecStore.getState().closeDiffModal();
     expect(useSpecStore.getState().diffModalOpen).toBe(false);
     expect(useSpecStore.getState().pendingSpec).toBeNull();
+  });
+
+  it('opens compare modal in compare mode without pending spec', () => {
+    useSpecStore.getState().openCompareModal();
+    expect(useSpecStore.getState().diffModalOpen).toBe(true);
+    expect(useSpecStore.getState().diffModalMode).toBe('compare');
+    expect(useSpecStore.getState().pendingSpec).toBeNull();
+  });
+
+  it('resets diffModalMode to apply when modal is closed', () => {
+    useSpecStore.getState().openCompareModal();
+    expect(useSpecStore.getState().diffModalMode).toBe('compare');
+    useSpecStore.getState().closeDiffModal();
+    expect(useSpecStore.getState().diffModalMode).toBe('apply');
   });
 });
 
@@ -162,6 +178,7 @@ describe('SpecHealthBadge', () => {
       plan: null,
       compareActive: false,
       diffModalOpen: false,
+      diffModalMode: 'apply',
       pendingSpec: null,
     });
   });
@@ -230,6 +247,7 @@ describe('SpecDiffModal', () => {
       spec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "1"' },
       appliedSpec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "1"' },
       diffModalOpen: false,
+      diffModalMode: 'apply',
       pendingSpec: null,
       health: null,
       specLoading: false,
@@ -320,5 +338,112 @@ describe('SpecDiffModal', () => {
     expect(screen.getByText('Validation errors in new spec')).toBeInTheDocument();
     expect(screen.getByText('servers: at least one server required')).toBeInTheDocument();
     expect(screen.getByText('name: invalid format')).toBeInTheDocument();
+  });
+
+  it('renders compare-mode title and hides Apply button', () => {
+    useSpecStore.setState({
+      diffModalOpen: true,
+      diffModalMode: 'compare',
+      spec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "2"' },
+      appliedSpec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "1"' },
+    });
+    const onApply = vi.fn();
+    render(<SpecDiffModal onApply={onApply} />);
+    expect(screen.getByText('Compare to Running')).toBeInTheDocument();
+    expect(screen.queryByText('Apply Changes')).not.toBeInTheDocument();
+    expect(screen.getByText('Close')).toBeInTheDocument();
+  });
+
+  it('renders no-drift empty state in compare mode when specs match', () => {
+    useSpecStore.setState({
+      diffModalOpen: true,
+      diffModalMode: 'compare',
+      spec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "1"' },
+      appliedSpec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "1"' },
+    });
+    const onApply = vi.fn();
+    render(<SpecDiffModal onApply={onApply} />);
+    expect(
+      screen.getByText('No drift — on-disk spec matches the running gateway.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Apply Changes')).not.toBeInTheDocument();
+  });
+
+  it('renders diff content in compare mode when specs differ', () => {
+    useSpecStore.setState({
+      diffModalOpen: true,
+      diffModalMode: 'compare',
+      spec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "2"' },
+      appliedSpec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "1"' },
+    });
+    const onApply = vi.fn();
+    render(<SpecDiffModal onApply={onApply} />);
+    // Modal renders via createPortal — query the document root
+    expect(document.querySelector('.text-status-running')).not.toBeNull();
+    expect(document.querySelector('.line-through')).not.toBeNull();
+  });
+
+  it('renders missing-baseline state when appliedSpec is null in compare mode', () => {
+    useSpecStore.setState({
+      diffModalOpen: true,
+      diffModalMode: 'compare',
+      spec: { path: '/tmp/stack.yaml', content: 'name: test' },
+      appliedSpec: null,
+    });
+    const onApply = vi.fn();
+    render(<SpecDiffModal onApply={onApply} />);
+    expect(
+      screen.getByText('Waiting for the gateway baseline — reload once to capture it.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('No drift — on-disk spec matches the running gateway.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides validation errors block in compare mode', () => {
+    useSpecStore.setState({
+      diffModalOpen: true,
+      diffModalMode: 'compare',
+      spec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "2"' },
+      appliedSpec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "1"' },
+    });
+    const onApply = vi.fn();
+    render(
+      <SpecDiffModal
+        onApply={onApply}
+        validationErrors={['this should not appear']}
+      />,
+    );
+    expect(screen.queryByText('Validation errors in new spec')).not.toBeInTheDocument();
+    expect(screen.queryByText('this should not appear')).not.toBeInTheDocument();
+  });
+});
+
+// --- SpecTab tests ---
+
+import { SpecTab } from '../components/spec/SpecTab';
+
+describe('SpecTab', () => {
+  beforeEach(() => {
+    useSpecStore.setState({
+      spec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "1"' },
+      appliedSpec: { path: '/tmp/stack.yaml', content: 'name: test\nversion: "1"' },
+      diffModalOpen: false,
+      diffModalMode: 'apply',
+      pendingSpec: null,
+      health: null,
+      specLoading: false,
+      specError: null,
+      validation: { valid: true, errorCount: 0, warningCount: 0, issues: [] },
+      plan: null,
+      compareActive: false,
+    });
+  });
+
+  it('opens compare modal when "Compare to running" is clicked', () => {
+    render(<SpecTab />);
+    fireEvent.click(screen.getByText('Compare to running'));
+    expect(useSpecStore.getState().diffModalOpen).toBe(true);
+    expect(useSpecStore.getState().diffModalMode).toBe('compare');
   });
 });

--- a/web/src/components/spec/SpecDiffModal.tsx
+++ b/web/src/components/spec/SpecDiffModal.tsx
@@ -65,9 +65,13 @@ interface SpecDiffModalProps {
 
 export function SpecDiffModal({ onApply, validationErrors }: SpecDiffModalProps) {
   const diffModalOpen = useSpecStore((s) => s.diffModalOpen);
+  const diffModalMode = useSpecStore((s) => s.diffModalMode);
   const closeDiffModal = useSpecStore((s) => s.closeDiffModal);
   const appliedSpec = useSpecStore((s) => s.appliedSpec);
   const pendingSpec = useSpecStore((s) => s.pendingSpec);
+  const spec = useSpecStore((s) => s.spec);
+
+  const isCompareMode = diffModalMode === 'compare';
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -83,13 +87,16 @@ export function SpecDiffModal({ onApply, validationErrors }: SpecDiffModalProps)
     }
   }, [diffModalOpen, handleKeyDown]);
 
-  const diffLines = useMemo(() => {
-    if (!appliedSpec || !pendingSpec) return [];
-    return computeLineDiff(appliedSpec.content, pendingSpec);
-  }, [appliedSpec, pendingSpec]);
+  const compareSource = isCompareMode ? spec?.content ?? null : pendingSpec;
 
+  const diffLines = useMemo(() => {
+    if (!appliedSpec || compareSource === null) return [];
+    return computeLineDiff(appliedSpec.content, compareSource);
+  }, [appliedSpec, compareSource]);
+
+  const missingBaseline = isCompareMode && !appliedSpec;
   const hasChanges = diffLines.some((l) => l.type !== 'context');
-  const hasErrors = validationErrors && validationErrors.length > 0;
+  const hasErrors = !isCompareMode && validationErrors && validationErrors.length > 0;
 
   const addedCount = diffLines.filter((l) => l.type === 'added').length;
   const removedCount = diffLines.filter((l) => l.type === 'removed').length;
@@ -102,7 +109,9 @@ export function SpecDiffModal({ onApply, validationErrors }: SpecDiffModalProps)
       {/* Header — pinned */}
       <div className="flex-shrink-0 flex items-center justify-between px-6 py-3 border-b border-border/50 bg-surface-elevated">
         <div className="flex items-center gap-4">
-          <h2 className="text-sm font-semibold text-text-primary">Configuration Changed</h2>
+          <h2 className="text-sm font-semibold text-text-primary">
+            {isCompareMode ? 'Compare to Running' : 'Configuration Changed'}
+          </h2>
           {hasChanges && (
             <div className="flex items-center gap-3 text-xs">
               <span className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-status-running/10 text-status-running">
@@ -130,9 +139,15 @@ export function SpecDiffModal({ onApply, validationErrors }: SpecDiffModalProps)
 
       {/* Diff body — scrollable, takes all remaining space */}
       <div className="flex-1 min-h-0 overflow-auto scrollbar-dark">
-        {!hasChanges ? (
+        {missingBaseline ? (
           <div className="flex items-center justify-center h-full text-text-muted text-sm">
-            No changes detected
+            Waiting for the gateway baseline — reload once to capture it.
+          </div>
+        ) : !hasChanges ? (
+          <div className="flex items-center justify-center h-full text-text-muted text-sm">
+            {isCompareMode
+              ? 'No drift — on-disk spec matches the running gateway.'
+              : 'No changes detected'}
           </div>
         ) : (
           <table className="w-full font-mono text-xs border-collapse">
@@ -204,18 +219,20 @@ export function SpecDiffModal({ onApply, validationErrors }: SpecDiffModalProps)
 
         <div className="flex items-center justify-end gap-3">
           <Button variant="secondary" onClick={closeDiffModal}>
-            Cancel
+            {isCompareMode ? 'Close' : 'Cancel'}
           </Button>
-          <Button
-            variant="primary"
-            onClick={() => {
-              onApply();
-              closeDiffModal();
-            }}
-            disabled={!!hasErrors}
-          >
-            Apply Changes
-          </Button>
+          {!isCompareMode && (
+            <Button
+              variant="primary"
+              onClick={() => {
+                onApply();
+                closeDiffModal();
+              }}
+              disabled={!!hasErrors}
+            >
+              Apply Changes
+            </Button>
+          )}
         </div>
       </div>
     </div>,

--- a/web/src/components/spec/SpecTab.tsx
+++ b/web/src/components/spec/SpecTab.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useCallback, useRef } from 'react';
 import { GitCompareArrows, AlertCircle, CheckCircle2, AlertTriangle, RefreshCw } from 'lucide-react';
-import { cn } from '../../lib/cn';
 import { useSpecStore } from '../../stores/useSpecStore';
-import { fetchStackSpec, fetchStackHealth, fetchStackPlan, validateStackSpec } from '../../lib/api';
-import type { ValidationIssue, DiffItem, IssueSeverity } from '../../types';
+import { fetchStackSpec, fetchStackHealth, validateStackSpec } from '../../lib/api';
+import type { ValidationIssue, IssueSeverity } from '../../types';
 
 // YAML syntax highlighting tokens
 interface HighlightedToken {
@@ -85,28 +84,12 @@ function getLineIssues(lineNum: number, issues: ValidationIssue[]): ValidationIs
   });
 }
 
-function getDriftForLine(lineNum: number, content: string, plan: DiffItem[] | null): 'added' | 'removed' | 'changed' | null {
-  if (!plan || plan.length === 0) return null;
-  const line = content.split('\n')[lineNum - 1] ?? '';
-  const trimmed = line.trimStart();
-
-  for (const item of plan) {
-    // Check if line references a changed item by name
-    if (trimmed.includes(item.name)) {
-      return item.action === 'add' ? 'added' : item.action === 'remove' ? 'removed' : 'changed';
-    }
-  }
-  return null;
-}
-
 export function SpecTab() {
   const spec = useSpecStore((s) => s.spec);
   const specLoading = useSpecStore((s) => s.specLoading);
   const specError = useSpecStore((s) => s.specError);
   const validation = useSpecStore((s) => s.validation);
-  const plan = useSpecStore((s) => s.plan);
-  const compareActive = useSpecStore((s) => s.compareActive);
-  const toggleCompare = useSpecStore((s) => s.toggleCompare);
+  const openCompareModal = useSpecStore((s) => s.openCompareModal);
   const pollRef = useRef<ReturnType<typeof setInterval>>(null);
 
   const loadSpec = useCallback(async () => {
@@ -120,15 +103,8 @@ export function SpecTab() {
       store.setSpec(specData);
       store.setHealth(healthData);
 
-      // Run validation on spec content
       const validationResult = await validateStackSpec(specData.content);
       store.setValidation(validationResult);
-
-      // Load plan if compare is active
-      if (store.compareActive) {
-        const planData = await fetchStackPlan();
-        store.setPlan(planData);
-      }
     } catch (err) {
       store.setSpecError(err instanceof Error ? err.message : 'Failed to load spec');
     } finally {
@@ -138,19 +114,11 @@ export function SpecTab() {
 
   useEffect(() => {
     loadSpec();
-    // Poll every 10s
     pollRef.current = setInterval(loadSpec, 10000);
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
     };
   }, [loadSpec]);
-
-  // Load plan when compare mode is toggled on
-  useEffect(() => {
-    if (compareActive && spec) {
-      fetchStackPlan().then((p) => useSpecStore.getState().setPlan(p)).catch(() => {});
-    }
-  }, [compareActive, spec]);
 
   if (specLoading && !spec) {
     return (
@@ -215,13 +183,8 @@ export function SpecTab() {
         </div>
 
         <button
-          onClick={toggleCompare}
-          className={cn(
-            'flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium transition-all duration-200',
-            compareActive
-              ? 'bg-primary/15 text-primary border border-primary/30'
-              : 'text-text-muted hover:text-text-secondary hover:bg-surface-highlight/40'
-          )}
+          onClick={openCompareModal}
+          className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium transition-all duration-200 text-text-muted hover:text-text-secondary hover:bg-surface-highlight/40"
         >
           <GitCompareArrows size={12} />
           Compare to running
@@ -235,7 +198,6 @@ export function SpecTab() {
             {lines.map((line, idx) => {
               const lineNum = idx + 1;
               const lineIssues = getLineIssues(lineNum, issues);
-              const drift = compareActive ? getDriftForLine(lineNum, spec.content, plan?.items ?? null) : null;
               const highestSeverity = lineIssues.length > 0
                 ? lineIssues.some((i) => i.severity === 'error') ? 'error'
                   : lineIssues.some((i) => i.severity === 'warning') ? 'warning'
@@ -245,12 +207,7 @@ export function SpecTab() {
               return (
                 <tr
                   key={lineNum}
-                  className={cn(
-                    'group',
-                    drift === 'changed' && 'bg-primary/[0.06]',
-                    drift === 'added' && 'border-l-2 border-l-status-running bg-status-running/[0.04]',
-                    drift === 'removed' && 'line-through opacity-50',
-                  )}
+                  className="group"
                 >
                   {/* Line number */}
                   <td className="w-12 pr-3 text-right text-text-muted/40 select-none align-top py-px">

--- a/web/src/stores/useSpecStore.ts
+++ b/web/src/stores/useSpecStore.ts
@@ -30,6 +30,7 @@ interface SpecState {
 
   // Diff modal
   diffModalOpen: boolean;
+  diffModalMode: 'apply' | 'compare';
   pendingSpec: string | null;
 
   // Actions
@@ -43,6 +44,7 @@ interface SpecState {
   toggleCompare: () => void;
   setCompareActive: (active: boolean) => void;
   openDiffModal: (pendingSpec: string) => void;
+  openCompareModal: () => void;
   closeDiffModal: () => void;
 }
 
@@ -57,6 +59,7 @@ export const useSpecStore = create<SpecState>()(
     plan: null,
     compareActive: false,
     diffModalOpen: false,
+    diffModalMode: 'apply',
     pendingSpec: null,
 
     setSpec: (spec) => set((s) => ({
@@ -73,8 +76,9 @@ export const useSpecStore = create<SpecState>()(
     setPlan: (plan) => set({ plan }),
     toggleCompare: () => set((s) => ({ compareActive: !s.compareActive })),
     setCompareActive: (compareActive) => set({ compareActive }),
-    openDiffModal: (pendingSpec) => set({ diffModalOpen: true, pendingSpec }),
-    closeDiffModal: () => set({ diffModalOpen: false, pendingSpec: null }),
+    openDiffModal: (pendingSpec) => set({ diffModalOpen: true, diffModalMode: 'apply', pendingSpec }),
+    openCompareModal: () => set({ diffModalOpen: true, diffModalMode: 'compare', pendingSpec: null }),
+    closeDiffModal: () => set({ diffModalOpen: false, diffModalMode: 'apply', pendingSpec: null }),
   }))
 );
 


### PR DESCRIPTION
## Description

The Spec tab's "Compare to running" button only toggled its own active styling — it never opened a diff view. This wires the button to the existing `SpecDiffModal` in a new read-only `compare` mode that diffs the on-disk spec against `appliedSpec` (the gateway's last applied baseline already tracked in the Zustand store).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `diffModalMode: 'apply' | 'compare'` to `useSpecStore` plus an `openCompareModal()` action; `openDiffModal`/`closeDiffModal` set and reset the mode.
- `SpecDiffModal` now reads the mode and renders accordingly: `"Compare to Running"` title, no Apply button, `Close` instead of `Cancel`, and a "No drift" empty state. Apply mode is unchanged.
- Defensive empty state when `appliedSpec` is null in compare mode (avoids a misleading "No drift" message before any reload has captured a baseline).
- Removed dead per-line drift tinting from `SpecTab` (`getDriftForLine` and the substring-based highlight that produced no useful output).
- 8 new tests covering store transitions, compare-mode rendering paths, and the SpecTab button click.

## Testing

```bash
cd web && npm run build && npm test
# 471/471 passing
```

Manual: `make build && ./gridctl up`, open the web UI's Spec tab, click "Compare to running" — modal opens with a unified diff (or the no-drift empty state when on-disk matches the running gateway). Existing reload flow from the header still opens the modal in apply mode with a working Apply button.

## Known Limitations / Follow-ups

- `appliedSpec` is seeded from the first on-disk spec the UI loads. Compare reflects post-reload drift correctly, but on a fresh session before any reload the baseline equals the on-disk file. A follow-up could add `GET /api/stack/spec/running` for a true running-spec endpoint.
- The store fields `compareActive`, `setCompareActive`, `plan`, `setPlan`, `toggleCompare` no longer have any readers. Left in place for this PR; safe to delete in a follow-up cleanup.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #528