### PR TITLE
fix: isolate skills source handlers from $HOME in tests

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -60,6 +60,12 @@ type Server struct {
 	// with the gateway). Nil disables the /api/servers/probe endpoint.
 	prober       *probe.Prober
 	probeLimiter *probeLimiter
+
+	// Skill source paths. Empty values fall back to the global defaults
+	// (skills.LockFilePath / skills.SkillsConfigPath) so production code is
+	// unchanged; tests inject temp paths to stay isolated from $HOME.
+	skillLockPath    string
+	skillsConfigPath string
 }
 
 // NewServer creates a new API server.
@@ -173,6 +179,13 @@ func (s *Server) SetTokenizerName(name string) {
 // the given stack path. Called by POST /api/stack/initialize after cold-loading.
 func (s *Server) SetStartWatcher(fn func(stackPath string)) {
 	s.startWatcher = fn
+}
+
+// SetSkillSourcePaths overrides the skill lock-file and skills.yaml paths used
+// by /api/skills/* handlers. Empty values keep the global defaults.
+func (s *Server) SetSkillSourcePaths(lockPath, configPath string) {
+	s.skillLockPath = lockPath
+	s.skillsConfigPath = configPath
 }
 
 // RegistryServer returns the registry server.

--- a/internal/api/registry_test.go
+++ b/internal/api/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -14,6 +15,8 @@ import (
 )
 
 // setupRegistryTestServer creates a Server with a temp registry store for testing.
+// Skill source paths are pinned to the temp dir so handlers don't read the
+// developer's real ~/.gridctl/skills.{lock.yaml,yaml}.
 func setupRegistryTestServer(t *testing.T) (*Server, *registry.Server) {
 	t.Helper()
 	dir := t.TempDir()
@@ -24,6 +27,10 @@ func setupRegistryTestServer(t *testing.T) (*Server, *registry.Server) {
 	gateway := mcp.NewGateway()
 	apiServer := NewServer(gateway, nil)
 	apiServer.SetRegistryServer(regServer)
+	apiServer.SetSkillSourcePaths(
+		filepath.Join(dir, "skills.lock.yaml"),
+		filepath.Join(dir, "skills.yaml"),
+	)
 	return apiServer, regServer
 }
 

--- a/internal/api/skills.go
+++ b/internal/api/skills.go
@@ -14,6 +14,24 @@ import (
 	"github.com/gridctl/gridctl/pkg/vault"
 )
 
+// lockFilePath returns the configured skill lock-file path, falling back to
+// the global default. Tests inject a temp path via SetSkillSourcePaths.
+func (s *Server) lockFilePath() string {
+	if s.skillLockPath != "" {
+		return s.skillLockPath
+	}
+	return skills.LockFilePath()
+}
+
+// configFilePath returns the configured skills.yaml path, falling back to the
+// global default. Tests inject a temp path via SetSkillSourcePaths.
+func (s *Server) configFilePath() string {
+	if s.skillsConfigPath != "" {
+		return s.skillsConfigPath
+	}
+	return skills.SkillsConfigPath()
+}
+
 // SkillSourceStatus represents a skill source with its update status.
 type SkillSourceStatus struct {
 	Name           string             `json:"name"`
@@ -170,11 +188,11 @@ func (s *Server) handleSkillSourcesList(w http.ResponseWriter, _ *http.Request) 
 		return
 	}
 	store := s.registryServer.Store()
-	lockPath := skills.LockFilePath()
+	lockPath := s.lockFilePath()
 	lf, _ := skills.ReadLockFile(lockPath)
 
 	// Load skills.yaml config
-	cfg, err := skills.LoadSkillsConfig(skills.SkillsConfigPath())
+	cfg, err := skills.LoadSkillsConfig(s.configFilePath())
 	if err != nil {
 		// No config = no sources; return lock file sources
 		cfg = skills.DefaultSkillsConfig()
@@ -262,7 +280,7 @@ func (s *Server) handleSkillSourceAdd(w http.ResponseWriter, r *http.Request) {
 
 	store := s.registryServer.Store()
 	registryDir := store.Dir()
-	lockPath := skills.LockFilePath()
+	lockPath := s.lockFilePath()
 	logger := slog.Default()
 
 	imp := skills.NewImporter(store, registryDir, lockPath, logger)
@@ -297,7 +315,7 @@ func (s *Server) handleSkillSourceRemove(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	lockPath := skills.LockFilePath()
+	lockPath := s.lockFilePath()
 	lf, err := skills.ReadLockFile(lockPath)
 	if err != nil {
 		writeJSONError(w, "Failed to read lock file: "+err.Error(), http.StatusInternalServerError)
@@ -337,7 +355,7 @@ func (s *Server) handleSkillSourceRemove(w http.ResponseWriter, r *http.Request)
 func (s *Server) handleSkillSourceCheck(w http.ResponseWriter, r *http.Request) {
 	sourceName := r.PathValue("name")
 
-	lockPath := skills.LockFilePath()
+	lockPath := s.lockFilePath()
 	lf, err := skills.ReadLockFile(lockPath)
 	if err != nil {
 		writeJSONError(w, "Failed to read lock file: "+err.Error(), http.StatusInternalServerError)
@@ -410,7 +428,7 @@ func (s *Server) handleSkillSourceUpdate(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	lockPath := skills.LockFilePath()
+	lockPath := s.lockFilePath()
 	lf, err := skills.ReadLockFile(lockPath)
 	if err != nil {
 		writeJSONError(w, "Failed to read lock file: "+err.Error(), http.StatusInternalServerError)
@@ -488,7 +506,7 @@ func (s *Server) handleSkillSourcePreview(w http.ResponseWriter, r *http.Request
 
 	var storedRef string
 	if repo == "" {
-		lockPath := skills.LockFilePath()
+		lockPath := s.lockFilePath()
 		lf, _ := skills.ReadLockFile(lockPath)
 		if src, ok := lf.Sources[sourceName]; ok {
 			repo = src.Repo
@@ -562,7 +580,7 @@ func (s *Server) handleSkillSourcePreview(w http.ResponseWriter, r *http.Request
 // handleSkillUpdates returns pending update summary across all sources.
 // GET /api/skills/updates
 func (s *Server) handleSkillUpdates(w http.ResponseWriter, _ *http.Request) {
-	lockPath := skills.LockFilePath()
+	lockPath := s.lockFilePath()
 	lf, err := skills.ReadLockFile(lockPath)
 	if err != nil {
 		writeJSONError(w, "Failed to read lock file: "+err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
## Description

`/api/skills/sources` and friends read `$HOME/.gridctl/skills.lock.yaml` and `$HOME/.gridctl/skills.yaml` directly via the package-level `skills.LockFilePath()` / `skills.SkillsConfigPath()`. Tests pass a temp dir to the registry store but the handlers ignored it, so `TestHandleSkills_SourcesList_Empty` and `TestHandleSkills_UpdatesEmpty` failed on any developer machine that has actually used `gridctl skill add`. CI passes only because CI has no `~/.gridctl`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Add `skillLockPath` / `skillsConfigPath` fields and a `SetSkillSourcePaths` setter on `internal/api.Server`.
- Add `lockFilePath()` / `configFilePath()` helpers that return the override when set and fall back to the global defaults otherwise; route all 9 handler call sites through them.
- Pin the test helper `setupRegistryTestServer` to temp paths so skills tests stay hermetic.

## Testing

- `go test -race ./...` — passes (previously failed on `TestHandleSkills_SourcesList_Empty` and `TestHandleSkills_UpdatesEmpty` when `~/.gridctl/skills.lock.yaml` had real sources).
- `golangci-lint run` — clean.

## Checklist

- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed