### PR TITLE
feat: add telemetry persistence API endpoints

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -263,6 +263,13 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/stack/recipes", s.handleStackRecipes)
 	mux.HandleFunc("POST /api/stack/append", s.handleStackAppend)
 	mux.HandleFunc("POST /api/stack/initialize", s.handleStackInitialize)
+	mux.HandleFunc("PATCH /api/stack/telemetry", s.handlePatchStackTelemetry)
+
+	// Telemetry persistence endpoints — opt-in disk persistence inventory
+	// and wipe; the per-server PATCH lives under /api/mcp-servers/{name}/.
+	mux.HandleFunc("PATCH /api/mcp-servers/{name}/telemetry", s.handlePatchServerTelemetry)
+	mux.HandleFunc("GET /api/telemetry/inventory", s.handleGetTelemetryInventory)
+	mux.HandleFunc("DELETE /api/telemetry", s.handleDeleteTelemetry)
 
 	// Stack library endpoints
 	mux.HandleFunc("GET /api/stacks", s.handleStacksList)

--- a/internal/api/stack_telemetry.go
+++ b/internal/api/stack_telemetry.go
@@ -1,0 +1,394 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+// stackPersistDelta is the persist subblock of a PATCH /api/stack/telemetry
+// request. Each *bool is tri-state: nil = no change, &true/&false = set the
+// stack-global default. Stack-global persistence is binary (the on-disk YAML
+// stores plain bool); the *bool is here so JSON `null` and absence both
+// surface as "no change" rather than "set to false".
+type stackPersistDelta struct {
+	Logs    *bool `json:"logs,omitempty"`
+	Metrics *bool `json:"metrics,omitempty"`
+	Traces  *bool `json:"traces,omitempty"`
+}
+
+// retentionDelta is the retention subblock of a PATCH /api/stack/telemetry
+// request. Each *int is "no change" when nil, "set to value" when non-nil.
+type retentionDelta struct {
+	MaxSizeMB  *int `json:"max_size_mb,omitempty"`
+	MaxBackups *int `json:"max_backups,omitempty"`
+	MaxAgeDays *int `json:"max_age_days,omitempty"`
+}
+
+// stackTelemetryRequest is the wire shape for PATCH /api/stack/telemetry.
+type stackTelemetryRequest struct {
+	Persist   *stackPersistDelta `json:"persist,omitempty"`
+	Retention *retentionDelta    `json:"retention,omitempty"`
+}
+
+// hasChanges reports whether at least one field is non-nil. A request with
+// neither persist nor retention is rejected upstream as "nothing to do".
+func (r stackTelemetryRequest) hasChanges() bool {
+	if r.Persist != nil && (r.Persist.Logs != nil || r.Persist.Metrics != nil || r.Persist.Traces != nil) {
+		return true
+	}
+	if r.Retention != nil && (r.Retention.MaxSizeMB != nil || r.Retention.MaxBackups != nil || r.Retention.MaxAgeDays != nil) {
+		return true
+	}
+	return false
+}
+
+// serverPersistOp expresses the four states a per-server signal override can
+// transition to in a single PATCH: leave it alone, clear it (revert to
+// inheriting the stack-global), or set an explicit true/false override.
+type serverPersistOp int
+
+const (
+	serverPersistNoop serverPersistOp = iota
+	serverPersistClear
+	serverPersistTrue
+	serverPersistFalse
+)
+
+// serverPersistDelta captures the per-signal ops for a single server PATCH.
+type serverPersistDelta struct {
+	Logs    serverPersistOp
+	Metrics serverPersistOp
+	Traces  serverPersistOp
+}
+
+// hasOps reports whether the delta would mutate any signal.
+func (d serverPersistDelta) hasOps() bool {
+	return d.Logs != serverPersistNoop || d.Metrics != serverPersistNoop || d.Traces != serverPersistNoop
+}
+
+// serverTelemetryRequest is the wire shape for PATCH
+// /api/mcp-servers/{name}/telemetry. Persist is captured raw so the handler
+// can distinguish three states that *bool cannot:
+//
+//  1. key absent          → no change
+//  2. persist: null       → remove the entire per-server telemetry block
+//  3. persist: { ... }    → per-signal ops, where each signal independently
+//     follows the same three-state rule (absent / null / bool).
+type serverTelemetryRequest struct {
+	Persist json.RawMessage `json:"persist"`
+}
+
+// parseServerPersist resolves the raw persist value into a delta and a
+// "clearAll" flag. clearAll==true means the request body had `persist: null`,
+// which deletes the entire telemetry mapping from the server entry.
+func parseServerPersist(raw json.RawMessage) (delta serverPersistDelta, clearAll bool, err error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return delta, false, nil
+	}
+	if string(trimmed) == "null" {
+		return delta, true, nil
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &fields); err != nil {
+		return delta, false, fmt.Errorf("persist must be an object or null: %w", err)
+	}
+
+	parseSignal := func(name string) (serverPersistOp, error) {
+		v, ok := fields[name]
+		if !ok {
+			return serverPersistNoop, nil
+		}
+		v = bytes.TrimSpace(v)
+		if string(v) == "null" {
+			return serverPersistClear, nil
+		}
+		var b bool
+		if err := json.Unmarshal(v, &b); err != nil {
+			return serverPersistNoop, fmt.Errorf("persist.%s must be true, false, or null", name)
+		}
+		if b {
+			return serverPersistTrue, nil
+		}
+		return serverPersistFalse, nil
+	}
+
+	if delta.Logs, err = parseSignal("logs"); err != nil {
+		return delta, false, err
+	}
+	if delta.Metrics, err = parseSignal("metrics"); err != nil {
+		return delta, false, err
+	}
+	if delta.Traces, err = parseSignal("traces"); err != nil {
+		return delta, false, err
+	}
+	return delta, false, nil
+}
+
+// patchStackTelemetry rewrites source with the requested updates to the
+// top-level telemetry mapping. The yaml.Node round-trip preserves comments
+// and key ordering across both the affected and the unaffected parts of the
+// document, mirroring patchServerTools / patchAppendResource.
+//
+// A nil persist or retention pointer leaves the corresponding subblock alone.
+// Within each subblock, only the non-nil leaf fields are mutated; the rest
+// retain their existing on-disk values. The telemetry block is created if
+// absent; subblocks (persist, retention) are created lazily as needed.
+func patchStackTelemetry(source []byte, persist *stackPersistDelta, retention *retentionDelta) ([]byte, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(source, &root); err != nil {
+		return nil, fmt.Errorf("parse stack yaml: %w", err)
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil, fmt.Errorf("parse stack yaml: not a document")
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse stack yaml: top-level not a mapping")
+	}
+
+	if persist != nil || retention != nil {
+		telemetryNode := findOrCreateMapping(doc, "telemetry")
+		if telemetryNode == nil {
+			return nil, fmt.Errorf("locate telemetry mapping")
+		}
+		if persist != nil {
+			applyStackPersist(telemetryNode, persist)
+		}
+		if retention != nil {
+			applyStackRetention(telemetryNode, retention)
+		}
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func applyStackPersist(telemetry *yaml.Node, delta *stackPersistDelta) {
+	persistNode := findOrCreateMapping(telemetry, "persist")
+	if persistNode == nil {
+		return
+	}
+	if delta.Logs != nil {
+		setMappingBool(persistNode, "logs", *delta.Logs)
+	}
+	if delta.Metrics != nil {
+		setMappingBool(persistNode, "metrics", *delta.Metrics)
+	}
+	if delta.Traces != nil {
+		setMappingBool(persistNode, "traces", *delta.Traces)
+	}
+}
+
+func applyStackRetention(telemetry *yaml.Node, delta *retentionDelta) {
+	retNode := findOrCreateMapping(telemetry, "retention")
+	if retNode == nil {
+		return
+	}
+	if delta.MaxSizeMB != nil {
+		setMappingInt(retNode, "max_size_mb", *delta.MaxSizeMB)
+	}
+	if delta.MaxBackups != nil {
+		setMappingInt(retNode, "max_backups", *delta.MaxBackups)
+	}
+	if delta.MaxAgeDays != nil {
+		setMappingInt(retNode, "max_age_days", *delta.MaxAgeDays)
+	}
+}
+
+// patchServerTelemetry rewrites source with the requested updates to a single
+// MCP server's telemetry mapping. It mirrors patchServerTools: locate the
+// named server in mcp-servers, mutate the target node tree in place, and
+// re-emit via yaml.Encoder so comments and key ordering elsewhere in the
+// document survive untouched.
+//
+// Behavior:
+//   - clearAll=true: delete the server's `telemetry:` key entirely
+//     (matches the "remove the block" idiom of replaceOrInsertTools when
+//     the whitelist is empty).
+//   - clearAll=false with delta: per-signal ops on telemetry.persist; clear
+//     ops remove the corresponding key, true/false ops upsert it. After
+//     applying, an empty persist mapping is removed; if telemetry is then
+//     also empty, the telemetry key itself is removed.
+//
+// Returns errServerNotFound when the server name is absent.
+func patchServerTelemetry(source []byte, serverName string, delta serverPersistDelta, clearAll bool) ([]byte, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(source, &root); err != nil {
+		return nil, fmt.Errorf("parse stack yaml: %w", err)
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil, fmt.Errorf("parse stack yaml: not a document")
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse stack yaml: top-level not a mapping")
+	}
+
+	serversSeq := findMappingValue(doc, "mcp-servers")
+	if serversSeq == nil || serversSeq.Kind != yaml.SequenceNode {
+		return nil, errServerNotFound
+	}
+
+	var targetServer *yaml.Node
+	for _, entry := range serversSeq.Content {
+		if entry.Kind != yaml.MappingNode {
+			continue
+		}
+		nameNode := findMappingValue(entry, "name")
+		if nameNode != nil && nameNode.Value == serverName {
+			targetServer = entry
+			break
+		}
+	}
+	if targetServer == nil {
+		return nil, errServerNotFound
+	}
+
+	if clearAll {
+		deleteMappingKey(targetServer, "telemetry")
+	} else if delta.hasOps() {
+		applyServerPersist(targetServer, delta)
+	}
+	// All-noop deltas are valid (callers may PATCH with nothing to do); fall
+	// through to the round-trip so the response is shaped consistently.
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func applyServerPersist(server *yaml.Node, delta serverPersistDelta) {
+	telemetryNode := findOrCreateMapping(server, "telemetry")
+	if telemetryNode == nil {
+		return
+	}
+	persistNode := findOrCreateMapping(telemetryNode, "persist")
+	if persistNode == nil {
+		return
+	}
+
+	applyServerPersistOp(persistNode, "logs", delta.Logs)
+	applyServerPersistOp(persistNode, "metrics", delta.Metrics)
+	applyServerPersistOp(persistNode, "traces", delta.Traces)
+
+	// Cleanup: collapse empty containers so an all-cleared override doesn't
+	// leave behind an empty `telemetry: {persist: {}}` skeleton.
+	if len(persistNode.Content) == 0 {
+		deleteMappingKey(telemetryNode, "persist")
+	}
+	if len(telemetryNode.Content) == 0 {
+		deleteMappingKey(server, "telemetry")
+	}
+}
+
+func applyServerPersistOp(persist *yaml.Node, key string, op serverPersistOp) {
+	switch op {
+	case serverPersistNoop:
+	case serverPersistClear:
+		deleteMappingKey(persist, key)
+	case serverPersistTrue:
+		setMappingBool(persist, key, true)
+	case serverPersistFalse:
+		setMappingBool(persist, key, false)
+	}
+}
+
+// findOrCreateMapping is the mapping-node analogue of findOrCreateSequence.
+// When parent has key with a mapping value it is returned; otherwise a fresh
+// empty mapping is installed in place (replacing a non-mapping value or
+// appending a new key+mapping pair to the end of parent).
+func findOrCreateMapping(parent *yaml.Node, key string) *yaml.Node {
+	if parent == nil || parent.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(parent.Content); i += 2 {
+		if parent.Content[i].Value != key {
+			continue
+		}
+		v := parent.Content[i+1]
+		if v.Kind == yaml.MappingNode {
+			return v
+		}
+		// Replacing a non-mapping value (e.g. `telemetry: null` or
+		// `telemetry: "oops"`) with an empty mapping. Carry over any
+		// comments attached to the old value so the replacement does not
+		// silently drop user-written prose. (See pitfall #1 in the spec:
+		// "YAML comment loss is silent.")
+		m := &yaml.Node{
+			Kind:        yaml.MappingNode,
+			Tag:         "!!map",
+			HeadComment: v.HeadComment,
+			LineComment: v.LineComment,
+			FootComment: v.FootComment,
+		}
+		parent.Content[i+1] = m
+		return m
+	}
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+	m := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	parent.Content = append(parent.Content, keyNode, m)
+	return m
+}
+
+// deleteMappingKey removes the key/value pair from a mapping node. No-op on
+// nil, non-mapping, or absent-key inputs.
+func deleteMappingKey(mapping *yaml.Node, key string) {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			mapping.Content = append(mapping.Content[:i], mapping.Content[i+2:]...)
+			return
+		}
+	}
+}
+
+func setMappingBool(mapping *yaml.Node, key string, val bool) {
+	v := "false"
+	if val {
+		v = "true"
+	}
+	setScalar(mapping, key, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: v})
+}
+
+func setMappingInt(mapping *yaml.Node, key string, val int) {
+	setScalar(mapping, key, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.Itoa(val)})
+}
+
+func setScalar(mapping *yaml.Node, key string, value *yaml.Node) {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			mapping.Content[i+1] = value
+			return
+		}
+	}
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		value,
+	)
+}

--- a/internal/api/stack_telemetry_test.go
+++ b/internal/api/stack_telemetry_test.go
@@ -1,0 +1,254 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// telemetryFixture is the shared fixture for patcher unit tests. It carries:
+//   - a top-of-file comment
+//   - inline comments inside mcp-servers
+//   - a stack-global telemetry block with persist + retention pre-populated
+//   - one mcp-server with an existing telemetry override and one without
+//   - non-canonical key order (`transport: http` before `url:`) so a struct
+//     round-trip would visibly reshuffle it
+const telemetryFixture = `# top-of-file comment — must survive round-trip
+version: "1"
+name: example
+network:
+  name: example-net
+  driver: bridge
+telemetry:
+  persist:
+    logs: true
+    metrics: false
+    traces: true
+  retention:
+    max_size_mb: 100
+    max_backups: 5
+    max_age_days: 7
+mcp-servers:
+  - name: github
+    transport: http
+    url: https://api.github.com/mcp
+    telemetry:
+      persist:
+        traces: false # explicit override
+  - name: filesystem
+    transport: stdio
+    command: gridctl-fs
+`
+
+func boolPtr(b bool) *bool { return &b }
+func intPtr(i int) *int    { return &i }
+
+func TestPatchStackTelemetry_PreservesCommentsAndOrder(t *testing.T) {
+	out, err := patchStackTelemetry([]byte(telemetryFixture),
+		&stackPersistDelta{Logs: boolPtr(false)},
+		nil,
+	)
+	require.NoError(t, err)
+	got := string(out)
+
+	assert.Contains(t, got, "# top-of-file comment")
+	assert.Contains(t, got, "explicit override")
+
+	// transport must remain before url for github even after the unrelated
+	// stack-global telemetry mutation.
+	transportIdx := strings.Index(got, "transport: http")
+	urlIdx := strings.Index(got, "url: https://api.github.com/mcp")
+	require.Greater(t, transportIdx, 0)
+	require.Greater(t, urlIdx, 0)
+	assert.Less(t, transportIdx, urlIdx)
+
+	// logs flipped to false, metrics/traces unchanged from fixture.
+	assert.Regexp(t, `(?m)^\s*logs:\s*false`, got)
+	assert.Regexp(t, `(?m)^\s*metrics:\s*false`, got)
+	assert.Regexp(t, `(?m)^\s*traces:\s*true`, got)
+
+	// Retention is untouched because retention delta is nil.
+	assert.Contains(t, got, "max_size_mb: 100")
+	assert.Contains(t, got, "max_backups: 5")
+	assert.Contains(t, got, "max_age_days: 7")
+}
+
+func TestPatchStackTelemetry_RetentionOnly(t *testing.T) {
+	out, err := patchStackTelemetry([]byte(telemetryFixture),
+		nil,
+		&retentionDelta{MaxAgeDays: intPtr(30)},
+	)
+	require.NoError(t, err)
+	got := string(out)
+
+	// Persist subblock untouched.
+	assert.Regexp(t, `(?m)^\s*logs:\s*true`, got)
+	// Retention max_age_days bumped, others preserved.
+	assert.Contains(t, got, "max_age_days: 30")
+	assert.Contains(t, got, "max_size_mb: 100")
+	assert.Contains(t, got, "max_backups: 5")
+}
+
+func TestPatchStackTelemetry_CreatesBlockOnEmptyStack(t *testing.T) {
+	source := `# header
+version: "1"
+name: empty
+mcp-servers: []
+`
+	out, err := patchStackTelemetry([]byte(source),
+		&stackPersistDelta{Logs: boolPtr(true), Metrics: boolPtr(true)},
+		&retentionDelta{MaxSizeMB: intPtr(50)},
+	)
+	require.NoError(t, err)
+	got := string(out)
+
+	assert.Contains(t, got, "# header")
+	assert.Contains(t, got, "telemetry:")
+	assert.Contains(t, got, "persist:")
+	assert.Regexp(t, `(?m)logs:\s*true`, got)
+	assert.Regexp(t, `(?m)metrics:\s*true`, got)
+	assert.Contains(t, got, "max_size_mb: 50")
+}
+
+func TestPatchStackTelemetry_Idempotent(t *testing.T) {
+	delta := &stackPersistDelta{Logs: boolPtr(true), Metrics: boolPtr(false), Traces: boolPtr(true)}
+	first, err := patchStackTelemetry([]byte(telemetryFixture), delta, nil)
+	require.NoError(t, err)
+	second, err := patchStackTelemetry(first, delta, nil)
+	require.NoError(t, err)
+	assert.Equal(t, string(first), string(second))
+}
+
+func TestPatchServerTelemetry_SetExplicitOverride(t *testing.T) {
+	out, err := patchServerTelemetry([]byte(telemetryFixture), "filesystem",
+		serverPersistDelta{Logs: serverPersistTrue, Metrics: serverPersistFalse},
+		false,
+	)
+	require.NoError(t, err)
+	got := string(out)
+
+	// Comments survive.
+	assert.Contains(t, got, "# top-of-file comment")
+	assert.Contains(t, got, "explicit override")
+
+	// New filesystem.telemetry block written; github untouched.
+	fsIdx := strings.Index(got, "name: filesystem")
+	require.Greater(t, fsIdx, 0)
+	tail := got[fsIdx:]
+	assert.Contains(t, tail, "telemetry:")
+	assert.Contains(t, tail, "persist:")
+	assert.Regexp(t, `(?m)^\s*logs:\s*true`, tail)
+	assert.Regexp(t, `(?m)^\s*metrics:\s*false`, tail)
+	assert.NotContains(t, tail, "traces:") // not specified, must not appear
+}
+
+func TestPatchServerTelemetry_ClearSingleSignalRemovesKey(t *testing.T) {
+	// github has `traces: false` in the fixture; clearing it should remove
+	// the traces key, then collapse the empty persist mapping, then collapse
+	// the empty telemetry mapping.
+	out, err := patchServerTelemetry([]byte(telemetryFixture), "github",
+		serverPersistDelta{Traces: serverPersistClear},
+		false,
+	)
+	require.NoError(t, err)
+	got := string(out)
+
+	githubIdx := strings.Index(got, "name: github")
+	fsIdx := strings.Index(got, "name: filesystem")
+	require.Greater(t, githubIdx, 0)
+	require.Greater(t, fsIdx, githubIdx)
+	githubBlock := got[githubIdx:fsIdx]
+
+	// Whole telemetry block under github is gone because it had only this
+	// override.
+	assert.NotContains(t, githubBlock, "telemetry:")
+	assert.NotContains(t, githubBlock, "persist:")
+	assert.NotContains(t, githubBlock, "traces:")
+}
+
+func TestPatchServerTelemetry_ClearAllRemovesBlock(t *testing.T) {
+	out, err := patchServerTelemetry([]byte(telemetryFixture), "github",
+		serverPersistDelta{}, // ignored when clearAll=true
+		true,
+	)
+	require.NoError(t, err)
+	got := string(out)
+
+	githubIdx := strings.Index(got, "name: github")
+	fsIdx := strings.Index(got, "name: filesystem")
+	require.Greater(t, githubIdx, 0)
+	require.Greater(t, fsIdx, githubIdx)
+	githubBlock := got[githubIdx:fsIdx]
+
+	assert.NotContains(t, githubBlock, "telemetry:")
+
+	// Filesystem entry is unchanged.
+	assert.Contains(t, got, "command: gridctl-fs")
+}
+
+func TestPatchServerTelemetry_NotFound(t *testing.T) {
+	_, err := patchServerTelemetry([]byte(telemetryFixture), "nope",
+		serverPersistDelta{Logs: serverPersistTrue}, false,
+	)
+	assert.ErrorIs(t, err, errServerNotFound)
+}
+
+func TestPatchServerTelemetry_PartialUpdatePreservesOthers(t *testing.T) {
+	// github currently has `traces: false`. Setting logs:true should add it
+	// without disturbing the existing traces override.
+	out, err := patchServerTelemetry([]byte(telemetryFixture), "github",
+		serverPersistDelta{Logs: serverPersistTrue},
+		false,
+	)
+	require.NoError(t, err)
+	got := string(out)
+
+	githubIdx := strings.Index(got, "name: github")
+	fsIdx := strings.Index(got, "name: filesystem")
+	require.Greater(t, fsIdx, githubIdx)
+	githubBlock := got[githubIdx:fsIdx]
+
+	assert.Contains(t, githubBlock, "telemetry:")
+	assert.Regexp(t, `(?m)^\s*logs:\s*true`, githubBlock)
+	assert.Regexp(t, `(?m)^\s*traces:\s*false`, githubBlock)
+}
+
+func TestParseServerPersist(t *testing.T) {
+	type want struct {
+		delta    serverPersistDelta
+		clearAll bool
+		errMatch string
+	}
+	cases := []struct {
+		name string
+		in   string
+		want want
+	}{
+		{"empty", ``, want{}},
+		{"null", `null`, want{clearAll: true}},
+		{"empty object", `{}`, want{}},
+		{"all true", `{"logs":true,"metrics":true,"traces":true}`,
+			want{delta: serverPersistDelta{Logs: serverPersistTrue, Metrics: serverPersistTrue, Traces: serverPersistTrue}}},
+		{"mixed clear", `{"logs":true,"metrics":null}`,
+			want{delta: serverPersistDelta{Logs: serverPersistTrue, Metrics: serverPersistClear}}},
+		{"explicit false", `{"traces":false}`,
+			want{delta: serverPersistDelta{Traces: serverPersistFalse}}},
+		{"bad type", `{"logs":"yes"}`, want{errMatch: "persist.logs"}},
+		{"bad shape", `"hello"`, want{errMatch: "persist must be an object"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			delta, clearAll, err := parseServerPersist([]byte(tc.in))
+			if tc.want.errMatch != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.want.errMatch)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want.clearAll, clearAll)
+			assert.Equal(t, tc.want.delta, delta)
+		})
+	}
+}

--- a/internal/api/telemetry.go
+++ b/internal/api/telemetry.go
@@ -1,0 +1,309 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/telemetry"
+)
+
+// telemetryRequestMaxBytes caps the JSON body of telemetry PATCH requests.
+// Bodies are tiny (a handful of keys); 64 KiB matches setToolsRequestMaxBytes
+// so no realistic payload is ever near the limit.
+const telemetryRequestMaxBytes = 64 * 1024
+
+// telemetryPatchResponse is the success envelope for both PATCH endpoints.
+// The refreshed Inventory snapshot lets the UI render the header pill and
+// graph node indicators without a follow-up GET — the gateway has not
+// rebuilt yet, but the on-disk footprint is what the next render needs.
+type telemetryPatchResponse struct {
+	Success   bool                        `json:"success"`
+	Inventory []telemetry.InventoryRecord `json:"inventory"`
+}
+
+// handlePatchStackTelemetry updates the top-level telemetry mapping in the
+// active stack YAML. The persistence path uses the same lock + hash + atomic-
+// write pattern as setServerTools and handleStackAppend, so concurrent
+// callers serialize, external edits between read and write are detected as
+// HTTP 409, and a mid-write crash leaves the original file intact.
+//
+// PATCH /api/stack/telemetry
+func (s *Server) handlePatchStackTelemetry(w http.ResponseWriter, r *http.Request) {
+	if s.stackFile == "" {
+		writeJSONError(w, "No stack file configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, telemetryRequestMaxBytes))
+	if err != nil {
+		writeJSONError(w, "Failed to read request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var req stackTelemetryRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !req.hasChanges() {
+		writeJSONError(w, "Request must include at least one persist or retention field", http.StatusBadRequest)
+		return
+	}
+
+	mu := stackFileLock(s.stackFile)
+	mu.Lock()
+	defer mu.Unlock()
+
+	original, err := os.ReadFile(s.stackFile)
+	if err != nil {
+		writeJSONError(w, "Failed to read stack file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	originalHash := sha256.Sum256(original)
+
+	updated, err := patchStackTelemetry(original, req.Persist, req.Retention)
+	if err != nil {
+		writeJSONError(w, "Failed to patch stack: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := s.validatePatchedStack(w, updated, "telemetry patch"); err != nil {
+		return
+	}
+
+	fireBetweenReadsHook()
+
+	current, err := os.ReadFile(s.stackFile)
+	if err != nil {
+		writeJSONError(w, "Failed to re-read stack file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if sha256.Sum256(current) != originalHash {
+		writeStructuredError(w, http.StatusConflict, errCodeStackModified,
+			"The stack file was modified outside the canvas.",
+			"Reload the file to see the latest contents, then re-apply your changes.")
+		return
+	}
+
+	if err := atomicWrite(s.stackFile, updated); err != nil {
+		writeJSONError(w, "Failed to write stack file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if s.reloadHandler != nil {
+		// Fire-and-forget: the watcher will also see this change and trigger a
+		// reload, but invoking it here makes the UI feel snappy when watching
+		// is disabled or temporarily blocked. Errors here surface as 502 with
+		// the same code handleSetServerTools uses.
+		if result, err := s.reloadHandler.Reload(r.Context()); err != nil {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed,
+				err.Error(),
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		} else if !result.Success {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed,
+				result.Message,
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+	}
+
+	writeJSON(w, telemetryPatchResponse{
+		Success:   true,
+		Inventory: s.telemetryInventoryOrEmpty(),
+	})
+}
+
+// handlePatchServerTelemetry updates the per-server telemetry mapping. Same
+// safe-rewrite contract as handlePatchStackTelemetry.
+//
+// PATCH /api/mcp-servers/{name}/telemetry
+func (s *Server) handlePatchServerTelemetry(w http.ResponseWriter, r *http.Request) {
+	serverName := r.PathValue("name")
+	if serverName == "" {
+		writeJSONError(w, "Server name is required", http.StatusBadRequest)
+		return
+	}
+	if s.stackFile == "" {
+		writeJSONError(w, "No stack file configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, telemetryRequestMaxBytes))
+	if err != nil {
+		writeJSONError(w, "Failed to read request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var req serverTelemetryRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	delta, clearAll, err := parseServerPersist(req.Persist)
+	if err != nil {
+		writeJSONError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !clearAll && !delta.hasOps() {
+		writeJSONError(w, "Request must include at least one persist override or persist:null to clear", http.StatusBadRequest)
+		return
+	}
+
+	mu := stackFileLock(s.stackFile)
+	mu.Lock()
+	defer mu.Unlock()
+
+	original, err := os.ReadFile(s.stackFile)
+	if err != nil {
+		writeJSONError(w, "Failed to read stack file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	originalHash := sha256.Sum256(original)
+
+	updated, err := patchServerTelemetry(original, serverName, delta, clearAll)
+	switch {
+	case err == nil:
+		// proceed
+	case errors.Is(err, errServerNotFound):
+		writeJSONError(w, "MCP server not found: "+serverName, http.StatusNotFound)
+		return
+	default:
+		writeJSONError(w, "Failed to patch stack: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := s.validatePatchedStack(w, updated, "server telemetry patch"); err != nil {
+		return
+	}
+
+	fireBetweenReadsHook()
+
+	current, err := os.ReadFile(s.stackFile)
+	if err != nil {
+		writeJSONError(w, "Failed to re-read stack file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if sha256.Sum256(current) != originalHash {
+		writeStructuredError(w, http.StatusConflict, errCodeStackModified,
+			"The stack file was modified outside the canvas.",
+			"Reload the file to see the latest contents, then re-apply your changes.")
+		return
+	}
+
+	if err := atomicWrite(s.stackFile, updated); err != nil {
+		writeJSONError(w, "Failed to write stack file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if s.reloadHandler != nil {
+		if result, err := s.reloadHandler.Reload(r.Context()); err != nil {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed,
+				err.Error(),
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		} else if !result.Success {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed,
+				result.Message,
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+	}
+
+	writeJSON(w, telemetryPatchResponse{
+		Success:   true,
+		Inventory: s.telemetryInventoryOrEmpty(),
+	})
+}
+
+// handleGetTelemetryInventory returns one record per (server, signal) pair
+// that has at least one file on disk.
+//
+// GET /api/telemetry/inventory
+func (s *Server) handleGetTelemetryInventory(w http.ResponseWriter, r *http.Request) {
+	records, err := telemetry.Inventory(s.stackName, "")
+	if err != nil {
+		writeJSONError(w, "Failed to read telemetry inventory: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if records == nil {
+		records = []telemetry.InventoryRecord{}
+	}
+	writeJSON(w, records)
+}
+
+// handleDeleteTelemetry wipes telemetry files for the requested scope.
+// Both query parameters are optional; when both are empty the wipe covers
+// every server and signal in the stack.
+//
+// DELETE /api/telemetry?server={name}&signal={logs|metrics|traces}
+func (s *Server) handleDeleteTelemetry(w http.ResponseWriter, r *http.Request) {
+	if s.stackName == "" {
+		writeJSONError(w, "No stack loaded", http.StatusServiceUnavailable)
+		return
+	}
+	server := r.URL.Query().Get("server")
+	signal := r.URL.Query().Get("signal")
+	if signal != "" && !telemetry.IsValidSignal(signal) {
+		writeJSONError(w, "Invalid signal: "+signal+" (expected logs, metrics, or traces)", http.StatusBadRequest)
+		return
+	}
+
+	if err := telemetry.Wipe(s.stackName, server, signal); err != nil {
+		writeJSONError(w, "Failed to wipe telemetry: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, telemetryPatchResponse{
+		Success:   true,
+		Inventory: s.telemetryInventoryOrEmpty(),
+	})
+}
+
+// validatePatchedStack parses updated YAML bytes through the typed schema and
+// the standard validator. On failure it writes the same 422 envelope as
+// handleStackAppend and returns a sentinel non-nil error so the caller can
+// short-circuit. On success it returns nil with no body written.
+func (s *Server) validatePatchedStack(w http.ResponseWriter, updated []byte, label string) error {
+	var stack config.Stack
+	if err := yaml.Unmarshal(updated, &stack); err != nil {
+		writeJSONError(w, "Failed to parse patched stack: "+err.Error(), http.StatusInternalServerError)
+		return err
+	}
+	config.ExpandStackVarsWithEnv(&stack)
+	stack.SetDefaults()
+	if result := config.ValidateWithIssues(&stack); !result.Valid {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":      "stack validation failed after " + label,
+			"validation": result,
+		})
+		return errors.New("validation failed")
+	}
+	return nil
+}
+
+// telemetryInventoryOrEmpty wraps telemetry.Inventory so handler responses
+// always carry a JSON array (never null) for the inventory field. Errors are
+// swallowed and reported as an empty list — the inventory is informational
+// alongside the primary success status, and surfacing a partial failure here
+// would mask the more useful patch/wipe-succeeded signal.
+func (s *Server) telemetryInventoryOrEmpty() []telemetry.InventoryRecord {
+	if s.stackName == "" {
+		return []telemetry.InventoryRecord{}
+	}
+	records, err := telemetry.Inventory(s.stackName, "")
+	if err != nil || records == nil {
+		return []telemetry.InventoryRecord{}
+	}
+	return records
+}

--- a/internal/api/telemetry_test.go
+++ b/internal/api/telemetry_test.go
@@ -1,0 +1,523 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// telemetryHandlerFixture is a minimal valid stack with one server and a
+// pre-populated telemetry block. Comments and non-canonical key order
+// (transport before url) are present so round-trip preservation regressions
+// fail loudly.
+const telemetryHandlerFixture = `# top-of-file comment — must survive round-trip
+version: "1"
+name: example
+network:
+  name: example-net
+  driver: bridge
+telemetry:
+  persist:
+    logs: false
+    metrics: false
+    traces: false
+  retention:
+    max_size_mb: 100
+    max_backups: 5
+    max_age_days: 7
+mcp-servers:
+  - name: github
+    transport: http
+    url: https://api.github.com/mcp
+`
+
+func patchStackTelemetryRequest(t *testing.T, server *Server, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPatch, "/api/stack/telemetry", strings.NewReader(string(raw)))
+	w := httptest.NewRecorder()
+	server.handlePatchStackTelemetry(w, req)
+	return w
+}
+
+func patchServerTelemetryRequest(t *testing.T, server *Server, name string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPatch, "/api/mcp-servers/"+name+"/telemetry", strings.NewReader(string(raw)))
+	req.SetPathValue("name", name)
+	w := httptest.NewRecorder()
+	server.handlePatchServerTelemetry(w, req)
+	return w
+}
+
+func TestHandlePatchStackTelemetry_PreservesCommentsAndOrder(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(telemetryHandlerFixture), 0o600))
+
+	s := &Server{stackFile: path}
+	w := patchStackTelemetryRequest(t, s, map[string]any{
+		"persist": map[string]any{"logs": true},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	out, err := os.ReadFile(path)
+	require.NoError(t, err)
+	got := string(out)
+
+	assert.Contains(t, got, "# top-of-file comment")
+
+	// transport must remain before url (struct round-trip would reverse).
+	transportIdx := strings.Index(got, "transport: http")
+	urlIdx := strings.Index(got, "url: https://api.github.com/mcp")
+	require.Greater(t, transportIdx, 0)
+	require.Greater(t, urlIdx, 0)
+	assert.Less(t, transportIdx, urlIdx)
+
+	// logs flipped, others retained.
+	assert.Regexp(t, `(?m)^\s*logs:\s*true`, got)
+	assert.Regexp(t, `(?m)^\s*metrics:\s*false`, got)
+	assert.Regexp(t, `(?m)^\s*traces:\s*false`, got)
+
+	// Response carries an inventory array (empty in this no-files test).
+	var resp telemetryPatchResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.NotNil(t, resp.Inventory)
+}
+
+func TestHandlePatchStackTelemetry_ConflictWhenDiskChanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(telemetryHandlerFixture), 0o600))
+
+	external := telemetryHandlerFixture + "\n# touched externally\n"
+	swapBetweenReadsHook(func() {
+		_ = os.WriteFile(path, []byte(external), 0o600)
+	})
+	defer swapBetweenReadsHook(nil)
+
+	s := &Server{stackFile: path}
+	w := patchStackTelemetryRequest(t, s, map[string]any{
+		"persist": map[string]any{"logs": true},
+	})
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	var resp structuredError
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, errCodeStackModified, resp.Error.Code)
+
+	// On-disk file retains the external edit; intended PATCH did not land.
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, external, string(got))
+	assert.NotRegexp(t, `(?m)^\s*logs:\s*true`, string(got))
+}
+
+func TestHandlePatchStackTelemetry_AtomicOnWriteFailure(t *testing.T) {
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(realPath, []byte(telemetryHandlerFixture), 0o600))
+
+	missing := filepath.Join(dir, "nonexistent-subdir", "stack.yaml")
+	s := &Server{stackFile: missing}
+	w := patchStackTelemetryRequest(t, s, map[string]any{
+		"persist": map[string]any{"logs": true},
+	})
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	// Original file is bit-for-bit unchanged.
+	got, err := os.ReadFile(realPath)
+	require.NoError(t, err)
+	assert.Equal(t, telemetryHandlerFixture, string(got))
+
+	// No leftover temp files.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.Contains(e.Name(), ".tmp."), "leftover temp file: %s", e.Name())
+	}
+}
+
+func TestHandlePatchStackTelemetry_SerializesConcurrentCallers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(telemetryHandlerFixture), 0o600))
+
+	s := &Server{stackFile: path}
+
+	var wg sync.WaitGroup
+	codes := make([]int, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		w := patchStackTelemetryRequest(t, s, map[string]any{
+			"persist": map[string]any{"logs": true},
+		})
+		codes[0] = w.Code
+	}()
+	go func() {
+		defer wg.Done()
+		w := patchStackTelemetryRequest(t, s, map[string]any{
+			"persist": map[string]any{"metrics": true},
+		})
+		codes[1] = w.Code
+	}()
+	wg.Wait()
+
+	assert.Equal(t, http.StatusOK, codes[0])
+	assert.Equal(t, http.StatusOK, codes[1])
+
+	out, err := os.ReadFile(path)
+	require.NoError(t, err)
+	got := string(out)
+
+	// Both writes landed.
+	assert.Regexp(t, `(?m)^\s*logs:\s*true`, got)
+	assert.Regexp(t, `(?m)^\s*metrics:\s*true`, got)
+
+	// Comments survived and the file is well-formed.
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal(out, &node))
+	assert.Contains(t, got, "# top-of-file comment")
+}
+
+func TestHandlePatchStackTelemetry_RejectsEmptyBody(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(telemetryHandlerFixture), 0o600))
+
+	s := &Server{stackFile: path}
+	w := patchStackTelemetryRequest(t, s, map[string]any{})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandlePatchStackTelemetry_RejectsInvalidRetention(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(telemetryHandlerFixture), 0o600))
+
+	s := &Server{stackFile: path}
+	// 99999 backups is above telemetryMaxBackupsHardCap (1024). SetDefaults
+	// only fills zeros, so a non-zero out-of-range value survives to the
+	// validator and surfaces the 422 we expect.
+	w := patchStackTelemetryRequest(t, s, map[string]any{
+		"retention": map[string]any{"max_backups": 99999},
+	})
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+
+	// File on disk unchanged.
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, telemetryHandlerFixture, string(got))
+}
+
+func TestHandlePatchStackTelemetry_NoStackFile(t *testing.T) {
+	s := &Server{}
+	w := patchStackTelemetryRequest(t, s, map[string]any{
+		"persist": map[string]any{"logs": true},
+	})
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestHandlePatchServerTelemetry_AddsBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(telemetryHandlerFixture), 0o600))
+
+	s := &Server{stackFile: path}
+	w := patchServerTelemetryRequest(t, s, "github", map[string]any{
+		"persist": map[string]any{"logs": true, "traces": false},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	out, err := os.ReadFile(path)
+	require.NoError(t, err)
+	got := string(out)
+
+	// Comments and order preserved.
+	assert.Contains(t, got, "# top-of-file comment")
+	transportIdx := strings.Index(got, "transport: http")
+	urlIdx := strings.Index(got, "url: https://api.github.com/mcp")
+	assert.Less(t, transportIdx, urlIdx)
+
+	// Github now has the override; metrics absent because not specified.
+	gIdx := strings.Index(got, "name: github")
+	require.Greater(t, gIdx, 0)
+	tail := got[gIdx:]
+	assert.Contains(t, tail, "telemetry:")
+	assert.Regexp(t, `(?m)^\s*logs:\s*true`, tail)
+	assert.Regexp(t, `(?m)^\s*traces:\s*false`, tail)
+}
+
+func TestHandlePatchServerTelemetry_ClearAllRemovesBlock(t *testing.T) {
+	// First seed a server-level override, then clear it.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	seed := strings.ReplaceAll(telemetryHandlerFixture,
+		"    url: https://api.github.com/mcp\n",
+		"    url: https://api.github.com/mcp\n    telemetry:\n      persist:\n        logs: true\n",
+	)
+	require.NoError(t, os.WriteFile(path, []byte(seed), 0o600))
+
+	s := &Server{stackFile: path}
+	// persist:null clears the entire server telemetry block.
+	w := patchServerTelemetryRequest(t, s, "github", map[string]json.RawMessage{
+		"persist": json.RawMessage("null"),
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	out, err := os.ReadFile(path)
+	require.NoError(t, err)
+	got := string(out)
+	gIdx := strings.Index(got, "name: github")
+	require.Greater(t, gIdx, 0)
+	tail := got[gIdx:]
+	assert.NotContains(t, tail, "telemetry:")
+	assert.NotContains(t, tail, "persist:")
+}
+
+func TestHandlePatchServerTelemetry_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(telemetryHandlerFixture), 0o600))
+
+	s := &Server{stackFile: path}
+	w := patchServerTelemetryRequest(t, s, "missing", map[string]any{
+		"persist": map[string]any{"logs": true},
+	})
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandlePatchServerTelemetry_ConflictWhenDiskChanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(telemetryHandlerFixture), 0o600))
+
+	external := telemetryHandlerFixture + "\n# touched externally\n"
+	swapBetweenReadsHook(func() {
+		_ = os.WriteFile(path, []byte(external), 0o600)
+	})
+	defer swapBetweenReadsHook(nil)
+
+	s := &Server{stackFile: path}
+	w := patchServerTelemetryRequest(t, s, "github", map[string]any{
+		"persist": map[string]any{"logs": true},
+	})
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, external, string(got))
+}
+
+func TestHandlePatchServerTelemetry_SerializesConcurrentCallers(t *testing.T) {
+	// Same fixture extended with a second server so the two PATCHes target
+	// different entries (proving the per-path lock serializes both writes
+	// without lost updates).
+	source := strings.Replace(telemetryHandlerFixture,
+		"    url: https://api.github.com/mcp\n",
+		"    url: https://api.github.com/mcp\n  - name: filesystem\n    transport: http\n    url: https://example.com/fs\n",
+		1,
+	)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(source), 0o600))
+
+	s := &Server{stackFile: path}
+
+	var wg sync.WaitGroup
+	codes := make([]int, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		w := patchServerTelemetryRequest(t, s, "github", map[string]any{
+			"persist": map[string]any{"logs": true},
+		})
+		codes[0] = w.Code
+	}()
+	go func() {
+		defer wg.Done()
+		w := patchServerTelemetryRequest(t, s, "filesystem", map[string]any{
+			"persist": map[string]any{"metrics": true},
+		})
+		codes[1] = w.Code
+	}()
+	wg.Wait()
+
+	assert.Equal(t, http.StatusOK, codes[0])
+	assert.Equal(t, http.StatusOK, codes[1])
+
+	out, err := os.ReadFile(path)
+	require.NoError(t, err)
+	got := string(out)
+
+	gIdx := strings.Index(got, "name: github")
+	fIdx := strings.Index(got, "name: filesystem")
+	require.Greater(t, fIdx, gIdx)
+	githubBlock := got[gIdx:fIdx]
+	fsBlock := got[fIdx:]
+
+	assert.Contains(t, githubBlock, "logs: true")
+	assert.Contains(t, fsBlock, "metrics: true")
+}
+
+func TestHandleGetTelemetryInventory_EmptyStack(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir) // isolate from real ~/.gridctl
+
+	s := &Server{stackName: "no-such-stack"}
+	req := httptest.NewRequest(http.MethodGet, "/api/telemetry/inventory", nil)
+	w := httptest.NewRecorder()
+	s.handleGetTelemetryInventory(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	// Response is a JSON array, never null.
+	body := strings.TrimSpace(w.Body.String())
+	assert.Equal(t, "[]", body)
+}
+
+func TestHandleGetTelemetryInventory_PopulatedStack(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stackName := "demo"
+	srvDir := filepath.Join(home, ".gridctl", "telemetry", stackName, "github")
+	require.NoError(t, os.MkdirAll(srvDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(srvDir, "logs.jsonl"), []byte("ab\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(srvDir, "metrics.jsonl"), []byte("c\n"), 0o600))
+
+	s := &Server{stackName: stackName}
+	req := httptest.NewRequest(http.MethodGet, "/api/telemetry/inventory", nil)
+	w := httptest.NewRecorder()
+	s.handleGetTelemetryInventory(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var records []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &records))
+	require.Len(t, records, 2)
+	assert.Equal(t, "github", records[0]["server"])
+	assert.Equal(t, "logs", records[0]["signal"])
+	assert.Equal(t, "github", records[1]["server"])
+	assert.Equal(t, "metrics", records[1]["signal"])
+}
+
+func TestHandleDeleteTelemetry_WildcardWipesEverything(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stackName := "demo"
+	for _, server := range []string{"github", "filesystem"} {
+		srvDir := filepath.Join(home, ".gridctl", "telemetry", stackName, server)
+		require.NoError(t, os.MkdirAll(srvDir, 0o700))
+		for _, sig := range []string{"logs", "metrics", "traces"} {
+			require.NoError(t, os.WriteFile(filepath.Join(srvDir, sig+".jsonl"), []byte("{}\n"), 0o600))
+		}
+	}
+
+	s := &Server{stackName: stackName}
+	req := httptest.NewRequest(http.MethodDelete, "/api/telemetry", nil)
+	w := httptest.NewRecorder()
+	s.handleDeleteTelemetry(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	for _, server := range []string{"github", "filesystem"} {
+		for _, sig := range []string{"logs", "metrics", "traces"} {
+			_, err := os.Stat(filepath.Join(home, ".gridctl", "telemetry", stackName, server, sig+".jsonl"))
+			assert.True(t, os.IsNotExist(err), "expected %s/%s gone", server, sig)
+		}
+	}
+
+	// Inventory in response is now empty.
+	var resp telemetryPatchResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Inventory)
+}
+
+func TestHandlePatchStackTelemetry_PreservesCommentOnNullReplacement(t *testing.T) {
+	// Edge case from pitfall #1: replacing a non-mapping `telemetry: null`
+	// with a fresh mapping must not silently drop the head comment attached
+	// to the old null node.
+	source := `# header
+version: "1"
+name: example
+network:
+  name: example-net
+  driver: bridge
+# legacy placeholder; switch to opt-in once we audit traffic
+telemetry: null
+mcp-servers:
+  - name: github
+    transport: http
+    url: https://api.github.com/mcp
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(source), 0o600))
+
+	s := &Server{stackFile: path}
+	w := patchStackTelemetryRequest(t, s, map[string]any{
+		"persist": map[string]any{"logs": true},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	out, err := os.ReadFile(path)
+	require.NoError(t, err)
+	got := string(out)
+	assert.Contains(t, got, "legacy placeholder")
+}
+
+func TestHandleDeleteTelemetry_NoStack(t *testing.T) {
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodDelete, "/api/telemetry", nil)
+	w := httptest.NewRecorder()
+	s.handleDeleteTelemetry(w, req)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestHandleDeleteTelemetry_InvalidSignal(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	s := &Server{stackName: "demo"}
+	req := httptest.NewRequest(http.MethodDelete, "/api/telemetry?signal=garbage", nil)
+	w := httptest.NewRecorder()
+	s.handleDeleteTelemetry(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleDeleteTelemetry_DeletesScopedFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	stackName := "demo"
+	srvDir := filepath.Join(home, ".gridctl", "telemetry", stackName, "github")
+	require.NoError(t, os.MkdirAll(srvDir, 0o700))
+	for _, sig := range []string{"logs", "metrics", "traces"} {
+		require.NoError(t, os.WriteFile(filepath.Join(srvDir, sig+".jsonl"), []byte("{}\n"), 0o600))
+	}
+
+	s := &Server{stackName: stackName}
+	req := httptest.NewRequest(http.MethodDelete, "/api/telemetry?server=github&signal=logs", nil)
+	w := httptest.NewRecorder()
+	s.handleDeleteTelemetry(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Logs gone, metrics + traces still present.
+	_, err := os.Stat(filepath.Join(srvDir, "logs.jsonl"))
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(srvDir, "metrics.jsonl"))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(srvDir, "traces.jsonl"))
+	assert.NoError(t, err)
+}

--- a/pkg/telemetry/inventory.go
+++ b/pkg/telemetry/inventory.go
@@ -1,0 +1,203 @@
+package telemetry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/state"
+)
+
+// signals lists the three telemetry signal types in display order. Inventory
+// records and the wipe entry-point both validate against this list so unknown
+// signal names never silently leak through.
+var signals = []string{"logs", "metrics", "traces"}
+
+// InventoryRecord describes the on-disk footprint of a single (server, signal)
+// pair. Sizes and times aggregate the active jsonl plus any rotated/compressed
+// lumberjack siblings (e.g. `logs.jsonl`, `logs-2026-04-30T12-00-00.000.jsonl`,
+// `logs-…jsonl.gz`). Records are only emitted when at least one matching file
+// exists so the wipe modal can drive its enumeration without filtering empties.
+type InventoryRecord struct {
+	Server     string    `json:"server"`
+	Signal     string    `json:"signal"`
+	Path       string    `json:"path"`
+	SizeBytes  int64     `json:"sizeBytes"`
+	OldestTime time.Time `json:"oldestTime"`
+	NewestTime time.Time `json:"newestTime"`
+	FileCount  int       `json:"fileCount"`
+}
+
+// Inventory walks ~/.gridctl/telemetry/<stackName>/ and returns one record per
+// (server, signal) pair where at least one file exists. When serverName is
+// non-empty only that server's records are returned.
+//
+// Records are sorted by server name then by the canonical signal order
+// (logs, metrics, traces) so the API response is deterministic. A missing
+// stack directory returns an empty slice without error — the daemon may
+// legitimately have no persisted telemetry yet.
+func Inventory(stackName, serverName string) ([]InventoryRecord, error) {
+	if stackName == "" {
+		return []InventoryRecord{}, nil
+	}
+	stackDir := filepath.Join(state.TelemetryDir(), stackName)
+	entries, err := os.ReadDir(stackDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []InventoryRecord{}, nil
+		}
+		return nil, fmt.Errorf("read telemetry dir: %w", err)
+	}
+
+	records := make([]InventoryRecord, 0, len(entries)*len(signals))
+	for _, srv := range entries {
+		if !srv.IsDir() {
+			continue
+		}
+		if serverName != "" && srv.Name() != serverName {
+			continue
+		}
+		srvRecords, err := inventoryServer(stackDir, srv.Name())
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, srvRecords...)
+	}
+
+	sort.SliceStable(records, func(i, j int) bool {
+		if records[i].Server != records[j].Server {
+			return records[i].Server < records[j].Server
+		}
+		return signalOrder(records[i].Signal) < signalOrder(records[j].Signal)
+	})
+	return records, nil
+}
+
+func inventoryServer(stackDir, serverName string) ([]InventoryRecord, error) {
+	srvDir := filepath.Join(stackDir, serverName)
+	files, err := os.ReadDir(srvDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read server telemetry dir: %w", err)
+	}
+
+	bySignal := make(map[string]*InventoryRecord, len(signals))
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		sig := matchSignal(f.Name())
+		if sig == "" {
+			continue
+		}
+		info, err := f.Info()
+		if err != nil {
+			continue
+		}
+		rec, ok := bySignal[sig]
+		if !ok {
+			rec = &InventoryRecord{
+				Server: serverName,
+				Signal: sig,
+				Path:   filepath.Join(srvDir, sig+".jsonl"),
+			}
+			bySignal[sig] = rec
+		}
+		rec.SizeBytes += info.Size()
+		rec.FileCount++
+		mt := info.ModTime()
+		if rec.OldestTime.IsZero() || mt.Before(rec.OldestTime) {
+			rec.OldestTime = mt
+		}
+		if mt.After(rec.NewestTime) {
+			rec.NewestTime = mt
+		}
+	}
+
+	out := make([]InventoryRecord, 0, len(bySignal))
+	for _, sig := range signals {
+		if rec, ok := bySignal[sig]; ok {
+			out = append(out, *rec)
+		}
+	}
+	return out, nil
+}
+
+// rotatedTimestamp matches lumberjack's rotated-file timestamp segment exactly:
+// YYYY-MM-DDTHH-MM-SS.fff. Anchoring to the timestamp shape keeps a
+// user-created `logs-backup.jsonl` from being claimed as a rotation and
+// (more importantly) deleted by Wipe.
+var rotatedTimestamp = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}$`)
+
+// matchSignal returns "logs", "metrics", or "traces" when name matches the
+// active jsonl or one of lumberjack's rotated variants for that signal. Empty
+// string for any other filename so callers can skip it.
+//
+// Lumberjack v2 names rotated files <base>-<timestamp>.<ext>, optionally
+// followed by .gz when Compress is true. With our active filename
+// `<sig>.jsonl`, base = "<sig>" and ext = "jsonl"; rotated siblings look
+// like `<sig>-2026-04-30T12-00-00.000.jsonl[.gz]`.
+func matchSignal(name string) string {
+	for _, sig := range signals {
+		if name == sig+".jsonl" {
+			return sig
+		}
+		// Strip optional .gz then the .jsonl suffix; anchor the remaining
+		// stem to "<sig>-<timestamp>".
+		stem := name
+		if suffix, ok := stripSuffix(stem, ".gz"); ok {
+			stem = suffix
+		}
+		stem, ok := stripSuffix(stem, ".jsonl")
+		if !ok {
+			continue
+		}
+		ts, ok := stripPrefix(stem, sig+"-")
+		if !ok {
+			continue
+		}
+		if rotatedTimestamp.MatchString(ts) {
+			return sig
+		}
+	}
+	return ""
+}
+
+func stripPrefix(s, prefix string) (string, bool) {
+	if len(s) >= len(prefix) && s[:len(prefix)] == prefix {
+		return s[len(prefix):], true
+	}
+	return s, false
+}
+
+func stripSuffix(s, suffix string) (string, bool) {
+	if len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix {
+		return s[:len(s)-len(suffix)], true
+	}
+	return s, false
+}
+
+func signalOrder(sig string) int {
+	for i, s := range signals {
+		if s == sig {
+			return i
+		}
+	}
+	return len(signals)
+}
+
+// IsValidSignal reports whether sig names a known telemetry signal. Used by
+// the DELETE handler to reject invalid query parameters before touching disk.
+func IsValidSignal(sig string) bool {
+	for _, s := range signals {
+		if s == sig {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/telemetry/inventory_test.go
+++ b/pkg/telemetry/inventory_test.go
@@ -1,0 +1,142 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// telemetryDirForTest returns the per-stack telemetry root inside a temp HOME
+// so callers can stage files matching the daemon's on-disk layout.
+func telemetryDirForTest(t *testing.T, stack string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	d := filepath.Join(home, ".gridctl", "telemetry", stack)
+	require.NoError(t, os.MkdirAll(d, 0o700))
+	return d
+}
+
+func writeFile(t *testing.T, path string, size int) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, make([]byte, size), 0o600))
+}
+
+func TestMatchSignal(t *testing.T) {
+	cases := map[string]string{
+		"logs.jsonl":                               "logs",
+		"metrics.jsonl":                            "metrics",
+		"traces.jsonl":                             "traces",
+		"logs-2026-04-30T12-00-00.000.jsonl":       "logs",
+		"metrics-2026-04-30T12-00-00.000.jsonl.gz": "metrics",
+		"traces-2026-04-30T12-00-00.000.jsonl":     "traces",
+		"random.txt":                               "",
+		"jsonl":                                    "",
+		"logs.jsonlx":                              "",
+		"loggish.jsonl":                            "",
+		// User-created files that look like signals but lack the lumberjack
+		// timestamp must NOT match — Wipe would otherwise delete them.
+		"logs-backup.jsonl":     "",
+		"logs-foo.jsonl":        "",
+		"logs-2026-bad.jsonl":   "",
+		"logs-2026-04-30.jsonl": "",
+	}
+	for name, want := range cases {
+		assert.Equal(t, want, matchSignal(name), "match for %q", name)
+	}
+}
+
+func TestInventory_EmptyStack(t *testing.T) {
+	telemetryDirForTest(t, "demo") // creates the dir but no files
+	records, err := Inventory("demo", "")
+	require.NoError(t, err)
+	assert.Empty(t, records)
+}
+
+func TestInventory_MissingStackDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	records, err := Inventory("never-existed", "")
+	require.NoError(t, err)
+	assert.Empty(t, records)
+}
+
+func TestInventory_NoStackName(t *testing.T) {
+	records, err := Inventory("", "")
+	require.NoError(t, err)
+	assert.Empty(t, records)
+}
+
+func TestInventory_AggregatesRotatedFiles(t *testing.T) {
+	stackDir := telemetryDirForTest(t, "demo")
+	srvDir := filepath.Join(stackDir, "github")
+
+	writeFile(t, filepath.Join(srvDir, "logs.jsonl"), 100)
+	writeFile(t, filepath.Join(srvDir, "logs-2026-04-30T12-00-00.000.jsonl"), 200)
+	writeFile(t, filepath.Join(srvDir, "logs-2026-04-29T12-00-00.000.jsonl.gz"), 50)
+	writeFile(t, filepath.Join(srvDir, "metrics.jsonl"), 25)
+	writeFile(t, filepath.Join(srvDir, "stray.txt"), 999) // ignored
+
+	// Make rotated logs older than the active file so OldestTime picks them up.
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(filepath.Join(srvDir, "logs-2026-04-29T12-00-00.000.jsonl.gz"), old, old))
+
+	records, err := Inventory("demo", "")
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+
+	// Ordering: logs before metrics (canonical signal order).
+	assert.Equal(t, "logs", records[0].Signal)
+	assert.Equal(t, "metrics", records[1].Signal)
+
+	logs := records[0]
+	assert.Equal(t, "github", logs.Server)
+	assert.Equal(t, int64(350), logs.SizeBytes)
+	assert.Equal(t, 3, logs.FileCount)
+	assert.True(t, logs.OldestTime.Before(logs.NewestTime) || logs.OldestTime.Equal(logs.NewestTime))
+	assert.Equal(t, filepath.Join(srvDir, "logs.jsonl"), logs.Path)
+
+	metrics := records[1]
+	assert.Equal(t, int64(25), metrics.SizeBytes)
+	assert.Equal(t, 1, metrics.FileCount)
+}
+
+func TestInventory_FiltersByServer(t *testing.T) {
+	stackDir := telemetryDirForTest(t, "demo")
+	writeFile(t, filepath.Join(stackDir, "github", "logs.jsonl"), 10)
+	writeFile(t, filepath.Join(stackDir, "filesystem", "logs.jsonl"), 20)
+
+	records, err := Inventory("demo", "filesystem")
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "filesystem", records[0].Server)
+	assert.Equal(t, int64(20), records[0].SizeBytes)
+}
+
+func TestInventory_StableServerOrdering(t *testing.T) {
+	stackDir := telemetryDirForTest(t, "demo")
+	writeFile(t, filepath.Join(stackDir, "zeta", "logs.jsonl"), 1)
+	writeFile(t, filepath.Join(stackDir, "alpha", "logs.jsonl"), 1)
+	writeFile(t, filepath.Join(stackDir, "mid", "logs.jsonl"), 1)
+
+	records, err := Inventory("demo", "")
+	require.NoError(t, err)
+	require.Len(t, records, 3)
+	assert.Equal(t, "alpha", records[0].Server)
+	assert.Equal(t, "mid", records[1].Server)
+	assert.Equal(t, "zeta", records[2].Server)
+}
+
+func TestIsValidSignal(t *testing.T) {
+	for _, s := range []string{"logs", "metrics", "traces"} {
+		assert.True(t, IsValidSignal(s), s)
+	}
+	for _, s := range []string{"", "log", "Logs", "all", "garbage"} {
+		assert.False(t, IsValidSignal(s), s)
+	}
+}

--- a/pkg/telemetry/wipe.go
+++ b/pkg/telemetry/wipe.go
@@ -1,0 +1,103 @@
+package telemetry
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/state"
+)
+
+// wipeLockTimeout bounds how long Wipe will wait for state.WithLock to
+// acquire the per-stack flock. The flock serializes wipes against daemon
+// startup (which seeds in-memory buffers from disk). Ten seconds is generous
+// for a filesystem operation but short enough that a stuck wipe surfaces as
+// an explicit error rather than a hang.
+const wipeLockTimeout = 10 * time.Second
+
+// Wipe deletes telemetry files matching the requested scope. Empty serverName
+// or signal acts as a wildcard. Both the active <sig>.jsonl and any rotated
+// lumberjack siblings are removed.
+//
+// Scope combinations:
+//
+//	serverName="", signal=""      → everything for this stack
+//	serverName="X", signal=""     → all signals for server X
+//	serverName="", signal="logs"  → logs across all servers in the stack
+//	serverName="X", signal="logs" → logs for server X only
+//
+// The operation is wrapped in state.WithLock so a wipe and a daemon
+// reload/seed cannot interleave on the same stack file. Lumberjack keeps
+// its active file open across rotations; on POSIX, removing the file while
+// the writer holds it is safe (unlink-on-close), and lumberjack will
+// transparently reopen on the next emit.
+//
+// A missing stack directory is treated as a successful no-op; signal
+// validation (against the known {logs, metrics, traces}) is the caller's
+// responsibility.
+func Wipe(stackName, serverName, signal string) error {
+	if stackName == "" {
+		return fmt.Errorf("stack name is required")
+	}
+	return state.WithLock(stackName, wipeLockTimeout, func() error {
+		return doWipe(stackName, serverName, signal)
+	})
+}
+
+func doWipe(stackName, serverName, signal string) error {
+	stackDir := filepath.Join(state.TelemetryDir(), stackName)
+	entries, err := os.ReadDir(stackDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read telemetry dir: %w", err)
+	}
+	// Accumulate per-file failures rather than aborting on the first error,
+	// so a half-applied wipe never silently leaves intact files behind a
+	// single transient failure (e.g. a stale handle on macOS, a perms gap
+	// on one rotated sibling). Callers see the joined error and can retry.
+	var errs []error
+	for _, srv := range entries {
+		if !srv.IsDir() {
+			continue
+		}
+		if serverName != "" && srv.Name() != serverName {
+			continue
+		}
+		if err := wipeServerDir(filepath.Join(stackDir, srv.Name()), signal); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func wipeServerDir(srvDir, signal string) error {
+	files, err := os.ReadDir(srvDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read server telemetry dir: %w", err)
+	}
+	var errs []error
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		sig := matchSignal(f.Name())
+		if sig == "" {
+			continue
+		}
+		if signal != "" && sig != signal {
+			continue
+		}
+		fpath := filepath.Join(srvDir, f.Name())
+		if err := os.Remove(fpath); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("remove %s: %w", fpath, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/pkg/telemetry/wipe_test.go
+++ b/pkg/telemetry/wipe_test.go
@@ -1,0 +1,114 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupWipeFixture(t *testing.T, stack string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := filepath.Join(home, ".gridctl", "telemetry", stack)
+
+	for _, server := range []string{"github", "filesystem"} {
+		srvDir := filepath.Join(root, server)
+		require.NoError(t, os.MkdirAll(srvDir, 0o700))
+		for _, sig := range []string{"logs", "metrics", "traces"} {
+			require.NoError(t, os.WriteFile(filepath.Join(srvDir, sig+".jsonl"), []byte("{}\n"), 0o600))
+		}
+		// One rotated sibling for logs.
+		require.NoError(t, os.WriteFile(filepath.Join(srvDir, "logs-2026-04-30T12-00-00.000.jsonl"), []byte("{}\n"), 0o600))
+	}
+	return root
+}
+
+func mustExist(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.NoError(t, err, "expected to exist: %s", path)
+}
+
+func mustNotExist(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "expected to be removed: %s (err=%v)", path, err)
+}
+
+func TestWipe_SingleSignalForServer(t *testing.T) {
+	root := setupWipeFixture(t, "demo")
+
+	require.NoError(t, Wipe("demo", "github", "logs"))
+
+	mustNotExist(t, filepath.Join(root, "github", "logs.jsonl"))
+	mustNotExist(t, filepath.Join(root, "github", "logs-2026-04-30T12-00-00.000.jsonl"))
+	// Other signals for github survived.
+	mustExist(t, filepath.Join(root, "github", "metrics.jsonl"))
+	mustExist(t, filepath.Join(root, "github", "traces.jsonl"))
+	// Other server is untouched.
+	mustExist(t, filepath.Join(root, "filesystem", "logs.jsonl"))
+}
+
+func TestWipe_AllSignalsForServer(t *testing.T) {
+	root := setupWipeFixture(t, "demo")
+
+	require.NoError(t, Wipe("demo", "github", ""))
+
+	for _, sig := range []string{"logs", "metrics", "traces"} {
+		mustNotExist(t, filepath.Join(root, "github", sig+".jsonl"))
+	}
+	mustNotExist(t, filepath.Join(root, "github", "logs-2026-04-30T12-00-00.000.jsonl"))
+	// Filesystem untouched.
+	mustExist(t, filepath.Join(root, "filesystem", "metrics.jsonl"))
+}
+
+func TestWipe_AllServersAllSignals(t *testing.T) {
+	root := setupWipeFixture(t, "demo")
+
+	require.NoError(t, Wipe("demo", "", ""))
+
+	for _, server := range []string{"github", "filesystem"} {
+		for _, sig := range []string{"logs", "metrics", "traces"} {
+			mustNotExist(t, filepath.Join(root, server, sig+".jsonl"))
+		}
+	}
+}
+
+func TestWipe_SignalAcrossAllServers(t *testing.T) {
+	root := setupWipeFixture(t, "demo")
+
+	require.NoError(t, Wipe("demo", "", "metrics"))
+
+	mustNotExist(t, filepath.Join(root, "github", "metrics.jsonl"))
+	mustNotExist(t, filepath.Join(root, "filesystem", "metrics.jsonl"))
+	// Other signals survived.
+	mustExist(t, filepath.Join(root, "github", "logs.jsonl"))
+	mustExist(t, filepath.Join(root, "filesystem", "traces.jsonl"))
+}
+
+func TestWipe_MissingStackIsNoOp(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	assert.NoError(t, Wipe("never-existed", "", ""))
+}
+
+func TestWipe_RequiresStackName(t *testing.T) {
+	err := Wipe("", "anything", "logs")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stack name is required")
+}
+
+func TestWipe_LeavesNonTelemetryFilesAlone(t *testing.T) {
+	root := setupWipeFixture(t, "demo")
+	stray := filepath.Join(root, "github", "stray.txt")
+	require.NoError(t, os.WriteFile(stray, []byte("keep me"), 0o600))
+
+	require.NoError(t, Wipe("demo", "github", ""))
+
+	mustNotExist(t, filepath.Join(root, "github", "logs.jsonl"))
+	mustExist(t, stray)
+}


### PR DESCRIPTION
## Description

Adds the four HTTP endpoints that drive opt-in telemetry persistence: PATCH for stack-global and per-server toggles, GET for the on-disk inventory, and DELETE for wipes. Phase 3 of 6 of the telemetry persistence feature.

## Type of Change

- [x] New feature

## Changes Made

- `PATCH /api/stack/telemetry` — updates the top-level `telemetry:` mapping (persist + retention deltas).
- `PATCH /api/mcp-servers/{name}/telemetry` — updates per-server overrides; `persist: null` clears the entire block; per-signal `null` clears that override.
- `GET /api/telemetry/inventory` — returns one record per (server, signal) pair where files exist.
- `DELETE /api/telemetry?server=&signal=` — wipes telemetry files for the requested scope; both query params optional.
- `internal/api/stack_telemetry.go` — `patchStackTelemetry` and `patchServerTelemetry` mirror `patchServerTools` / `patchAppendResource` with comment- and key-order-preserving `yaml.Node` round-trips. `findOrCreateMapping` carries head/line/foot comments forward when replacing a non-mapping value.
- `pkg/telemetry/inventory.go` + `wipe.go` — file walker (matches active jsonl plus lumberjack rotated siblings via anchored regex) and partial-failure-tolerant wipe (`errors.Join`) wrapped in `state.WithLock`.

## Testing

- Patcher unit tests: comment/order preservation, retention-only PATCH, idempotency, partial-update, clear-single-signal-removes-key, clear-all-removes-block, server-not-found.
- Handler tests mirror the `handleStackAppend` regression suite: TOCTOU 409, atomic-on-write-failure, serialized concurrent callers, comment preservation, comment preservation on `telemetry: null` replacement, invalid-retention 422, no-stack-file 503.
- Inventory/wipe: empty stack, populated stack, rotated-file aggregation, server filter, stable ordering, single-signal wipe, all-signals-for-server wipe, all-servers-all-signals wildcard, non-telemetry-file safety.
- All existing tests still pass; ` go test -race ./... ` and ` golangci-lint run ` are green.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #550