### PR TITLE
Release v0.1.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,39 @@
 
 All notable changes to gridctl will be documented in this file.
 
-## [Unreleased]
+## [0.1.0-beta.7] - 2026-04-28
+
+
+### Bug Fixes
+
+
+- Redact URL userinfo in clone log line ([#507](https://github.com/gridctl/gridctl/pull/507))
+- Clear stale autoscale health rollup and render scale-to-zero as idle ([#518](https://github.com/gridctl/gridctl/pull/518))
+- Restore chart axis contrast on dark theme ([#520](https://github.com/gridctl/gridctl/pull/520))
+- Wire compare-to-running button to diff modal ([#529](https://github.com/gridctl/gridctl/pull/529))
+- Thread MCP server source auth through to git clone ([#534](https://github.com/gridctl/gridctl/pull/534))
+- Isolate skills source handlers from $HOME in tests ([#535](https://github.com/gridctl/gridctl/pull/535))
+
+### Features
+
+
+- Add searchable tools picker to wizard MCP server form ([#495](https://github.com/gridctl/gridctl/pull/495))
+- Add ephemeral probe endpoint for external URL servers ([#497](https://github.com/gridctl/gridctl/pull/497))
+- Live tool whitelist editor in topology sidebar ([#499](https://github.com/gridctl/gridctl/pull/499))
+- Add git auth primitives ([#502](https://github.com/gridctl/gridctl/pull/502))
+- Wire git auth through importer, CLI, and skills API ([#504](https://github.com/gridctl/gridctl/pull/504))
+- Add git auth UI to skill wizard and MCP source form ([#505](https://github.com/gridctl/gridctl/pull/505))
+- Reactive autoscaling for MCP ReplicaSet ([#512](https://github.com/gridctl/gridctl/pull/512))
+- Wizard UI for reactive autoscaling ([#514](https://github.com/gridctl/gridctl/pull/514))
+- Autoscale status observability ([#515](https://github.com/gridctl/gridctl/pull/515))
+- Add curl install script with upgrade and uninstall ([#531](https://github.com/gridctl/gridctl/pull/531))
+
+### Refactoring
+
+
+- Extract shared pkg/git clone helpers ([#501](https://github.com/gridctl/gridctl/pull/501))
+- Polish registry dialogs, typography, and layout ([#509](https://github.com/gridctl/gridctl/pull/509))
+- Unify registry primitives and add keyboard nav ([#511](https://github.com/gridctl/gridctl/pull/511))## [0.1.0-beta.6] - 2026-04-19
 
 
 ### Bug Fixes
@@ -23,7 +55,6 @@ All notable changes to gridctl will be documented in this file.
 ### Features
 
 
-- **feat: reactive autoscaling for MCP ReplicaSet.** Replace static `replicas: N` with an `autoscale:` block (min/max/target_in_flight/scale_up_after/scale_down_after/warm_pool/idle_to_zero) and gridctl will spawn and reap replicas reactively based on median in-flight load. Supported on container, local-process, and SSH transports; rejected (with a precise YAML path) on external URL and OpenAPI. Adds a new `AUTOSCALE` column to `gridctl status --replicas`, an `autoscale` object to `/api/mcp-servers`, and structured log lines / trace spans per scaling decision. `autoscale` is mutually exclusive with `replicas`; servers without it behave identically to previous releases. See [docs/scaling.md](docs/scaling.md#autoscaling) and [examples/autoscale/](examples/autoscale/).
 - Graduate Podman runtime to stable ([#424](https://github.com/gridctl/gridctl/pull/424))
 - Expand OpenAPI auth to support OAuth2 CC, query-param keys, mTLS, and basic auth ([#427](https://github.com/gridctl/gridctl/pull/427))
 - Complete wizard spec for SSH advanced fields, OpenAPI auth types, mTLS, and pin_schemas ([#429](https://github.com/gridctl/gridctl/pull/429))
@@ -37,11 +68,7 @@ All notable changes to gridctl will be documented in this file.
 - Add MCP replicas schema and router (phase 1 of #470) ([#477](https://github.com/gridctl/gridctl/pull/477))
 - Wire MCP replicas runtime and health (phase 2 of #470) ([#478](https://github.com/gridctl/gridctl/pull/478))
 - Replicas observability, status, and API (phase 3 of #470) ([#479](https://github.com/gridctl/gridctl/pull/479))
-- Replicas wizard input and canvas badge (phase 4 of #470) ([#480](https://github.com/gridctl/gridctl/pull/480))
-- Wizard UI for reactive autoscaling. A new segmented "Scaling" control in the MCP server form lets users pick between static `replicas` and the `autoscale:` block shipped in [#512](https://github.com/gridctl/gridctl/pull/512); toggling between modes clears the opposite field group so the output YAML carries at most one. Defaults (min=1, max=5, target=10, scale_up=30s, scale_down=5m) keep the form valid on first view. Backend validation errors surface inline at apply time at the `mcp-servers[i].autoscale.*` paths.
-- Status observability for autoscaled MCP servers. Canvas nodes now render `×current/target` with an amber pulse ring while scaling up and a teal ring while scaling down. Selecting an autoscaled server reveals a Sidebar "Scaling" section with a live headline, dwell phrase, inline-SVG sparkline (current solid vs. target dashed), and a collapsible decision feed derived client-side from polling snapshots.
-
-## [0.1.0-beta.5] - 2026-04-08
+- Replicas wizard input and canvas badge (phase 4 of #470) ([#480](https://github.com/gridctl/gridctl/pull/480))## [0.1.0-beta.5] - 2026-04-08
 
 
 ### Bug Fixes


### PR DESCRIPTION
## Release v0.1.0-beta.7

Updates CHANGELOG.md for release. Stays in beta — reactive autoscaling, git auth, and the curl install script all landed in this cycle and are still flagged Experimental in the stability table.

## Highlights

**Features**
- Reactive autoscaling for MCP ReplicaSet (#512, #514, #515)
- Private git auth across importer, CLI, skills API, and wizards (#502, #504, #505)
- Curl install script with upgrade and uninstall (#531)
- Live tool whitelist editor in topology sidebar (#499)
- Ephemeral probe endpoint for external URL servers (#497)
- Searchable tools picker in wizard MCP server form (#495)

**Fixes**
- Thread MCP server source auth through to git clone (#534)
- Isolate skills source handlers from $HOME in tests (#535)
- Wire compare-to-running button to diff modal (#529)
- Restore chart axis contrast on dark theme (#520)
- Clear stale autoscale health rollup; render scale-to-zero as idle (#518)
- Redact URL userinfo in clone log line (#507)

## Checklist

- [x] All checks passed (lint, test, build, web build)
- [x] Changelog generated with git-cliff
- [ ] PR reviewed and approved
- [ ] After merge, run `/release-gridctl --tag` to create the release tag