### PR TITLE
fix: use x-access-token in HTTPS basic auth

### DIFF
--- a/pkg/git/auth.go
+++ b/pkg/git/auth.go
@@ -62,14 +62,15 @@ type NoAuth struct{}
 // AuthFor always returns (nil, nil).
 func (NoAuth) AuthFor(string) (transport.AuthMethod, error) { return nil, nil }
 
-// HTTPSTokenAuth sends a Personal Access Token as HTTP basic-auth username
-// with an empty password — the shape GitHub, GitLab, Bitbucket, and most
-// self-hosted servers accept for PAT-based authentication.
+// HTTPSTokenAuth sends a token as HTTP basic-auth using the literal username
+// "x-access-token" with the token in the password slot — the shape required
+// by GitHub App installation tokens and accepted uniformly by GitHub PATs,
+// GitLab, and Bitbucket.
 type HTTPSTokenAuth struct {
 	Token string
 }
 
-// AuthFor returns an *http.BasicAuth carrying the PAT, or an error if the
+// AuthFor returns an *http.BasicAuth carrying the token, or an error if the
 // token is empty or the URL is not HTTPS.
 func (a HTTPSTokenAuth) AuthFor(url string) (transport.AuthMethod, error) {
 	if a.Token == "" {
@@ -78,7 +79,7 @@ func (a HTTPSTokenAuth) AuthFor(url string) (transport.AuthMethod, error) {
 	if p := DetectProtocol(url); p != ProtocolHTTPS {
 		return nil, fmt.Errorf("%w: HTTPSTokenAuth requires an https:// URL, got %q (%s)", ErrProtocolMismatch, url, p)
 	}
-	return &http.BasicAuth{Username: a.Token, Password: ""}, nil
+	return &http.BasicAuth{Username: "x-access-token", Password: a.Token}, nil
 }
 
 // SSHAgentAuth delegates authentication to the user's running ssh-agent.

--- a/pkg/git/auth_test.go
+++ b/pkg/git/auth_test.go
@@ -63,7 +63,7 @@ func TestHTTPSTokenAuth_HappyPath(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *http.BasicAuth, got %T", auth)
 	}
-	if ba.Username != "abc123" || ba.Password != "" {
+	if ba.Username != "x-access-token" || ba.Password != "abc123" {
 		t.Errorf("unexpected basic auth: user=%q pass=%q", ba.Username, ba.Password)
 	}
 }

--- a/pkg/runtime/auth_test.go
+++ b/pkg/runtime/auth_test.go
@@ -49,8 +49,9 @@ func TestAuthForSource_Token_ResolvesCredentialRef(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *http.BasicAuth, got %T", got)
 	}
-	if basic.Username != "ghp_real_token" {
-		t.Errorf("username: got %q, want resolved token", basic.Username)
+	if basic.Username != "x-access-token" || basic.Password != "ghp_real_token" {
+		t.Errorf("basic auth: got user=%q pass=%q, want user=%q pass=%q",
+			basic.Username, basic.Password, "x-access-token", "ghp_real_token")
 	}
 }
 

--- a/pkg/skills/auth_test.go
+++ b/pkg/skills/auth_test.go
@@ -55,8 +55,8 @@ func TestResolveAuther_ExplicitWins(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *http.BasicAuth, got %T", auth)
 	}
-	if ba.Username != "explicit" {
-		t.Errorf("expected explicit token to win over env, got %q", ba.Username)
+	if ba.Username != "x-access-token" || ba.Password != "explicit" {
+		t.Errorf("expected explicit token in password slot, got user=%q pass=%q", ba.Username, ba.Password)
 	}
 }
 
@@ -74,8 +74,8 @@ func TestResolveAuther_GitHubTokenFallback(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *http.BasicAuth, got %T", auth)
 	}
-	if ba.Username != "env-token" {
-		t.Errorf("expected GITHUB_TOKEN fallback, got %q", ba.Username)
+	if ba.Username != "x-access-token" || ba.Password != "env-token" {
+		t.Errorf("expected GITHUB_TOKEN fallback in password slot, got user=%q pass=%q", ba.Username, ba.Password)
 	}
 }
 

--- a/tests/integration/skills_private_git_test.go
+++ b/tests/integration/skills_private_git_test.go
@@ -95,13 +95,13 @@ func startAuthedGitHTTPServer(t *testing.T, bareParent, validToken string) *http
 	}
 
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		user, _, ok := r.BasicAuth()
+		_, pass, ok := r.BasicAuth()
 		switch {
 		case !ok:
 			w.Header().Set("WWW-Authenticate", `Basic realm="gridctl-it"`)
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
-		case user != validToken:
+		case pass != validToken:
 			http.Error(w, "forbidden", http.StatusForbidden)
 			return
 		}


### PR DESCRIPTION
## Description

`HTTPSTokenAuth.AuthFor` was building `*http.BasicAuth` with the token in the username slot and an empty password — a shape GitHub rejects for App installation tokens (`ghs_*`) and fine-grained PATs (`github_pat_*`) with *"Invalid username or token. Password authentication is not supported for Git operations."* This PR switches to the GitHub-documented shape `Username: "x-access-token", Password: <token>`, which is also accepted uniformly by GitLab and Bitbucket.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `pkg/git/auth.go`: flip basic-auth slots to `Username: "x-access-token", Password: a.Token`; rewrite the godoc on `HTTPSTokenAuth` and `AuthFor` to describe the corrected shape.
- `pkg/git/auth_test.go`: `TestHTTPSTokenAuth_HappyPath` asserts the corrected shape.
- `pkg/runtime/auth_test.go`, `pkg/skills/auth_test.go`: sibling tests that pinned the buggy shape from a layer up are flipped to assert the corrected shape.
- `tests/integration/skills_private_git_test.go`: `startAuthedGitHTTPServer` now validates the password slot of basic auth instead of the username slot, so future regressions in the production shape actually fail CI.

## Testing

- `go test -race ./...` passes.
- `go test -tags=integration ./tests/integration/...` passes (143s, full `git http-backend` round-trip).
- `golangci-lint run` on changed packages reports 0 issues.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #548