### PR TITLE
fix: thread MCP server source auth through to git clone

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -352,6 +352,47 @@ Build configuration for container images from source code.
 | `ref` | string | No | `"main"` | Git ref — branch, tag, or commit (git sources only) |
 | `path` | string | Conditional | — | Local path (required for `local`, not allowed for `git`). Relative paths are resolved from the stack file |
 | `dockerfile` | string | No | `"Dockerfile"` | Dockerfile path relative to source root |
+| `auth` | object | No | — | Authentication block for private git repositories (see [Source Auth](#source-auth)) |
+
+### Source Auth
+
+Declares how gridctl authenticates when cloning a private git repository at build time. Raw tokens must **never** appear in `stack.yaml` — use `credential_ref` to point at a vault key, which is resolved against the live vault on every clone.
+
+```yaml
+mcp-servers:
+  - name: private-mcp
+    source:
+      type: git
+      url: https://github.com/acme/private-mcp.git
+      ref: main
+      auth:
+        method: token
+        credential_ref: "${vault:GIT_TOKEN}"
+    port: 3000
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `method` | string | **Yes** | — | One of `"token"`, `"ssh-agent"`, `"ssh-key"`, or `"none"` |
+| `credential_ref` | string | Conditional | — | `${vault:KEY}` reference resolved at clone time. Required for `"token"` |
+| `ssh_user` | string | No | `git` | SSH username used with `"ssh-agent"` or `"ssh-key"` |
+| `ssh_key_path` | string | Conditional | — | Path to a private key file. Supports `~` expansion. Required for `"ssh-key"` |
+
+**Method behavior:**
+
+| Method | Transport | Credential source | Persisted |
+|--------|-----------|-------------------|-----------|
+| `token` | HTTPS | `credential_ref` (vault) — resolved on every clone | Reference only |
+| `ssh-agent` | SSH | Ambient `SSH_AUTH_SOCK` | None |
+| `ssh-key` | SSH | `ssh_key_path` on disk | Path only |
+| `none` / omitted | HTTPS or SSH | Unauthenticated clone (public-repo path) | None |
+
+**Security rules:**
+
+- Raw PAT or SSH key material must never appear in `stack.yaml`. `credential_ref` is the only credential field persisted to YAML.
+- The vault is consulted on every clone so rotating a secret takes effect immediately — there is no on-disk caching of the resolved token.
+- Vault references survive `stack.yaml` extends/merges and variable expansion as opaque strings; they are only resolved at apply time inside the orchestrator.
+- The skills registry uses the identical schema for `skills.yaml` source auth — see [Skill Source Auth](#skill-source-auth).
 
 ### SSH
 

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -92,7 +92,7 @@ func (b *Builder) prepareGitSource(opts BuildOptions, logger *slog.Logger) (stri
 		ref = "main"
 	}
 
-	return CloneOrUpdate(opts.URL, ref, logger)
+	return CloneOrUpdate(opts.URL, ref, opts.Auth, logger)
 }
 
 func (b *Builder) prepareLocalSource(opts BuildOptions) (string, error) {

--- a/pkg/builder/git.go
+++ b/pkg/builder/git.go
@@ -6,13 +6,14 @@ import (
 	"os"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 
 	gitpkg "github.com/gridctl/gridctl/pkg/git"
 )
 
 // CloneOrUpdate clones a git repository or updates it if it already exists.
-// Returns the path to the cloned repository.
-func CloneOrUpdate(url, ref string, logger *slog.Logger) (string, error) {
+// Returns the path to the cloned repository. A nil auth means unauthenticated.
+func CloneOrUpdate(url, ref string, auth transport.AuthMethod, logger *slog.Logger) (string, error) {
 	if err := EnsureReposCacheDir(); err != nil {
 		return "", fmt.Errorf("creating cache dir: %w", err)
 	}
@@ -25,17 +26,18 @@ func CloneOrUpdate(url, ref string, logger *slog.Logger) (string, error) {
 	// Check if repo already exists
 	if _, err := os.Stat(repoPath); err == nil {
 		// Repo exists, try to update
-		return updateRepo(repoPath, ref, logger)
+		return updateRepo(repoPath, ref, auth, logger)
 	}
 
 	// Clone the repository
-	return cloneRepo(url, ref, repoPath, logger)
+	return cloneRepo(url, ref, repoPath, auth, logger)
 }
 
-func cloneRepo(url, ref, destPath string, logger *slog.Logger) (string, error) {
+func cloneRepo(url, ref, destPath string, auth transport.AuthMethod, logger *slog.Logger) (string, error) {
 	repo, err := gitpkg.Clone(destPath, gitpkg.CloneOptions{
-		URL: url,
-		Ref: ref,
+		URL:  url,
+		Ref:  ref,
+		Auth: auth,
 	}, logger)
 	if err != nil {
 		return "", fmt.Errorf("cloning repository: %w", err)
@@ -56,7 +58,7 @@ func cloneRepo(url, ref, destPath string, logger *slog.Logger) (string, error) {
 	return destPath, nil
 }
 
-func updateRepo(repoPath, ref string, logger *slog.Logger) (string, error) {
+func updateRepo(repoPath, ref string, auth transport.AuthMethod, logger *slog.Logger) (string, error) {
 	logger.Info("updating cached repository")
 
 	repo, err := gitpkg.Open(repoPath)
@@ -65,7 +67,7 @@ func updateRepo(repoPath, ref string, logger *slog.Logger) (string, error) {
 		return "", fmt.Errorf("opening repository (will need to re-clone): %w", err)
 	}
 
-	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{}, logger); err != nil {
+	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{Auth: auth}, logger); err != nil {
 		logger.Warn("fetch failed, using existing", "error", err)
 	}
 

--- a/pkg/builder/git_test.go
+++ b/pkg/builder/git_test.go
@@ -1,12 +1,20 @@
 package builder
 
 import (
+	"errors"
+	"net/http"
+	"net/http/cgi" //nolint:gosec // G504: CVE-2016-5386 (Httpoxy) fixed in Go 1.6.3; used only against httptest.Server in this test
+	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
+	gohttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/plumbing/object"
+
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
 )
 
 // initBareRepo creates a bare git repo with an initial commit and returns its path.
@@ -60,7 +68,7 @@ func TestCloneRepo(t *testing.T) {
 	destDir := filepath.Join(t.TempDir(), "clone")
 	logger := newTestLogger()
 
-	path, err := cloneRepo(bareRepo, "", destDir, logger)
+	path, err := cloneRepo(bareRepo, "", destDir, nil, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -84,7 +92,7 @@ func TestCloneRepo_WithRef(t *testing.T) {
 	logger := newTestLogger()
 
 	// go-git PlainInit creates "master" as the default branch
-	path, err := cloneRepo(bareRepo, "master", destDir, logger)
+	path, err := cloneRepo(bareRepo, "master", destDir, nil, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -101,7 +109,7 @@ func TestCloneRepo_InvalidURL(t *testing.T) {
 	destDir := filepath.Join(t.TempDir(), "clone")
 	logger := newTestLogger()
 
-	_, err := cloneRepo("/nonexistent/path", "", destDir, logger)
+	_, err := cloneRepo("/nonexistent/path", "", destDir, nil, logger)
 	if err == nil {
 		t.Fatal("expected error for invalid URL")
 	}
@@ -116,12 +124,12 @@ func TestUpdateRepo(t *testing.T) {
 	cloneDir := filepath.Join(t.TempDir(), "clone")
 	logger := newTestLogger()
 
-	_, err := cloneRepo(bareRepo, "", cloneDir, logger)
+	_, err := cloneRepo(bareRepo, "", cloneDir, nil, logger)
 	if err != nil {
 		t.Fatalf("clone failed: %v", err)
 	}
 
-	path, err := updateRepo(cloneDir, "", logger)
+	path, err := updateRepo(cloneDir, "", nil, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -138,7 +146,7 @@ func TestUpdateRepo_InvalidRepo(t *testing.T) {
 	invalidDir := t.TempDir()
 	logger := newTestLogger()
 
-	_, err := updateRepo(invalidDir, "", logger)
+	_, err := updateRepo(invalidDir, "", nil, logger)
 	if err == nil {
 		t.Fatal("expected error for invalid repo")
 	}
@@ -154,7 +162,7 @@ func TestCloneOrUpdate_Clone(t *testing.T) {
 
 	logger := newTestLogger()
 
-	path, err := CloneOrUpdate(bareRepo, "", logger)
+	path, err := CloneOrUpdate(bareRepo, "", nil, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -179,19 +187,98 @@ func TestCloneOrUpdate_Update(t *testing.T) {
 	logger := newTestLogger()
 
 	// First call clones
-	path1, err := CloneOrUpdate(bareRepo, "", logger)
+	path1, err := CloneOrUpdate(bareRepo, "", nil, logger)
 	if err != nil {
 		t.Fatalf("first call: %v", err)
 	}
 
 	// Second call updates
-	path2, err := CloneOrUpdate(bareRepo, "", logger)
+	path2, err := CloneOrUpdate(bareRepo, "", nil, logger)
 	if err != nil {
 		t.Fatalf("second call: %v", err)
 	}
 
 	if path1 != path2 {
 		t.Errorf("expected same path, got %q and %q", path1, path2)
+	}
+}
+
+// startAuthedGitHTTPServer wraps a bare repository with httptest + git http-backend,
+// gated by HTTP basic auth. Returns the server; t.Cleanup handles teardown. Skips
+// when the `git` binary is unavailable.
+func startAuthedGitHTTPServer(t *testing.T, bareParent, validToken string) *httptest.Server {
+	t.Helper()
+
+	gitBin, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git binary not found; skipping http-backend integration")
+	}
+
+	cgiHandler := &cgi.Handler{
+		Path: gitBin,
+		Args: []string{"http-backend"},
+		Env: []string{
+			"GIT_PROJECT_ROOT=" + bareParent,
+			"GIT_HTTP_EXPORT_ALL=1",
+		},
+	}
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, _, ok := r.BasicAuth()
+		switch {
+		case !ok:
+			w.Header().Set("WWW-Authenticate", `Basic realm="gridctl-builder-it"`)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		case user != validToken:
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		cgiHandler.ServeHTTP(w, r)
+	})
+
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestCloneOrUpdate_ForwardsAuth locks in the contract that an auth method
+// supplied to CloneOrUpdate flows through to the underlying git transport. A
+// regression here would re-introduce the "auth block silently dropped" bug
+// even if the config struct still exposed the field.
+func TestCloneOrUpdate_ForwardsAuth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git test in short mode")
+	}
+
+	const validToken = "correct-horse"
+
+	// Build a bare repo and serve it behind HTTP basic auth.
+	bareDir := initBareRepo(t)
+	bareParent := filepath.Dir(bareDir)
+	bareName := filepath.Base(bareDir)
+	srv := startAuthedGitHTTPServer(t, bareParent, validToken)
+	t.Setenv("HOME", t.TempDir())
+
+	repoURL := srv.URL + "/" + bareName
+	logger := newTestLogger()
+
+	// Without auth: clone must fail with the classified ErrAuthRequired so
+	// callers can distinguish auth from network errors.
+	_, err := CloneOrUpdate(repoURL, "", nil, logger)
+	if err == nil {
+		t.Fatal("expected error cloning without auth")
+	}
+	if !errors.Is(gitpkg.ClassifyError(err), gitpkg.ErrAuthRequired) {
+		t.Errorf("expected ErrAuthRequired, got %v", err)
+	}
+
+	// With valid auth: clone must succeed, proving the auth method is
+	// forwarded into the git transport.
+	t.Setenv("HOME", t.TempDir())
+	auth := &gohttp.BasicAuth{Username: validToken, Password: ""}
+	if _, err := CloneOrUpdate(repoURL, "", auth, logger); err != nil {
+		t.Fatalf("clone with valid auth: %v", err)
 	}
 }
 

--- a/pkg/builder/types.go
+++ b/pkg/builder/types.go
@@ -1,6 +1,10 @@
 package builder
 
-import "log/slog"
+import (
+	"log/slog"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
 
 // BuildOptions contains options for building an image.
 type BuildOptions struct {
@@ -17,6 +21,12 @@ type BuildOptions struct {
 
 	// Cache control
 	NoCache bool // Force rebuild, ignore cache
+
+	// Auth carries an already-resolved git auth method for private repository
+	// clones. Nil means an unauthenticated clone (the public-repo default).
+	// Resolution from a declarative SourceAuth happens upstream so that this
+	// package never has to know about vaults or credential references.
+	Auth transport.AuthMethod
 
 	// Logger for build operations (optional, defaults to discard)
 	Logger *slog.Logger

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -182,6 +182,13 @@ func expandStackVars(s *Stack, resolve Resolver) (unresolvedVault []string, empt
 			s.MCPServers[i].Source.URL = expand(s.MCPServers[i].Source.URL)
 			s.MCPServers[i].Source.Path = expand(s.MCPServers[i].Source.Path)
 			s.MCPServers[i].Source.Ref = expand(s.MCPServers[i].Source.Ref)
+			// Source.Auth.CredentialRef intentionally NOT expanded here:
+			// vault references stay literal until clone time so the
+			// orchestrator can resolve them against the live vault.
+			if s.MCPServers[i].Source.Auth != nil {
+				s.MCPServers[i].Source.Auth.SSHKeyPath = expand(s.MCPServers[i].Source.Auth.SSHKeyPath)
+				s.MCPServers[i].Source.Auth.SSHUser = expand(s.MCPServers[i].Source.Auth.SSHUser)
+			}
 		}
 
 		for k, v := range s.MCPServers[i].Env {
@@ -233,6 +240,11 @@ func resolveRelativePaths(s *Stack, basePath string) {
 		}
 		if s.MCPServers[i].SSH != nil && s.MCPServers[i].SSH.KnownHostsFile != "" {
 			s.MCPServers[i].SSH.KnownHostsFile = expandTildeAndResolvePath(s.MCPServers[i].SSH.KnownHostsFile, basePath)
+		}
+
+		// Resolve source.auth.ssh_key_path (mirrors SSH.IdentityFile handling).
+		if s.MCPServers[i].Source != nil && s.MCPServers[i].Source.Auth != nil && s.MCPServers[i].Source.Auth.SSHKeyPath != "" {
+			s.MCPServers[i].Source.Auth.SSHKeyPath = expandTildeAndResolvePath(s.MCPServers[i].Source.Auth.SSHKeyPath, basePath)
 		}
 
 		// Resolve OpenAPI spec paths (if not a URL)

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -82,6 +82,52 @@ mcp-servers:
 	}
 }
 
+// TestLoadStack_SourceAuth_PreservedRoundTrip locks in that the wizard-emitted
+// source.auth block survives YAML unmarshal end-to-end. Before the fix,
+// config.Source had no Auth field and the block was silently dropped — the
+// "auth-required" failure would surface only at clone time. The credential
+// reference must remain literal (no vault expansion at load time) so the
+// orchestrator can resolve it against the live vault on every clone/fetch.
+func TestLoadStack_SourceAuth_PreservedRoundTrip(t *testing.T) {
+	content := `
+version: "1"
+name: test
+mcp-servers:
+  - name: private-mcp
+    source:
+      type: git
+      url: https://github.com/example/repo.git
+      ref: main
+      auth:
+        method: token
+        credential_ref: "${vault:GIT_TOKEN}"
+    port: 3000
+`
+	path := writeTempFile(t, content)
+
+	stack, err := LoadStack(path)
+	if err != nil {
+		t.Fatalf("LoadStack: %v", err)
+	}
+
+	if len(stack.MCPServers) != 1 {
+		t.Fatalf("expected 1 MCP server, got %d", len(stack.MCPServers))
+	}
+	src := stack.MCPServers[0].Source
+	if src == nil {
+		t.Fatal("expected Source, got nil")
+	}
+	if src.Auth == nil {
+		t.Fatal("source.auth block was silently dropped")
+	}
+	if src.Auth.Method != "token" {
+		t.Errorf("Auth.Method: got %q, want %q", src.Auth.Method, "token")
+	}
+	if src.Auth.CredentialRef != "${vault:GIT_TOKEN}" {
+		t.Errorf("Auth.CredentialRef: got %q, want %q (must remain literal until clone time)", src.Auth.CredentialRef, "${vault:GIT_TOKEN}")
+	}
+}
+
 func TestLoadStack_EnvExpansion(t *testing.T) {
 	os.Setenv("TEST_API_KEY", "secret123")
 	defer os.Unsetenv("TEST_API_KEY")

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -329,11 +329,23 @@ func (s *MCPServer) IsContainerBased() bool {
 
 // Source defines how to build an MCP server from source code.
 type Source struct {
-	Type       string `yaml:"type"` // "git" or "local"
-	URL        string `yaml:"url,omitempty"`
-	Ref        string `yaml:"ref,omitempty"`
-	Path       string `yaml:"path,omitempty"`
-	Dockerfile string `yaml:"dockerfile,omitempty"`
+	Type       string      `yaml:"type"` // "git" or "local"
+	URL        string      `yaml:"url,omitempty"`
+	Ref        string      `yaml:"ref,omitempty"`
+	Path       string      `yaml:"path,omitempty"`
+	Dockerfile string      `yaml:"dockerfile,omitempty"`
+	Auth       *SourceAuth `yaml:"auth,omitempty"`
+}
+
+// SourceAuth is the declarative auth block on an MCP server git source. Raw
+// tokens must NOT appear here — use CredentialRef (e.g. "${vault:GIT_TOKEN}")
+// which is resolved against the live vault at clone time. Never add a Token
+// field to this struct: anything with a yaml tag here gets persisted to disk.
+type SourceAuth struct {
+	Method        string `yaml:"method,omitempty"`         // "", "none", "token", "ssh-agent", "ssh-key"
+	CredentialRef string `yaml:"credential_ref,omitempty"` // e.g. "${vault:GIT_TOKEN}" — resolved on every clone/fetch
+	SSHUser       string `yaml:"ssh_user,omitempty"`       // defaults to "git" when empty
+	SSHKeyPath    string `yaml:"ssh_key_path,omitempty"`   // required for method "ssh-key"
 }
 
 // Resource defines a supporting container (database, cache, etc).

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -73,6 +73,24 @@ func New(cfg Config) *StackController {
 	return &StackController{config: cfg}
 }
 
+// credentialResolver returns a runtime.CredentialResolver that expands
+// references like "${vault:GIT_TOKEN}" against the controller's live vault.
+// An unresolved reference is a hard error — we never fall through to an
+// unauthenticated clone.
+func (sc *StackController) credentialResolver() runtime.CredentialResolver {
+	return func(ref string) (string, error) {
+		if sc.vaultStore == nil {
+			return "", fmt.Errorf("vault not configured; cannot resolve %s", ref)
+		}
+		resolver := config.VaultResolver(sc.vaultStore)
+		expanded, unresolved, _ := config.ExpandString(ref, resolver)
+		if len(unresolved) > 0 {
+			return "", fmt.Errorf("vault key %q not found", unresolved[0])
+		}
+		return expanded, nil
+	}
+}
+
 // SetVersion sets the version string for the gateway.
 func (sc *StackController) SetVersion(v string) {
 	sc.version = v
@@ -465,7 +483,21 @@ func (sc *StackController) newGatewayBuilder(stack *config.Stack, rt *runtime.Or
 }
 
 // createRuntime detects the container runtime and creates an Orchestrator.
+// The vault-backed credential resolver is wired in here so every caller —
+// Deploy, runDaemonChild, plan/replace flows — gets MCP source.auth
+// resolution without needing to remember the registration step.
 func (sc *StackController) createRuntime() (*runtime.Orchestrator, error) {
+	rt, err := sc.newRuntime()
+	if err != nil {
+		return nil, err
+	}
+	if sc.vaultStore != nil {
+		rt.SetCredentialResolver(sc.credentialResolver())
+	}
+	return rt, nil
+}
+
+func (sc *StackController) newRuntime() (*runtime.Orchestrator, error) {
 	if sc.config.Runtime != "" {
 		info, err := runtime.DetectRuntime(runtime.DetectOptions{Explicit: sc.config.Runtime})
 		if err != nil {

--- a/pkg/runtime/auth.go
+++ b/pkg/runtime/auth.go
@@ -1,0 +1,53 @@
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
+)
+
+// AuthForSource turns a declarative SourceAuth block into a ready-to-use
+// transport.AuthMethod. CredentialRef is resolved via the supplied resolver
+// (typically vault-backed); raw tokens are produced only in memory and never
+// persisted. A nil block, or Method == "" or "none", yields (nil, nil) — the
+// public-repo path. The resolver may be nil only when no CredentialRef is
+// present; otherwise we fail fast rather than silently fall through to an
+// unauthenticated clone that 401s with a confusing error.
+func AuthForSource(auth *config.SourceAuth, url string, resolver CredentialResolver) (transport.AuthMethod, error) {
+	if auth == nil {
+		return nil, nil
+	}
+	switch auth.Method {
+	case "", "none":
+		return nil, nil
+	case "token":
+		token, err := resolveCredentialRef(auth.CredentialRef, resolver)
+		if err != nil {
+			return nil, err
+		}
+		return gitpkg.HTTPSTokenAuth{Token: token}.AuthFor(url)
+	case "ssh-agent":
+		return gitpkg.SSHAgentAuth{User: auth.SSHUser}.AuthFor(url)
+	case "ssh-key":
+		return gitpkg.SSHKeyFileAuth{User: auth.SSHUser, KeyPath: auth.SSHKeyPath}.AuthFor(url)
+	default:
+		return nil, fmt.Errorf("unknown source.auth.method %q", auth.Method)
+	}
+}
+
+func resolveCredentialRef(ref string, resolver CredentialResolver) (string, error) {
+	if ref == "" {
+		return "", nil
+	}
+	if resolver == nil {
+		return "", fmt.Errorf("source.auth.credential_ref %q is set but no credential resolver is configured (is the vault unlocked?)", ref)
+	}
+	token, err := resolver(ref)
+	if err != nil {
+		return "", fmt.Errorf("resolving %s: %w", ref, err)
+	}
+	return token, nil
+}

--- a/pkg/runtime/auth_test.go
+++ b/pkg/runtime/auth_test.go
@@ -1,0 +1,91 @@
+package runtime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
+)
+
+func TestAuthForSource_Nil(t *testing.T) {
+	got, err := AuthForSource(nil, "https://example.com/repo.git", nil)
+	if err != nil {
+		t.Fatalf("nil SourceAuth should not error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("nil SourceAuth should yield nil AuthMethod, got %T", got)
+	}
+}
+
+func TestAuthForSource_NoneMethod(t *testing.T) {
+	for _, method := range []string{"", "none"} {
+		got, err := AuthForSource(&config.SourceAuth{Method: method}, "https://example.com/repo.git", nil)
+		if err != nil {
+			t.Errorf("method %q should not error: %v", method, err)
+		}
+		if got != nil {
+			t.Errorf("method %q should yield nil AuthMethod, got %T", method, got)
+		}
+	}
+}
+
+func TestAuthForSource_Token_ResolvesCredentialRef(t *testing.T) {
+	resolver := func(ref string) (string, error) {
+		if ref != "${vault:GIT_TOKEN}" {
+			return "", errors.New("unexpected ref")
+		}
+		return "ghp_real_token", nil
+	}
+	auth := &config.SourceAuth{Method: "token", CredentialRef: "${vault:GIT_TOKEN}"}
+
+	got, err := AuthForSource(auth, "https://example.com/repo.git", resolver)
+	if err != nil {
+		t.Fatalf("AuthForSource: %v", err)
+	}
+	basic, ok := got.(*http.BasicAuth)
+	if !ok {
+		t.Fatalf("expected *http.BasicAuth, got %T", got)
+	}
+	if basic.Username != "ghp_real_token" {
+		t.Errorf("username: got %q, want resolved token", basic.Username)
+	}
+}
+
+func TestAuthForSource_Token_MissingResolver(t *testing.T) {
+	auth := &config.SourceAuth{Method: "token", CredentialRef: "${vault:GIT_TOKEN}"}
+	_, err := AuthForSource(auth, "https://example.com/repo.git", nil)
+	if err == nil {
+		t.Fatal("expected error when credential_ref is set but no resolver is configured")
+	}
+}
+
+func TestAuthForSource_Token_EmptyRef(t *testing.T) {
+	// An empty CredentialRef with method=token surfaces ErrEmptyToken from the
+	// auth primitive — clear signal to fix the config rather than a confusing 401.
+	auth := &config.SourceAuth{Method: "token"}
+	_, err := AuthForSource(auth, "https://example.com/repo.git", nil)
+	if !errors.Is(err, gitpkg.ErrEmptyToken) {
+		t.Errorf("expected ErrEmptyToken, got %v", err)
+	}
+}
+
+func TestAuthForSource_ResolverError(t *testing.T) {
+	resolver := func(string) (string, error) { return "", errors.New("vault locked") }
+	auth := &config.SourceAuth{Method: "token", CredentialRef: "${vault:GIT_TOKEN}"}
+
+	_, err := AuthForSource(auth, "https://example.com/repo.git", resolver)
+	if err == nil {
+		t.Fatal("expected resolver error to propagate")
+	}
+}
+
+func TestAuthForSource_UnknownMethod(t *testing.T) {
+	auth := &config.SourceAuth{Method: "magic"}
+	_, err := AuthForSource(auth, "https://example.com/repo.git", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown method")
+	}
+}

--- a/pkg/runtime/docker/init.go
+++ b/pkg/runtime/docker/init.go
@@ -55,6 +55,7 @@ func (a *dockerBuilderAdapter) Build(ctx context.Context, opts runtime.BuildOpti
 		Tag:        opts.Tag,
 		BuildArgs:  opts.BuildArgs,
 		NoCache:    opts.NoCache,
+		Auth:       opts.Auth,
 		Logger:     opts.Logger,
 	})
 	if err != nil {

--- a/pkg/runtime/orchestrator.go
+++ b/pkg/runtime/orchestrator.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
+
 	"github.com/gridctl/gridctl/pkg/config"
 	"github.com/gridctl/gridctl/pkg/logging"
 )
@@ -17,11 +19,18 @@ type LoggerSetter interface {
 // Orchestrator manages the lifecycle of gridctl workloads.
 // It uses a WorkloadRuntime to start/stop workloads and a Builder for image builds.
 type Orchestrator struct {
-	runtime     WorkloadRuntime
-	builder     Builder
-	logger      *slog.Logger
-	runtimeInfo *RuntimeInfo
+	runtime            WorkloadRuntime
+	builder            Builder
+	logger             *slog.Logger
+	runtimeInfo        *RuntimeInfo
+	credentialResolver CredentialResolver
 }
+
+// CredentialResolver expands a credential reference (e.g. "${vault:GIT_TOKEN}")
+// to its raw token. Set via SetCredentialResolver. Without one, MCP source
+// blocks that carry a CredentialRef fail fast at build time so the user sees
+// "missing vault secret" rather than a confusing 401 from the git server.
+type CredentialResolver func(ref string) (string, error)
 
 // Builder handles image/artifact building.
 // This is kept separate from WorkloadRuntime as image building is a distinct concern.
@@ -31,15 +40,16 @@ type Builder interface {
 
 // BuildOptions for the Builder interface.
 type BuildOptions struct {
-	SourceType string            // "git" or "local"
-	URL        string            // Git URL
-	Ref        string            // Git ref/branch
-	Path       string            // Local path
-	Dockerfile string            // Dockerfile path within context
-	Tag        string            // Image tag
-	BuildArgs  map[string]string // Build arguments
-	NoCache    bool              // Force rebuild
-	Logger     *slog.Logger      // Logger for build operations (optional)
+	SourceType string               // "git" or "local"
+	URL        string               // Git URL
+	Ref        string               // Git ref/branch
+	Path       string               // Local path
+	Dockerfile string               // Dockerfile path within context
+	Tag        string               // Image tag
+	BuildArgs  map[string]string    // Build arguments
+	NoCache    bool                 // Force rebuild
+	Auth       transport.AuthMethod // Resolved git auth (nil = unauthenticated)
+	Logger     *slog.Logger         // Logger for build operations (optional)
 }
 
 // BuildResult from a build operation.
@@ -124,6 +134,14 @@ func (o *Orchestrator) SetLogger(logger *slog.Logger) {
 func (o *Orchestrator) SetRuntimeInfo(info *RuntimeInfo) {
 	o.runtimeInfo = info
 }
+
+// SetCredentialResolver registers a resolver used to expand a CredentialRef
+// like "${vault:GIT_TOKEN}" into a raw token at clone time. Without a
+// resolver, MCP servers whose source carries a CredentialRef fail fast.
+func (o *Orchestrator) SetCredentialResolver(r CredentialResolver) {
+	o.credentialResolver = r
+}
+
 
 // RuntimeInfo returns the detected runtime info, or nil if not set.
 func (o *Orchestrator) RuntimeInfo() *RuntimeInfo {
@@ -366,6 +384,14 @@ func (o *Orchestrator) startMCPServer(ctx context.Context, stack *config.Stack, 
 			BuildArgs:  server.BuildArgs,
 			NoCache:    opts.NoCache,
 			Logger:     o.logger,
+		}
+
+		if server.Source.Auth != nil {
+			authMethod, err := AuthForSource(server.Source.Auth, server.Source.URL, o.credentialResolver)
+			if err != nil {
+				return nil, fmt.Errorf("resolving source auth for %q: %w", server.Name, err)
+			}
+			buildOpts.Auth = authMethod
 		}
 
 		result, err := o.builder.Build(ctx, buildOpts)

--- a/tests/integration/mcp_private_git_test.go
+++ b/tests/integration/mcp_private_git_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package integration
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/builder"
+	"github.com/gridctl/gridctl/pkg/config"
+	gitpkg "github.com/gridctl/gridctl/pkg/git"
+	"github.com/gridctl/gridctl/pkg/logging"
+	"github.com/gridctl/gridctl/pkg/runtime"
+)
+
+// These tests mirror skills_private_git_test.go but exercise the MCP server
+// source build path: config.SourceAuth → runtime.AuthForSource → resolved
+// transport.AuthMethod → builder.CloneOrUpdate → gitpkg.Clone. The helpers
+// initPrivateBareRepo / startAuthedGitHTTPServer / isolateGridctlHome live
+// in skills_private_git_test.go (same package, same build tag).
+
+func TestMCP_PrivateHTTPS_NoAuth_ReturnsAuthRequired(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	isolateGridctlHome(t)
+
+	bareParent, bareName := initPrivateBareRepo(t)
+	srv := startAuthedGitHTTPServer(t, bareParent, privateRepoValidToken)
+
+	repoURL := srv.URL + "/" + bareName
+
+	// No SourceAuth at all — the public-repo path. Must fail with the
+	// classified ErrAuthRequired so callers can distinguish it from a
+	// network or DNS error.
+	_, err := builder.CloneOrUpdate(repoURL, "", nil, logging.NewDiscardLogger())
+	if err == nil {
+		t.Fatal("expected error cloning private repo without auth")
+	}
+	if !errors.Is(gitpkg.ClassifyError(err), gitpkg.ErrAuthRequired) {
+		t.Errorf("expected ErrAuthRequired, got %v", err)
+	}
+}
+
+func TestMCP_PrivateHTTPS_WrongToken_ReturnsAuthFailed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	isolateGridctlHome(t)
+
+	bareParent, bareName := initPrivateBareRepo(t)
+	srv := startAuthedGitHTTPServer(t, bareParent, privateRepoValidToken)
+
+	repoURL := srv.URL + "/" + bareName
+
+	// Resolver returns the wrong token; expect 403 → ErrAuthFailed.
+	resolver := func(string) (string, error) { return "not-the-right-token", nil }
+	auth, err := runtime.AuthForSource(
+		&config.SourceAuth{Method: "token", CredentialRef: "${vault:GIT_TOKEN}"},
+		repoURL,
+		resolver,
+	)
+	if err != nil {
+		t.Fatalf("AuthForSource (wrong token): %v", err)
+	}
+
+	_, err = builder.CloneOrUpdate(repoURL, "", auth, logging.NewDiscardLogger())
+	if err == nil {
+		t.Fatal("expected error cloning with wrong token")
+	}
+	if !errors.Is(gitpkg.ClassifyError(err), gitpkg.ErrAuthFailed) {
+		t.Errorf("expected ErrAuthFailed, got %v", err)
+	}
+}
+
+func TestMCP_PrivateHTTPS_ValidToken_Succeeds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	isolateGridctlHome(t)
+
+	bareParent, bareName := initPrivateBareRepo(t)
+	srv := startAuthedGitHTTPServer(t, bareParent, privateRepoValidToken)
+
+	repoURL := srv.URL + "/" + bareName
+
+	resolver := func(ref string) (string, error) {
+		if ref != "${vault:GIT_TOKEN}" {
+			return "", errors.New("unexpected ref")
+		}
+		return privateRepoValidToken, nil
+	}
+	auth, err := runtime.AuthForSource(
+		&config.SourceAuth{Method: "token", CredentialRef: "${vault:GIT_TOKEN}"},
+		repoURL,
+		resolver,
+	)
+	if err != nil {
+		t.Fatalf("AuthForSource: %v", err)
+	}
+	if auth == nil {
+		t.Fatal("expected non-nil auth method for token+credential_ref")
+	}
+
+	path, err := builder.CloneOrUpdate(repoURL, "", auth, logging.NewDiscardLogger())
+	if err != nil {
+		t.Fatalf("CloneOrUpdate with valid auth: %v", err)
+	}
+	if path == "" {
+		t.Error("expected non-empty clone path")
+	}
+}


### PR DESCRIPTION
## Description

`config.Source` had no `Auth` field, so the wizard's `source.auth.{method,credential_ref}` block was silently dropped during YAML unmarshal and the build path always cloned unauthenticated. The README, the wizard, and the skills registry path all promised this feature worked — only the MCP server backend was unwired. This PR mirrors the existing skills-path pipeline (declarative `SourceAuth` → `AuthForSource` resolver → `transport.AuthMethod` → `gitpkg.Clone`) so the documented feature actually functions end-to-end.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `pkg/config/types.go` — new declarative `SourceAuth` type (`method`, `credential_ref`, `ssh_user`, `ssh_key_path`); `Source` now carries `Auth *SourceAuth`. Mirrors `pkg/skills/config.go:24-33` exactly. No transient `Token` field — raw tokens never get a yaml tag.
- `pkg/config/loader.go` — `CredentialRef` is intentionally **not** expanded at load time so `${vault:KEY}` survives to clone time; `ssh_key_path` gets the same env/tilde expansion as `ssh.identityFile`.
- `pkg/builder/{types,git,builder}.go` — `BuildOptions.Auth` (`transport.AuthMethod`); `CloneOrUpdate(url, ref, auth, logger)` forwards to both `gitpkg.Clone` and `gitpkg.Fetch` (the update path was also auth-blind).
- `pkg/runtime/auth.go` — new exported `AuthForSource(*config.SourceAuth, url, CredentialResolver)` helper; resolves `CredentialRef` via the supplied resolver, builds a `gitpkg.Auther`, returns a ready `transport.AuthMethod`. Missing resolver + non-empty `CredentialRef` is a hard error (no silent fall-through to unauthenticated clone).
- `pkg/runtime/orchestrator.go` — `BuildOptions.Auth` field, `SetCredentialResolver`, and call to `AuthForSource` in `startMCPServer` when `Source.Auth != nil`.
- `pkg/runtime/docker/init.go` — adapter forwards `Auth` between `runtime.BuildOptions` and `builder.BuildOptions`.
- `pkg/controller/controller.go` — `createRuntime()` now registers a vault-backed `CredentialResolver` so every code path (Deploy, daemon-child, replace flows) gets MCP source auth without callers having to remember.
- `docs/config-schema.md` — new "Source Auth" section under `### Source` with field reference, security rules, and an example. Mirrors the existing skill-source-auth section.

Public-repo flows are unchanged: when `Source.Auth == nil`, `BuildOptions.Auth` stays nil and the clone path behaves exactly as before.

## Testing

- `TestLoadStack_SourceAuth_PreservedRoundTrip` — asserts `source.auth` survives YAML load and that `CredentialRef` remains the literal `${vault:KEY}` string.
- `TestCloneOrUpdate_ForwardsAuth` — full HTTP basic auth round-trip via `httptest` + `git http-backend`. Asserts no-auth → `ErrAuthRequired`, valid auth → success.
- `TestAuthForSource_*` — seven unit cases covering nil block, none/empty methods, token + resolver, missing resolver hard-fail, empty credential ref → `ErrEmptyToken`, resolver error propagation, unknown method.
- `TestMCP_PrivateHTTPS_{NoAuth,WrongToken,ValidToken}_*` — integration tests mirroring `tests/integration/skills_private_git_test.go`. Reuses the existing `initPrivateBareRepo` / `startAuthedGitHTTPServer` / `isolateGridctlHome` helpers (same package, same `//go:build integration` tag).
- All existing tests in `pkg/config`, `pkg/builder`, `pkg/runtime`, `pkg/controller`, `pkg/skills`, and `tests/integration/` continue to pass.

```
go build ./...                                   # clean
go test ./pkg/config/... ./pkg/builder/... ./pkg/runtime/... ./pkg/controller/...  # ok
go test -tags integration -run "TestMCP_Private|TestSkills_PrivateHTTPS" ./tests/integration/  # ok
golangci-lint run ./pkg/config/... ./pkg/builder/... ./pkg/runtime/... ./pkg/controller/...  # 0 issues
```

## Out of Scope (Tracked Separately)

- `gridctl apply --auth-token` / `--vault-key` / `--ssh-key` CLI flags for parity with `gridctl skill add`. With `${vault:KEY}` working end-to-end, these are conveniences rather than blockers.
- Web wizard `parseYAMLToForm` read-back at `web/src/lib/yaml-builder.ts:443-554` so the wizard can re-edit a saved stack with auth (currently the form-side load drops the field independently of this fix).
- Extracting a shared `SourceAuth` / `AuthConfig` package across `pkg/config` and `pkg/skills` to deduplicate the declarative type. Worth doing as a follow-up; not blocking.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #533