### PR TITLE
feat: add telemetry persistence backends

### DIFF
--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -12,6 +12,8 @@ import (
 	"syscall"
 	"time"
 
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+
 	"github.com/gridctl/gridctl/internal/api"
 	"github.com/gridctl/gridctl/internal/probe"
 	"github.com/gridctl/gridctl/pkg/config"
@@ -25,6 +27,7 @@ import (
 	"github.com/gridctl/gridctl/pkg/runtime"
 	"github.com/gridctl/gridctl/pkg/skills"
 	"github.com/gridctl/gridctl/pkg/state"
+	"github.com/gridctl/gridctl/pkg/telemetry"
 	"github.com/gridctl/gridctl/pkg/token"
 	"github.com/gridctl/gridctl/pkg/tracing"
 	"github.com/gridctl/gridctl/pkg/vault"
@@ -70,6 +73,20 @@ type GatewayBuilder struct {
 
 	// tracingProvider is retained so Shutdown() can be called on gateway exit.
 	tracingProvider *tracing.Provider
+
+	// telemetry holds the opt-in disk-persistence writers wired at Build
+	// time. Nil when no server in the stack opts in.
+	telemetry *telemetryWiring
+}
+
+// telemetryWiring bundles the three per-signal writers + the otlptrace
+// exporter that feeds TracesFileClient. Lifecycle is owned by GatewayBuilder
+// (Build/Run/waitForShutdown).
+type telemetryWiring struct {
+	logRouter      *telemetry.LogRouter
+	metricsFlusher *telemetry.MetricsFlusher
+	tracesClient   *telemetry.TracesFileClient
+	tracesExporter *otlptrace.Exporter // started lazily inside Provider.RegisterExporter
 }
 
 // NewGatewayBuilder creates a GatewayBuilder.
@@ -171,6 +188,12 @@ func (b *GatewayBuilder) Build(verbose bool) (*GatewayInstance, error) {
 	inst.Gateway.SetLogger(slog.New(inst.Handler))
 	registryServer.SetLogger(slog.New(inst.Handler))
 
+	// Seed the in-memory log buffer from any pre-existing per-server
+	// logs.jsonl files BEFORE registry init or any other component starts
+	// emitting records. Otherwise live records can interleave with seeded
+	// history and scramble ring ordering.
+	b.seedLogsFromDisk(inst.LogBuffer, inst.Handler)
+
 	// Initialize registry after logging is configured so warnings are captured
 	if err := registryServer.Initialize(context.Background()); err != nil {
 		slog.New(inst.Handler).Warn("registry initialization failed", "error", err)
@@ -205,6 +228,53 @@ func (b *GatewayBuilder) Build(verbose bool) (*GatewayInstance, error) {
 	}
 
 	return inst, nil
+}
+
+// telemetrySeedLimit caps the number of pre-restart entries replayed into a
+// ring buffer at startup. Leaves room for new live entries and bounds
+// startup I/O.
+const telemetrySeedLimit = 500
+
+// seedLogsFromDisk replays any existing per-server logs.jsonl into the
+// shared in-memory log buffer. Called early in Build (before registry init
+// or any other goroutine emits a record) so seeded history precedes live
+// records in the ring.
+func (b *GatewayBuilder) seedLogsFromDisk(buf *logging.LogBuffer, handler slog.Handler) {
+	if b.stack == nil || buf == nil {
+		return
+	}
+	logger := slog.New(handler)
+	for i := range b.stack.MCPServers {
+		srv := &b.stack.MCPServers[i]
+		if srv.Name == "" || !srv.PersistLogs(b.stack) {
+			continue
+		}
+		path := state.TelemetryServerPath(b.stack.Name, srv.Name, "logs")
+		if err := buf.SeedFromFile(path, telemetrySeedLimit); err != nil {
+			logger.Warn("telemetry: seed logs failed", "server", srv.Name, "path", path, "error", err)
+		}
+	}
+}
+
+// seedTracesFromDisk replays any existing per-server traces.jsonl into the
+// shared tracing buffer. Called immediately after tracingProvider.Init —
+// before the trace file exporter is registered and before registry init —
+// so seeded traces don't interleave with live spans.
+func (b *GatewayBuilder) seedTracesFromDisk(handler slog.Handler) {
+	if b.stack == nil || b.tracingProvider == nil || b.tracingProvider.Buffer == nil {
+		return
+	}
+	logger := slog.New(handler)
+	for i := range b.stack.MCPServers {
+		srv := &b.stack.MCPServers[i]
+		if srv.Name == "" || !srv.PersistTraces(b.stack) {
+			continue
+		}
+		path := state.TelemetryServerPath(b.stack.Name, srv.Name, "traces")
+		if err := b.tracingProvider.Buffer.SeedFromFile(path, telemetrySeedLimit); err != nil {
+			logger.Warn("telemetry: seed traces failed", "server", srv.Name, "path", path, "error", err)
+		}
+	}
 }
 
 // Run starts the HTTP server, registers MCP servers, and blocks until shutdown.
@@ -251,6 +321,11 @@ func (b *GatewayBuilder) Run(ctx context.Context, inst *GatewayInstance, verbose
 		filepath.Join(state.BaseDir(), "registry"),
 		slog.New(bufferHandler),
 	)
+
+	// Start the telemetry metrics flusher (no-op when no server opts in).
+	if b.telemetry != nil && b.telemetry.metricsFlusher != nil {
+		b.telemetry.metricsFlusher.Start()
+	}
 
 	// Set up hot reload
 	b.setupHotReload(ctx, inst, registrar, bufferHandler, verbose)
@@ -326,7 +401,18 @@ func (b *GatewayBuilder) buildLogging(verbose bool) (*logging.LogBuffer, slog.Ha
 			"rotation", fmt.Sprintf("%dMB", maxSizeMB))
 	}
 
-	return logBuffer, redactHandler, nil
+	// Wrap the existing chain with the telemetry log router. The router is
+	// always installed; per-server file fan-out only kicks in when
+	// AddServer is called for a given component. This keeps the install
+	// cost zero for stacks that don't opt in.
+	router := telemetry.NewLogRouter(redactHandler)
+	if b.telemetry == nil {
+		b.telemetry = &telemetryWiring{}
+	}
+	b.telemetry.logRouter = router
+	router.SetSelfLogger(slog.New(redactHandler))
+
+	return logBuffer, router, nil
 }
 
 // buildAPIServer creates and configures the API server.
@@ -374,6 +460,17 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 	server.SetMetricsAccumulator(accumulator)
 	server.SetTokenizerName(b.tokenizerName())
 
+	// Telemetry persistence: wire the metrics flusher. Adding per-server
+	// outputs happens in wireTelemetryPersistence after the tracing
+	// provider is initialized below — keeps all opt-in writers grouped.
+	if b.telemetry == nil {
+		b.telemetry = &telemetryWiring{}
+	}
+	b.telemetry.metricsFlusher = telemetry.NewMetricsFlusher(accumulator, 0)
+	if handler != nil {
+		b.telemetry.metricsFlusher.SetLogger(slog.New(handler))
+	}
+
 	// Wire the wizard's "Discover tools" probe. Scope: external URL
 	// servers only — container / stdio / local-process / SSH / OpenAPI are
 	// curated post-deploy from the topology sidebar.
@@ -396,7 +493,177 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 	b.tracingProvider = tracingProvider
 	server.SetTraceBuffer(tracingProvider.Buffer)
 
+	// Seed the trace buffer from disk before live spans land in it. Done
+	// here (not later in Build) because registry init and other Build
+	// stages can begin emitting spans the moment the provider is live.
+	b.seedTracesFromDisk(handler)
+
+	// Telemetry persistence: register the trace file client as an extra
+	// span exporter alongside the in-memory buffer and the optional OTLP
+	// exporter. The exporter is started during otlptrace.NewUnstarted ->
+	// exporter.Start; failure is logged and the in-memory tracing path
+	// continues unaffected.
+	if tracingCfg.Enabled && b.telemetry != nil {
+		client := telemetry.NewTracesFileClient()
+		if handler != nil {
+			client.SetLogger(slog.New(handler))
+		}
+		exporter, err := otlptrace.New(context.Background(), client)
+		if err != nil {
+			slog.New(handler).Warn("telemetry trace exporter init failed; per-server traces.jsonl disabled",
+				"error", err)
+		} else {
+			b.telemetry.tracesClient = client
+			b.telemetry.tracesExporter = exporter
+			tracingProvider.RegisterExporter(exporter)
+		}
+	}
+
+	// Apply the current stack's per-server persistence settings.
+	b.applyTelemetryConfig(server, handler)
+
 	return server, nil
+}
+
+// applyTelemetryConfig walks the stack's MCP servers and registers per-
+// server file writers for every signal a server opts into. Idempotent:
+// re-running with a changed stack adds new writers and removes ones that
+// flipped to off. Used both at initial Build time and from the hot-reload
+// callback so a YAML change takes effect without restarting the daemon.
+func (b *GatewayBuilder) applyTelemetryConfig(apiServer *api.Server, handler slog.Handler) {
+	_ = apiServer // reserved for Phase 3 (inventory hookup); keeps callers stable
+	if b.telemetry == nil || b.stack == nil {
+		return
+	}
+
+	logger := slog.New(handler)
+	stack := b.stack
+
+	// Compute desired set per signal.
+	wantLogs := map[string]bool{}
+	wantMetrics := map[string]bool{}
+	wantTraces := map[string]bool{}
+	for i := range stack.MCPServers {
+		srv := &stack.MCPServers[i]
+		if srv.Name == "" {
+			continue
+		}
+		if srv.PersistLogs(stack) {
+			wantLogs[srv.Name] = true
+		}
+		if srv.PersistMetrics(stack) {
+			wantMetrics[srv.Name] = true
+		}
+		if srv.PersistTraces(stack) {
+			wantTraces[srv.Name] = true
+		}
+	}
+
+	if len(wantLogs)+len(wantMetrics)+len(wantTraces) == 0 {
+		// Nothing to persist; ensure any previously-registered writers
+		// are torn down (handles hot-reload "off").
+		if b.telemetry.logRouter != nil {
+			for _, n := range b.telemetry.logRouter.ConfiguredServers() {
+				b.telemetry.logRouter.RemoveServer(n)
+			}
+		}
+		if b.telemetry.metricsFlusher != nil {
+			for _, n := range b.telemetry.metricsFlusher.ConfiguredServers() {
+				b.telemetry.metricsFlusher.RemoveServer(n)
+			}
+		}
+		if b.telemetry.tracesClient != nil {
+			for _, n := range b.telemetry.tracesClient.ConfiguredServers() {
+				b.telemetry.tracesClient.RemoveServer(n)
+			}
+		}
+		return
+	}
+
+	opts := telemetryRotationOpts(stack)
+
+	// Logs.
+	if router := b.telemetry.logRouter; router != nil {
+		current := stringSet(router.ConfiguredServers())
+		for name := range wantLogs {
+			if err := state.EnsureTelemetryServerDir(stack.Name, name); err != nil {
+				logger.Warn("telemetry: cannot ensure dir", "server", name, "error", err)
+				continue
+			}
+			path := state.TelemetryServerPath(stack.Name, name, "logs")
+			if err := router.AddServer(name, path, opts); err != nil {
+				logger.Warn("telemetry: log writer install failed", "server", name, "path", path, "error", err)
+			}
+		}
+		for name := range current {
+			if !wantLogs[name] {
+				router.RemoveServer(name)
+			}
+		}
+	}
+
+	// Metrics.
+	if flusher := b.telemetry.metricsFlusher; flusher != nil {
+		current := stringSet(flusher.ConfiguredServers())
+		for name := range wantMetrics {
+			if err := state.EnsureTelemetryServerDir(stack.Name, name); err != nil {
+				logger.Warn("telemetry: cannot ensure dir", "server", name, "error", err)
+				continue
+			}
+			path := state.TelemetryServerPath(stack.Name, name, "metrics")
+			if err := flusher.AddServer(name, path, opts); err != nil {
+				logger.Warn("telemetry: metrics writer install failed", "server", name, "path", path, "error", err)
+			}
+		}
+		for name := range current {
+			if !wantMetrics[name] {
+				flusher.RemoveServer(name)
+			}
+		}
+	}
+
+	// Traces.
+	if tc := b.telemetry.tracesClient; tc != nil {
+		current := stringSet(tc.ConfiguredServers())
+		for name := range wantTraces {
+			if err := state.EnsureTelemetryServerDir(stack.Name, name); err != nil {
+				logger.Warn("telemetry: cannot ensure dir", "server", name, "error", err)
+				continue
+			}
+			path := state.TelemetryServerPath(stack.Name, name, "traces")
+			if err := tc.AddServer(name, path, opts); err != nil {
+				logger.Warn("telemetry: traces writer install failed", "server", name, "path", path, "error", err)
+			}
+		}
+		for name := range current {
+			if !wantTraces[name] {
+				tc.RemoveServer(name)
+			}
+		}
+	}
+}
+
+// telemetryRotationOpts pulls retention from stack config or falls back to
+// the lumberjack defaults. Phase 1's SetDefaults already fills retention
+// when telemetry is set, so the zero-value fallbacks are belt-and-braces.
+func telemetryRotationOpts(stack *config.Stack) telemetry.LogOpts {
+	if stack == nil || stack.Telemetry == nil || stack.Telemetry.Retention == nil {
+		return telemetry.LogOpts{}
+	}
+	r := stack.Telemetry.Retention
+	return telemetry.LogOpts{
+		MaxSizeMB:  r.MaxSizeMB,
+		MaxBackups: r.MaxBackups,
+		MaxAgeDays: r.MaxAgeDays,
+	}
+}
+
+func stringSet(in []string) map[string]bool {
+	out := make(map[string]bool, len(in))
+	for _, s := range in {
+		out[s] = true
+	}
+	return out
 }
 
 // tokenizerName returns the configured tokenizer mode, defaulting to "embedded".
@@ -482,6 +749,13 @@ func (b *GatewayBuilder) setupHotReload(ctx context.Context, inst *GatewayInstan
 			runtimes = append(runtimes, ReplicaRuntime{HostPort: rep.HostPort, ContainerID: rep.ContainerID})
 		}
 		return registrar.RegisterOne(ctx, server, runtimes, stackPath)
+	})
+	// After a successful reload, refresh per-server telemetry writers so a
+	// YAML-toggled persist setting takes effect without restart. The
+	// callback fires under reload.Handler.mu — keep it allocation-light.
+	reloadHandler.SetOnConfigApplied(func(newCfg *config.Stack) {
+		b.stack = newCfg
+		b.applyTelemetryConfig(inst.APIServer, handler)
 	})
 	inst.APIServer.SetReloadHandler(reloadHandler)
 
@@ -579,10 +853,18 @@ func (b *GatewayBuilder) waitForShutdown(inst *GatewayInstance, handler slog.Han
 			logger.Error("HTTP server shutdown error", "error", err)
 		}
 
+		if b.telemetry != nil && b.telemetry.metricsFlusher != nil {
+			b.telemetry.metricsFlusher.Stop()
+		}
+
 		if b.tracingProvider != nil {
 			if err := b.tracingProvider.Shutdown(shutdownCtx); err != nil {
 				logger.Error("tracing shutdown error", "error", err)
 			}
+		}
+
+		if b.telemetry != nil && b.telemetry.logRouter != nil {
+			b.telemetry.logRouter.Close()
 		}
 
 		_ = state.Delete(b.stack.Name)

--- a/pkg/logging/buffer.go
+++ b/pkg/logging/buffer.go
@@ -2,9 +2,13 @@
 package logging
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -88,6 +92,97 @@ func (b *LogBuffer) GetRecent(n int) []BufferedEntry {
 	}
 
 	return result
+}
+
+// SeedFromFile reads up to the last n NDJSON entries from path and inserts
+// them into the buffer in chronological order. Used on daemon startup to
+// preload the in-memory ring with pre-restart entries from a persisted
+// per-server log file. Missing or empty files return nil — that's expected
+// on the very first run with persistence enabled.
+//
+// The on-disk format is the JSON-formatted output produced by
+// NewFileHandler: top-level keys "level" / "ts" / "msg" / "component" plus
+// arbitrary attrs. Lines that fail to parse are skipped without aborting
+// the seed; a single corrupt line should not lose the rest of the history.
+func (b *LogBuffer) SeedFromFile(path string, n int) error {
+	if path == "" {
+		return nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("seed log buffer from %q: %w", path, err)
+	}
+	defer f.Close()
+
+	// Read every line — file size is bounded by lumberjack rotation, and
+	// scanner buffers grow on demand. Take the last n on a second pass.
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("seed log buffer scan %q: %w", path, err)
+	}
+
+	if n > 0 && len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		entry, ok := parseFileLogLine(line)
+		if !ok {
+			continue
+		}
+		b.Add(entry)
+	}
+	return nil
+}
+
+// parseFileLogLine converts one JSON log line written by NewFileHandler back
+// into a BufferedEntry. Returns ok=false on malformed input so callers can
+// skip and continue.
+func parseFileLogLine(line string) (BufferedEntry, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return BufferedEntry{}, false
+	}
+	entry := BufferedEntry{
+		Attrs: make(map[string]any),
+	}
+	if v, ok := raw["level"].(string); ok {
+		entry.Level = v
+	}
+	if v, ok := raw["ts"].(string); ok {
+		entry.Timestamp = v
+	}
+	if v, ok := raw["msg"].(string); ok {
+		entry.Message = v
+	}
+	if v, ok := raw["component"].(string); ok {
+		entry.Component = v
+	}
+	if v, ok := raw["trace_id"].(string); ok {
+		entry.TraceID = v
+	}
+	for k, v := range raw {
+		switch k {
+		case "level", "ts", "msg", "component", "trace_id", "time", "subsystem":
+			continue
+		}
+		entry.Attrs[k] = v
+	}
+	if len(entry.Attrs) == 0 {
+		entry.Attrs = nil
+	}
+	return entry, true
 }
 
 // Clear removes all entries from the buffer.

--- a/pkg/reload/reload.go
+++ b/pkg/reload/reload.go
@@ -42,6 +42,11 @@ type Handler struct {
 	// stack path; passed through to the registrar so the gateway_builder closure
 	// does not need to re-enter the Handler mutex to look it up.
 	registerServer func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error
+
+	// onConfigApplied fires after currentCfg has been swapped to newCfg and
+	// per-server diffs have applied. Used by gateway_builder to refresh
+	// telemetry persistence wiring without rebuilding the gateway.
+	onConfigApplied func(*config.Stack)
 }
 
 // ReplicaRuntime carries runtime handles for one replica that the reload
@@ -82,6 +87,15 @@ func (h *Handler) SetNoExpand(noExpand bool) {
 // SetRegisterServerFunc sets the callback for registering MCP servers.
 func (h *Handler) SetRegisterServerFunc(fn func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error) {
 	h.registerServer = fn
+}
+
+// SetOnConfigApplied registers a hook fired after a successful reload swaps
+// currentCfg. Today only the telemetry persistence layer hooks this — it
+// uses the new stack to refresh per-server file writers without restarting
+// the gateway. The hook runs while the handler still holds its mutex, so
+// callbacks must be quick and must not call back into Handler.
+func (h *Handler) SetOnConfigApplied(fn func(*config.Stack)) {
+	h.onConfigApplied = fn
 }
 
 // CurrentConfig returns the current stack configuration.
@@ -187,6 +201,12 @@ func (h *Handler) Reload(ctx context.Context) (*ReloadResult, error) {
 
 	// Update current config
 	h.currentCfg = newCfg
+
+	// Notify any registered post-reload hook (telemetry writer refresh).
+	// Runs under h.mu — hooks must not re-enter the handler.
+	if h.onConfigApplied != nil {
+		h.onConfigApplied(newCfg)
+	}
 
 	// Per-item failures collected during applyMCPServerChanges /
 	// applyResourceChanges must flip Success so callers (HTTP handler, file

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -242,6 +242,33 @@ func EnsureLogDir() error {
 	return os.MkdirAll(LogDir(), 0755)
 }
 
+// TelemetryDir returns the root directory for opt-in telemetry persistence
+// (~/.gridctl/telemetry/). Subtree layout: <stack>/<server>/{logs,metrics,traces}.jsonl.
+func TelemetryDir() string {
+	return filepath.Join(BaseDir(), "telemetry")
+}
+
+// TelemetryServerDir returns the per-server directory under TelemetryDir for
+// the given stack and server.
+func TelemetryServerDir(stackName, serverName string) string {
+	return filepath.Join(TelemetryDir(), stackName, serverName)
+}
+
+// TelemetryServerPath returns the path to a single signal file for a server.
+// signal must be "logs", "metrics", or "traces"; any string is accepted but
+// only those three are produced by the daemon.
+func TelemetryServerPath(stackName, serverName, signal string) string {
+	return filepath.Join(TelemetryServerDir(stackName, serverName), signal+".jsonl")
+}
+
+// EnsureTelemetryServerDir creates the per-server telemetry directory with
+// mode 0700, matching the vault/state convention. Any new directories on the
+// path inherit the same restrictive permissions because lumberjack will not
+// chmod them on its own.
+func EnsureTelemetryServerDir(stackName, serverName string) error {
+	return os.MkdirAll(TelemetryServerDir(stackName, serverName), 0700)
+}
+
 // WithLock executes fn while holding an exclusive lock on the stack state.
 // Returns error if lock cannot be acquired within timeout.
 func WithLock(name string, timeout time.Duration, fn func() error) error {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -74,6 +74,62 @@ func TestLogPath(t *testing.T) {
 	}
 }
 
+func TestTelemetryDir(t *testing.T) {
+	cleanup := setTempHome(t)
+	defer cleanup()
+
+	home := os.Getenv("HOME")
+	expected := filepath.Join(home, ".gridctl", "telemetry")
+	if got := TelemetryDir(); got != expected {
+		t.Errorf("TelemetryDir() = %q, want %q", got, expected)
+	}
+}
+
+func TestTelemetryServerPath(t *testing.T) {
+	cleanup := setTempHome(t)
+	defer cleanup()
+
+	home := os.Getenv("HOME")
+	tests := []struct {
+		stack  string
+		server string
+		signal string
+		want   string
+	}{
+		{"my-stack", "github", "logs", filepath.Join(home, ".gridctl", "telemetry", "my-stack", "github", "logs.jsonl")},
+		{"my-stack", "github", "metrics", filepath.Join(home, ".gridctl", "telemetry", "my-stack", "github", "metrics.jsonl")},
+		{"my-stack", "github", "traces", filepath.Join(home, ".gridctl", "telemetry", "my-stack", "github", "traces.jsonl")},
+		{"prod", "weather-api", "logs", filepath.Join(home, ".gridctl", "telemetry", "prod", "weather-api", "logs.jsonl")},
+	}
+	for _, tc := range tests {
+		got := TelemetryServerPath(tc.stack, tc.server, tc.signal)
+		if got != tc.want {
+			t.Errorf("TelemetryServerPath(%q,%q,%q) = %q, want %q", tc.stack, tc.server, tc.signal, got, tc.want)
+		}
+	}
+}
+
+func TestEnsureTelemetryServerDir(t *testing.T) {
+	cleanup := setTempHome(t)
+	defer cleanup()
+
+	if err := EnsureTelemetryServerDir("my-stack", "github"); err != nil {
+		t.Fatalf("EnsureTelemetryServerDir: %v", err)
+	}
+	dir := TelemetryServerDir("my-stack", "github")
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("expected directory at %s", dir)
+	}
+	// Mode 0700 — leaf directory must match the vault/state convention.
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Errorf("dir mode = %v, want 0700", got)
+	}
+}
+
 func TestSave_CreatesFile(t *testing.T) {
 	cleanup := setTempHome(t)
 	defer cleanup()

--- a/pkg/telemetry/logs.go
+++ b/pkg/telemetry/logs.go
@@ -1,0 +1,295 @@
+// Package telemetry implements opt-in disk persistence for the three signal
+// types gridctl already captures in memory: logs, metrics, and traces. All
+// writers are async with respect to the request path — a failed disk write
+// logs an error and continues so a telemetry persistence fault never breaks
+// an MCP call.
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/gridctl/gridctl/pkg/logging"
+)
+
+// LogRouter is a slog.Handler that fans every record out to the inner handler
+// (the existing buffer/redact chain that powers the UI) AND, when a record's
+// resolved `component` attribute matches a configured server, to a per-server
+// lumberjack file. The component attribute is set today by every server-bound
+// logger via `logger.With("component", serverName)` — slog stores that on the
+// derived handler, not on the record, so this router tracks its own
+// accumulated attrs across WithAttrs/WithGroup the way BufferHandler does.
+//
+// Records without a configured component pass through to the inner handler
+// only.
+type LogRouter struct {
+	inner slog.Handler
+
+	component string      // resolved from accumulated attrs (live across WithAttrs)
+	attrs     []slog.Attr // handler-level attrs accumulated through .With()
+
+	// servers is shared by every derived router (WithAttrs, WithGroup) — the
+	// per-server writer set is logically a property of the root router, not
+	// of any particular logger view.
+	servers *serverWriterSet
+
+	// selfLog is also shared so persistence errors get the same destination
+	// regardless of which logger view emitted the record.
+	selfLog **slog.Logger
+}
+
+type serverWriterSet struct {
+	mu      sync.RWMutex
+	writers map[string]*serverLogWriter
+}
+
+type serverLogWriter struct {
+	handler slog.Handler
+	// The underlying file fd lives inside logging.NewFileHandler's
+	// lumberjack instance, which is package-private. lumberjack uses
+	// POSIX append semantics so we don't need our own handle for
+	// rotation/cleanup, and we explicitly don't close the writer on
+	// RemoveServer (matches Pitfall #5 in the spec — lumberjack reopens
+	// transparently). The file fd is released at process exit.
+}
+
+// LogOpts mirrors lumberjack rotation knobs and matches RetentionConfig in
+// pkg/config. Zero values fall back to lumberjack defaults via
+// logging.NewFileHandler.
+type LogOpts struct {
+	MaxSizeMB  int
+	MaxBackups int
+	MaxAgeDays int
+}
+
+// NewLogRouter wraps an existing slog.Handler chain. The router itself is a
+// slog.Handler — install it in place of the existing chain to enable per-
+// server fan-out. inner must not be nil; pass the existing redact/buffer
+// chain that powers the in-memory ring buffer.
+func NewLogRouter(inner slog.Handler) *LogRouter {
+	var selfPtr *slog.Logger
+	return &LogRouter{
+		inner:   inner,
+		servers: &serverWriterSet{writers: make(map[string]*serverLogWriter)},
+		selfLog: &selfPtr,
+	}
+}
+
+// SetSelfLogger configures where the router itself logs persistence errors.
+// Pass a logger backed by the in-memory buffer so users see write failures
+// surface in the UI. The setting propagates to all derived router views.
+func (r *LogRouter) SetSelfLogger(logger *slog.Logger) {
+	if logger == nil {
+		return
+	}
+	tagged := logger.With("subsystem", "telemetry")
+	*r.selfLog = tagged
+}
+
+// AddServer registers a per-server file handler. Subsequent records with a
+// resolved component=name will be appended to path. AddServer is idempotent:
+// calling it twice for the same server replaces the previous handler (the
+// underlying lumberjack file fd persists until process exit). A failure to
+// open the file is returned to the caller; gateway_builder logs and
+// proceeds.
+func (r *LogRouter) AddServer(name, path string, opts LogOpts) error {
+	r.servers.mu.Lock()
+	defer r.servers.mu.Unlock()
+
+	handler, err := newPerServerLogHandler(path, opts)
+	if err != nil {
+		return fmt.Errorf("telemetry log writer for %q: %w", name, err)
+	}
+	r.servers.writers[name] = &serverLogWriter{handler: handler}
+	return nil
+}
+
+// RemoveServer stops persisting logs for a server. Safe to call for an
+// unregistered server. The on-disk file fd is not closed here — lumberjack
+// owns it, and POSIX append semantics make explicit close unnecessary.
+func (r *LogRouter) RemoveServer(name string) {
+	r.servers.mu.Lock()
+	defer r.servers.mu.Unlock()
+	delete(r.servers.writers, name)
+}
+
+// ConfiguredServers returns the names currently persisting logs.
+func (r *LogRouter) ConfiguredServers() []string {
+	r.servers.mu.RLock()
+	defer r.servers.mu.RUnlock()
+	names := make([]string, 0, len(r.servers.writers))
+	for n := range r.servers.writers {
+		names = append(names, n)
+	}
+	return names
+}
+
+// Close drops every per-server writer entry. The on-disk file fds remain
+// open until process exit (lumberjack-owned). The router itself remains
+// usable; records continue to flow to the inner handler.
+func (r *LogRouter) Close() {
+	r.servers.mu.Lock()
+	defer r.servers.mu.Unlock()
+	r.servers.writers = make(map[string]*serverLogWriter)
+}
+
+// Enabled implements slog.Handler. Returns true if either inner or any per-
+// server handler is enabled at this level — keeps log emission cheap when
+// everything is disabled.
+func (r *LogRouter) Enabled(ctx context.Context, level slog.Level) bool {
+	if r.inner != nil && r.inner.Enabled(ctx, level) {
+		return true
+	}
+	r.servers.mu.RLock()
+	defer r.servers.mu.RUnlock()
+	for _, w := range r.servers.writers {
+		if w.handler.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+// Handle implements slog.Handler. Always forwards to inner; additionally
+// forwards to the per-server file handler when the resolved component (from
+// either accumulated handler-level attrs or this record's own attrs) matches
+// a configured server. Errors from the per-server write are reported via
+// SelfLogger and swallowed.
+func (r *LogRouter) Handle(ctx context.Context, record slog.Record) error {
+	var innerErr error
+	if r.inner != nil {
+		innerErr = r.inner.Handle(ctx, record.Clone())
+	}
+
+	component := r.resolveComponent(record)
+	if component == "" {
+		return innerErr
+	}
+
+	r.servers.mu.RLock()
+	w, ok := r.servers.writers[component]
+	r.servers.mu.RUnlock()
+	if !ok {
+		return innerErr
+	}
+
+	// The per-server file handler is a stock JSON handler; it doesn't see
+	// attrs that we accumulated in our own .With chain. Replay them onto a
+	// cloned record so component/trace_id/etc make it to disk.
+	enriched := record.Clone()
+	if len(r.attrs) > 0 {
+		enriched.AddAttrs(r.attrs...)
+	}
+	if err := w.handler.Handle(ctx, enriched); err != nil {
+		if logger := *r.selfLog; logger != nil {
+			logger.Warn("telemetry log write failed", "component", component, "error", err)
+		}
+	}
+	return innerErr
+}
+
+// resolveComponent looks up `component` in accumulated handler-level attrs
+// first (set via .With at construction time on the per-server logger), then
+// falls back to the record's own attrs. The router-level value wins because
+// .With is the canonical way every gridctl component tags itself.
+//
+// Records emitted by the router's own self logger are tagged `subsystem=
+// telemetry`; routing those would feed write-failure warnings back into the
+// failing server's file, so they are explicitly ignored here.
+func (r *LogRouter) resolveComponent(record slog.Record) string {
+	if r.isSelfLog(record) {
+		return ""
+	}
+	if r.component != "" {
+		return r.component
+	}
+	var component string
+	record.Attrs(func(a slog.Attr) bool {
+		if a.Key == "component" {
+			component = a.Value.String()
+			return false
+		}
+		return true
+	})
+	return component
+}
+
+// isSelfLog returns true when this record was produced by the router's own
+// self logger (any attr tier carries `subsystem=telemetry`). The check is
+// O(handler-attrs + record-attrs) and runs on every Handle call, so it
+// short-circuits on first match.
+func (r *LogRouter) isSelfLog(record slog.Record) bool {
+	for _, a := range r.attrs {
+		if a.Key == "subsystem" && a.Value.String() == "telemetry" {
+			return true
+		}
+	}
+	var found bool
+	record.Attrs(func(a slog.Attr) bool {
+		if a.Key == "subsystem" && a.Value.String() == "telemetry" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// WithAttrs implements slog.Handler. Returns a derived router that carries
+// the additional attrs alongside the inner-with-attrs handler. The shared
+// per-server map is unchanged.
+func (r *LogRouter) WithAttrs(attrs []slog.Attr) slog.Handler {
+	derived := &LogRouter{
+		inner:     r.inner.WithAttrs(attrs),
+		component: r.component,
+		attrs:     append(append([]slog.Attr(nil), r.attrs...), attrs...),
+		servers:   r.servers,
+		selfLog:   r.selfLog,
+	}
+	for _, a := range attrs {
+		if a.Key == "component" {
+			derived.component = a.Value.String()
+		}
+	}
+	return derived
+}
+
+// WithGroup implements slog.Handler. Group nesting does not affect component
+// resolution — component is conventionally a top-level attr.
+func (r *LogRouter) WithGroup(name string) slog.Handler {
+	return &LogRouter{
+		inner:     r.inner.WithGroup(name),
+		component: r.component,
+		attrs:     r.attrs,
+		servers:   r.servers,
+		selfLog:   r.selfLog,
+	}
+}
+
+// newPerServerLogHandler builds a JSON-formatted slog.Handler backed by a
+// lumberjack rotator owned internally by logging.NewFileHandler. Reusing
+// that helper preserves mode 0600 + slog field renaming (msg, ts) +
+// parent-dir validation in one place.
+func newPerServerLogHandler(path string, opts LogOpts) (slog.Handler, error) {
+	if opts.MaxSizeMB <= 0 {
+		opts.MaxSizeMB = 100
+	}
+	if opts.MaxBackups <= 0 {
+		opts.MaxBackups = 5
+	}
+	if opts.MaxAgeDays <= 0 {
+		opts.MaxAgeDays = 7
+	}
+
+	handler, err := logging.NewFileHandler(path, logging.FileOpts{
+		MaxSizeMB:  opts.MaxSizeMB,
+		MaxBackups: opts.MaxBackups,
+		MaxAgeDays: opts.MaxAgeDays,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return handler, nil
+}

--- a/pkg/telemetry/logs_test.go
+++ b/pkg/telemetry/logs_test.go
@@ -1,0 +1,146 @@
+package telemetry
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/logging"
+)
+
+func TestLogRouter_RoutesByComponent(t *testing.T) {
+	dir := t.TempDir()
+	githubPath := filepath.Join(dir, "github.jsonl")
+	weatherPath := filepath.Join(dir, "weather.jsonl")
+
+	// Inner buffer captures everything; the router fans out to per-server
+	// files only for matching components.
+	buf := logging.NewLogBuffer(100)
+	inner := logging.NewBufferHandler(buf, nil)
+	router := NewLogRouter(inner)
+	t.Cleanup(router.Close)
+
+	if err := router.AddServer("github", githubPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer github: %v", err)
+	}
+	if err := router.AddServer("weather", weatherPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer weather: %v", err)
+	}
+
+	logger := slog.New(router)
+	logger.With("component", "github").Info("hit github tool", "tool", "list_repos")
+	logger.With("component", "weather").Info("hit weather tool", "tool", "forecast")
+	logger.With("component", "unknown").Info("anonymous component — should not write file")
+	logger.Info("no component — should not write file")
+
+	githubLines := readJSONLines(t, githubPath)
+	weatherLines := readJSONLines(t, weatherPath)
+
+	if len(githubLines) != 1 {
+		t.Errorf("github file got %d lines, want 1; lines=%v", len(githubLines), githubLines)
+	} else if msg := githubLines[0]["msg"]; msg != "hit github tool" {
+		t.Errorf("github line msg = %v, want %q", msg, "hit github tool")
+	}
+	if len(weatherLines) != 1 {
+		t.Errorf("weather file got %d lines, want 1", len(weatherLines))
+	}
+
+	// Inner buffer should hold all 4 entries (the router always fans to it).
+	if got := buf.Count(); got != 4 {
+		t.Errorf("inner buffer count = %d, want 4", got)
+	}
+}
+
+func TestLogRouter_FileMode0600(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "github.jsonl")
+
+	buf := logging.NewLogBuffer(10)
+	router := NewLogRouter(logging.NewBufferHandler(buf, nil))
+	t.Cleanup(router.Close)
+	if err := router.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	// Force creation of the file by emitting one record.
+	slog.New(router).With("component", "github").Info("hi")
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	// FileHandler creates the file with mode 0600 explicitly. Verify we
+	// inherited that here.
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("file mode = %v, want 0600", got)
+	}
+}
+
+func TestLogRouter_RemoveServerStopsWriting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "github.jsonl")
+
+	buf := logging.NewLogBuffer(10)
+	router := NewLogRouter(logging.NewBufferHandler(buf, nil))
+	t.Cleanup(router.Close)
+	if err := router.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	logger := slog.New(router).With("component", "github")
+	logger.Info("first")
+	router.RemoveServer("github")
+	logger.Info("second")
+
+	lines := readJSONLines(t, path)
+	if len(lines) != 1 {
+		t.Errorf("after RemoveServer: lines = %d, want 1 (first only)", len(lines))
+	}
+	if got := buf.Count(); got != 2 {
+		t.Errorf("inner buffer = %d, want 2", got)
+	}
+}
+
+func TestLogRouter_EnabledHandlesNilInner(t *testing.T) {
+	// Defensive — Enabled must not panic if a derived child handler ever
+	// has a nil inner. Today inner is always non-nil but the Handle path
+	// short-circuits on nil, so Enabled should too.
+	r := NewLogRouter(slog.NewJSONHandler(os.Stderr, nil))
+	if !r.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("Enabled returned false with stderr handler installed")
+	}
+}
+
+// readJSONLines parses a path produced by NewFileHandler — one JSON line per
+// log record — into a slice of decoded maps. Skips blank lines.
+func readJSONLines(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	var out []map[string]any
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("malformed json line %q: %v", string(line), err)
+		}
+		out = append(out, rec)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan %s: %v", path, err)
+	}
+	return out
+}

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -1,0 +1,302 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/metrics"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// DefaultMetricsFlushInterval is the period at which the metrics flusher
+// snapshots the accumulator and appends a per-server diff line. 60s matches
+// the in-memory bucket granularity (1-minute buckets in metrics.Accumulator).
+const DefaultMetricsFlushInterval = 60 * time.Second
+
+// MetricsSnapshotLine is the on-disk schema for one NDJSON entry in
+// metrics.jsonl. Time, Server, and Diff are populated for every line; Reset
+// is true on the first line written after a counter reset (server restart,
+// Accumulator.Clear) and the diff for that line is the *full* snapshot, not
+// a negative delta.
+type MetricsSnapshotLine struct {
+	Time   time.Time            `json:"ts"`
+	Server string               `json:"server"`
+	Reset  bool                 `json:"reset,omitempty"`
+	Diff   metrics.TokenCounts  `json:"diff"`
+	Total  metrics.TokenCounts  `json:"total"`
+}
+
+// MetricsFlusher periodically serializes per-server token counters from a
+// metrics.Accumulator and appends one NDJSON line per server with non-zero
+// deltas. Single goroutine; one-shot Start/Stop pair (re-Starting after Stop
+// is a no-op). Failed writes are logged via the self logger and do not crash
+// the goroutine.
+type MetricsFlusher struct {
+	acc      *metrics.Accumulator
+	interval time.Duration
+	logger   *slog.Logger
+
+	mu      sync.Mutex
+	writers map[string]*lumberjack.Logger  // serverName -> writer
+	prev    map[string]metrics.TokenCounts // serverName -> last snapshot
+
+	stop     chan struct{}
+	done     chan struct{}
+	started  bool
+	stopOnce sync.Once
+}
+
+// NewMetricsFlusher creates a flusher with the given accumulator and
+// per-flush interval. interval <= 0 falls back to DefaultMetricsFlushInterval.
+func NewMetricsFlusher(acc *metrics.Accumulator, interval time.Duration) *MetricsFlusher {
+	if interval <= 0 {
+		interval = DefaultMetricsFlushInterval
+	}
+	return &MetricsFlusher{
+		acc:      acc,
+		interval: interval,
+		writers:  make(map[string]*lumberjack.Logger),
+		prev:     make(map[string]metrics.TokenCounts),
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+}
+
+// SetLogger configures where flush errors are logged. Pass a logger backed
+// by the in-memory buffer so users see write failures in the UI.
+func (f *MetricsFlusher) SetLogger(logger *slog.Logger) {
+	if logger != nil {
+		f.logger = logger.With("subsystem", "telemetry")
+	}
+}
+
+// AddServer registers a per-server output file. Idempotent: re-adding a
+// server replaces the prior writer (the lumberjack handle is closed). The
+// previous-snapshot tracking is preserved so re-adding does not synthesize a
+// reset.
+func (f *MetricsFlusher) AddServer(name, path string, opts LogOpts) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if existing, ok := f.writers[name]; ok && existing != nil {
+		_ = existing.Close()
+	}
+
+	if opts.MaxSizeMB <= 0 {
+		opts.MaxSizeMB = 100
+	}
+	if opts.MaxBackups <= 0 {
+		opts.MaxBackups = 5
+	}
+	if opts.MaxAgeDays <= 0 {
+		opts.MaxAgeDays = 7
+	}
+
+	lj := &lumberjack.Logger{
+		Filename:   path,
+		MaxSize:    opts.MaxSizeMB,
+		MaxBackups: opts.MaxBackups,
+		MaxAge:     opts.MaxAgeDays,
+		Compress:   true,
+	}
+	// Touch the file so it gets created with mode 0600 even if no flush
+	// happens before the next AddServer / Close cycle. lumberjack itself
+	// creates files on first write but with the umask applied — explicit
+	// open guarantees 0600 to match vault/state convention.
+	if err := touchMode0600(path); err != nil {
+		return fmt.Errorf("telemetry metrics writer for %q: %w", name, err)
+	}
+	f.writers[name] = lj
+	return nil
+}
+
+// RemoveServer stops persisting metrics for a server and closes its writer.
+// The previous-snapshot tracking is dropped so re-adding produces a fresh
+// reset line as the first entry.
+func (f *MetricsFlusher) RemoveServer(name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if existing, ok := f.writers[name]; ok && existing != nil {
+		_ = existing.Close()
+		delete(f.writers, name)
+	}
+	delete(f.prev, name)
+}
+
+// ConfiguredServers returns the names currently persisting metrics.
+func (f *MetricsFlusher) ConfiguredServers() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	names := make([]string, 0, len(f.writers))
+	for n := range f.writers {
+		names = append(names, n)
+	}
+	return names
+}
+
+// Start launches the flush goroutine. Safe to call once; subsequent calls
+// are no-ops. The goroutine runs until Stop is called.
+func (f *MetricsFlusher) Start() {
+	f.mu.Lock()
+	if f.started {
+		f.mu.Unlock()
+		return
+	}
+	f.started = true
+	f.mu.Unlock()
+
+	go f.run()
+}
+
+// Stop signals the flush goroutine to exit and waits for it to drain — one
+// final flush is performed before exit so the on-disk file reflects the
+// last in-memory state. Safe to call multiple times concurrently; the
+// stop-channel close is sync.Once-guarded so racing Stop() calls don't
+// panic with a "close of closed channel".
+func (f *MetricsFlusher) Stop() {
+	f.mu.Lock()
+	started := f.started
+	f.mu.Unlock()
+	if !started {
+		return
+	}
+
+	f.stopOnce.Do(func() { close(f.stop) })
+	<-f.done
+
+	// Close all per-server writers after the final flush.
+	f.mu.Lock()
+	for _, lj := range f.writers {
+		if lj != nil {
+			_ = lj.Close()
+		}
+	}
+	f.mu.Unlock()
+}
+
+// run is the flush goroutine.
+func (f *MetricsFlusher) run() {
+	defer close(f.done)
+	ticker := time.NewTicker(f.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-f.stop:
+			f.flushOnce(time.Now())
+			return
+		case t := <-ticker.C:
+			f.flushOnce(t)
+		}
+	}
+}
+
+// flushOnce snapshots the accumulator and writes one NDJSON line per
+// configured server with a non-zero delta vs the previous snapshot. The
+// per-server writer map is snapshotted under the mutex; disk I/O happens
+// outside the lock so a slow writer can't block AddServer/RemoveServer.
+func (f *MetricsFlusher) flushOnce(now time.Time) {
+	if f.acc == nil {
+		return
+	}
+	snap := f.acc.Snapshot()
+
+	type planned struct {
+		writer *lumberjack.Logger
+		line   MetricsSnapshotLine
+	}
+	var plan []planned
+
+	f.mu.Lock()
+	for name, writer := range f.writers {
+		current, ok := snap.PerServer[name]
+		if !ok {
+			continue
+		}
+		prev, hadPrev := f.prev[name]
+		line := MetricsSnapshotLine{
+			Time:   now.UTC(),
+			Server: name,
+			Total:  current,
+		}
+		switch {
+		case !hadPrev:
+			line.Reset = true
+			line.Diff = current
+		case isCounterReset(prev, current):
+			line.Reset = true
+			line.Diff = current
+		default:
+			line.Diff = metrics.TokenCounts{
+				InputTokens:  current.InputTokens - prev.InputTokens,
+				OutputTokens: current.OutputTokens - prev.OutputTokens,
+				TotalTokens:  current.TotalTokens - prev.TotalTokens,
+			}
+			if line.Diff.InputTokens == 0 && line.Diff.OutputTokens == 0 && line.Diff.TotalTokens == 0 {
+				continue
+			}
+		}
+		plan = append(plan, planned{writer: writer, line: line})
+		// Update prev under the lock — even if the write fails the in-memory
+		// state advances; lumberjack rotates rather than retaining failed
+		// writes, so retry would emit the same delta on the next tick anyway.
+		f.prev[name] = current
+	}
+	f.mu.Unlock()
+
+	for _, p := range plan {
+		if p.line.Reset {
+			// Reset sentinel is itself valid NDJSON so strict line-by-line
+			// JSON parsers (e.g. otelcol filelog receiver) don't choke.
+			data, err := json.Marshal(struct {
+				Reset  bool      `json:"reset"`
+				Time   time.Time `json:"ts"`
+				Server string    `json:"server"`
+			}{Reset: true, Time: p.line.Time, Server: p.line.Server})
+			if err == nil {
+				data = append(data, '\n')
+				if _, werr := p.writer.Write(data); werr != nil && f.logger != nil {
+					f.logger.Warn("telemetry metrics reset marker write failed", "server", p.line.Server, "error", werr)
+				}
+			}
+		}
+
+		data, err := json.Marshal(p.line)
+		if err != nil {
+			if f.logger != nil {
+				f.logger.Warn("telemetry metrics marshal failed", "server", p.line.Server, "error", err)
+			}
+			continue
+		}
+		data = append(data, '\n')
+		if _, err := p.writer.Write(data); err != nil && f.logger != nil {
+			f.logger.Warn("telemetry metrics write failed", "server", p.line.Server, "error", err)
+		}
+	}
+}
+
+// isCounterReset returns true when any counter in current is strictly less
+// than its corresponding value in prev — a hard signal that the counter
+// space restarted.
+func isCounterReset(prev, current metrics.TokenCounts) bool {
+	return current.InputTokens < prev.InputTokens ||
+		current.OutputTokens < prev.OutputTokens ||
+		current.TotalTokens < prev.TotalTokens
+}
+
+// touchMode0600 ensures the file exists with mode 0600. lumberjack would
+// otherwise apply the process umask on first write; an explicit open
+// guarantees the vault/state convention. POSIX append semantics let
+// lumberjack continue using the same path independently.
+func touchMode0600(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/pkg/telemetry/metrics_test.go
+++ b/pkg/telemetry/metrics_test.go
@@ -1,0 +1,233 @@
+package telemetry
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/metrics"
+)
+
+func TestMetricsFlusher_FirstFlushIsFullSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+
+	acc := metrics.NewAccumulator(100)
+	acc.Record("github", 100, 50)
+
+	f := NewMetricsFlusher(acc, time.Hour) // long interval — we trigger flushOnce manually
+	if err := f.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	now := time.Now()
+	f.flushOnce(now)
+
+	lines := readMetricsLines(t, path)
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines (reset sentinel + payload), got %d", len(lines))
+	}
+	// First line is a reset sentinel — itself valid NDJSON so strict
+	// line-by-line parsers don't choke. Confirm shape.
+	var sentinel struct {
+		Reset  bool   `json:"reset"`
+		Server string `json:"server"`
+	}
+	if err := json.Unmarshal([]byte(lines[0]), &sentinel); err != nil {
+		t.Fatalf("reset sentinel not valid JSON: %v (line=%q)", err, lines[0])
+	}
+	if !sentinel.Reset || sentinel.Server != "github" {
+		t.Errorf("sentinel = %+v, want reset=true server=github", sentinel)
+	}
+	var entry MetricsSnapshotLine
+	if err := json.Unmarshal([]byte(lines[1]), &entry); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if !entry.Reset {
+		t.Errorf("first JSON entry reset = false, want true")
+	}
+	if entry.Server != "github" {
+		t.Errorf("server = %q, want %q", entry.Server, "github")
+	}
+	if entry.Diff.InputTokens != 100 || entry.Diff.OutputTokens != 50 {
+		t.Errorf("diff = %+v, want full snapshot 100/50", entry.Diff)
+	}
+}
+
+func TestMetricsFlusher_DiffsBetweenFlushes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+
+	acc := metrics.NewAccumulator(100)
+	f := NewMetricsFlusher(acc, time.Hour)
+	if err := f.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	acc.Record("github", 100, 50)
+	f.flushOnce(time.Now())
+
+	// Add 25 more input tokens and flush again — expect a diff line, no
+	// reset, no `// reset` separator.
+	acc.Record("github", 25, 0)
+	f.flushOnce(time.Now())
+
+	lines := readMetricsLines(t, path)
+	// First two lines are `// reset` + initial snapshot (handled by previous test).
+	// The third line should be a plain diff with reset=false.
+	if len(lines) < 3 {
+		t.Fatalf("expected >=3 lines after second flush, got %d: %v", len(lines), lines)
+	}
+	var entry MetricsSnapshotLine
+	if err := json.Unmarshal([]byte(lines[2]), &entry); err != nil {
+		t.Fatalf("unmarshal third line: %v", err)
+	}
+	if entry.Reset {
+		t.Errorf("third line reset = true, want false")
+	}
+	if entry.Diff.InputTokens != 25 || entry.Diff.OutputTokens != 0 {
+		t.Errorf("diff = %+v, want delta {25,0,25}", entry.Diff)
+	}
+}
+
+func TestMetricsFlusher_IdleSkipsZeroDiff(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+
+	acc := metrics.NewAccumulator(100)
+	f := NewMetricsFlusher(acc, time.Hour)
+	if err := f.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	acc.Record("github", 100, 50)
+	f.flushOnce(time.Now())
+
+	// Second flush with no new activity — should NOT append a zero diff.
+	beforeLen := len(readMetricsLines(t, path))
+	f.flushOnce(time.Now())
+	afterLen := len(readMetricsLines(t, path))
+	if afterLen != beforeLen {
+		t.Errorf("idle flush appended %d new lines; want 0", afterLen-beforeLen)
+	}
+}
+
+func TestMetricsFlusher_DetectsCounterReset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+
+	acc := metrics.NewAccumulator(100)
+	f := NewMetricsFlusher(acc, time.Hour)
+	if err := f.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	acc.Record("github", 100, 50)
+	f.flushOnce(time.Now())
+
+	// Simulate a counter reset (Accumulator.Clear or process restart) and
+	// give the server a non-zero state again so PerServer is populated.
+	acc.Clear()
+	acc.Record("github", 25, 10)
+	f.flushOnce(time.Now())
+
+	lines := readMetricsLines(t, path)
+	// Count reset sentinels — they are now valid JSON objects with a
+	// distinguishing `reset:true` plus no `total` key.
+	resetCount := 0
+	for _, l := range lines {
+		var probe map[string]any
+		if err := json.Unmarshal([]byte(l), &probe); err != nil {
+			continue
+		}
+		_, hasReset := probe["reset"]
+		_, hasTotal := probe["total"]
+		if hasReset && !hasTotal {
+			resetCount++
+		}
+	}
+	if resetCount != 2 {
+		t.Errorf("expected 2 reset sentinels in %v, got %d", lines, resetCount)
+	}
+
+	// The last full payload line should be the post-reset full snapshot.
+	var last MetricsSnapshotLine
+	for i := len(lines) - 1; i >= 0; i-- {
+		if !strings.HasPrefix(lines[i], "{") {
+			continue
+		}
+		if err := json.Unmarshal([]byte(lines[i]), &last); err != nil {
+			continue
+		}
+		if last.Total.TotalTokens != 0 {
+			break
+		}
+	}
+	if !last.Reset {
+		t.Error("post-reset entry reset = false; want true")
+	}
+	if last.Diff.InputTokens != 25 || last.Diff.OutputTokens != 10 {
+		t.Errorf("post-reset diff = %+v, want full {25,10,35}", last.Diff)
+	}
+}
+
+func TestMetricsFlusher_FileMode0600(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+	acc := metrics.NewAccumulator(100)
+	f := NewMetricsFlusher(acc, time.Hour)
+	if err := f.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("file mode = %v, want 0600", got)
+	}
+}
+
+func TestMetricsFlusher_StartStopFinalFlush(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+	acc := metrics.NewAccumulator(100)
+
+	// Long interval so the only flush we get during this test is the
+	// final one driven by Stop().
+	f := NewMetricsFlusher(acc, time.Hour)
+	if err := f.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	f.Start()
+	acc.Record("github", 7, 3)
+	f.Stop()
+
+	lines := readMetricsLines(t, path)
+	if len(lines) < 2 {
+		t.Fatalf("expected final flush to write at least 2 lines, got %d: %v", len(lines), lines)
+	}
+}
+
+func readMetricsLines(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	return lines
+}

--- a/pkg/telemetry/seed_test.go
+++ b/pkg/telemetry/seed_test.go
@@ -1,0 +1,218 @@
+package telemetry
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/logging"
+	"github.com/gridctl/gridctl/pkg/tracing"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+func TestLogBuffer_SeedFromFileEndToEnd(t *testing.T) {
+	// Write three lines through the actual LogRouter → file path, then
+	// open a fresh LogBuffer and seed from the same file. Asserts the
+	// round-trip preserves message + component + custom attrs.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "logs.jsonl")
+
+	writeBuf := logging.NewLogBuffer(10)
+	router := NewLogRouter(logging.NewBufferHandler(writeBuf, nil))
+	t.Cleanup(router.Close)
+	if err := router.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	logger := slog.New(router).With("component", "github")
+	logger.Info("first call", "tool", "list_repos")
+	logger.Info("second call", "tool", "create_issue")
+	logger.Info("third call")
+
+	// Fresh buffer simulates a restart.
+	seedBuf := logging.NewLogBuffer(10)
+	if err := seedBuf.SeedFromFile(path, 100); err != nil {
+		t.Fatalf("SeedFromFile: %v", err)
+	}
+	if got := seedBuf.Count(); got != 3 {
+		t.Fatalf("seed count = %d, want 3", got)
+	}
+	entries := seedBuf.GetRecent(3)
+	if entries[0].Message != "first call" || entries[2].Message != "third call" {
+		t.Errorf("seeded order wrong: %+v", entries)
+	}
+	for _, e := range entries {
+		if e.Component != "github" {
+			t.Errorf("component lost: %+v", e)
+		}
+	}
+}
+
+func TestLogBuffer_SeedFromFile_MissingFileNoError(t *testing.T) {
+	// First-ever boot — no file yet — must succeed silently.
+	buf := logging.NewLogBuffer(10)
+	if err := buf.SeedFromFile(filepath.Join(t.TempDir(), "missing.jsonl"), 100); err != nil {
+		t.Errorf("missing file should not error: %v", err)
+	}
+	if got := buf.Count(); got != 0 {
+		t.Errorf("seeded an empty buffer with %d entries; want 0", got)
+	}
+}
+
+func TestLogBuffer_SeedFromFile_TakesLastNOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "logs.jsonl")
+
+	// Write 5 lines then seed with n=2.
+	writeBuf := logging.NewLogBuffer(10)
+	router := NewLogRouter(logging.NewBufferHandler(writeBuf, nil))
+	t.Cleanup(router.Close)
+	if err := router.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	logger := slog.New(router).With("component", "github")
+	for i := 0; i < 5; i++ {
+		logger.Info("entry", "i", i)
+	}
+
+	seedBuf := logging.NewLogBuffer(10)
+	if err := seedBuf.SeedFromFile(path, 2); err != nil {
+		t.Fatalf("SeedFromFile: %v", err)
+	}
+	if got := seedBuf.Count(); got != 2 {
+		t.Errorf("count = %d, want 2 (last n)", got)
+	}
+	got := seedBuf.GetRecent(2)
+	if iv, ok := got[1].Attrs["i"].(float64); !ok || iv != 4 {
+		t.Errorf("last attr i = %v (%T), want 4 (last of 5)", got[1].Attrs["i"], got[1].Attrs["i"])
+	}
+}
+
+func TestTracingBuffer_SeedFromFileEndToEnd(t *testing.T) {
+	// Write spans for two servers via TracesFileClient, then seed a fresh
+	// tracing.Buffer from the github file and verify the trace appears.
+	dir := t.TempDir()
+	githubPath := filepath.Join(dir, "github-traces.jsonl")
+	weatherPath := filepath.Join(dir, "weather-traces.jsonl")
+
+	c := NewTracesFileClient()
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+	if err := c.AddServer("github", githubPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	if err := c.AddServer("weather", weatherPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	rs := &tracepb.ResourceSpans{
+		Resource: &resourcepb.Resource{},
+		ScopeSpans: []*tracepb.ScopeSpans{{
+			Scope: &commonpb.InstrumentationScope{Name: "gridctl/test"},
+			Spans: []*tracepb.Span{
+				makeSpan("github", "list_repos", 1),
+				makeSpan("github", "create_issue", 2),
+				makeSpan("weather", "forecast", 3),
+			},
+		}},
+	}
+	if err := c.UploadTraces(context.Background(), []*tracepb.ResourceSpans{rs}); err != nil {
+		t.Fatalf("UploadTraces: %v", err)
+	}
+
+	// Seed an empty trace buffer and confirm it picks up the github traces only.
+	buf := tracing.NewBuffer(100, time.Hour)
+	if err := buf.SeedFromFile(githubPath, 100); err != nil {
+		t.Fatalf("SeedFromFile: %v", err)
+	}
+	count := buf.Count()
+	if count == 0 {
+		t.Fatal("seeded buffer empty after SeedFromFile")
+	}
+	// Each span we wrote becomes its own root trace (no parent), so we
+	// expect 2 traces from the github file.
+	if count != 2 {
+		t.Errorf("seeded trace count = %d, want 2 (github only)", count)
+	}
+}
+
+func TestTracingBuffer_SeedFromFile_MissingFileNoError(t *testing.T) {
+	buf := tracing.NewBuffer(100, time.Hour)
+	if err := buf.SeedFromFile(filepath.Join(t.TempDir(), "missing.jsonl"), 100); err != nil {
+		t.Errorf("missing file should not error: %v", err)
+	}
+	if got := buf.Count(); got != 0 {
+		t.Errorf("seeded buffer count = %d, want 0", got)
+	}
+}
+
+// TestEndToEnd_PersistAndReseed simulates a daemon restart with persistence
+// enabled: write logs + traces, throw away the in-memory buffers, seed fresh
+// buffers from the same files, and verify history is recovered. This is the
+// integration test required by Phase 2's acceptance criteria.
+func TestEndToEnd_PersistAndReseed(t *testing.T) {
+	dir := t.TempDir()
+	logsPath := filepath.Join(dir, "logs.jsonl")
+	tracesPath := filepath.Join(dir, "traces.jsonl")
+
+	// === Daemon "instance 1" ===
+	buf1 := logging.NewLogBuffer(100)
+	router := NewLogRouter(logging.NewBufferHandler(buf1, nil))
+	if err := router.AddServer("github", logsPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer logs: %v", err)
+	}
+	tc := NewTracesFileClient()
+	if err := tc.AddServer("github", tracesPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer traces: %v", err)
+	}
+
+	logger := slog.New(router).With("component", "github")
+	logger.Info("pre-restart entry one")
+	logger.Info("pre-restart entry two", "tool", "list_repos")
+
+	rs := &tracepb.ResourceSpans{
+		Resource: &resourcepb.Resource{},
+		ScopeSpans: []*tracepb.ScopeSpans{{
+			Scope: &commonpb.InstrumentationScope{Name: "gridctl/test"},
+			Spans: []*tracepb.Span{makeSpan("github", "pre-restart-trace", 1)},
+		}},
+	}
+	if err := tc.UploadTraces(context.Background(), []*tracepb.ResourceSpans{rs}); err != nil {
+		t.Fatalf("UploadTraces: %v", err)
+	}
+
+	// "Restart": tear down instance 1's writers so the files flush.
+	router.Close()
+	_ = tc.Stop(context.Background())
+
+	// === Daemon "instance 2" ===
+	buf2 := logging.NewLogBuffer(100)
+	if err := buf2.SeedFromFile(logsPath, 100); err != nil {
+		t.Fatalf("seed logs: %v", err)
+	}
+	traceBuf2 := tracing.NewBuffer(100, time.Hour)
+	if err := traceBuf2.SeedFromFile(tracesPath, 100); err != nil {
+		t.Fatalf("seed traces: %v", err)
+	}
+
+	if got := buf2.Count(); got != 2 {
+		t.Errorf("re-seeded log buffer count = %d, want 2", got)
+	}
+	if got := traceBuf2.Count(); got != 1 {
+		t.Errorf("re-seeded trace buffer count = %d, want 1", got)
+	}
+
+	// Verify the on-disk files are mode 0600 (security acceptance).
+	for _, p := range []string{logsPath, tracesPath} {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %s: %v", p, err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("file %s mode = %v, want 0600", p, got)
+		}
+	}
+}

--- a/pkg/telemetry/traces.go
+++ b/pkg/telemetry/traces.go
@@ -1,0 +1,237 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// serverNameAttrKey is the OTel attribute used today by the gateway tracer
+// to tag every server-bound span (see pkg/tracing). It mirrors the
+// well-known `server.name` semantic convention.
+const serverNameAttrKey = "server.name"
+
+// TracesFileClient implements otlptrace.Client by writing each batch as one
+// OTLP-JSON line per configured server. The OTel SDK calls UploadTraces with
+// a slice of *tracepb.ResourceSpans already converted from ReadOnlySpan, so
+// this avoids re-implementing the SDK's transform code.
+//
+// Each emitted line is a fully valid TracesData envelope, matching the OTLP
+// File Exporter spec — `tail -f traces.jsonl | otelcol --config ...
+// otlpjsonfilereceiver` ingests cleanly.
+//
+// Spans without a resolvable server.name attribute (rare; the gateway
+// stamps it on every tool-call span) are dropped. This is documented as an
+// accepted Phase-2 limitation: per-server file routing is what users want,
+// and a "miscellaneous" file would muddy the inventory model.
+type TracesFileClient struct {
+	mu      sync.RWMutex
+	writers map[string]*lumberjack.Logger
+	logger  *slog.Logger
+}
+
+// NewTracesFileClient constructs an empty client. Add servers via AddServer
+// before passing the client to otlptrace.NewUnstarted.
+func NewTracesFileClient() *TracesFileClient {
+	return &TracesFileClient{
+		writers: make(map[string]*lumberjack.Logger),
+	}
+}
+
+// SetLogger configures where the client logs persistence errors.
+func (c *TracesFileClient) SetLogger(logger *slog.Logger) {
+	if logger != nil {
+		c.logger = logger.With("subsystem", "telemetry")
+	}
+}
+
+// AddServer registers a per-server traces.jsonl file. Idempotent: re-adding
+// a server replaces the prior writer (the lumberjack handle is closed).
+func (c *TracesFileClient) AddServer(name, path string, opts LogOpts) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if existing, ok := c.writers[name]; ok && existing != nil {
+		_ = existing.Close()
+	}
+
+	if opts.MaxSizeMB <= 0 {
+		opts.MaxSizeMB = 100
+	}
+	if opts.MaxBackups <= 0 {
+		opts.MaxBackups = 5
+	}
+	if opts.MaxAgeDays <= 0 {
+		opts.MaxAgeDays = 7
+	}
+
+	if err := touchMode0600(path); err != nil {
+		return fmt.Errorf("telemetry traces writer for %q: %w", name, err)
+	}
+
+	c.writers[name] = &lumberjack.Logger{
+		Filename:   path,
+		MaxSize:    opts.MaxSizeMB,
+		MaxBackups: opts.MaxBackups,
+		MaxAge:     opts.MaxAgeDays,
+		Compress:   true,
+	}
+	return nil
+}
+
+// RemoveServer stops persisting traces for a server and closes its writer.
+func (c *TracesFileClient) RemoveServer(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.writers[name]; ok && existing != nil {
+		_ = existing.Close()
+	}
+	delete(c.writers, name)
+}
+
+// ConfiguredServers returns the names currently persisting traces.
+func (c *TracesFileClient) ConfiguredServers() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	names := make([]string, 0, len(c.writers))
+	for n := range c.writers {
+		names = append(names, n)
+	}
+	return names
+}
+
+// Start implements otlptrace.Client. No connection setup required for files.
+func (c *TracesFileClient) Start(_ context.Context) error { return nil }
+
+// Stop implements otlptrace.Client. Closes every per-server writer. Safe to
+// call multiple times.
+func (c *TracesFileClient) Stop(_ context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, lj := range c.writers {
+		if lj != nil {
+			_ = lj.Close()
+		}
+	}
+	c.writers = make(map[string]*lumberjack.Logger)
+	return nil
+}
+
+// UploadTraces implements otlptrace.Client. Re-routes spans by server.name
+// attribute and writes one TracesData envelope per server per call. The
+// per-server writer map is snapshotted under the lock; disk I/O happens
+// outside the lock so a slow writer can't block AddServer/RemoveServer/Stop.
+// Errors from individual writers are logged and swallowed — the SDK's batch
+// processor must not stall because a disk write failed.
+func (c *TracesFileClient) UploadTraces(_ context.Context, resourceSpans []*tracepb.ResourceSpans) error {
+	if len(resourceSpans) == 0 {
+		return nil
+	}
+
+	// Group spans by server.name. Each group keeps the resource and scope
+	// metadata of the source ResourceSpans so the line stays a faithful
+	// OTLP envelope; only the span set is partitioned.
+	type bucket struct {
+		spans []*tracepb.Span
+		scope *commonpb.InstrumentationScope
+	}
+	perServer := make(map[string]map[*tracepb.ResourceSpans]*bucket) // server -> rs -> bucket
+
+	for _, rs := range resourceSpans {
+		for _, ss := range rs.ScopeSpans {
+			for _, span := range ss.Spans {
+				server := extractServerNameFromAttrs(span.Attributes)
+				if server == "" {
+					continue
+				}
+				rsMap, ok := perServer[server]
+				if !ok {
+					rsMap = make(map[*tracepb.ResourceSpans]*bucket)
+					perServer[server] = rsMap
+				}
+				b, ok := rsMap[rs]
+				if !ok {
+					b = &bucket{scope: ss.Scope}
+					rsMap[rs] = b
+				}
+				b.spans = append(b.spans, span)
+			}
+		}
+	}
+
+	type planned struct {
+		writer *lumberjack.Logger
+		server string
+		data   []byte
+	}
+	var plan []planned
+
+	c.mu.RLock()
+	for server, rsMap := range perServer {
+		writer, ok := c.writers[server]
+		if !ok {
+			continue
+		}
+		envelope := &tracepb.TracesData{}
+		for rs, b := range rsMap {
+			envelope.ResourceSpans = append(envelope.ResourceSpans, &tracepb.ResourceSpans{
+				Resource: rs.Resource,
+				ScopeSpans: []*tracepb.ScopeSpans{{
+					Scope: b.scope,
+					Spans: b.spans,
+				}},
+				SchemaUrl: rs.SchemaUrl,
+			})
+		}
+		data, err := protojson.Marshal(envelope)
+		if err != nil {
+			c.logWarn("telemetry traces marshal failed", "server", server, "error", err)
+			continue
+		}
+		data = append(data, '\n')
+		plan = append(plan, planned{writer: writer, server: server, data: data})
+	}
+	c.mu.RUnlock()
+
+	for _, p := range plan {
+		if _, err := p.writer.Write(p.data); err != nil {
+			c.logWarn("telemetry traces write failed", "server", p.server, "error", err)
+		}
+	}
+	return nil
+}
+
+func (c *TracesFileClient) logWarn(msg string, args ...any) {
+	if c.logger != nil {
+		c.logger.Warn(msg, args...)
+	}
+}
+
+// extractServerNameFromAttrs walks an attribute slice and returns the value
+// of `server.name` if present. Match strategy is by key only — proto
+// AnyValue strings are accepted; non-string values are coerced to "".
+func extractServerNameFromAttrs(attrs []*commonpb.KeyValue) string {
+	for _, kv := range attrs {
+		if kv.Key != serverNameAttrKey {
+			continue
+		}
+		if kv.Value == nil {
+			return ""
+		}
+		if sv, ok := kv.Value.Value.(*commonpb.AnyValue_StringValue); ok {
+			return sv.StringValue
+		}
+	}
+	return ""
+}
+
+// Verify that TracesFileClient satisfies the otlptrace.Client interface at
+// compile time. otlptrace.NewUnstarted accepts any Client.
+var _ otlptrace.Client = (*TracesFileClient)(nil)

--- a/pkg/telemetry/traces_test.go
+++ b/pkg/telemetry/traces_test.go
@@ -1,0 +1,190 @@
+package telemetry
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func TestTracesFileClient_RoutesByServerName(t *testing.T) {
+	dir := t.TempDir()
+	githubPath := filepath.Join(dir, "github-traces.jsonl")
+	weatherPath := filepath.Join(dir, "weather-traces.jsonl")
+
+	c := NewTracesFileClient()
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+
+	if err := c.AddServer("github", githubPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer github: %v", err)
+	}
+	if err := c.AddServer("weather", weatherPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer weather: %v", err)
+	}
+
+	// Build one ResourceSpans containing three spans: one tagged github,
+	// one tagged weather, one untagged. The client should split them into
+	// two files.
+	rs := &tracepb.ResourceSpans{
+		Resource: &resourcepb.Resource{},
+		ScopeSpans: []*tracepb.ScopeSpans{{
+			Scope: &commonpb.InstrumentationScope{Name: "gridctl/test"},
+			Spans: []*tracepb.Span{
+				makeSpan("github", "span-github", 1),
+				makeSpan("weather", "span-weather", 2),
+				makeSpan("", "span-orphan", 3), // no server.name → dropped
+			},
+		}},
+	}
+	if err := c.UploadTraces(context.Background(), []*tracepb.ResourceSpans{rs}); err != nil {
+		t.Fatalf("UploadTraces: %v", err)
+	}
+
+	githubLines := readTraceLines(t, githubPath)
+	weatherLines := readTraceLines(t, weatherPath)
+
+	if len(githubLines) != 1 {
+		t.Fatalf("github lines = %d, want 1", len(githubLines))
+	}
+	if len(weatherLines) != 1 {
+		t.Fatalf("weather lines = %d, want 1", len(weatherLines))
+	}
+
+	// Verify each line is a parseable TracesData envelope and contains
+	// only spans from its server.
+	for _, line := range githubLines {
+		var td tracepb.TracesData
+		if err := protojson.Unmarshal([]byte(line), &td); err != nil {
+			t.Errorf("github line not OTLP-JSON: %v", err)
+			continue
+		}
+		count := 0
+		for _, rs := range td.ResourceSpans {
+			for _, ss := range rs.ScopeSpans {
+				count += len(ss.Spans)
+				for _, sp := range ss.Spans {
+					if got := extractServerNameFromAttrs(sp.Attributes); got != "github" {
+						t.Errorf("github line contained span tagged %q, want github", got)
+					}
+				}
+			}
+		}
+		if count != 1 {
+			t.Errorf("github envelope contained %d spans; want 1", count)
+		}
+	}
+}
+
+func TestTracesFileClient_RemoveServerStopsWriting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "github-traces.jsonl")
+
+	c := NewTracesFileClient()
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+	if err := c.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	rs := &tracepb.ResourceSpans{
+		Resource: &resourcepb.Resource{},
+		ScopeSpans: []*tracepb.ScopeSpans{{
+			Scope: &commonpb.InstrumentationScope{Name: "gridctl/test"},
+			Spans: []*tracepb.Span{makeSpan("github", "first", 1)},
+		}},
+	}
+	if err := c.UploadTraces(context.Background(), []*tracepb.ResourceSpans{rs}); err != nil {
+		t.Fatalf("UploadTraces #1: %v", err)
+	}
+
+	c.RemoveServer("github")
+
+	rs2 := &tracepb.ResourceSpans{
+		Resource: &resourcepb.Resource{},
+		ScopeSpans: []*tracepb.ScopeSpans{{
+			Scope: &commonpb.InstrumentationScope{Name: "gridctl/test"},
+			Spans: []*tracepb.Span{makeSpan("github", "second", 2)},
+		}},
+	}
+	if err := c.UploadTraces(context.Background(), []*tracepb.ResourceSpans{rs2}); err != nil {
+		t.Fatalf("UploadTraces #2: %v", err)
+	}
+
+	lines := readTraceLines(t, path)
+	if len(lines) != 1 {
+		t.Errorf("after RemoveServer: lines = %d, want 1", len(lines))
+	}
+}
+
+func TestTracesFileClient_FileMode0600(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "traces.jsonl")
+	c := NewTracesFileClient()
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+	if err := c.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("file mode = %v, want 0600", got)
+	}
+}
+
+func TestTracesFileClient_NoOpOnEmptyBatch(t *testing.T) {
+	c := NewTracesFileClient()
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+	if err := c.UploadTraces(context.Background(), nil); err != nil {
+		t.Errorf("UploadTraces(nil) returned %v, want nil", err)
+	}
+}
+
+// makeSpan builds a minimal valid Span with a server.name attribute. seed
+// distinguishes ids so spans don't collide in tests.
+func makeSpan(serverName, name string, seed byte) *tracepb.Span {
+	s := &tracepb.Span{
+		Name:              name,
+		TraceId:           []byte{seed, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		SpanId:            []byte{seed, 0, 0, 0, 0, 0, 0, 0},
+		StartTimeUnixNano: 1_000_000_000,
+		EndTimeUnixNano:   2_000_000_000,
+	}
+	if serverName != "" {
+		s.Attributes = []*commonpb.KeyValue{{
+			Key: serverNameAttrKey,
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_StringValue{StringValue: serverName},
+			},
+		}}
+	}
+	return s
+}
+
+func readTraceLines(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		txt := scanner.Text()
+		if txt != "" {
+			lines = append(lines, txt)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan %s: %v", path, err)
+	}
+	return lines
+}

--- a/pkg/tracing/buffer.go
+++ b/pkg/tracing/buffer.go
@@ -1,12 +1,19 @@
 package tracing
 
 import (
+	"bufio"
 	"context"
+	"encoding/hex"
+	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // SpanRecord is a completed OTel span stored in the trace buffer.
@@ -214,6 +221,133 @@ func (b *Buffer) Count() int {
 	b.bufMu.RLock()
 	defer b.bufMu.RUnlock()
 	return b.count()
+}
+
+// SeedFromFile reads up to the last n OTLP-JSON envelope lines from path and
+// rehydrates them into TraceRecords in the buffer. Used on daemon startup to
+// preload the in-memory ring with pre-restart trace history from a persisted
+// per-server traces.jsonl file. Missing or empty files return nil — that's
+// expected on the very first run with persistence enabled.
+//
+// The on-disk format is one tracepb.TracesData per line, written by
+// pkg/telemetry.TracesFileClient. Lines that fail to parse are skipped
+// without aborting the seed.
+func (b *Buffer) SeedFromFile(path string, n int) error {
+	if path == "" {
+		return nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("seed trace buffer from %q: %w", path, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("seed trace buffer scan %q: %w", path, err)
+	}
+
+	if n > 0 && len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+
+	// Group reconstructed spans by trace ID, then build TraceRecords. This
+	// mirrors ExportSpans's grouping and gives the same UX when tabs render
+	// pre-restart history.
+	byTrace := make(map[string][]SpanRecord)
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var td tracepb.TracesData
+		if err := protojson.Unmarshal([]byte(line), &td); err != nil {
+			continue
+		}
+		for _, rs := range td.ResourceSpans {
+			for _, ss := range rs.ScopeSpans {
+				for _, sp := range ss.Spans {
+					rec := protoSpanToRecord(sp)
+					byTrace[rec.TraceID] = append(byTrace[rec.TraceID], rec)
+				}
+			}
+		}
+	}
+
+	for tid, spans := range byTrace {
+		if len(spans) == 0 {
+			continue
+		}
+		root := spans[0]
+		for _, s := range spans[1:] {
+			if s.StartTime.Before(root.StartTime) {
+				root = s
+			}
+		}
+		tr := buildTraceRecord(root, spans)
+		tr.TraceID = tid
+		b.addToBuffer(tr)
+	}
+	return nil
+}
+
+// protoSpanToRecord mirrors spanToRecord but for tracepb.Span (the OTLP
+// proto type produced by SeedFromFile's JSON decode). Only fields the UI
+// already exposes are copied — events, links, and dropped counts are
+// preserved by the OTLP file but not surfaced back into SpanRecord.
+func protoSpanToRecord(sp *tracepb.Span) SpanRecord {
+	traceID := hex.EncodeToString(sp.TraceId)
+	spanID := hex.EncodeToString(sp.SpanId)
+
+	rec := SpanRecord{
+		TraceID:   traceID,
+		SpanID:    spanID,
+		Name:      sp.Name,
+		StartTime: time.Unix(0, int64(sp.StartTimeUnixNano)),
+		EndTime:   time.Unix(0, int64(sp.EndTimeUnixNano)),
+	}
+	rec.DurationMs = rec.EndTime.Sub(rec.StartTime).Milliseconds()
+	if sp.Status != nil {
+		rec.Status = sp.Status.Code.String()
+		rec.IsError = strings.Contains(rec.Status, "Error")
+	}
+	if len(sp.ParentSpanId) > 0 {
+		rec.ParentID = hex.EncodeToString(sp.ParentSpanId)
+	}
+	if len(sp.Attributes) > 0 {
+		rec.Attrs = make(map[string]string, len(sp.Attributes))
+		for _, kv := range sp.Attributes {
+			if kv.Value == nil {
+				continue
+			}
+			rec.Attrs[kv.Key] = anyValueToString(kv.Value)
+		}
+	}
+	return rec
+}
+
+// anyValueToString flattens a proto AnyValue into the simple string shape
+// SpanRecord expects. Non-string scalars are formatted via fmt.
+func anyValueToString(v *commonpb.AnyValue) string {
+	switch x := v.Value.(type) {
+	case *commonpb.AnyValue_StringValue:
+		return x.StringValue
+	case *commonpb.AnyValue_BoolValue:
+		return fmt.Sprintf("%t", x.BoolValue)
+	case *commonpb.AnyValue_IntValue:
+		return fmt.Sprintf("%d", x.IntValue)
+	case *commonpb.AnyValue_DoubleValue:
+		return fmt.Sprintf("%g", x.DoubleValue)
+	default:
+		return ""
+	}
 }
 
 // addToBuffer appends a TraceRecord to the ring buffer. Thread-safe.

--- a/pkg/tracing/provider.go
+++ b/pkg/tracing/provider.go
@@ -115,6 +115,18 @@ func (p *Provider) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+// RegisterExporter attaches an additional SpanExporter to the live
+// TracerProvider via a BatchSpanProcessor. Used by the telemetry persistence
+// layer to plug a per-server file exporter alongside the in-memory buffer
+// and the optional OTLP exporter without rebuilding the provider. No-op
+// when tracing is disabled or Init has not yet run.
+func (p *Provider) RegisterExporter(exp sdktrace.SpanExporter) {
+	if p == nil || p.provider == nil || exp == nil {
+		return
+	}
+	p.provider.RegisterSpanProcessor(sdktrace.NewBatchSpanProcessor(exp))
+}
+
 // bufferSize returns the effective ring buffer capacity from config.
 func bufferSize(cfg *Config) int {
 	if cfg.MaxTraces > 0 {


### PR DESCRIPTION
## Description

Phase 2 of 6 toward opt-in telemetry persistence. Adds the disk writers, seeding-from-disk on restart, and gateway wiring. Phase 1 (config schema + resolvers) is already on main.

## Type of Change

- [x] New feature (non-breaking — opt-in; default off)

## Changes Made

- **State path helpers** (`pkg/state/state.go`): `TelemetryDir`, `TelemetryServerDir`, `TelemetryServerPath`, `EnsureTelemetryServerDir` (mode 0700).
- **`pkg/telemetry/` package**:
  - `LogRouter` — slog handler that fans every record to the inner buffer/redact chain AND, when component matches, to a per-server lumberjack file. Self-log records (`subsystem=telemetry`) are excluded from routing to prevent recursion on write failures.
  - `MetricsFlusher` — periodic snapshot/diff goroutine. First flush per server is a full snapshot; counter resets emit a JSON sentinel + full snapshot. Idle servers don't append zero deltas. `Stop` is sync.Once-guarded.
  - `TracesFileClient` — implements `otlptrace.Client`; reuses the SDK's ReadOnlySpan→proto conversion. Spans are routed to `traces.jsonl` per server by the `server.name` attribute. One `TracesData` envelope per line via `protojson` (collector-compatible OTLP-JSON).
  - All three writers snapshot their per-server map under lock and perform disk I/O outside the lock so slow disks can't block AddServer/RemoveServer/Stop.
- **Seeding from disk**:
  - `LogBuffer.SeedFromFile` (parses NDJSON entries written by `NewFileHandler` back into `BufferedEntry`).
  - `tracing.Buffer.SeedFromFile` (parses OTLP-JSON envelopes via `protojson` and rebuilds `TraceRecord`s grouped by trace ID).
- **Provider extension**: `tracing.Provider.RegisterExporter` plugs additional span exporters into a live TracerProvider via `BatchSpanProcessor`.
- **Gateway wiring** (`pkg/controller/gateway_builder.go`):
  - `LogRouter` always installed; per-server file fan-out only kicks in when `AddServer` is called.
  - `seedLogsFromDisk` runs early in `Build` (before registry init or any goroutine emits records).
  - `seedTracesFromDisk` runs immediately after `tracingProvider.Init` (before any span emission).
  - `applyTelemetryConfig` walks `MCPServers`, calls `PersistLogs/Metrics/Traces(stack)`, and reconciles writer registrations across all three signals. Idempotent — used both at Build time and from the hot-reload callback.
  - Lifecycle: metrics flusher Start/Stop wired into Run/waitForShutdown; LogRouter and TracesFileClient close on shutdown.
- **Hot reload** (`pkg/reload/reload.go`): new `SetOnConfigApplied` hook fires after a successful reload swaps `currentCfg`. Gateway builder uses it to refresh per-server writer registrations without restarting.

## Testing

- Per-signal unit tests:
  - LogRouter routes by component, removes cleanly, file mode 0600.
  - MetricsFlusher: full snapshot first flush, diff between flushes, idle skip, counter-reset detection, file mode 0600, Start/Stop final flush.
  - TracesFileClient: server.name routing, RemoveServer stops writing, file mode 0600, empty-batch no-op.
- SeedFromFile end-to-end on both buffers (write via real router → close → seed fresh buffer).
- `TestEndToEnd_PersistAndReseed` simulates a daemon restart with persistence enabled: writes logs+traces, tears down instance 1, seeds fresh buffers from the same files, and verifies counts + file modes.
- `make build` passes; `go test -race ./...` passes; `golangci-lint run` clean on touched packages.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #550