### PR TITLE
feat: add telemetry persistence schema and resolvers

### DIFF
--- a/pkg/config/telemetry_test.go
+++ b/pkg/config/telemetry_test.go
@@ -1,0 +1,496 @@
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestMCPServer_PersistResolvers(t *testing.T) {
+	// Inheritance matrix: every cell of stack-global × per-server. Each
+	// helper resolves the same way, so we exercise PersistLogs only and
+	// then spot-check the other two.
+	type cell struct {
+		name         string
+		stackPersist *bool // nil = no telemetry block on stack
+		serverPersist *bool // nil = no override; serverTelemetryAbsent makes the whole block nil
+		serverTelemetryAbsent bool
+		want bool
+	}
+
+	cells := []cell{
+		// Stack absent (Stack.Telemetry == nil).
+		{name: "stack absent, server absent", serverTelemetryAbsent: true, want: false},
+		{name: "stack absent, server inherit (nil override)", serverPersist: nil, want: false},
+		{name: "stack absent, server explicit on", serverPersist: boolPtr(true), want: true},
+		{name: "stack absent, server explicit off", serverPersist: boolPtr(false), want: false},
+
+		// Stack global off.
+		{name: "stack off, server absent", stackPersist: boolPtr(false), serverTelemetryAbsent: true, want: false},
+		{name: "stack off, server inherit", stackPersist: boolPtr(false), want: false},
+		{name: "stack off, server explicit on", stackPersist: boolPtr(false), serverPersist: boolPtr(true), want: true},
+		{name: "stack off, server explicit off", stackPersist: boolPtr(false), serverPersist: boolPtr(false), want: false},
+
+		// Stack global on.
+		{name: "stack on, server absent", stackPersist: boolPtr(true), serverTelemetryAbsent: true, want: true},
+		{name: "stack on, server inherit", stackPersist: boolPtr(true), want: true},
+		{name: "stack on, server explicit on", stackPersist: boolPtr(true), serverPersist: boolPtr(true), want: true},
+		{name: "stack on, server explicit off", stackPersist: boolPtr(true), serverPersist: boolPtr(false), want: false},
+	}
+
+	for _, c := range cells {
+		t.Run(c.name, func(t *testing.T) {
+			stack := &Stack{Name: "s"}
+			if c.stackPersist != nil {
+				stack.Telemetry = &TelemetryConfig{
+					Persist: TelemetryPersistence{Logs: *c.stackPersist},
+				}
+			}
+			server := &MCPServer{Name: "srv"}
+			if !c.serverTelemetryAbsent {
+				server.Telemetry = &MCPServerTelemetry{
+					Persist: MCPServerPersistence{Logs: c.serverPersist},
+				}
+			}
+
+			got := server.PersistLogs(stack)
+			if got != c.want {
+				t.Errorf("PersistLogs() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestMCPServer_PersistMetricsTracesParity(t *testing.T) {
+	// Confirms PersistMetrics and PersistTraces share the same inheritance
+	// shape as PersistLogs. We don't repeat the full matrix — one inherit
+	// case + one explicit override per signal is enough.
+	stack := &Stack{
+		Name: "s",
+		Telemetry: &TelemetryConfig{
+			Persist: TelemetryPersistence{Logs: true, Metrics: true, Traces: true},
+		},
+	}
+	server := &MCPServer{
+		Name: "srv",
+		Telemetry: &MCPServerTelemetry{
+			Persist: MCPServerPersistence{
+				Metrics: boolPtr(false), // explicit off overrides global on
+				// Traces left nil — should inherit global on
+			},
+		},
+	}
+
+	if !server.PersistLogs(stack) {
+		t.Error("PersistLogs: expected true (inherits global on), got false")
+	}
+	if server.PersistMetrics(stack) {
+		t.Error("PersistMetrics: expected false (explicit override), got true")
+	}
+	if !server.PersistTraces(stack) {
+		t.Error("PersistTraces: expected true (inherits global on), got false")
+	}
+}
+
+func TestMCPServer_PersistResolvers_NilStack(t *testing.T) {
+	// Defensive: nil stack and nil server must not panic and must return false.
+	var server *MCPServer
+	if server.PersistLogs(nil) {
+		t.Error("nil server / nil stack: expected false, got true")
+	}
+
+	s := &MCPServer{Name: "srv", Telemetry: &MCPServerTelemetry{
+		Persist: MCPServerPersistence{Logs: boolPtr(true)},
+	}}
+	if !s.PersistLogs(nil) {
+		t.Error("explicit on with nil stack: expected true, got false")
+	}
+}
+
+func TestMCPServer_PersistResolvers_EmptyTelemetryBlock(t *testing.T) {
+	// Telemetry: &MCPServerTelemetry{} with all-nil Persist fields must
+	// behave the same as no Telemetry block at all (every field inherits).
+	stack := &Stack{Name: "s", Telemetry: &TelemetryConfig{
+		Persist: TelemetryPersistence{Logs: true, Metrics: false, Traces: true},
+	}}
+	server := &MCPServer{Name: "srv", Telemetry: &MCPServerTelemetry{}}
+
+	if !server.PersistLogs(stack) {
+		t.Error("empty server.Telemetry must inherit stack.Logs (true), got false")
+	}
+	if server.PersistMetrics(stack) {
+		t.Error("empty server.Telemetry must inherit stack.Metrics (false), got true")
+	}
+	if !server.PersistTraces(stack) {
+		t.Error("empty server.Telemetry must inherit stack.Traces (true), got false")
+	}
+}
+
+func TestStack_SetDefaults_TelemetryRetention(t *testing.T) {
+	t.Run("no telemetry block: SetDefaults does not synthesize one", func(t *testing.T) {
+		s := &Stack{Name: "s", Network: Network{Name: "n"}}
+		s.SetDefaults()
+		if s.Telemetry != nil {
+			t.Errorf("Telemetry must remain nil, got %+v", s.Telemetry)
+		}
+	})
+
+	t.Run("telemetry present, retention nil: defaults filled", func(t *testing.T) {
+		s := &Stack{
+			Name:      "s",
+			Network:   Network{Name: "n"},
+			Telemetry: &TelemetryConfig{Persist: TelemetryPersistence{Logs: true}},
+		}
+		s.SetDefaults()
+		if s.Telemetry.Retention == nil {
+			t.Fatal("Retention must be created")
+		}
+		if got := s.Telemetry.Retention.MaxSizeMB; got != 100 {
+			t.Errorf("MaxSizeMB = %d, want 100", got)
+		}
+		if got := s.Telemetry.Retention.MaxBackups; got != 5 {
+			t.Errorf("MaxBackups = %d, want 5", got)
+		}
+		if got := s.Telemetry.Retention.MaxAgeDays; got != 7 {
+			t.Errorf("MaxAgeDays = %d, want 7", got)
+		}
+	})
+
+	t.Run("telemetry present, retention partially set: only zero fields filled", func(t *testing.T) {
+		s := &Stack{
+			Name:    "s",
+			Network: Network{Name: "n"},
+			Telemetry: &TelemetryConfig{
+				Retention: &RetentionConfig{MaxSizeMB: 250},
+			},
+		}
+		s.SetDefaults()
+		if s.Telemetry.Retention.MaxSizeMB != 250 {
+			t.Errorf("MaxSizeMB = %d, want 250 (preserved)", s.Telemetry.Retention.MaxSizeMB)
+		}
+		if s.Telemetry.Retention.MaxBackups != 5 {
+			t.Errorf("MaxBackups = %d, want 5 (defaulted)", s.Telemetry.Retention.MaxBackups)
+		}
+		if s.Telemetry.Retention.MaxAgeDays != 7 {
+			t.Errorf("MaxAgeDays = %d, want 7 (defaulted)", s.Telemetry.Retention.MaxAgeDays)
+		}
+	})
+
+	t.Run("idempotent: calling SetDefaults twice produces the same result", func(t *testing.T) {
+		// SetDefaults runs from both LoadStack and the hot-reload path, so
+		// double-application must be a no-op on the second pass.
+		s := &Stack{
+			Name:      "s",
+			Network:   Network{Name: "n"},
+			Telemetry: &TelemetryConfig{Persist: TelemetryPersistence{Logs: true}},
+		}
+		s.SetDefaults()
+		first := *s.Telemetry.Retention
+		s.SetDefaults()
+		second := *s.Telemetry.Retention
+		if !reflect.DeepEqual(first, second) {
+			t.Errorf("SetDefaults not idempotent: first=%+v second=%+v", first, second)
+		}
+	})
+}
+
+func TestValidate_TelemetryRetention(t *testing.T) {
+	base := func(r *RetentionConfig) *Stack {
+		return &Stack{
+			Name:       "test",
+			Network:    Network{Name: "test-net"},
+			MCPServers: []MCPServer{{Name: "s1", Image: "alpine", Port: 3000}},
+			Telemetry:  &TelemetryConfig{Retention: r},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		stack   *Stack
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "no telemetry block — accepted",
+			stack:   &Stack{Name: "test", Network: Network{Name: "n"}, MCPServers: []MCPServer{{Name: "s1", Image: "alpine", Port: 3000}}},
+			wantErr: false,
+		},
+		{
+			name:    "valid retention",
+			stack:   base(&RetentionConfig{MaxSizeMB: 100, MaxBackups: 5, MaxAgeDays: 7}),
+			wantErr: false,
+		},
+		{
+			name:    "max_size_mb zero",
+			stack:   base(&RetentionConfig{MaxSizeMB: 0, MaxBackups: 5, MaxAgeDays: 7}),
+			wantErr: true,
+			errMsg:  "telemetry.retention.max_size_mb",
+		},
+		{
+			name:    "max_size_mb negative",
+			stack:   base(&RetentionConfig{MaxSizeMB: -1, MaxBackups: 5, MaxAgeDays: 7}),
+			wantErr: true,
+			errMsg:  "telemetry.retention.max_size_mb",
+		},
+		{
+			name:    "max_backups zero",
+			stack:   base(&RetentionConfig{MaxSizeMB: 100, MaxBackups: 0, MaxAgeDays: 7}),
+			wantErr: true,
+			errMsg:  "telemetry.retention.max_backups",
+		},
+		{
+			name:    "max_age_days zero",
+			stack:   base(&RetentionConfig{MaxSizeMB: 100, MaxBackups: 5, MaxAgeDays: 0}),
+			wantErr: true,
+			errMsg:  "telemetry.retention.max_age_days",
+		},
+		{
+			name:    "above 5GB soft cap — accepted with warning (not an error)",
+			stack:   base(&RetentionConfig{MaxSizeMB: 2048, MaxBackups: 4, MaxAgeDays: 30}),
+			wantErr: false,
+		},
+		{
+			name:    "max_size_mb above hard cap",
+			stack:   base(&RetentionConfig{MaxSizeMB: telemetryMaxSizeMBHardCap + 1, MaxBackups: 5, MaxAgeDays: 7}),
+			wantErr: true,
+			errMsg:  "telemetry.retention.max_size_mb",
+		},
+		{
+			name:    "max_backups above hard cap",
+			stack:   base(&RetentionConfig{MaxSizeMB: 100, MaxBackups: telemetryMaxBackupsHardCap + 1, MaxAgeDays: 7}),
+			wantErr: true,
+			errMsg:  "telemetry.retention.max_backups",
+		},
+		{
+			name:    "max_age_days above hard cap",
+			stack:   base(&RetentionConfig{MaxSizeMB: 100, MaxBackups: 5, MaxAgeDays: telemetryMaxAgeDaysHardCap + 1}),
+			wantErr: true,
+			errMsg:  "telemetry.retention.max_age_days",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.stack)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errMsg != "" && !strings.Contains(err.Error(), tc.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tc.errMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestTelemetry_YAMLRoundTrip(t *testing.T) {
+	// Source-of-truth YAML mirrors the schema example in the prompt. After
+	// unmarshal → marshal → unmarshal, the *bool tri-state semantics must
+	// survive untouched: nil stays nil, &false stays &false, &true stays &true.
+	source := `version: "1"
+name: my-stack
+telemetry:
+  persist:
+    logs: true
+    metrics: false
+    traces: true
+  retention:
+    max_size_mb: 100
+    max_backups: 5
+    max_age_days: 7
+network:
+  name: my-stack-net
+mcp-servers:
+  - name: github
+    image: alpine
+    port: 3000
+    telemetry:
+      persist:
+        traces: false
+  - name: weather
+    image: alpine
+    port: 3001
+  - name: explicit-on
+    image: alpine
+    port: 3002
+    telemetry:
+      persist:
+        logs: true
+        metrics: true
+        traces: true
+`
+
+	var first Stack
+	if err := yaml.Unmarshal([]byte(source), &first); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Spot-check parsed semantics on the first pass.
+	if first.Telemetry == nil {
+		t.Fatal("Telemetry block must parse")
+	}
+	if !first.Telemetry.Persist.Logs || first.Telemetry.Persist.Metrics || !first.Telemetry.Persist.Traces {
+		t.Errorf("stack persist mismatch: %+v", first.Telemetry.Persist)
+	}
+	if first.Telemetry.Retention == nil || first.Telemetry.Retention.MaxSizeMB != 100 {
+		t.Errorf("retention mismatch: %+v", first.Telemetry.Retention)
+	}
+
+	github := first.MCPServers[0]
+	if github.Telemetry == nil {
+		t.Fatal("github server must have a telemetry block")
+	}
+	if github.Telemetry.Persist.Logs != nil {
+		t.Errorf("github.persist.logs must be nil (inherit), got %v", *github.Telemetry.Persist.Logs)
+	}
+	if github.Telemetry.Persist.Metrics != nil {
+		t.Errorf("github.persist.metrics must be nil (inherit), got %v", *github.Telemetry.Persist.Metrics)
+	}
+	if github.Telemetry.Persist.Traces == nil || *github.Telemetry.Persist.Traces != false {
+		t.Errorf("github.persist.traces must be &false, got %v", github.Telemetry.Persist.Traces)
+	}
+
+	weather := first.MCPServers[1]
+	if weather.Telemetry != nil {
+		t.Errorf("weather server must have nil Telemetry block, got %+v", weather.Telemetry)
+	}
+
+	explicit := first.MCPServers[2]
+	if explicit.Telemetry == nil {
+		t.Fatal("explicit-on server must have a telemetry block")
+	}
+	if explicit.Telemetry.Persist.Logs == nil || !*explicit.Telemetry.Persist.Logs {
+		t.Errorf("explicit-on.persist.logs must be &true")
+	}
+
+	// Round-trip: marshal then unmarshal again and confirm pointer semantics
+	// survived. yaml.v3 must not collapse nil → &false or vice-versa.
+	out, err := yaml.Marshal(&first)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var second Stack
+	if err := yaml.Unmarshal(out, &second); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+
+	// Round-trip equivalence on the stack-global block.
+	if second.Telemetry == nil {
+		t.Fatal("second.Telemetry must survive round-trip")
+	}
+	if !reflect.DeepEqual(second.Telemetry.Persist, first.Telemetry.Persist) {
+		t.Errorf("stack persist round-trip mismatch: got %+v want %+v",
+			second.Telemetry.Persist, first.Telemetry.Persist)
+	}
+
+	// Round-trip equivalence on the per-server tri-state.
+	for i, server := range second.MCPServers {
+		want := first.MCPServers[i]
+		if (server.Telemetry == nil) != (want.Telemetry == nil) {
+			t.Errorf("server[%s]: Telemetry presence mismatch after round-trip", server.Name)
+			continue
+		}
+		if server.Telemetry == nil {
+			continue
+		}
+		if !boolPtrEqual(server.Telemetry.Persist.Logs, want.Telemetry.Persist.Logs) {
+			t.Errorf("server[%s].persist.logs round-trip: got %v, want %v",
+				server.Name, derefOrNil(server.Telemetry.Persist.Logs), derefOrNil(want.Telemetry.Persist.Logs))
+		}
+		if !boolPtrEqual(server.Telemetry.Persist.Metrics, want.Telemetry.Persist.Metrics) {
+			t.Errorf("server[%s].persist.metrics round-trip mismatch", server.Name)
+		}
+		if !boolPtrEqual(server.Telemetry.Persist.Traces, want.Telemetry.Persist.Traces) {
+			t.Errorf("server[%s].persist.traces round-trip mismatch", server.Name)
+		}
+	}
+}
+
+func TestValidate_TelemetryRetention_SoftCapWarning(t *testing.T) {
+	// Capture slog output and assert exactly one warning is emitted when the
+	// per-server worst case crosses the soft cap. Future refactors that drop
+	// the warning will fail this test.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	stack := &Stack{
+		Name:       "test",
+		Network:    Network{Name: "test-net"},
+		MCPServers: []MCPServer{{Name: "s1", Image: "alpine", Port: 3000}},
+		Telemetry: &TelemetryConfig{
+			Retention: &RetentionConfig{MaxSizeMB: 2048, MaxBackups: 4, MaxAgeDays: 30},
+		},
+	}
+	if err := Validate(stack); err != nil {
+		t.Fatalf("Validate must accept above-soft-cap retention, got %v", err)
+	}
+	if !strings.Contains(buf.String(), "telemetry retention exceeds soft cap") {
+		t.Errorf("expected soft-cap warning in slog output, got: %q", buf.String())
+	}
+
+	// Below the cap must not warn.
+	buf.Reset()
+	stack.Telemetry.Retention = &RetentionConfig{MaxSizeMB: 100, MaxBackups: 5, MaxAgeDays: 7}
+	if err := Validate(stack); err != nil {
+		t.Fatalf("Validate must accept default retention: %v", err)
+	}
+	if strings.Contains(buf.String(), "soft cap") {
+		t.Errorf("did not expect soft-cap warning for default retention, got: %q", buf.String())
+	}
+}
+
+func TestTelemetry_NoBlockBackwardsCompatible(t *testing.T) {
+	// A stack file with no telemetry block must parse with Stack.Telemetry == nil
+	// and resolver helpers returning false for every server. This guards the
+	// "default off in beta" acceptance criterion.
+	source := `version: "1"
+name: legacy
+network:
+  name: legacy-net
+mcp-servers:
+  - name: github
+    image: alpine
+    port: 3000
+`
+	var stack Stack
+	if err := yaml.Unmarshal([]byte(source), &stack); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	stack.SetDefaults()
+
+	if stack.Telemetry != nil {
+		t.Errorf("Stack.Telemetry must be nil for legacy stacks, got %+v", stack.Telemetry)
+	}
+	server := &stack.MCPServers[0]
+	if server.PersistLogs(&stack) || server.PersistMetrics(&stack) || server.PersistTraces(&stack) {
+		t.Error("legacy stack: every persist resolver must return false")
+	}
+}
+
+func boolPtrEqual(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func derefOrNil(p *bool) interface{} {
+	if p == nil {
+		return nil
+	}
+	return *p
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -7,16 +7,17 @@ import (
 
 // Stack represents the complete gridctl configuration.
 type Stack struct {
-	Version    string          `yaml:"version"`
-	Name       string          `yaml:"name"`
-	Extends    string          `yaml:"extends,omitempty"`    // Path to a parent stack file for composition
-	Gateway    *GatewayConfig  `yaml:"gateway,omitempty"`
-	Logging    *LoggingConfig  `yaml:"logging,omitempty"`
-	Secrets    *Secrets        `yaml:"secrets,omitempty"`     // Variable set references
-	Network    Network         `yaml:"network"`               // Single network (simple mode)
-	Networks   []Network       `yaml:"networks,omitempty"`    // Multiple networks (advanced mode)
-	MCPServers []MCPServer     `yaml:"mcp-servers"`
-	Resources  []Resource      `yaml:"resources,omitempty"`
+	Version    string           `yaml:"version"`
+	Name       string           `yaml:"name"`
+	Extends    string           `yaml:"extends,omitempty"` // Path to a parent stack file for composition
+	Gateway    *GatewayConfig   `yaml:"gateway,omitempty"`
+	Logging    *LoggingConfig   `yaml:"logging,omitempty"`
+	Telemetry  *TelemetryConfig `yaml:"telemetry,omitempty"` // Opt-in disk persistence for logs/metrics/traces
+	Secrets    *Secrets         `yaml:"secrets,omitempty"`   // Variable set references
+	Network    Network          `yaml:"network"`             // Single network (simple mode)
+	Networks   []Network        `yaml:"networks,omitempty"`  // Multiple networks (advanced mode)
+	MCPServers []MCPServer      `yaml:"mcp-servers"`
+	Resources  []Resource       `yaml:"resources,omitempty"`
 }
 
 // LoggingConfig configures log file output with automatic rotation.
@@ -30,6 +31,60 @@ type LoggingConfig struct {
 	MaxAgeDays int `yaml:"maxAgeDays,omitempty" json:"maxAgeDays,omitempty"`
 	// MaxBackups is the maximum number of compressed old log files to keep (default: 3).
 	MaxBackups int `yaml:"maxBackups,omitempty" json:"maxBackups,omitempty"`
+}
+
+// TelemetryConfig configures opt-in disk persistence for the three signals
+// gridctl already captures (logs, metrics, traces). All fields are optional;
+// when the block is omitted entirely, every signal stays ephemeral (today's
+// behavior). Per-server overrides on MCPServer.Telemetry can flip individual
+// signals on or off relative to these defaults.
+//
+// Stack-global Persist fields are plain bool (binary on/off). Per-server
+// MCPServerPersistence fields are *bool to express tri-state inheritance —
+// see MCPServerTelemetry.
+type TelemetryConfig struct {
+	// Persist names which signals are written to disk by default. Per-server
+	// blocks can override individual signals.
+	Persist TelemetryPersistence `yaml:"persist,omitempty" json:"persist,omitempty"`
+	// Retention controls lumberjack rotation for every persisted signal file.
+	// SetDefaults fills sensible defaults when this block is omitted.
+	Retention *RetentionConfig `yaml:"retention,omitempty" json:"retention,omitempty"`
+}
+
+// TelemetryPersistence is the stack-global signal toggle. Stack-global is
+// binary (a bool) — the per-server override carries the tri-state.
+type TelemetryPersistence struct {
+	Logs    bool `yaml:"logs,omitempty" json:"logs,omitempty"`
+	Metrics bool `yaml:"metrics,omitempty" json:"metrics,omitempty"`
+	Traces  bool `yaml:"traces,omitempty" json:"traces,omitempty"`
+}
+
+// RetentionConfig controls lumberjack rotation for persisted telemetry files.
+// One block per stack — per-signal retention is intentionally out of scope at
+// MVP. Defaults: 100MB / 5 backups / 7d. YAML tags use snake_case to match the
+// AutoscaleConfig precedent for control-plane structs (LoggingConfig uses
+// camelCase, but is closer to a runtime-rotation knob than a control-plane
+// resource).
+type RetentionConfig struct {
+	MaxSizeMB  int `yaml:"max_size_mb,omitempty" json:"max_size_mb,omitempty"`
+	MaxBackups int `yaml:"max_backups,omitempty" json:"max_backups,omitempty"`
+	MaxAgeDays int `yaml:"max_age_days,omitempty" json:"max_age_days,omitempty"`
+}
+
+// MCPServerTelemetry holds per-server telemetry persistence overrides. Each
+// *bool field uses tri-state semantics: nil = inherit stack-global, &true =
+// explicitly persist, &false = explicitly do not persist (overrides stack
+// global). Never default these to &false in SetDefaults — that would collapse
+// inherit and explicit-off into the same value.
+type MCPServerTelemetry struct {
+	Persist MCPServerPersistence `yaml:"persist,omitempty" json:"persist,omitempty"`
+}
+
+// MCPServerPersistence is the *bool tri-state mirror of TelemetryPersistence.
+type MCPServerPersistence struct {
+	Logs    *bool `yaml:"logs,omitempty" json:"logs,omitempty"`
+	Metrics *bool `yaml:"metrics,omitempty" json:"metrics,omitempty"`
+	Traces  *bool `yaml:"traces,omitempty" json:"traces,omitempty"`
 }
 
 // Secrets configures automatic secret injection from variable sets.
@@ -167,6 +222,10 @@ type MCPServer struct {
 	// autoscaling bounded by Min and Max. Mutually exclusive with Replicas.
 	// Not supported on external URL or OpenAPI transports.
 	Autoscale *AutoscaleConfig `yaml:"autoscale,omitempty" json:"autoscale,omitempty"`
+
+	// Telemetry, when set, overrides stack-global telemetry persistence for
+	// this server. nil fields inherit; *bool fields explicitly opt in or out.
+	Telemetry *MCPServerTelemetry `yaml:"telemetry,omitempty" json:"telemetry,omitempty"`
 }
 
 // AutoscaleConfig controls reactive autoscaling of a ReplicaSet. All fields are
@@ -327,6 +386,33 @@ func (s *MCPServer) IsContainerBased() bool {
 	return !s.IsExternal() && !s.IsLocalProcess() && !s.IsSSH() && !s.IsOpenAPI()
 }
 
+// PersistLogs reports whether log persistence is effectively enabled for this
+// server. An explicit per-server *bool override wins; otherwise the stack-
+// global default is returned. Returns false when both stack and server are
+// nil.
+func (s *MCPServer) PersistLogs(stack *Stack) bool {
+	if s != nil && s.Telemetry != nil && s.Telemetry.Persist.Logs != nil {
+		return *s.Telemetry.Persist.Logs
+	}
+	return stack != nil && stack.Telemetry != nil && stack.Telemetry.Persist.Logs
+}
+
+// PersistMetrics — see PersistLogs for inheritance semantics.
+func (s *MCPServer) PersistMetrics(stack *Stack) bool {
+	if s != nil && s.Telemetry != nil && s.Telemetry.Persist.Metrics != nil {
+		return *s.Telemetry.Persist.Metrics
+	}
+	return stack != nil && stack.Telemetry != nil && stack.Telemetry.Persist.Metrics
+}
+
+// PersistTraces — see PersistLogs for inheritance semantics.
+func (s *MCPServer) PersistTraces(stack *Stack) bool {
+	if s != nil && s.Telemetry != nil && s.Telemetry.Persist.Traces != nil {
+		return *s.Telemetry.Persist.Traces
+	}
+	return stack != nil && stack.Telemetry != nil && stack.Telemetry.Persist.Traces
+}
+
 // Source defines how to build an MCP server from source code.
 type Source struct {
 	Type       string      `yaml:"type"` // "git" or "local"
@@ -462,5 +548,22 @@ func (s *Stack) SetDefaults() {
 		}
 	}
 
+	// Telemetry retention defaults. Only fill when the stack opts in to
+	// telemetry; never synthesize a Telemetry block on stacks that omit one,
+	// since that would change parsed-config equality vs today's behavior.
+	if s.Telemetry != nil {
+		if s.Telemetry.Retention == nil {
+			s.Telemetry.Retention = &RetentionConfig{}
+		}
+		if s.Telemetry.Retention.MaxSizeMB == 0 {
+			s.Telemetry.Retention.MaxSizeMB = 100
+		}
+		if s.Telemetry.Retention.MaxBackups == 0 {
+			s.Telemetry.Retention.MaxBackups = 5
+		}
+		if s.Telemetry.Retention.MaxAgeDays == 0 {
+			s.Telemetry.Retention.MaxAgeDays = 7
+		}
+	}
 }
 

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -11,6 +12,23 @@ import (
 // are almost certainly a config error; the cap also bounds per-server
 // fan-out costs for things like health checking and least-connections scans.
 const maxReplicas = 32
+
+// telemetryWarnBytesPerServer is the soft cap above which a stack-wide
+// retention block triggers a warning. 5 GiB matches the prompt and is large
+// enough that legitimate tuning rarely crosses it; users who explicitly
+// configure higher retention still get a load-time warning rather than a
+// hard reject.
+const telemetryWarnBytesPerServer = 5 * 1024 * 1024 * 1024
+
+// Hard upper bounds on retention values. These exist to defuse arithmetic
+// overflow on the per-server-bytes math and to catch obvious typos
+// (e.g. an extra zero). They are intentionally generous; the soft cap above
+// will warn long before these trip.
+const (
+	telemetryMaxSizeMBHardCap  = 1 << 20 // 1 TiB per file
+	telemetryMaxBackupsHardCap = 1024
+	telemetryMaxAgeDaysHardCap = 365 * 10 // 10 years
+)
 
 // ValidationError represents a configuration validation error.
 type ValidationError struct {
@@ -67,6 +85,11 @@ func Validate(s *Stack) error {
 	// Gateway maxToolResultBytes validation
 	if s.Gateway != nil && s.Gateway.MaxToolResultBytes < 0 {
 		errs = append(errs, ValidationError{"gateway.maxToolResultBytes", "must be a non-negative integer"})
+	}
+
+	// Telemetry retention validation
+	if s.Telemetry != nil && s.Telemetry.Retention != nil {
+		errs = append(errs, validateTelemetryRetention(s.Telemetry.Retention)...)
 	}
 
 	// Gateway auth validation
@@ -498,6 +521,47 @@ func validateAutoscale(server MCPServer, prefix string) ValidationErrors {
 	}
 	if a.Max >= 1 && a.Min+a.WarmPool > a.Max {
 		errs = append(errs, ValidationError{asPrefix + ".warm_pool", "min + warm_pool must be <= max"})
+	}
+
+	return errs
+}
+
+// validateTelemetryRetention enforces hard bounds on the telemetry.retention
+// block and emits a soft warning when the worst-case footprint per server
+// exceeds telemetryWarnBytesPerServer. Hard bounds: every field must be a
+// positive integer; max_size_mb must be >= 1.
+func validateTelemetryRetention(r *RetentionConfig) ValidationErrors {
+	var errs ValidationErrors
+	const prefix = "telemetry.retention"
+
+	if r.MaxSizeMB < 1 {
+		errs = append(errs, ValidationError{prefix + ".max_size_mb", "must be >= 1"})
+	} else if r.MaxSizeMB > telemetryMaxSizeMBHardCap {
+		errs = append(errs, ValidationError{prefix + ".max_size_mb", fmt.Sprintf("must be <= %d", telemetryMaxSizeMBHardCap)})
+	}
+	if r.MaxBackups < 1 {
+		errs = append(errs, ValidationError{prefix + ".max_backups", "must be >= 1"})
+	} else if r.MaxBackups > telemetryMaxBackupsHardCap {
+		errs = append(errs, ValidationError{prefix + ".max_backups", fmt.Sprintf("must be <= %d", telemetryMaxBackupsHardCap)})
+	}
+	if r.MaxAgeDays < 1 {
+		errs = append(errs, ValidationError{prefix + ".max_age_days", "must be >= 1"})
+	} else if r.MaxAgeDays > telemetryMaxAgeDaysHardCap {
+		errs = append(errs, ValidationError{prefix + ".max_age_days", fmt.Sprintf("must be <= %d", telemetryMaxAgeDaysHardCap)})
+	}
+
+	// Soft warning. Only meaningful when the hard bounds are satisfied so the
+	// product can't underflow into a misleading number.
+	if len(errs) == 0 {
+		bytesPerServer := int64(r.MaxSizeMB) * 1024 * 1024 * int64(r.MaxBackups)
+		if bytesPerServer > telemetryWarnBytesPerServer {
+			slog.Warn("telemetry retention exceeds soft cap; per-server footprint may grow large",
+				"max_size_mb", r.MaxSizeMB,
+				"max_backups", r.MaxBackups,
+				"per_server_bytes", bytesPerServer,
+				"soft_cap_bytes", telemetryWarnBytesPerServer,
+			)
+		}
 	}
 
 	return errs


### PR DESCRIPTION
## Description

Phase 1 of 6 toward opt-in telemetry persistence. Adds the config schema, retention defaults, validation, and per-server inheritance resolvers. Persistence backends, API endpoints, frontend, CLI, and docs ship in subsequent PRs.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- New types: `TelemetryConfig`, `TelemetryPersistence`, `RetentionConfig`, `MCPServerTelemetry`, `MCPServerPersistence`. `Stack.Telemetry` and `MCPServer.Telemetry` fields added.
- Resolver helpers `PersistLogs/PersistMetrics/PersistTraces(stack)` apply tri-state inheritance: `nil` per-server = inherit, `&true`/`&false` = explicit override.
- `SetDefaults` fills retention (100MB / 5 backups / 7 days) only when `Telemetry != nil` — never synthesizes a block on legacy stacks. Idempotent across hot-reload.
- Validation: hard bounds (`max_size_mb >= 1`, upper caps at 1 TiB / 1024 backups / 10 years) plus a `slog.Warn` soft cap when per-server worst case > 5 GiB.
- Stack-global persistence is binary `bool`; per-server is `*bool` to express tri-state. Documented on `TelemetryConfig`.

## Testing

- Full inheritance matrix across stack-global × per-server.
- `SetDefaults` idempotence test.
- YAML round-trip of stack-global block and per-server `nil`/`&true`/`&false`.
- Validation: every hard-bound failure path, hard-cap failure paths, soft-cap warning capture via test slog handler.
- Backwards compatibility: legacy stacks with no telemetry block parse to `Stack.Telemetry == nil` and every resolver returns `false`.
- `make build`, `go test -race ./...`, and `golangci-lint run ./pkg/config/...` all pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #550