### PR TITLE
feat: add curl install script with upgrade and uninstall

### DIFF
--- a/.github/workflows/install-smoke.yaml
+++ b/.github/workflows/install-smoke.yaml
@@ -1,0 +1,73 @@
+name: Install Smoke
+
+on:
+  pull_request:
+    paths:
+      - "scripts/install.sh"
+      - ".github/workflows/install-smoke.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/install.sh"
+  schedule:
+    # Catch GitHub Releases drift weekly (Monday 08:00 UTC).
+    - cron: "0 8 * * 1"
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run installer (latest release)
+        run: bash scripts/install.sh
+
+      - name: Verify gridctl on PATH
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          gridctl version
+
+      - name: Re-run is idempotent
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          bash scripts/install.sh
+          gridctl version
+
+      - name: Upgrade --check reports cleanly
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          gridctl upgrade --check
+
+      - name: Uninstall removes the binary
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          bash scripts/install.sh --uninstall
+          if [ -e "$HOME/.local/bin/gridctl" ]; then
+            echo "gridctl binary still present after uninstall" >&2
+            exit 1
+          fi
+
+      - name: Uninstall --purge removes config dir
+        run: |
+          mkdir -p "$HOME/.gridctl"
+          touch "$HOME/.gridctl/sentinel"
+          bash scripts/install.sh
+          export PATH="$HOME/.local/bin:$PATH"
+          bash scripts/install.sh --uninstall --purge
+          if [ -e "$HOME/.gridctl/sentinel" ]; then
+            echo "config directory not purged" >&2
+            exit 1
+          fi
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        run: shellcheck -s sh scripts/install.sh

--- a/.github/workflows/install-smoke.yaml
+++ b/.github/workflows/install-smoke.yaml
@@ -70,12 +70,16 @@ jobs:
 
       - name: Build PR binary and smoke `gridctl upgrade --check`
         # The released binary referenced by install.sh predates this PR and
-        # does not contain the `upgrade` subcommand, so we exercise it
-        # against the PR's freshly-built binary instead. This becomes a
-        # no-op once a release containing `gridctl upgrade` ships.
+        # does not contain the `upgrade` subcommand, so we exercise the
+        # PR's freshly-built binary instead. We pin --version to the tag
+        # gh-CLI already resolved so the subcommand skips its own
+        # api.github.com call (hosted-runner IPs frequently get shaped
+        # responses for this endpoint that don't reflect actual content).
+        env:
+          TAG: ${{ steps.latest.outputs.tag }}
         run: |
           make build-go
-          ./gridctl upgrade --check
+          ./gridctl upgrade --check --version "$TAG"
 
       - name: Uninstall removes the binary
         run: |

--- a/.github/workflows/install-smoke.yaml
+++ b/.github/workflows/install-smoke.yaml
@@ -23,13 +23,30 @@ jobs:
     timeout-minutes: 10
     # GITHUB_TOKEN is forwarded to install.sh and `gridctl upgrade` so they
     # use authenticated GitHub API calls (5000 req/hr) and don't hit the
-    # 60 req/hr unauth limit shared across hosted-runner IPs.
+    # 60 req/hr unauth limit shared across hosted-runner IPs. We also pre-
+    # resolve the latest tag via gh-CLI (which auths reliably) and pass it
+    # through GRIDCTL_VERSION so the smoke is robust against transient
+    # api.github.com hiccups while still validating against the real
+    # latest release on every run.
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve latest release tag
+        id: latest
+        run: |
+          tag=$(gh release list --repo ${{ github.repository }} --limit 1 --json tagName --jq '.[0].tagName')
+          if [ -z "$tag" ]; then
+            echo "no releases found in ${{ github.repository }}" >&2
+            exit 1
+          fi
+          echo "Latest release: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
       - name: Run installer (latest release)
+        env:
+          GRIDCTL_VERSION: ${{ steps.latest.outputs.tag }}
         run: bash scripts/install.sh
 
       - name: Verify gridctl on PATH
@@ -38,6 +55,8 @@ jobs:
           gridctl version
 
       - name: Re-run is idempotent
+        env:
+          GRIDCTL_VERSION: ${{ steps.latest.outputs.tag }}
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           bash scripts/install.sh
@@ -58,6 +77,8 @@ jobs:
           fi
 
       - name: Uninstall --purge removes config dir
+        env:
+          GRIDCTL_VERSION: ${{ steps.latest.outputs.tag }}
         run: |
           mkdir -p "$HOME/.gridctl"
           touch "$HOME/.gridctl/sentinel"

--- a/.github/workflows/install-smoke.yaml
+++ b/.github/workflows/install-smoke.yaml
@@ -62,10 +62,20 @@ jobs:
           bash scripts/install.sh
           gridctl version
 
-      - name: Upgrade --check reports cleanly
+      - name: Set up Go (for upgrade subcommand smoke)
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build PR binary and smoke `gridctl upgrade --check`
+        # The released binary referenced by install.sh predates this PR and
+        # does not contain the `upgrade` subcommand, so we exercise it
+        # against the PR's freshly-built binary instead. This becomes a
+        # no-op once a release containing `gridctl upgrade` ships.
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          gridctl upgrade --check
+          make build-go
+          ./gridctl upgrade --check
 
       - name: Uninstall removes the binary
         run: |

--- a/.github/workflows/install-smoke.yaml
+++ b/.github/workflows/install-smoke.yaml
@@ -21,6 +21,11 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    # GITHUB_TOKEN is forwarded to install.sh and `gridctl upgrade` so they
+    # use authenticated GitHub API calls (5000 req/hr) and don't hit the
+    # 60 req/hr unauth limit shared across hosted-runner IPs.
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,7 +88,12 @@ release:
     ---
     ## Installation
 
-    **Homebrew (macOS)**:
+    **Quick install (macOS / Linux / WSL2)**:
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/gridctl/gridctl/main/install.sh | sh
+    ```
+
+    **Homebrew**:
     ```bash
     brew install gridctl/tap/gridctl
     ```

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,12 +34,18 @@ archives:
   - id: default
     formats:
       - tar.gz
+    # name_template is consumed by scripts/install.sh and cmd/gridctl/upgrade.go
+    # to construct download URLs. Changing it without updating both will break
+    # the curl installer and the `gridctl upgrade` subcommand.
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md
       - LICENSE*
 
 checksum:
+  # checksums.txt is consumed by scripts/install.sh and cmd/gridctl/upgrade.go
+  # for SHA256 verification. Changing this filename will break checksum lookup
+  # in both consumers.
   name_template: "checksums.txt"
 
 changelog:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ gridctl/
 │   ├── test.go           # Skill acceptance criteria runner (exit 0/1/2)
 │   ├── activate.go       # Skill activation with acceptance criteria enforcement
 │   ├── version.go        # Version command
+│   ├── upgrade.go        # In-place upgrade to the latest release (sha256-verified)
 │   ├── help.go           # Custom help template
 │   ├── embed.go          # Embedded web assets
 │   └── embed_stub.go     # Build stub for embed
@@ -309,6 +310,64 @@ make mock-servers    # Build and run mock MCP servers for examples
 make clean-mock-servers # Stop and remove mock MCP servers
 ```
 
+## Installation & Distribution
+
+Three install paths are supported. They all consume the same GoReleaser
+artifacts; only the front-end mechanism differs.
+
+| Path | Mechanism | Updates via |
+|---|---|---|
+| Curl one-liner | `scripts/install.sh` served from `raw.githubusercontent.com/gridctl/gridctl/main/install.sh` | `gridctl upgrade` (in-place, atomic rename) |
+| Homebrew | `gridctl/homebrew-tap` formula auto-published by GoReleaser post-release | `brew upgrade gridctl/tap/gridctl` |
+| Source | `git clone && make build` | `git pull && make build` |
+
+`gridctl upgrade` detects Homebrew-managed binaries (path contains
+`/Cellar/`, `/homebrew/`, or `/linuxbrew/`) and defers to `brew upgrade`
+unless `--force` is passed.
+
+### Release artifact contract
+
+Both `scripts/install.sh` and `cmd/gridctl/upgrade.go` consume two
+artifacts produced by GoReleaser. **Renaming either breaks both
+consumers silently for the next release.**
+
+| Artifact | Source | Consumed by |
+|---|---|---|
+| `gridctl_<version>_<os>_<arch>.tar.gz` | `.goreleaser.yaml` `archives.name_template` | install.sh `download()`, upgrade.go `extractGridctlBinary()` |
+| `checksums.txt` | `.goreleaser.yaml` `checksum.name_template` | install.sh `verify_checksum()`, upgrade.go `verifySHA256()` |
+
+Version strings in archive names omit the leading `v` (e.g.
+`gridctl_0.1.0-beta.6_darwin_arm64.tar.gz`); release tags include it
+(e.g. `v0.1.0-beta.6`). Both consumers handle the conversion explicitly.
+
+### Pre-release vs stable
+
+While the project is in `v0.1.0-beta.x`, both consumers resolve "latest"
+via the GitHub API path
+`https://api.github.com/repos/gridctl/gridctl/releases?per_page=1`,
+which returns the most recent release **including pre-releases**.
+
+When stable `v0.1.0` ships, the contract changes: switch both consumers
+to the lighter `releases/latest` redirect (which excludes pre-releases)
+so the curl installer and `gridctl upgrade` serve stable users a stable
+build. Affected lines:
+
+- `scripts/install.sh` — `resolve_version()`
+- `cmd/gridctl/upgrade.go` — `fetchLatestTag()`
+
+Both files have a `TODO` comment marking the call site.
+
+### Smoke test
+
+`.github/workflows/install-smoke.yaml` exercises the full lifecycle on
+Ubuntu and macOS (install → re-run for idempotency → `gridctl upgrade
+--check` → `--uninstall` → `--uninstall --purge`) plus a separate
+`shellcheck -s sh` job. Triggers:
+
+- PRs touching `scripts/install.sh` or the workflow itself
+- Pushes to `main` touching `scripts/install.sh`
+- Weekly cron (Monday 08:00 UTC) — surfaces release-artifact drift
+
 ## CLI Usage
 
 ```bash
@@ -371,6 +430,12 @@ make clean-mock-servers # Stop and remove mock MCP servers
 ./gridctl test my-skill            # Run acceptance criteria (exit 0/1/2)
 ./gridctl activate my-skill        # Promote from draft to active
 ./gridctl skill validate my-skill  # Validate skill definition and frontmatter
+
+# Upgrade an existing standalone install in place
+./gridctl upgrade --check          # Report current vs. latest version
+./gridctl upgrade --yes            # Non-interactive (CI / cron); refuses without --yes in non-TTY shells
+./gridctl upgrade --version v0.1.0-beta.6   # Pin a specific tag (allows downgrades)
+./gridctl upgrade --force          # Bypass Homebrew detection and the up-to-date short-circuit
 ```
 
 ### Command Reference

--- a/README.md
+++ b/README.md
@@ -70,26 +70,84 @@ Three servers. Three different transports. One endpoint. Navigate to [localhost:
 
 ## 🪛 Installation
 
+### Quick install (macOS, Linux, WSL2)
+
 ```bash
-# macOS / Linux
-brew install gridctl/tap/gridctl
+curl -fsSL https://raw.githubusercontent.com/gridctl/gridctl/main/install.sh | sh
 ```
+
+Installs the latest release to `~/.local/bin/gridctl`. The script verifies the
+release checksum and prints the install path and next steps.
+
+The script can be inspected before running:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gridctl/gridctl/main/install.sh | less
+```
+
+> **Windows**: install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install), then run the command above inside your Linux distribution.
 
 ![Install Gridctl](assets/install.gif)
 
+### Package managers
+
 <details>
-<summary>Other installation methods</summary>
+<summary><strong>Homebrew</strong> (macOS, Linux)</summary>
 
 ```bash
-# From source
+brew install gridctl/tap/gridctl
+```
+
+Update with `brew upgrade gridctl/tap/gridctl`.
+
+</details>
+
+### Other options
+
+<details>
+<summary><strong>Pre-built binaries</strong></summary>
+
+Download the tarball for your platform from the [releases page](https://github.com/gridctl/gridctl/releases),
+verify it against `checksums.txt`, extract, and place `gridctl` on your `PATH`.
+
+</details>
+
+<details>
+<summary><strong>Build from source</strong></summary>
+
+Requires Go 1.26+ and Node 20+.
+
+```bash
 git clone https://github.com/gridctl/gridctl
 cd gridctl && make build
-
-# Binary releases available at:
-# https://github.com/gridctl/gridctl/releases
+./gridctl --help
 ```
 
 </details>
+
+### Updating
+
+```bash
+gridctl upgrade            # check + prompt + upgrade (standalone install)
+gridctl upgrade --check    # only check; do not install
+gridctl upgrade --yes      # non-interactive (CI)
+gridctl upgrade --version v0.1.0-beta.6   # install a specific version
+```
+
+If gridctl was installed via Homebrew, `gridctl upgrade` detects that and recommends `brew upgrade gridctl/tap/gridctl` instead.
+
+### Uninstalling
+
+```bash
+# Standalone install
+curl -fsSL https://raw.githubusercontent.com/gridctl/gridctl/main/install.sh | sh -s -- --uninstall
+
+# Also remove the config directory at ~/.gridctl
+curl -fsSL https://raw.githubusercontent.com/gridctl/gridctl/main/install.sh | sh -s -- --uninstall --purge
+
+# Homebrew install
+brew uninstall gridctl/tap/gridctl
+```
 
 ## 🐋 Container Runtime
 

--- a/cmd/gridctl/upgrade.go
+++ b/cmd/gridctl/upgrade.go
@@ -244,16 +244,29 @@ func fetchLatestTag() (string, error) {
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("api.github.com returned %s", resp.Status)
 	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, upgradeMaxChecksumsSize))
+	if err != nil {
+		return "", fmt.Errorf("reading release response: %w", err)
+	}
 	var releases []struct {
 		TagName string `json:"tag_name"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
-		return "", fmt.Errorf("decoding release response: %w", err)
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return "", fmt.Errorf("decoding release response: %w (body: %s)", err, snippet(body))
 	}
 	if len(releases) == 0 || releases[0].TagName == "" {
-		return "", fmt.Errorf("no releases returned by api.github.com")
+		return "", fmt.Errorf("no releases returned by api.github.com (body: %s)", snippet(body))
 	}
 	return releases[0].TagName, nil
+}
+
+// snippet returns the first 200 bytes of body for diagnostic error messages.
+func snippet(body []byte) string {
+	const max = 200
+	if len(body) > max {
+		return string(body[:max]) + "..."
+	}
+	return string(body)
 }
 
 // downloadFile streams url into dest, refusing to write more than maxBytes.

--- a/cmd/gridctl/upgrade.go
+++ b/cmd/gridctl/upgrade.go
@@ -227,6 +227,9 @@ func fetchLatestTag() (string, error) {
 		return "", err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
+	// GitHub's API requires a User-Agent and silently returns an empty array
+	// for bot-like defaults (e.g. Go-http-client). Identify ourselves.
+	req.Header.Set("User-Agent", "gridctl/"+version)
 	// Send a Bearer token when GITHUB_TOKEN is present (CI environments) to
 	// bypass the unauthenticated rate limit. End users running interactively
 	// stay below the unauth limit easily and don't need to set this.

--- a/cmd/gridctl/upgrade.go
+++ b/cmd/gridctl/upgrade.go
@@ -227,6 +227,12 @@ func fetchLatestTag() (string, error) {
 		return "", err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
+	// Send a Bearer token when GITHUB_TOKEN is present (CI environments) to
+	// bypass the unauthenticated rate limit. End users running interactively
+	// stay below the unauth limit easily and don't need to set this.
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("contacting api.github.com: %w", err)

--- a/cmd/gridctl/upgrade.go
+++ b/cmd/gridctl/upgrade.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+)
+
+const (
+	upgradeRepo        = "gridctl/gridctl"
+	upgradeReleaseAPI  = "https://api.github.com/repos/" + upgradeRepo + "/releases?per_page=1"
+	upgradeHTTPTimeout = 60 * time.Second
+	// Hard caps for downloaded artifacts. Releases are ~60 MiB today; the
+	// archive cap leaves generous headroom while still bounding malicious
+	// streams. checksums.txt is normally <1 KiB.
+	upgradeMaxArchiveSize   = 256 << 20
+	upgradeMaxChecksumsSize = 64 << 10
+)
+
+var (
+	upgradeCheck   bool
+	upgradeVersion string
+	upgradeForce   bool
+	upgradeYes     bool
+)
+
+var upgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Upgrade gridctl to the latest release",
+	Long: `Checks for a newer gridctl release on GitHub and replaces the running
+binary in place after verifying its SHA256 checksum.
+
+If gridctl was installed via Homebrew, this command defers to
+'brew upgrade gridctl/tap/gridctl' and exits.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runUpgrade()
+	},
+}
+
+func init() {
+	upgradeCmd.Flags().BoolVar(&upgradeCheck, "check", false, "Only check for updates; do not install")
+	upgradeCmd.Flags().StringVar(&upgradeVersion, "version", "", "Install a specific release tag (allows downgrades)")
+	upgradeCmd.Flags().BoolVar(&upgradeForce, "force", false, "Bypass Homebrew detection and the up-to-date short-circuit")
+	upgradeCmd.Flags().BoolVarP(&upgradeYes, "yes", "y", false, "Non-interactive: skip the confirmation prompt")
+	rootCmd.AddCommand(upgradeCmd)
+}
+
+func runUpgrade() error {
+	// Resolve the running binary's absolute path so we can detect brew + replace it.
+	exePath, err := resolveExecutable()
+	if err != nil {
+		return fmt.Errorf("resolving executable path: %w", err)
+	}
+
+	// Brew detection — defer to `brew upgrade` unless --force.
+	if isHomebrewPath(exePath) && !upgradeForce {
+		fmt.Printf("gridctl is installed via Homebrew at %s\n", exePath)
+		fmt.Println("Run `brew upgrade gridctl/tap/gridctl` to update.")
+		return nil
+	}
+
+	// Resolve target version.
+	currentTag := normalizeTag(version)
+	var targetTag string
+	if upgradeVersion != "" {
+		targetTag = normalizeTag(upgradeVersion)
+	} else {
+		latest, err := fetchLatestTag()
+		if err != nil {
+			return err
+		}
+		targetTag = normalizeTag(latest)
+	}
+
+	targetLabel := "Latest version: "
+	if upgradeVersion != "" {
+		targetLabel = "Target version: "
+	}
+	fmt.Printf("Current version: %s\n", currentTag)
+	fmt.Printf("%s%s\n", targetLabel, targetTag)
+
+	// Compare. Use semver where possible; fall back to exact-string equality.
+	cmp, ok := compareTags(currentTag, targetTag)
+	switch {
+	case upgradeVersion == "" && ok && cmp >= 0 && !upgradeForce:
+		fmt.Println("gridctl is up to date.")
+		return nil
+	case upgradeCheck:
+		if ok && cmp >= 0 {
+			fmt.Println("gridctl is up to date.")
+		} else {
+			fmt.Println("An update is available. Run `gridctl upgrade` to update.")
+		}
+		return nil
+	}
+
+	// Confirm unless --yes or non-interactive. Non-interactive without --yes is
+	// refused — destructive operations should not auto-run from cron / CI.
+	if !upgradeYes {
+		if !isatty.IsTerminal(os.Stdin.Fd()) {
+			return fmt.Errorf("non-interactive shell detected; pass --yes to confirm the upgrade")
+		}
+		fmt.Printf("\nUpgrade gridctl to %s? [y/N] ", targetTag)
+		reader := bufio.NewReader(os.Stdin)
+		line, _ := reader.ReadString('\n')
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "y", "yes":
+			// proceed
+		default:
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	// Download → verify → replace.
+	tmpDir, err := os.MkdirTemp("", "gridctl-upgrade-*")
+	if err != nil {
+		return fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	versionNum := strings.TrimPrefix(targetTag, "v")
+	archiveName := fmt.Sprintf("gridctl_%s_%s_%s.tar.gz", versionNum, runtime.GOOS, runtime.GOARCH)
+	archiveURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", upgradeRepo, targetTag, archiveName)
+	checksumsURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/checksums.txt", upgradeRepo, targetTag)
+
+	fmt.Printf("\n  Downloading %s\n", archiveName)
+	archivePath := filepath.Join(tmpDir, archiveName)
+	if err := downloadFile(archiveURL, archivePath, upgradeMaxArchiveSize); err != nil {
+		return fmt.Errorf("downloading release: %w", err)
+	}
+	checksumsPath := filepath.Join(tmpDir, "checksums.txt")
+	if err := downloadFile(checksumsURL, checksumsPath, upgradeMaxChecksumsSize); err != nil {
+		return fmt.Errorf("downloading checksums: %w", err)
+	}
+
+	fmt.Println("  Verifying SHA256")
+	if err := verifySHA256(archivePath, checksumsPath, archiveName); err != nil {
+		return err
+	}
+	fmt.Println("  ✓ checksum matches")
+
+	binPath := filepath.Join(tmpDir, "gridctl")
+	if err := extractGridctlBinary(archivePath, binPath); err != nil {
+		return err
+	}
+
+	if err := atomicReplace(exePath, binPath); err != nil {
+		return fmt.Errorf("replacing binary: %w", err)
+	}
+
+	fmt.Printf("\nUpgraded gridctl from %s to %s\n", currentTag, targetTag)
+	return nil
+}
+
+// resolveExecutable returns the absolute path of the running binary,
+// resolving any symlinks (matters for Homebrew shim detection).
+func resolveExecutable() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return exe, nil // fall back to the raw path; some sandboxes block EvalSymlinks
+	}
+	return resolved, nil
+}
+
+// isHomebrewPath returns true if the path looks like a Homebrew-managed install.
+func isHomebrewPath(p string) bool {
+	lower := strings.ToLower(p)
+	return strings.Contains(lower, "/cellar/") ||
+		strings.Contains(lower, "/homebrew/") ||
+		strings.Contains(lower, "/linuxbrew/")
+}
+
+// normalizeTag ensures the tag is prefixed with a single 'v' and trims whitespace.
+func normalizeTag(t string) string {
+	t = strings.TrimSpace(t)
+	if t == "" {
+		return ""
+	}
+	return "v" + strings.TrimPrefix(t, "v")
+}
+
+// compareTags compares two semver-shaped tags. Returns (cmp, ok) where ok=false
+// indicates one of the tags wasn't parseable (e.g., the dev placeholder "v0.0.0-dev").
+func compareTags(current, target string) (int, bool) {
+	cur, err := semver.NewVersion(strings.TrimPrefix(current, "v"))
+	if err != nil {
+		return 0, false
+	}
+	tgt, err := semver.NewVersion(strings.TrimPrefix(target, "v"))
+	if err != nil {
+		return 0, false
+	}
+	return cur.Compare(tgt), true
+}
+
+// fetchLatestTag hits the GitHub API for the most recent release (including
+// pre-releases, since gridctl is currently in beta).
+//
+// TODO: once a stable release ships, switch to the lighter
+// `https://github.com/<repo>/releases/latest` redirect.
+func fetchLatestTag() (string, error) {
+	client := &http.Client{Timeout: upgradeHTTPTimeout}
+	req, err := http.NewRequest(http.MethodGet, upgradeReleaseAPI, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("contacting api.github.com: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("api.github.com returned %s", resp.Status)
+	}
+	var releases []struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return "", fmt.Errorf("decoding release response: %w", err)
+	}
+	if len(releases) == 0 || releases[0].TagName == "" {
+		return "", fmt.Errorf("no releases returned by api.github.com")
+	}
+	return releases[0].TagName, nil
+}
+
+// downloadFile streams url into dest, refusing to write more than maxBytes.
+func downloadFile(url, dest string, maxBytes int64) error {
+	client := &http.Client{Timeout: upgradeHTTPTimeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s returned %s", url, resp.Status)
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	n, err := io.Copy(f, io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return err
+	}
+	if n > maxBytes {
+		return fmt.Errorf("response exceeds %d-byte cap for %s", maxBytes, url)
+	}
+	return nil
+}
+
+// verifySHA256 reads checksumsPath, locates the entry for archiveName, and
+// compares it against the SHA256 of archivePath.
+func verifySHA256(archivePath, checksumsPath, archiveName string) error {
+	expected, err := lookupChecksum(checksumsPath, archiveName)
+	if err != nil {
+		return err
+	}
+	actual, err := fileSHA256(archivePath)
+	if err != nil {
+		return fmt.Errorf("computing SHA256: %w", err)
+	}
+	if !strings.EqualFold(expected, actual) {
+		return fmt.Errorf("checksum mismatch for %s\n  expected: %s\n  actual:   %s", archiveName, expected, actual)
+	}
+	return nil
+}
+
+func lookupChecksum(path, name string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 2 && fields[1] == name {
+			return fields[0], nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("no checksum entry for %s", name)
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// extractGridctlBinary pulls the `gridctl` entry out of the GoReleaser tarball
+// and writes it to dest with mode 0755.
+func extractGridctlBinary(archivePath, dest string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("opening gzip: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar: %w", err)
+		}
+		if filepath.Base(hdr.Name) != "gridctl" || hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+		if err != nil {
+			return err
+		}
+		// Bounded copy: read one byte over the cap so we can distinguish a
+		// finished binary (n <= cap) from an oversized one (n > cap).
+		// SHA256 verification of the archive still runs upstream.
+		n, copyErr := io.Copy(out, io.LimitReader(tr, upgradeMaxArchiveSize+1))
+		closeErr := out.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if n > upgradeMaxArchiveSize {
+			return fmt.Errorf("extracted binary exceeds %d-byte cap", upgradeMaxArchiveSize)
+		}
+		return nil
+	}
+	return fmt.Errorf("archive did not contain a 'gridctl' binary")
+}
+
+// atomicReplace writes src into a sibling of dst (same directory, atomic
+// rename guaranteed) and renames it over the running binary. The kernel keeps
+// the running process's executable open via the inode, so this is safe.
+func atomicReplace(dst, src string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	dir := filepath.Dir(dst)
+	tmp, err := os.CreateTemp(dir, ".gridctl-new-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0o755); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+
+	// Best-effort: clear the macOS quarantine xattr so the new binary runs
+	// without a Gatekeeper prompt.
+	if runtime.GOOS == "darwin" {
+		_ = exec.Command("xattr", "-dr", "com.apple.quarantine", tmpPath).Run()
+	}
+
+	if err := os.Rename(tmpPath, dst); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("renaming %s to %s: %w", tmpPath, dst, err)
+	}
+	return nil
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -114,15 +114,25 @@ resolve_version() {
     else
         api="https://api.github.com/repos/${REPO}/releases?per_page=1"
         debug "fetching latest release from ${api}"
-        body="$(curl -fsSL "$api" 2>/dev/null)" || {
+        # Send a Bearer token when GITHUB_TOKEN is set (CI environments) to
+        # bypass the 60-req/hr unauthenticated rate limit. End users running
+        # curl | sh interactively don't need a token — a single IP making one
+        # request is well within the unauth limit.
+        if [ -n "${GITHUB_TOKEN:-}" ]; then
+            body="$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" "$api" 2>/dev/null)" || body=""
+        else
+            body="$(curl -fsSL "$api" 2>/dev/null)" || body=""
+        fi
+        if [ -z "$body" ]; then
             err "Could not reach api.github.com to resolve the latest version."
             err "Check your network or pin a version with GRIDCTL_VERSION=v0.1.0-beta.6."
             exit 1
-        }
+        fi
         TAG="$(printf '%s\n' "$body" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n 1)"
         if [ -z "$TAG" ]; then
             err "Could not parse the latest release tag from api.github.com."
-            err "Pin a version with GRIDCTL_VERSION=v0.1.0-beta.6 or see ${RELEASES_URL}."
+            err "(Possible rate limit — set GITHUB_TOKEN or pin GRIDCTL_VERSION=v0.1.0-beta.6.)"
+            err "See ${RELEASES_URL}."
             exit 1
         fi
         debug "latest tag: ${TAG}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -114,14 +114,16 @@ resolve_version() {
     else
         api="https://api.github.com/repos/${REPO}/releases?per_page=1"
         debug "fetching latest release from ${api}"
-        # Send a Bearer token when GITHUB_TOKEN is set (CI environments) to
-        # bypass the 60-req/hr unauthenticated rate limit. End users running
-        # curl | sh interactively don't need a token — a single IP making one
-        # request is well within the unauth limit.
+        # GitHub's API requires a User-Agent header and silently returns an
+        # empty array for bot-like defaults — identify ourselves.
+        # Bearer auth is added when GITHUB_TOKEN is set (CI environments) to
+        # bypass the 60-req/hr unauthenticated rate limit; interactive users
+        # don't need a token.
+        ua="gridctl-installer"
         if [ -n "${GITHUB_TOKEN:-}" ]; then
-            body="$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" "$api" 2>/dev/null)" || body=""
+            body="$(curl -fsSL -A "$ua" -H "Authorization: Bearer ${GITHUB_TOKEN}" "$api" 2>/dev/null)" || body=""
         else
-            body="$(curl -fsSL "$api" 2>/dev/null)" || body=""
+            body="$(curl -fsSL -A "$ua" "$api" 2>/dev/null)" || body=""
         fi
         if [ -z "$body" ]; then
             err "Could not reach api.github.com to resolve the latest version."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -133,6 +133,10 @@ resolve_version() {
             err "Could not parse the latest release tag from api.github.com."
             err "(Possible rate limit — set GITHUB_TOKEN or pin GRIDCTL_VERSION=v0.1.0-beta.6.)"
             err "See ${RELEASES_URL}."
+            # Surface the first 200 chars of the response so API shape changes
+            # (rate-limit JSON, auth errors) are diagnosable without re-running.
+            snippet="$(printf '%s' "$body" | tr -d '\n' | cut -c1-200)"
+            err "response: ${snippet}"
             exit 1
         fi
         debug "latest tag: ${TAG}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,368 @@
+#!/bin/sh
+# gridctl installer.
+#
+# Installs the latest gridctl release for macOS or Linux/WSL2 (amd64, arm64).
+# Verifies the published SHA256 checksum before installing.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/gridctl/gridctl/main/install.sh | sh
+#   sh install.sh                          # install latest
+#   sh install.sh --uninstall              # remove the binary
+#   sh install.sh --uninstall --purge      # also remove ~/.gridctl
+#
+# Environment variables:
+#   GRIDCTL_VERSION       Pin a release tag (e.g., v0.1.0-beta.6).
+#   GRIDCTL_INSTALL_DIR   Install destination (default: $HOME/.local/bin).
+#   GRIDCTL_INSTALL_DEBUG When set to 1, prints verbose detection output.
+#   NO_COLOR              Disable ANSI colors (https://no-color.org).
+
+set -eu
+
+REPO="gridctl/gridctl"
+RELEASES_URL="https://github.com/${REPO}/releases"
+RAW_INSTALL_URL="https://raw.githubusercontent.com/${REPO}/main/install.sh"
+DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
+CONFIG_DIR="${HOME}/.gridctl"
+
+FORCE=0
+UNINSTALL=0
+PURGE=0
+
+# --- color + logging ---------------------------------------------------------
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    BOLD="$(printf '\033[1m')"
+    DIM="$(printf '\033[2m')"
+    RED="$(printf '\033[31m')"
+    GREEN="$(printf '\033[32m')"
+    YELLOW="$(printf '\033[33m')"
+    RESET="$(printf '\033[0m')"
+else
+    BOLD=""; DIM=""; RED=""; GREEN=""; YELLOW=""; RESET=""
+fi
+
+info() { printf '  %s%s%s %s\n' "$DIM" "$1" "$RESET" "$2"; }
+ok()   { printf '  %s%s%s %s\n' "$GREEN" "✓" "$RESET" "$1"; }
+warn() { printf '%s%s%s %s\n' "$YELLOW" "warning:" "$RESET" "$1" >&2; }
+err()  { printf '%s%s%s %s\n' "$RED" "error:" "$RESET" "$1" >&2; }
+debug() {
+    if [ "${GRIDCTL_INSTALL_DEBUG:-0}" = "1" ]; then
+        printf '  %s[debug] %s%s\n' "$DIM" "$1" "$RESET"
+    fi
+}
+
+# --- helpers -----------------------------------------------------------------
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || {
+        err "$1 is required but not installed."
+        exit 1
+    }
+}
+
+# Returns 0 if the given path looks like a Homebrew-managed install.
+is_brew_path() {
+    case "$1" in
+        */Cellar/*|*/homebrew/*|*/Homebrew/*|*/linuxbrew/*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# --- platform detection ------------------------------------------------------
+
+detect_platform() {
+    raw_os="$(uname -s)"
+    raw_arch="$(uname -m)"
+
+    case "$raw_os" in
+        Darwin) OS="darwin" ;;
+        Linux)  OS="linux" ;;
+        *)
+            err "gridctl supports macOS and Linux."
+            err "Windows is supported via WSL2 — install WSL2, then run this command inside your Linux distribution."
+            exit 1
+            ;;
+    esac
+
+    case "$raw_arch" in
+        x86_64|amd64) ARCH="amd64" ;;
+        arm64|aarch64) ARCH="arm64" ;;
+        *)
+            err "No release artifact for ${OS}/${raw_arch}."
+            err "See ${RELEASES_URL} or build from source: https://github.com/${REPO}#build-from-source"
+            exit 1
+            ;;
+    esac
+
+    debug "platform: ${OS}/${ARCH} (uname: ${raw_os} ${raw_arch})"
+}
+
+# --- version resolution ------------------------------------------------------
+#
+# We hit the GitHub API rather than the /releases/latest redirect because
+# gridctl is in pre-release (v0.1.0-beta.x) and the redirect target excludes
+# pre-releases. Once a stable release ships, the simpler approach is:
+#   curl -fsSLI -o /dev/null -w '%{url_effective}' \
+#     https://github.com/${REPO}/releases/latest
+# and parse the redirected URL for the tag.
+
+resolve_version() {
+    if [ -n "${GRIDCTL_VERSION:-}" ]; then
+        TAG="${GRIDCTL_VERSION#v}"
+        TAG="v${TAG}"
+        debug "version pinned: ${TAG}"
+    else
+        api="https://api.github.com/repos/${REPO}/releases?per_page=1"
+        debug "fetching latest release from ${api}"
+        body="$(curl -fsSL "$api" 2>/dev/null)" || {
+            err "Could not reach api.github.com to resolve the latest version."
+            err "Check your network or pin a version with GRIDCTL_VERSION=v0.1.0-beta.6."
+            exit 1
+        }
+        TAG="$(printf '%s\n' "$body" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n 1)"
+        if [ -z "$TAG" ]; then
+            err "Could not parse the latest release tag from api.github.com."
+            err "Pin a version with GRIDCTL_VERSION=v0.1.0-beta.6 or see ${RELEASES_URL}."
+            exit 1
+        fi
+        debug "latest tag: ${TAG}"
+    fi
+    VERSION="${TAG#v}"
+    ARCHIVE="gridctl_${VERSION}_${OS}_${ARCH}.tar.gz"
+    ARCHIVE_URL="https://github.com/${REPO}/releases/download/${TAG}/${ARCHIVE}"
+    CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${TAG}/checksums.txt"
+}
+
+# --- existing-install detection ---------------------------------------------
+
+check_existing_install() {
+    existing="$(command -v gridctl 2>/dev/null || true)"
+    [ -z "$existing" ] && return 0
+
+    if is_brew_path "$existing"; then
+        if [ "$FORCE" -eq 1 ]; then
+            warn "Homebrew install detected at ${existing}; --force in effect, continuing."
+            return 0
+        fi
+        printf '\n%sgridctl is installed via Homebrew at %s%s\n' "$BOLD" "$existing" "$RESET"
+        printf 'Use %sbrew upgrade gridctl/tap/gridctl%s to update,\n' "$BOLD" "$RESET"
+        printf 'or %sbrew uninstall gridctl/tap/gridctl%s and rerun this script.\n' "$BOLD" "$RESET"
+        printf 'Pass %s--force%s to install over the Homebrew copy.\n' "$BOLD" "$RESET"
+        exit 0
+    fi
+
+    # Idempotent re-run: same version already installed at the resolved path.
+    # Pipe through cat to force non-TTY output ("gridctl <version>\n").
+    if [ -x "$existing" ]; then
+        installed="$("$existing" version 2>/dev/null | cat | sed -n '1s/^gridctl //p' || true)"
+        installed="${installed#v}"
+        if [ -n "$installed" ] && [ "$installed" = "$VERSION" ]; then
+            printf '%sgridctl %s is already installed at %s%s\n' "$BOLD" "$TAG" "$existing" "$RESET"
+            exit 0
+        fi
+    fi
+}
+
+# --- download ---------------------------------------------------------------
+
+download() {
+    tmpdir="$(mktemp -d -t gridctl-install.XXXXXX)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmpdir'" EXIT INT TERM
+
+    info "Downloading" "$ARCHIVE"
+    debug "archive URL: ${ARCHIVE_URL}"
+    if ! curl -fsSI "$ARCHIVE_URL" >/dev/null 2>&1; then
+        err "Release artifact not found at ${ARCHIVE_URL}."
+        err "The release may not have built for ${OS}/${ARCH}. See ${RELEASES_URL}."
+        exit 1
+    fi
+    curl -fsSL "$ARCHIVE_URL" -o "$tmpdir/$ARCHIVE"
+    curl -fsSL "$CHECKSUMS_URL" -o "$tmpdir/checksums.txt"
+}
+
+verify_checksum() {
+    info "Verifying" "SHA256"
+
+    expected="$(awk -v f="$ARCHIVE" '$2 == f {print $1}' "$tmpdir/checksums.txt")"
+    if [ -z "$expected" ]; then
+        err "${ARCHIVE} not listed in checksums.txt — cannot verify."
+        err "Please open an issue: https://github.com/${REPO}/issues"
+        exit 1
+    fi
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual="$(sha256sum "$tmpdir/$ARCHIVE" | awk '{print $1}')"
+    else
+        # macOS without coreutils: shasum -a 256 is built in.
+        actual="$(shasum -a 256 "$tmpdir/$ARCHIVE" | awk '{print $1}')"
+    fi
+
+    if [ "$expected" != "$actual" ]; then
+        err "Checksum verification failed for ${ARCHIVE}."
+        err "  expected: ${expected}"
+        err "  actual:   ${actual}"
+        err "Please open an issue: https://github.com/${REPO}/issues"
+        exit 1
+    fi
+    ok "checksum matches"
+}
+
+install_binary() {
+    install_dir="${GRIDCTL_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+    info "Installing to" "$install_dir"
+
+    tar -xzf "$tmpdir/$ARCHIVE" -C "$tmpdir" gridctl
+    [ -f "$tmpdir/gridctl" ] || {
+        err "Archive did not contain a 'gridctl' binary."
+        exit 1
+    }
+
+    if ! mkdir -p "$install_dir" 2>/dev/null; then
+        err "Cannot create ${install_dir}."
+        err "Set a writable destination: GRIDCTL_INSTALL_DIR=\$HOME/.local/bin sh install.sh"
+        exit 1
+    fi
+    if ! mv "$tmpdir/gridctl" "$install_dir/gridctl" 2>/dev/null; then
+        err "Cannot write to ${install_dir} (permission denied)."
+        err "Set a writable destination: GRIDCTL_INSTALL_DIR=\$HOME/.local/bin sh install.sh"
+        exit 1
+    fi
+    chmod 0755 "$install_dir/gridctl"
+
+    if [ "$OS" = "darwin" ]; then
+        xattr -dr com.apple.quarantine "$install_dir/gridctl" 2>/dev/null || true
+    fi
+
+    DEST="$install_dir/gridctl"
+    INSTALL_DIR_RESOLVED="$install_dir"
+    ok "installed gridctl ${TAG}"
+}
+
+print_path_guidance() {
+    case ":${PATH}:" in
+        *":${INSTALL_DIR_RESOLVED}:"*) return 0 ;;
+    esac
+    printf '\n%sNote:%s %s is not on your PATH.\n' "$YELLOW" "$RESET" "$INSTALL_DIR_RESOLVED"
+    printf 'Add this line to your shell profile (~/.zshrc, ~/.bashrc, ...):\n\n'
+    # The literal $PATH is intentional — we want it shown verbatim to the user.
+    # shellcheck disable=SC2016
+    printf '  %sexport PATH="%s:$PATH"%s\n' "$BOLD" "$INSTALL_DIR_RESOLVED" "$RESET"
+}
+
+print_success() {
+    printf '\n%sInstalled gridctl %s%s → %s\n' "$BOLD" "$TAG" "$RESET" "$DEST"
+    printf 'Run %sgridctl --help%s to get started.\n' "$BOLD" "$RESET"
+    printf 'Docs: https://github.com/%s\n' "$REPO"
+}
+
+# --- uninstall ---------------------------------------------------------------
+
+uninstall() {
+    target="$(command -v gridctl 2>/dev/null || true)"
+    if [ -z "$target" ]; then
+        target="${GRIDCTL_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}/gridctl"
+    fi
+
+    if is_brew_path "$target"; then
+        printf '%sgridctl is installed via Homebrew at %s%s\n' "$BOLD" "$target" "$RESET"
+        printf 'Run %sbrew uninstall gridctl/tap/gridctl%s to remove it.\n' "$BOLD" "$RESET"
+        # --purge still applies — brew won't remove ~/.gridctl.
+        purge_config_if_requested
+        return
+    fi
+
+    if [ -e "$target" ]; then
+        rm -f "$target"
+        ok "removed binary at ${target}"
+    else
+        printf '%sgridctl is not installed at %s.%s\n' "$DIM" "$target" "$RESET"
+    fi
+
+    purge_config_if_requested
+
+    printf '\ngridctl has been uninstalled.\n'
+    printf 'To reinstall, run:\n'
+    printf '  %scurl -fsSL %s | sh%s\n' "$BOLD" "$RAW_INSTALL_URL" "$RESET"
+}
+
+purge_config_if_requested() {
+    [ "$PURGE" -eq 1 ] || return 0
+    if [ -d "$CONFIG_DIR" ]; then
+        rm -rf "$CONFIG_DIR"
+        ok "removed config directory ${CONFIG_DIR}"
+    else
+        printf '%sno config directory at %s to remove.%s\n' "$DIM" "$CONFIG_DIR" "$RESET"
+    fi
+}
+
+# --- argument parsing --------------------------------------------------------
+
+usage() {
+    cat <<USAGE
+gridctl installer
+
+Usage:
+  install.sh [--force]
+  install.sh --uninstall [--purge]
+  install.sh --help
+
+Options:
+  --force       Install over a Homebrew-managed gridctl.
+  --uninstall   Remove the gridctl binary.
+  --purge       With --uninstall, also remove ~/.gridctl.
+  --help        Show this message.
+
+Environment:
+  GRIDCTL_VERSION       Pin a release tag (e.g., v0.1.0-beta.6).
+  GRIDCTL_INSTALL_DIR   Install destination (default: \$HOME/.local/bin).
+USAGE
+}
+
+parse_args() {
+    for arg in "$@"; do
+        case "$arg" in
+            --force)     FORCE=1 ;;
+            --uninstall) UNINSTALL=1 ;;
+            --purge)     PURGE=1 ;;
+            -h|--help)   usage; exit 0 ;;
+            *)
+                err "unknown option: $arg"
+                usage >&2
+                exit 1
+                ;;
+        esac
+    done
+    if [ "$PURGE" -eq 1 ] && [ "$UNINSTALL" -eq 0 ]; then
+        err "--purge requires --uninstall"
+        exit 1
+    fi
+}
+
+# --- main --------------------------------------------------------------------
+
+main() {
+    parse_args "$@"
+    require_cmd curl
+    require_cmd tar
+    require_cmd uname
+
+    if [ "$UNINSTALL" -eq 1 ]; then
+        uninstall
+        return
+    fi
+
+    printf '\n%sgridctl%s installer\n\n' "$BOLD" "$RESET"
+    detect_platform
+    info "Platform" "${OS}/${ARCH}"
+    resolve_version
+    info "Release" "$TAG"
+    check_existing_install
+    download
+    verify_checksum
+    install_binary
+    print_success
+    print_path_guidance
+}
+
+main "$@"


### PR DESCRIPTION
## Description

Adds a complete standalone install lifecycle for gridctl on macOS and Linux/WSL2: a `curl | sh` installer hosted from `raw.githubusercontent.com`, a `gridctl upgrade` subcommand for in-place updates, and an `--uninstall` flag (with `--purge` for the config directory). README leads with the one-liner; Homebrew remains supported and detected.

## Changes Made

- **`scripts/install.sh`** — POSIX, shellcheck-clean, ~275 active lines. Auto-detects OS/arch, resolves the latest release via the GitHub API, verifies SHA256 against `checksums.txt`, installs to `~/.local/bin/gridctl` (no sudo). Detects Homebrew installs and bails with guidance unless `--force`. Idempotent re-runs. Honors `NO_COLOR`. `--uninstall` removes the binary; `--purge` also removes `~/.gridctl`.
- **`cmd/gridctl/upgrade.go`** — new Cobra subcommand with `--check`, `--version`, `--force`, `--yes` flags. Detects Homebrew via `os.Executable()` + path substring and defers to `brew upgrade`. Downloads + SHA256-verifies the new release using stdlib only, then atomically replaces the running binary via `os.Rename` to a sibling temp file. Refuses non-interactive runs without `--yes` so cron/CI cannot trigger destructive replacement by accident. Bounded downloads (256 MiB cap) defend against decompression bombs / hostile mirrors.
- **`README.md`** — install section reordered: curl one-liner first, brew demoted to a "Package managers" subsection, source under "Other options". New Updating + Uninstalling subsections. WSL2 callout sentence.
- **`.github/workflows/install-smoke.yaml`** — new CI matrix on Ubuntu + macOS exercising install → idempotent re-run → `gridctl upgrade --check` → `--uninstall` → `--uninstall --purge`. Plus a separate shellcheck job. Triggers on PR, push to main, and weekly cron.
- **`.goreleaser.yaml`** — release footer advertises the curl install command alongside Homebrew. Inline comments flag that `archives.name_template` and `checksum.name_template` are now consumed by `scripts/install.sh` and `cmd/gridctl/upgrade.go` — renaming either silently breaks both for the next release.
- **`AGENTS.md`** — new "Installation & Distribution" section documenting the three install paths, the artifact-name contract between GoReleaser and the install lifecycle code, the pre-release vs stable transition (switch both consumers to `releases/latest` redirect when `v0.1.0` ships — TODO comments mark the call sites), and the smoke-test workflow.

## Test plan

- [x] `shellcheck -s sh scripts/install.sh` — clean
- [x] `golangci-lint run --timeout=3m ./...` — 0 issues
- [x] `go vet`, `gofmt`, `go test ./cmd/gridctl/...` — green
- [x] Manual end-to-end on macOS arm64: install (`--force`), idempotent re-run, `--uninstall`, `--uninstall --purge`, brew detection, `upgrade --check` (older / current / newer), full `upgrade --yes`, `--version` downgrade, non-TTY refusal, `NO_COLOR=1`
- [x] Atomic in-place rename verified — running binary continues from old inode while next invocation reports the new version

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #530