### PR TITLE
feat: add telemetry persistence frontend

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
         "react-router-dom": "^7.13.0",
         "recharts": "^3.8.1",
         "tailwind-merge": "^3.5.0",
+        "yaml": "^2.8.4",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -5729,6 +5730,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "react-router-dom": "^7.13.0",
     "recharts": "^3.8.1",
     "tailwind-merge": "^3.5.0",
+    "yaml": "^2.8.4",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/web/src/__tests__/telemetry.test.ts
+++ b/web/src/__tests__/telemetry.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest';
+import {
+  effectiveSignal,
+  nextTriState,
+  parseStackTelemetry,
+  readTriState,
+  triStateToPatch,
+  type TriState,
+} from '../lib/telemetry-config';
+import { buildPillLabel } from '../components/telemetry/HeaderTelemetryPill';
+import { _testFormatScope } from '../components/telemetry/WipeTelemetryDialog';
+import type { InventoryRecord, ResolvedTelemetry } from '../types';
+
+const STACK_YAML = `version: "1"
+name: example
+telemetry:
+  persist:
+    logs: true
+    metrics: false
+    traces: true
+  retention:
+    max_size_mb: 100
+    max_backups: 5
+    max_age_days: 7
+mcp-servers:
+  - name: github
+    transport: http
+    url: https://api.github.com/mcp
+    telemetry:
+      persist:
+        traces: false
+  - name: filesystem
+    transport: http
+    url: https://example.com/fs
+`;
+
+describe('parseStackTelemetry', () => {
+  it('extracts global persist defaults', () => {
+    const cfg = parseStackTelemetry(STACK_YAML);
+    expect(cfg.global).toEqual({ logs: true, metrics: false, traces: true });
+  });
+
+  it('extracts retention block', () => {
+    const cfg = parseStackTelemetry(STACK_YAML);
+    expect(cfg.retention).toEqual({ max_size_mb: 100, max_backups: 5, max_age_days: 7 });
+  });
+
+  it('extracts per-server overrides only when present', () => {
+    const cfg = parseStackTelemetry(STACK_YAML);
+    expect(cfg.servers.github).toEqual({ traces: false });
+    expect(cfg.servers.filesystem).toBeUndefined();
+  });
+
+  it('returns empty config for null/empty input', () => {
+    expect(parseStackTelemetry(null)).toEqual({ global: {}, servers: {} });
+    expect(parseStackTelemetry('')).toEqual({ global: {}, servers: {} });
+  });
+
+  it('returns empty config for malformed YAML rather than throwing', () => {
+    const cfg = parseStackTelemetry('this: is: invalid: yaml: [unclosed');
+    expect(cfg).toEqual({ global: {}, servers: {} });
+  });
+
+  it('ignores non-object telemetry blocks gracefully', () => {
+    const cfg = parseStackTelemetry('telemetry: "wrong-shape"\n');
+    expect(cfg).toEqual({ global: {}, servers: {} });
+  });
+});
+
+describe('effectiveSignal — inheritance', () => {
+  const cfg: ResolvedTelemetry = parseStackTelemetry(STACK_YAML);
+
+  it('returns explicit override when set', () => {
+    expect(effectiveSignal(cfg, 'github', 'traces')).toBe(false);
+  });
+
+  it('falls back to stack-global when override is absent', () => {
+    expect(effectiveSignal(cfg, 'github', 'logs')).toBe(true);
+    expect(effectiveSignal(cfg, 'filesystem', 'logs')).toBe(true);
+  });
+
+  it('returns false when neither override nor global is set', () => {
+    const empty: ResolvedTelemetry = { global: {}, servers: {} };
+    expect(effectiveSignal(empty, 'unknown', 'logs')).toBe(false);
+  });
+});
+
+describe('readTriState + nextTriState — cycling state machine', () => {
+  const cfg: ResolvedTelemetry = parseStackTelemetry(STACK_YAML);
+
+  it('reads "off" when an explicit-false override exists', () => {
+    expect(readTriState(cfg, 'github', 'traces')).toBe('off');
+  });
+
+  it('reads "inherit" when no per-server override exists', () => {
+    expect(readTriState(cfg, 'filesystem', 'logs')).toBe('inherit');
+  });
+
+  it('cycles inherit -> on -> off -> inherit', () => {
+    let s: TriState = 'inherit';
+    s = nextTriState(s);
+    expect(s).toBe('on');
+    s = nextTriState(s);
+    expect(s).toBe('off');
+    s = nextTriState(s);
+    expect(s).toBe('inherit');
+  });
+
+  it('maps tri-state to PATCH body values', () => {
+    expect(triStateToPatch('inherit')).toBe(null);
+    expect(triStateToPatch('on')).toBe(true);
+    expect(triStateToPatch('off')).toBe(false);
+  });
+
+  it('cycle composes with patch mapping for the full state machine', () => {
+    // inherit (null) -> on (true) -> off (false) -> inherit (null)
+    expect(triStateToPatch(nextTriState('inherit'))).toBe(true);
+    expect(triStateToPatch(nextTriState('on'))).toBe(false);
+    expect(triStateToPatch(nextTriState('off'))).toBe(null);
+  });
+});
+
+describe('buildPillLabel — header pill formatting', () => {
+  it('returns Off when no signals are enabled', () => {
+    expect(buildPillLabel({})).toBe('Persistence: Off');
+    expect(buildPillLabel({ logs: false, metrics: false, traces: false })).toBe('Persistence: Off');
+  });
+
+  it('renders single signal', () => {
+    expect(buildPillLabel({ logs: true })).toBe('Persistence: Logs');
+  });
+
+  it('renders pair joined by + in canonical order', () => {
+    // Order matters: we want "Logs+Traces" regardless of input order to
+    // match the canonical SIGNALS list (logs, metrics, traces).
+    expect(buildPillLabel({ traces: true, logs: true })).toBe('Persistence: Logs+Traces');
+  });
+
+  it('renders all three abbreviations', () => {
+    expect(buildPillLabel({ logs: true, metrics: true, traces: true })).toBe(
+      'Persistence: Logs+Metrics+Traces',
+    );
+  });
+});
+
+describe('WipeTelemetryDialog scope formatting', () => {
+  const records: InventoryRecord[] = [
+    {
+      server: 'github',
+      signal: 'logs',
+      path: '/tmp/logs.jsonl',
+      sizeBytes: 1024 * 1024 * 100, // 100 MiB
+      oldestTime: '2026-04-30T00:00:00Z',
+      newestTime: '2026-05-04T12:00:00Z',
+      fileCount: 3,
+    },
+    {
+      server: 'github',
+      signal: 'traces',
+      path: '/tmp/traces.jsonl',
+      sizeBytes: 1024 * 1024 * 42, // 42 MiB
+      oldestTime: '2026-04-29T00:00:00Z',
+      newestTime: '2026-05-04T11:00:00Z',
+      fileCount: 1,
+    },
+    {
+      server: 'filesystem',
+      signal: 'metrics',
+      path: '/tmp/metrics.jsonl',
+      sizeBytes: 1024 * 50,
+      oldestTime: '2026-05-01T00:00:00Z',
+      newestTime: '2026-05-04T13:00:00Z',
+      fileCount: 1,
+    },
+  ];
+
+  it('aggregates total bytes, server count, and signal list', () => {
+    const view = _testFormatScope(records);
+    expect(view.totalBytes).toBe('142 MiB');
+    expect(view.servers).toBe(2);
+    // Signals always render in canonical order regardless of insertion.
+    expect(view.signals).toEqual(['logs', 'metrics', 'traces']);
+  });
+
+  it('renders span as oldest -> newest dates', () => {
+    const view = _testFormatScope(records);
+    expect(view.span).toBe('2026-04-29 → 2026-05-04');
+  });
+
+  it('returns empty/null span for no records', () => {
+    const view = _testFormatScope([]);
+    expect(view.totalBytes).toBe('0 B');
+    expect(view.servers).toBe(0);
+    expect(view.signals).toEqual([]);
+    expect(view.span).toBe(null);
+  });
+});
+
+describe('StackModifiedError — 409 surfacing', () => {
+  it('parses the 409 envelope into a typed error with hint', async () => {
+    // Reach into the api module after stubbing global fetch so the helper
+    // builds and throws StackModifiedError on the stack_modified envelope.
+    const { updateStackTelemetry, StackModifiedError } = await import('../lib/api');
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'stack_modified',
+              message: 'The stack file was modified outside the canvas.',
+              hint: 'Reload the file and try again.',
+            },
+          }),
+          { status: 409, headers: { 'content-type': 'application/json' } },
+        ),
+      )) as typeof fetch;
+
+    let caught: unknown = null;
+    try {
+      await updateStackTelemetry({ persist: { logs: true } });
+    } catch (err) {
+      caught = err;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(caught).toBeInstanceOf(StackModifiedError);
+    const err = caught as InstanceType<typeof StackModifiedError>;
+    expect(err.code).toBe('stack_modified');
+    expect(err.hint).toBe('Reload the file and try again.');
+  });
+});

--- a/web/src/components/graph/CustomNode.tsx
+++ b/web/src/components/graph/CustomNode.tsx
@@ -8,6 +8,7 @@ import { getTransportIcon, getTransportColorClasses } from '../../lib/transport'
 import { useUIStore } from '../../stores/useUIStore';
 import { useTokenHeat } from '../../hooks/useTokenHeat';
 import { LAYOUT } from '../../lib/constants';
+import { TelemetryNodeDot } from '../telemetry/TelemetryNodeDot';
 import type { MCPServerNodeData, ResourceNodeData } from '../../types';
 
 export type CustomNodeData = MCPServerNodeData | ResourceNodeData;
@@ -344,6 +345,12 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
           </div>
         </div>
       </div>
+
+      {/* Telemetry persistence dot indicator (MCP servers only).
+          Anchored to the node body so it tracks the card edge in both
+          compact and full modes. Hidden on resources — they don't have a
+          telemetry config of their own. */}
+      {isServer && <TelemetryNodeDot serverName={(data as MCPServerNodeData).name} />}
 
       {/* Connection Handles - match node color */}
       <Handle

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -9,6 +9,7 @@ import { triggerReload, fetchStackSpec, validateStackSpec } from '../../lib/api'
 import { VaultPanel } from '../vault/VaultPanel';
 import { SpecDiffModal } from '../spec/SpecDiffModal';
 import { CreationWizard } from '../wizard/CreationWizard';
+import { HeaderTelemetryPill } from '../telemetry/HeaderTelemetryPill';
 import { useSpecStore } from '../../stores/useSpecStore';
 import { useWizardStore } from '../../stores/useWizardStore';
 import logoSvg from '../../assets/brand/logo.svg';
@@ -144,6 +145,9 @@ export function Header({ onRefresh, isRefreshing }: HeaderProps) {
             </span>
           </div>
         )}
+
+        {/* Telemetry Persistence Pill (between stack name and server count) */}
+        {isConnected && <HeaderTelemetryPill />}
 
         {/* Server Count */}
         {totalCount > 0 && (

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Gauge,
   FileOutput,
   Activity,
+  Database,
 } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { Badge } from '../ui/Badge';
@@ -26,6 +27,7 @@ import { GatewaySidebar } from '../gateway/GatewaySidebar';
 import { TokenUsageSection } from '../sidebar/TokenUsageSection';
 import { ToolsEditor } from '../sidebar/ToolsEditor';
 import { AutoscalePanel } from '../status/AutoscalePanel';
+import { SidebarTelemetrySection } from '../telemetry/SidebarTelemetrySection';
 import { getTransportIcon, getTransportColorClasses } from '../../lib/transport';
 import { useStackStore, useSelectedNodeData } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
@@ -369,6 +371,13 @@ export function Sidebar() {
               <FileText size={14} />
               Show Logs Panel
             </button>
+          </Section>
+        )}
+
+        {/* Telemetry Section (MCP servers only) — between Actions and Tools */}
+        {isServer && (
+          <Section title="Telemetry" icon={Database}>
+            <SidebarTelemetrySection serverName={data.name} />
           </Section>
         )}
 

--- a/web/src/components/log/LogsTab.tsx
+++ b/web/src/components/log/LogsTab.tsx
@@ -12,6 +12,7 @@ import { cn } from '../../lib/cn';
 import { IconButton } from '../ui/IconButton';
 import { PopoutButton } from '../ui/PopoutButton';
 import { LogLine, LevelFilter, ZoomControls, parseLogEntry, type LogLevel, type ParsedLog } from '../log';
+import { PersistedFromMarker } from '../telemetry/PersistedFromMarker';
 import { useUIStore } from '../../stores/useUIStore';
 import { useSelectedNodeData } from '../../stores/useStackStore';
 import { useWindowManager } from '../../hooks/useWindowManager';
@@ -334,6 +335,16 @@ export function LogsTab() {
         {/* Log entries */}
         {hasSource && !isLoading && !error && (filteredLogs?.length ?? 0) > 0 && (
           <div className="divide-y divide-border/20">
+            {/* Boundary marker — visible only when the selected node is an
+                MCP server with logs persistence enabled and files on disk.
+                Marks where on-disk seeded data ends; live entries appear
+                below it. */}
+            {selectedData?.type === 'mcp-server' && (
+              <PersistedFromMarker
+                serverName={(selectedData as { name?: string }).name ?? null}
+                signal="logs"
+              />
+            )}
             {(filteredLogs ?? []).map((log, i) => (
               <LogLine
                 key={i}

--- a/web/src/components/metrics/MetricsTab.tsx
+++ b/web/src/components/metrics/MetricsTab.tsx
@@ -20,6 +20,7 @@ import { useWindowManager } from '../../hooks/useWindowManager';
 import { formatCompactNumber } from '../../lib/format';
 import { POLLING } from '../../lib/constants';
 import { AreaChart } from '../chart/AreaChart';
+import { PersistedFromMarker } from '../telemetry/PersistedFromMarker';
 import type { TokenMetricsResponse } from '../../types';
 
 type TimeRange = 'live' | '1h' | '6h' | '24h' | '7d';
@@ -294,6 +295,12 @@ export function MetricsTab() {
         {/* Data view — shown even while loading if we have stale data to prevent flash */}
         {!error && hasData && (
           <div className="space-y-4">
+            {/* Aggregate persisted-from boundary — only renders when at
+                least one server has metrics persistence enabled and files
+                exist on disk. Sits above the KPI cards so it reads as a
+                provenance hint for the data below. */}
+            <PersistedFromMarker serverName={null} signal="metrics" />
+
             {/* KPI Cards */}
             <div className={cn('grid gap-3', savingsPercent > 0 ? 'grid-cols-4' : 'grid-cols-3')}>
               <KPICard label="Input Tokens" value={sessionInput} colorClass="text-secondary" />

--- a/web/src/components/telemetry/HeaderTelemetryPill.tsx
+++ b/web/src/components/telemetry/HeaderTelemetryPill.tsx
@@ -1,0 +1,233 @@
+// HeaderTelemetryPill — the "Persistence: …" affordance in the header
+// status row. Mirrors the visual rhythm of the neighbouring stack-name
+// and server-count pills: glass surface, primary-color icon, compact
+// label. Click opens a popover with the three signal toggles and a
+// destructive "Wipe all" button; mutations call the API helpers and
+// hand the refreshed inventory back to the store.
+import { useEffect, useRef, useState } from 'react';
+import { Database, Power, PowerOff, Trash2 } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { showToast } from '../ui/Toast';
+import { WipeTelemetryDialog } from './WipeTelemetryDialog';
+import {
+  StackModifiedError,
+  updateStackTelemetry,
+  wipeTelemetry,
+} from '../../lib/api';
+import {
+  useInventory,
+  useTelemetryConfig,
+  useTelemetryStore,
+} from '../../stores/useTelemetryStore';
+import type { TelemetrySignal } from '../../types';
+
+const SIGNALS: TelemetrySignal[] = ['logs', 'metrics', 'traces'];
+
+// Uppercase three-letter abbreviations keep the pill compact when all
+// three signals are on (`Persistence: Logs+Metrics+Traces` would be
+// fine in English but starts to overflow when other status pills get
+// busy). Keep them title-case to match other pill copy in the header.
+const ABBREV: Record<TelemetrySignal, string> = {
+  logs: 'Logs',
+  metrics: 'Metrics',
+  traces: 'Traces',
+};
+
+export function buildPillLabel(global: Partial<Record<TelemetrySignal, boolean>>): string {
+  const on = SIGNALS.filter((s) => global[s] === true);
+  if (on.length === 0) return 'Persistence: Off';
+  return `Persistence: ${on.map((s) => ABBREV[s]).join('+')}`;
+}
+
+export function HeaderTelemetryPill() {
+  const config = useTelemetryConfig();
+  const inventory = useInventory();
+  const [open, setOpen] = useState(false);
+  const [wipeOpen, setWipeOpen] = useState(false);
+  const [pending, setPending] = useState<TelemetrySignal | 'wipe' | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  const anyOn = SIGNALS.some((s) => config.global[s] === true);
+  const label = buildPillLabel(config.global);
+
+  // Close the popover on outside click or Escape so it composes with the
+  // rest of the header's overlapping affordances (vault panel, wizard).
+  useEffect(() => {
+    if (!open) return;
+    const onPointer = (e: MouseEvent) => {
+      const t = e.target as Node | null;
+      if (!t) return;
+      if (popoverRef.current?.contains(t) || triggerRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointer);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onPointer);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  async function toggleSignal(signal: TelemetrySignal) {
+    const current = config.global[signal] === true;
+    setPending(signal);
+    try {
+      const resp = await updateStackTelemetry({ persist: { [signal]: !current } });
+      useTelemetryStore.getState().setInventory(resp.inventory);
+      showToast('success', `${ABBREV[signal]} persistence ${!current ? 'enabled' : 'disabled'}`);
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function confirmWipe() {
+    setWipeOpen(false);
+    setPending('wipe');
+    try {
+      const resp = await wipeTelemetry();
+      useTelemetryStore.getState().setInventory(resp.inventory);
+      showToast('success', 'Persisted telemetry wiped');
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setPending(null);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        title={label}
+        className={cn(
+          'flex items-center gap-2 px-3 py-1.5 rounded-full',
+          'bg-surface-elevated/60 backdrop-blur-sm border transition-all duration-200',
+          anyOn
+            ? 'border-status-running/30 hover:border-status-running/50'
+            : 'border-border/50 hover:border-text-muted/40',
+          'focus:outline-none focus:ring-2 focus:ring-primary/30',
+        )}
+      >
+        <Database size={12} className={anyOn ? 'text-status-running' : 'text-text-muted'} />
+        <span
+          className={cn(
+            'text-xs font-medium',
+            anyOn ? 'text-status-running' : 'text-text-secondary',
+          )}
+        >
+          {label}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          ref={popoverRef}
+          role="dialog"
+          aria-label="Stack telemetry persistence"
+          className={cn(
+            'absolute top-full mt-2 right-0 z-40 w-64',
+            'glass-panel-elevated rounded-xl p-3 shadow-lg',
+          )}
+        >
+          <div className="text-[10px] uppercase tracking-widest font-medium text-text-muted px-1 pb-2">
+            Stack-global signals
+          </div>
+          <ul className="space-y-1">
+            {SIGNALS.map((sig) => {
+              const isOn = config.global[sig] === true;
+              const isBusy = pending === sig;
+              return (
+                <li key={sig}>
+                  <button
+                    type="button"
+                    onClick={() => toggleSignal(sig)}
+                    disabled={isBusy}
+                    aria-pressed={isOn}
+                    className={cn(
+                      'w-full flex items-center justify-between gap-3 px-2 py-2 rounded-lg',
+                      'transition-all duration-200 group',
+                      'hover:bg-surface-highlight/60',
+                      'focus:outline-none focus:ring-2 focus:ring-primary/30',
+                      isBusy && 'opacity-60 cursor-wait',
+                    )}
+                  >
+                    <span className="flex items-center gap-2">
+                      {isOn ? (
+                        <Power size={12} className="text-status-running" />
+                      ) : (
+                        <PowerOff size={12} className="text-text-muted group-hover:text-status-running transition-colors" />
+                      )}
+                      <span className="text-sm text-text-primary capitalize">{sig}</span>
+                    </span>
+                    <span
+                      className={cn(
+                        'text-[10px] font-mono uppercase tracking-wider px-1.5 py-0.5 rounded',
+                        isOn
+                          ? 'bg-status-running/10 text-status-running border border-status-running/20'
+                          : 'bg-surface-elevated text-text-muted border border-border/40',
+                      )}
+                    >
+                      {isOn ? 'On' : 'Off'}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+          <div className="mt-2 pt-2 border-t border-border-subtle">
+            <button
+              type="button"
+              onClick={() => setWipeOpen(true)}
+              disabled={pending === 'wipe' || inventory.length === 0}
+              className={cn(
+                'w-full flex items-center justify-center gap-2 px-2 py-2 rounded-lg',
+                'text-xs font-medium transition-all duration-200',
+                inventory.length === 0
+                  ? 'text-text-muted/60 cursor-not-allowed'
+                  : 'text-status-error hover:bg-status-error/10',
+                'focus:outline-none focus:ring-2 focus:ring-status-error/30',
+              )}
+            >
+              <Trash2 size={12} />
+              Wipe all persisted data
+            </button>
+          </div>
+        </div>
+      )}
+
+      <WipeTelemetryDialog
+        isOpen={wipeOpen}
+        onClose={() => setWipeOpen(false)}
+        onConfirm={confirmWipe}
+        scope={inventory}
+        title="Wipe all persisted telemetry"
+      />
+    </div>
+  );
+}
+
+function handleError(err: unknown) {
+  if (err instanceof StackModifiedError) {
+    showToast('warning', err.message, {
+      duration: 6000,
+      // The hint guides the user to the Reload affordance which already
+      // exists in the header; we surface it as the action label so the
+      // toast doesn't disappear before the operator reads it.
+      action: err.hint
+        ? { label: 'Got it', onClick: () => undefined }
+        : undefined,
+    });
+    return;
+  }
+  showToast('error', err instanceof Error ? err.message : 'Telemetry update failed');
+}

--- a/web/src/components/telemetry/PersistedFromMarker.tsx
+++ b/web/src/components/telemetry/PersistedFromMarker.tsx
@@ -1,0 +1,63 @@
+// Subtle inline divider rendered above the first entry of a Logs /
+// Metrics / Traces tab when the active server has telemetry persistence
+// enabled AND inventory shows files exist for the matching signal. The
+// boundary is the inventory record's `oldestTime`, which marks the
+// earliest entry that came from disk. Live entries appended above the
+// marker have no special treatment — operators can tell what's "new"
+// from timestamps.
+import { useMemo } from 'react';
+import { formatDateOnly } from '../../lib/format-bytes';
+import { effectiveSignal } from '../../lib/telemetry-config';
+import {
+  inventoryByServer,
+  useInventory,
+  useTelemetryConfig,
+} from '../../stores/useTelemetryStore';
+import type { TelemetrySignal } from '../../types';
+
+interface Props {
+  // serverName scopes the boundary check to a single server's persistence
+  // configuration. Pass null for the aggregated tab views (Metrics,
+  // Traces) where the rendered data spans all servers — the marker then
+  // matches against any server with the signal effectively enabled.
+  serverName: string | null | undefined;
+  signal: TelemetrySignal;
+}
+
+export function PersistedFromMarker({ serverName, signal }: Props) {
+  const config = useTelemetryConfig();
+  const inventory = useInventory();
+
+  const date = useMemo(() => {
+    let records = inventory.filter((r) => r.signal === signal);
+    if (serverName) {
+      if (!effectiveSignal(config, serverName, signal)) return null;
+      records = inventoryByServer(records, serverName);
+    } else {
+      // Aggregated mode: keep records whose owning server has the signal
+      // effectively enabled. Shielding the marker behind the resolved
+      // config (rather than mere file existence) prevents stale files
+      // from a previously-enabled server from advertising as live.
+      records = records.filter((r) => effectiveSignal(config, r.server, signal));
+    }
+    if (records.length === 0) return null;
+    // Pick the earliest oldestTime across rotated siblings — we want the
+    // boundary at the very beginning of the on-disk window, not the last
+    // rotated file.
+    const earliest = records.reduce<string | null>((acc, r) => {
+      if (!acc) return r.oldestTime;
+      return r.oldestTime < acc ? r.oldestTime : acc;
+    }, null);
+    return earliest ? new Date(earliest) : null;
+  }, [config, inventory, serverName, signal]);
+
+  if (!date) return null;
+
+  return (
+    <div className="px-3 py-1.5 flex items-center gap-2 text-[10px] text-text-muted/80 font-mono select-none">
+      <span aria-hidden className="flex-1 h-px bg-border-subtle" />
+      <span>── persisted from {formatDateOnly(date)} ──</span>
+      <span aria-hidden className="flex-1 h-px bg-border-subtle" />
+    </div>
+  );
+}

--- a/web/src/components/telemetry/SidebarTelemetrySection.tsx
+++ b/web/src/components/telemetry/SidebarTelemetrySection.tsx
@@ -1,0 +1,277 @@
+// SidebarTelemetrySection — per-server tri-state controls. Each row
+// cycles inherit → on → off → inherit; the explicit states map to PATCH
+// bodies that set/clear the override on the server's telemetry block.
+// "Reset to global" wipes all overrides via the persist:null idiom and
+// the per-server "Wipe data" button reuses WipeTelemetryDialog with a
+// scope filtered to this server.
+import { useMemo, useState } from 'react';
+import { RotateCcw, Trash2 } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { showToast } from '../ui/Toast';
+import { WipeTelemetryDialog } from './WipeTelemetryDialog';
+import {
+  StackModifiedError,
+  updateServerTelemetry,
+  wipeTelemetry,
+} from '../../lib/api';
+import {
+  inventoryByServer,
+  useInventory,
+  useTelemetryConfig,
+  useTelemetryStore,
+} from '../../stores/useTelemetryStore';
+import {
+  nextTriState,
+  readTriState,
+  triStateToPatch,
+  type TriState,
+} from '../../lib/telemetry-config';
+import { useStackStore } from '../../stores/useStackStore';
+import type { TelemetrySignal } from '../../types';
+
+const SIGNALS: TelemetrySignal[] = ['logs', 'metrics', 'traces'];
+
+interface Props {
+  serverName: string;
+}
+
+export function SidebarTelemetrySection({ serverName }: Props) {
+  const config = useTelemetryConfig();
+  const inventory = useInventory();
+  const stackName = useStackStore((s) => s.stackName);
+  const [pending, setPending] = useState<TelemetrySignal | 'reset' | null>(null);
+  const [wipeOpen, setWipeOpen] = useState(false);
+
+  const serverInventory = useMemo(
+    () => inventoryByServer(inventory, serverName),
+    [inventory, serverName],
+  );
+  const override = config.servers[serverName] ?? {};
+  const hasAnyOverride = SIGNALS.some((s) => override[s] === true || override[s] === false);
+
+  const storagePath = stackName
+    ? `~/.gridctl/telemetry/${stackName}/${serverName}/`
+    : `~/.gridctl/telemetry/<stack>/${serverName}/`;
+
+  async function cycleSignal(signal: TelemetrySignal) {
+    const current = readTriState(config, serverName, signal);
+    const next = nextTriState(current);
+    setPending(signal);
+    try {
+      const resp = await updateServerTelemetry(serverName, {
+        persist: { [signal]: triStateToPatch(next) },
+      });
+      useTelemetryStore.getState().setInventory(resp.inventory);
+      showToast('success', triStateToast(signal, next, serverName));
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function resetOverrides() {
+    setPending('reset');
+    try {
+      const resp = await updateServerTelemetry(serverName, { persist: null });
+      useTelemetryStore.getState().setInventory(resp.inventory);
+      showToast('success', `Telemetry overrides cleared for ${serverName}`);
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function confirmWipe() {
+    setWipeOpen(false);
+    try {
+      const resp = await wipeTelemetry({ server: serverName });
+      useTelemetryStore.getState().setInventory(resp.inventory);
+      showToast('success', `Persisted telemetry wiped for ${serverName}`);
+    } catch (err) {
+      handleError(err);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="text-[10px] text-text-muted font-mono break-all bg-background/50 px-2 py-1 rounded-md border border-border-subtle">
+        {storagePath}
+      </div>
+
+      <ul className="space-y-1">
+        {SIGNALS.map((sig) => {
+          const state = readTriState(config, serverName, sig);
+          const globalDefault = config.global[sig] === true;
+          const isBusy = pending === sig;
+          return (
+            <li key={sig}>
+              <TriStateRow
+                signal={sig}
+                state={state}
+                globalDefault={globalDefault}
+                busy={isBusy}
+                onClick={() => cycleSignal(sig)}
+              />
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="flex items-center gap-2 pt-1">
+        {hasAnyOverride && (
+          <button
+            type="button"
+            onClick={resetOverrides}
+            disabled={pending === 'reset'}
+            className={cn(
+              'inline-flex items-center gap-1.5 px-2 py-1 rounded-md',
+              'text-[11px] font-medium text-text-secondary',
+              'hover:bg-surface-highlight transition-colors',
+              'focus:outline-none focus:ring-2 focus:ring-primary/30',
+            )}
+          >
+            <RotateCcw size={11} />
+            Reset to global
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => setWipeOpen(true)}
+          disabled={serverInventory.length === 0}
+          className={cn(
+            'inline-flex items-center gap-1.5 ml-auto px-2 py-1 rounded-md',
+            'text-[11px] font-medium transition-colors',
+            serverInventory.length === 0
+              ? 'text-text-muted/60 cursor-not-allowed'
+              : 'text-status-error hover:bg-status-error/10',
+            'focus:outline-none focus:ring-2 focus:ring-status-error/30',
+          )}
+        >
+          <Trash2 size={11} />
+          Wipe data
+        </button>
+      </div>
+
+      <WipeTelemetryDialog
+        isOpen={wipeOpen}
+        onClose={() => setWipeOpen(false)}
+        onConfirm={confirmWipe}
+        scope={serverInventory}
+        title={`Wipe persisted data for ${serverName}`}
+        subject={`for ${serverName}`}
+      />
+    </div>
+  );
+}
+
+function triStateToast(signal: TelemetrySignal, state: TriState, server: string): string {
+  const label = signal[0].toUpperCase() + signal.slice(1);
+  switch (state) {
+    case 'on':
+      return `${label} persistence enabled for ${server}`;
+    case 'off':
+      return `${label} persistence disabled for ${server}`;
+    case 'inherit':
+      return `${label} persistence reverts to global for ${server}`;
+  }
+}
+
+function handleError(err: unknown) {
+  if (err instanceof StackModifiedError) {
+    showToast('warning', err.message, { duration: 6000 });
+    return;
+  }
+  showToast('error', err instanceof Error ? err.message : 'Telemetry update failed');
+}
+
+interface RowProps {
+  signal: TelemetrySignal;
+  state: TriState;
+  globalDefault: boolean;
+  busy: boolean;
+  onClick: () => void;
+}
+
+function TriStateRow({ signal, state, globalDefault, busy, onClick }: RowProps) {
+  const label = signal[0].toUpperCase() + signal.slice(1);
+  const isOn = state === 'on';
+  const isOff = state === 'off';
+  const isInherit = state === 'inherit';
+
+  // ariaPressed reflects the *effective* state — accessibility tools should
+  // see "pressed" whenever persistence is on, regardless of whether that's
+  // due to inheritance or an explicit override.
+  const effectivePressed = state === 'on' || (state === 'inherit' && globalDefault);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      aria-pressed={effectivePressed}
+      title={triStateTitle(state, globalDefault)}
+      className={cn(
+        'w-full flex items-center justify-between gap-3 px-2 py-1.5 rounded-lg',
+        'transition-all duration-200 group',
+        'hover:bg-surface-highlight/60',
+        'focus:outline-none focus:ring-2 focus:ring-primary/30',
+        busy && 'opacity-60 cursor-wait',
+      )}
+    >
+      <span className="flex items-center gap-2">
+        <span
+          aria-hidden
+          className={cn(
+            'inline-block w-2.5 h-2.5 rounded-full border transition-all duration-200',
+            isOn && 'bg-status-running border-status-running shadow-[0_0_6px_rgba(16,185,129,0.5)]',
+            isOff && 'bg-transparent border-amber-400',
+            isInherit && (globalDefault
+              ? 'bg-status-running/30 border-status-running/40'
+              : 'bg-text-muted/20 border-text-muted/40'),
+          )}
+        />
+        <span
+          className={cn(
+            'text-sm capitalize',
+            isOn && 'text-text-primary',
+            isOff && 'text-amber-400 line-through',
+            isInherit && 'text-text-secondary',
+          )}
+        >
+          {label}
+        </span>
+      </span>
+      <span
+        className={cn(
+          'text-[10px] font-mono uppercase tracking-wider px-1.5 py-0.5 rounded',
+          isOn && 'bg-status-running/10 text-status-running border border-status-running/20',
+          isOff && 'bg-amber-400/10 text-amber-400 border border-amber-400/20',
+          isInherit && 'bg-surface-elevated text-text-muted border border-border/40',
+        )}
+      >
+        {triStateBadge(state, globalDefault)}
+      </span>
+    </button>
+  );
+}
+
+function triStateBadge(state: TriState, globalDefault: boolean): string {
+  switch (state) {
+    case 'on':
+      return 'On';
+    case 'off':
+      return 'Off';
+    case 'inherit':
+      return globalDefault ? 'Inherit · On' : 'Inherit · Off';
+  }
+}
+
+function triStateTitle(state: TriState, globalDefault: boolean): string {
+  const next = nextTriState(state);
+  const inheritWord = globalDefault ? 'on' : 'off';
+  const stateWord =
+    state === 'inherit' ? `inheriting global (${inheritWord})` : `explicitly ${state}`;
+  return `${stateWord} — click to set ${next}`;
+}

--- a/web/src/components/telemetry/TelemetryNodeDot.tsx
+++ b/web/src/components/telemetry/TelemetryNodeDot.tsx
@@ -1,0 +1,77 @@
+// 12px dot anchored to the bottom-right of an MCP server graph node,
+// indicating telemetry persistence state. Three visual states map onto
+// the (config, inventory) cross-product:
+//
+//   off       — gray solid: no signal effectively persisted for this server.
+//   pending   — outlined emerald: at least one signal is on but no files
+//               yet exist on disk. Useful for spotting silent failures
+//               (e.g., persistence enabled but the writer can't write).
+//   active    — filled emerald with glow: at least one signal is on AND
+//               inventory has files.
+//
+// Tooltip enumerates the per-signal status and total disk footprint.
+import { useMemo } from 'react';
+import { cn } from '../../lib/cn';
+import { formatBytes } from '../../lib/format-bytes';
+import { effectiveSignal } from '../../lib/telemetry-config';
+import {
+  inventoryByServer,
+  useInventory,
+  useTelemetryConfig,
+} from '../../stores/useTelemetryStore';
+import type { TelemetrySignal } from '../../types';
+
+const SIGNALS: TelemetrySignal[] = ['logs', 'metrics', 'traces'];
+
+interface Props {
+  serverName: string;
+}
+
+export function TelemetryNodeDot({ serverName }: Props) {
+  const config = useTelemetryConfig();
+  const inventory = useInventory();
+
+  const view = useMemo(() => {
+    const records = inventoryByServer(inventory, serverName);
+    const sizeBytes = records.reduce((sum, r) => sum + r.sizeBytes, 0);
+    const enabled: Record<TelemetrySignal, boolean> = {
+      logs: effectiveSignal(config, serverName, 'logs'),
+      metrics: effectiveSignal(config, serverName, 'metrics'),
+      traces: effectiveSignal(config, serverName, 'traces'),
+    };
+    const anyOn = SIGNALS.some((s) => enabled[s]);
+    const hasFiles = records.length > 0;
+    let state: 'off' | 'pending' | 'active';
+    if (!anyOn) state = 'off';
+    else if (!hasFiles) state = 'pending';
+    else state = 'active';
+    const tooltip = SIGNALS.map((s) => {
+      const label = s[0].toUpperCase() + s.slice(1);
+      return `${label}: ${enabled[s] ? 'persistent' : 'off'}`;
+    }).join(' · ') + ` · ${formatBytes(sizeBytes)} on disk`;
+    return { state, tooltip };
+  }, [config, inventory, serverName]);
+
+  if (view.state === 'off') {
+    return (
+      <span
+        aria-label={view.tooltip}
+        title={view.tooltip}
+        className="absolute bottom-1.5 right-1.5 w-3 h-3 rounded-full border border-text-muted/50 bg-text-muted/20"
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-label={view.tooltip}
+      title={view.tooltip}
+      className={cn(
+        'absolute bottom-1.5 right-1.5 w-3 h-3 rounded-full border transition-all duration-200',
+        view.state === 'active'
+          ? 'bg-status-running border-status-running shadow-[0_0_8px_rgba(16,185,129,0.55)]'
+          : 'border-status-running/70 bg-transparent',
+      )}
+    />
+  );
+}

--- a/web/src/components/telemetry/WipeTelemetryDialog.tsx
+++ b/web/src/components/telemetry/WipeTelemetryDialog.tsx
@@ -1,0 +1,88 @@
+// WipeTelemetryDialog wraps ConfirmDialog (variant="danger") with an
+// enumerated body so the operator sees the size and date span being
+// destroyed before confirming. The actual wipe call lives in callsites
+// (header for global, sidebar for per-server) so each can update its
+// store and toast in its own context.
+import { useMemo } from 'react';
+import type { InventoryRecord, TelemetrySignal } from '../../types';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
+import { formatBytes, formatDateOnly } from '../../lib/format-bytes';
+import { summarize } from '../../stores/useTelemetryStore';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  // Inventory subset that the wipe will affect. The caller is responsible
+  // for filtering (header passes everything; sidebar passes
+  // `inventoryByServer(name)`). Empty list disables the destructive
+  // affordance so we never confirm a no-op.
+  scope: InventoryRecord[];
+  // Title and subject (e.g., "Wipe persisted data" / "for github") so the
+  // copy reads correctly in both global and per-server callsites.
+  title: string;
+  subject?: string;
+}
+
+export function WipeTelemetryDialog({ isOpen, onClose, onConfirm, scope, title, subject }: Props) {
+  const summary = useMemo(() => summarize(scope), [scope]);
+  const empty = scope.length === 0;
+
+  return (
+    <ConfirmDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      title={title}
+      variant="danger"
+      confirmLabel={empty ? 'Nothing to wipe' : 'Wipe data'}
+      message={
+        <div className="space-y-2">
+          <p>
+            This permanently deletes telemetry files{subject ? ` ${subject}` : ''} from disk.
+            The change cannot be undone, but it does not modify the stack YAML — persistence
+            stays enabled and new files will be created as signals continue.
+          </p>
+          {empty ? (
+            <p className="text-text-muted italic">No persisted telemetry exists in scope.</p>
+          ) : (
+            <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 font-mono text-[11px] text-text-secondary">
+              <dt className="text-text-muted">Total</dt>
+              <dd>{formatBytes(summary.totalBytes)}</dd>
+              <dt className="text-text-muted">Servers</dt>
+              <dd>{summary.servers}</dd>
+              <dt className="text-text-muted">Signals</dt>
+              <dd>{summary.signals.length === 0 ? '—' : summary.signals.join(', ')}</dd>
+              {summary.oldest && summary.newest && (
+                <>
+                  <dt className="text-text-muted">Span</dt>
+                  <dd>
+                    {formatDateOnly(summary.oldest)} → {formatDateOnly(summary.newest)}
+                  </dd>
+                </>
+              )}
+            </dl>
+          )}
+        </div>
+      }
+    />
+  );
+}
+
+// Used by tests so the wipe modal renders deterministic text from a
+// fixture without standing up the whole telemetry store.
+export function _testFormatScope(scope: InventoryRecord[]): {
+  totalBytes: string;
+  servers: number;
+  signals: TelemetrySignal[];
+  span: string | null;
+} {
+  const s = summarize(scope);
+  return {
+    totalBytes: formatBytes(s.totalBytes),
+    servers: s.servers,
+    signals: s.signals,
+    span:
+      s.oldest && s.newest ? `${formatDateOnly(s.oldest)} → ${formatDateOnly(s.newest)}` : null,
+  };
+}

--- a/web/src/components/traces/TracesTab.tsx
+++ b/web/src/components/traces/TracesTab.tsx
@@ -10,6 +10,7 @@ import { useStackStore } from '../../stores/useStackStore';
 import { useWindowManager } from '../../hooks/useWindowManager';
 import { useTextZoom } from '../../hooks/useTextZoom';
 import { TraceWaterfall } from './TraceWaterfall';
+import { PersistedFromMarker } from '../telemetry/PersistedFromMarker';
 import { POLLING } from '../../lib/constants';
 
 function formatTime(iso: string): string {
@@ -257,6 +258,9 @@ export function TracesTab() {
               className="flex-1 overflow-y-auto scrollbar-dark min-h-0"
               style={{ '--text-zoom-size': `${fontSize}px` } as React.CSSProperties}
             >
+              {/* Provenance boundary — top-of-list marker when any server
+                  has traces persistence enabled with files on disk. */}
+              <PersistedFromMarker serverName={null} signal="traces" />
               <table className="w-full">
                 <thead className="sticky top-0 z-10 bg-surface-elevated/95 backdrop-blur-sm">
                   <tr className="border-b border-border/30">

--- a/web/src/hooks/usePolling.ts
+++ b/web/src/hooks/usePolling.ts
@@ -4,7 +4,8 @@ import { useAuthStore } from '../stores/useAuthStore';
 import { useRegistryStore } from '../stores/useRegistryStore';
 import { usePinsStore } from '../stores/usePinsStore';
 import { useUIStore } from '../stores/useUIStore';
-import { fetchStatus, fetchTools, fetchClients, fetchRegistryStatus, fetchRegistrySkills, fetchServerPins, AuthError } from '../lib/api';
+import { useTelemetryStore } from '../stores/useTelemetryStore';
+import { fetchStatus, fetchTools, fetchClients, fetchRegistryStatus, fetchRegistrySkills, fetchServerPins, fetchStackSpec, getTelemetryInventory, AuthError } from '../lib/api';
 import { showToast } from '../components/ui/Toast';
 import { POLLING } from '../lib/constants';
 
@@ -60,6 +61,28 @@ export function usePolling() {
         _prevDriftCount = driftedCount;
       } catch {
         // Pins endpoint unavailable (feature not enabled) — suppress silently
+      }
+
+      // Fetch telemetry inventory + stack spec — progressive disclosure.
+      // Inventory drives the header pill / wipe modal / graph dot; the
+      // raw spec is parsed client-side to derive the per-server overrides
+      // the tri-state controls need. Both endpoints fail closed: an
+      // unrelated API error (or stackless mode) collapses to empty data
+      // without surfacing a global error.
+      try {
+        const records = await getTelemetryInventory();
+        useTelemetryStore.getState().setInventory(records);
+      } catch {
+        // Telemetry endpoint may be unreachable (stackless mode, older
+        // daemon); leave the prior snapshot in place silently.
+      }
+      try {
+        const spec = await fetchStackSpec();
+        useTelemetryStore.getState().setRawSpec(spec.content);
+      } catch {
+        // Stackless mode returns 503; clear so the UI does not show
+        // stale telemetry config from a previous stack.
+        useTelemetryStore.getState().setRawSpec(null);
       }
 
       // Fetch registry data — progressive disclosure, never blocks main cycle

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, RegistryStatus, AgentSkill, SkillFile, SkillValidationResult, WorkflowDefinition, ExecutionResult, TokenMetricsResponse, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SkillTestResult } from '../types';
+import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, RegistryStatus, AgentSkill, SkillFile, SkillValidationResult, WorkflowDefinition, ExecutionResult, TokenMetricsResponse, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SkillTestResult, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
 
 // Base URL for API calls - empty for same origin
 const API_BASE = '';
@@ -1205,3 +1205,144 @@ export async function mcpRequest<T>(
 
   return result.result as T;
 }
+
+// === Telemetry Persistence (Phase 4) ===
+
+/**
+ * StackModifiedError surfaces the structured 409 envelope from the
+ * telemetry PATCH endpoints when the on-disk YAML changed between the
+ * handler reading it and the atomic write. Callers should toast the hint
+ * ("Reload the file to see the latest contents") and offer a refresh.
+ */
+export class StackModifiedError extends Error {
+  code: string;
+  hint?: string;
+  constructor(message: string, hint?: string) {
+    super(message);
+    this.name = 'StackModifiedError';
+    this.code = 'stack_modified';
+    this.hint = hint;
+  }
+}
+
+export interface UpdateStackTelemetryBody {
+  persist?: {
+    logs?: boolean | null;
+    metrics?: boolean | null;
+    traces?: boolean | null;
+  };
+  retention?: {
+    max_size_mb?: number;
+    max_backups?: number;
+    max_age_days?: number;
+  };
+}
+
+// Per-server PATCH body. Values are: undefined = no change, null = clear
+// override (revert to inherit), bool = set explicit override. The whole
+// `persist` field set to null deletes the entire telemetry block from the
+// server entry — matching the "clear all overrides" idiom.
+export interface UpdateServerTelemetryBody {
+  persist?: {
+    logs?: boolean | null;
+    metrics?: boolean | null;
+    traces?: boolean | null;
+  } | null;
+}
+
+export interface WipeTelemetryOpts {
+  server?: string;
+  signal?: 'logs' | 'metrics' | 'traces';
+}
+
+async function telemetryMutate<T>(
+  url: string,
+  init: RequestInit,
+): Promise<T> {
+  const response = await fetch(`${API_BASE}${url}`, {
+    ...init,
+    headers: { ...buildHeaders({ 'Content-Type': 'application/json' }), ...(init.headers || {}) },
+  });
+  if (response.status === 401) throw new AuthError('Authentication required');
+
+  // The body is JSON for both success and structured-error responses.
+  // For 409 the server returns {error: {code, message, hint}}; for 422
+  // it returns {error, validation}; otherwise plain {error: "..."}.
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    const err = (data as { error?: unknown } | null)?.error;
+    if (response.status === 409 && err && typeof err === 'object' && (err as { code?: string }).code === 'stack_modified') {
+      const e = err as { message?: string; hint?: string };
+      throw new StackModifiedError(
+        e.message ?? 'The stack file was modified outside the canvas.',
+        e.hint ?? 'Reload the file to see the latest contents, then re-apply your changes.',
+      );
+    }
+    const msg = typeof err === 'string' ? err : `Telemetry request failed: ${response.status}`;
+    throw new HTTPError(response.status, msg);
+  }
+  return data as T;
+}
+
+/**
+ * Update the stack-global telemetry block. Returns the refreshed inventory
+ * snapshot alongside the success flag so callers can update the store
+ * without a follow-up GET.
+ * PATCH /api/stack/telemetry
+ */
+export async function updateStackTelemetry(
+  body: UpdateStackTelemetryBody,
+): Promise<TelemetryMutationResponse> {
+  return telemetryMutate<TelemetryMutationResponse>('/api/stack/telemetry', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Update per-server telemetry overrides. `body.persist === null` clears
+ * the entire per-server telemetry block; per-signal `null` clears that
+ * single override; bool sets an explicit override.
+ * PATCH /api/mcp-servers/{name}/telemetry
+ */
+export async function updateServerTelemetry(
+  name: string,
+  body: UpdateServerTelemetryBody,
+): Promise<TelemetryMutationResponse> {
+  return telemetryMutate<TelemetryMutationResponse>(
+    `/api/mcp-servers/${encodeURIComponent(name)}/telemetry`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+/**
+ * Fetch the current on-disk telemetry inventory. Returns one record per
+ * (server, signal) pair where at least one file exists.
+ * GET /api/telemetry/inventory
+ */
+export async function getTelemetryInventory(): Promise<InventoryRecord[]> {
+  return fetchJSON<InventoryRecord[]>('/api/telemetry/inventory');
+}
+
+/**
+ * Wipe persisted telemetry files. Empty server/signal acts as a wildcard;
+ * passing neither wipes everything for the active stack.
+ * DELETE /api/telemetry?server=&signal=
+ */
+export async function wipeTelemetry(
+  opts: WipeTelemetryOpts = {},
+): Promise<TelemetryMutationResponse> {
+  const params = new URLSearchParams();
+  if (opts.server) params.set('server', opts.server);
+  if (opts.signal) params.set('signal', opts.signal);
+  const query = params.toString();
+  const url = query ? `/api/telemetry?${query}` : '/api/telemetry';
+  return telemetryMutate<TelemetryMutationResponse>(url, { method: 'DELETE' });
+}
+
+// Re-export the types used in mutation arguments so callers do not need to
+// reach into the types module separately.
+export type { TelemetryPersistDefaults, TelemetryRetention };

--- a/web/src/lib/format-bytes.ts
+++ b/web/src/lib/format-bytes.ts
@@ -1,0 +1,28 @@
+// Compact human-readable byte formatter for telemetry-inventory UI
+// callouts. Uses binary multiples (KiB / MiB / GiB) since lumberjack's
+// MaxSize is documented in MiB and operators on the wipe modal are
+// reasoning about disk footprint, not network throughput.
+
+const UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB'] as const;
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < UNITS.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  // < 10: one decimal; >= 10: integer. Keeps "1.4 MiB" but avoids
+  // "1024 KiB" or noisy decimals on bigger numbers.
+  const formatted = value < 10 ? value.toFixed(1) : Math.round(value).toString();
+  return `${formatted} ${UNITS[unitIndex]}`;
+}
+
+// ISO date-only formatter used by the persisted-from divider and the
+// wipe modal's "from / to" line. Keeps the UI stable across locales for
+// the technical audience (operators) without pulling in Intl complexity.
+export function formatDateOnly(date: Date | undefined): string {
+  if (!date || Number.isNaN(date.getTime())) return '';
+  return date.toISOString().slice(0, 10);
+}

--- a/web/src/lib/telemetry-config.ts
+++ b/web/src/lib/telemetry-config.ts
@@ -1,0 +1,155 @@
+// Parses raw stack YAML into a resolved view of telemetry persistence
+// configuration. The backend is the source of truth for the on-disk YAML;
+// this helper exists so the frontend can render the header pill, sidebar
+// tri-state, and graph dot without an extra round-trip after every PATCH.
+//
+// We accept "best effort" parsing: a malformed stack file should not crash
+// the UI — it returns an empty config so the rest of the app continues to
+// render and the operator can fix the YAML in the spec tab.
+
+import { parse as parseYAML } from 'yaml';
+import type {
+  ResolvedTelemetry,
+  ServerPersistOverride,
+  TelemetryPersistDefaults,
+  TelemetryRetention,
+  TelemetrySignal,
+} from '../types';
+
+const SIGNALS: TelemetrySignal[] = ['logs', 'metrics', 'traces'];
+
+interface RawStack {
+  telemetry?: {
+    persist?: Record<string, unknown>;
+    retention?: Record<string, unknown>;
+  };
+  'mcp-servers'?: Array<{
+    name?: string;
+    telemetry?: {
+      persist?: Record<string, unknown>;
+    } | null;
+  }>;
+}
+
+const EMPTY: ResolvedTelemetry = { global: {}, servers: {} };
+
+/**
+ * Parse a stack YAML string into a resolved telemetry view. Errors and
+ * unexpected shapes degrade to the empty config rather than throwing, so
+ * an unrelated parse failure never blocks the rest of the UI from rendering.
+ */
+export function parseStackTelemetry(raw: string | null | undefined): ResolvedTelemetry {
+  if (!raw) return EMPTY;
+  let doc: unknown;
+  try {
+    doc = parseYAML(raw);
+  } catch {
+    return EMPTY;
+  }
+  if (!doc || typeof doc !== 'object') return EMPTY;
+  const stack = doc as RawStack;
+
+  const global: TelemetryPersistDefaults = {};
+  for (const sig of SIGNALS) {
+    const v = stack.telemetry?.persist?.[sig];
+    if (typeof v === 'boolean') global[sig] = v;
+  }
+
+  let retention: TelemetryRetention | undefined;
+  const r = stack.telemetry?.retention;
+  if (r && typeof r === 'object') {
+    const out: TelemetryRetention = {};
+    if (typeof r.max_size_mb === 'number') out.max_size_mb = r.max_size_mb;
+    if (typeof r.max_backups === 'number') out.max_backups = r.max_backups;
+    if (typeof r.max_age_days === 'number') out.max_age_days = r.max_age_days;
+    if (Object.keys(out).length > 0) retention = out;
+  }
+
+  const servers: Record<string, ServerPersistOverride> = {};
+  const list = Array.isArray(stack['mcp-servers']) ? stack['mcp-servers'] : [];
+  for (const s of list) {
+    if (!s || typeof s.name !== 'string' || s.name === '') continue;
+    const persist = s.telemetry?.persist;
+    if (!persist || typeof persist !== 'object') continue;
+    const override: ServerPersistOverride = {};
+    for (const sig of SIGNALS) {
+      const v = persist[sig];
+      if (typeof v === 'boolean') override[sig] = v;
+    }
+    if (Object.keys(override).length > 0) {
+      servers[s.name] = override;
+    }
+  }
+
+  return { global, servers, ...(retention ? { retention } : {}) };
+}
+
+/**
+ * Resolve the effective on/off state for a single (server, signal) pair
+ * using the same inheritance rules as the Go backend's PersistLogs/Metrics/
+ * Traces helpers: explicit per-server override wins; otherwise the
+ * stack-global default; otherwise false.
+ */
+export function effectiveSignal(
+  cfg: ResolvedTelemetry,
+  serverName: string,
+  signal: TelemetrySignal,
+): boolean {
+  const override = cfg.servers[serverName]?.[signal];
+  if (typeof override === 'boolean') return override;
+  return cfg.global[signal] ?? false;
+}
+
+/**
+ * Convenience: are any signals effectively persisted for this server?
+ * Drives the graph node dot indicator and the sidebar "active" pill.
+ */
+export function anySignalEnabled(cfg: ResolvedTelemetry, serverName: string): boolean {
+  return SIGNALS.some((s) => effectiveSignal(cfg, serverName, s));
+}
+
+/**
+ * Tri-state for the sidebar control. inherit means the per-server override
+ * is absent; on/off mean explicit true/false. The state machine in the UI
+ * cycles inherit → on → off → inherit, mapping each transition to the
+ * PATCH body shape described in the API helpers.
+ */
+export type TriState = 'inherit' | 'on' | 'off';
+
+export function readTriState(
+  cfg: ResolvedTelemetry,
+  serverName: string,
+  signal: TelemetrySignal,
+): TriState {
+  const override = cfg.servers[serverName]?.[signal];
+  if (override === true) return 'on';
+  if (override === false) return 'off';
+  return 'inherit';
+}
+
+/** Cycle to the next tri-state: inherit → on → off → inherit. */
+export function nextTriState(state: TriState): TriState {
+  switch (state) {
+    case 'inherit':
+      return 'on';
+    case 'on':
+      return 'off';
+    case 'off':
+      return 'inherit';
+  }
+}
+
+/**
+ * Map a tri-state transition to the PATCH body value for a single signal:
+ * on → true, off → false, inherit → null (clears the override).
+ */
+export function triStateToPatch(state: TriState): boolean | null {
+  switch (state) {
+    case 'on':
+      return true;
+    case 'off':
+      return false;
+    case 'inherit':
+      return null;
+  }
+}

--- a/web/src/stores/useTelemetryStore.ts
+++ b/web/src/stores/useTelemetryStore.ts
@@ -1,0 +1,115 @@
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+import type { InventoryRecord, ResolvedTelemetry, TelemetrySignal } from '../types';
+import { parseStackTelemetry } from '../lib/telemetry-config';
+
+// Aggregate snapshot for the header pill / wipe modal. servers is the
+// distinct count of servers with at least one inventory record; oldest /
+// newest are the global span across all (server, signal) pairs. Computed
+// once per store update so consumers don't re-derive on every render.
+export interface TelemetrySummary {
+  totalBytes: number;
+  servers: number;
+  signals: TelemetrySignal[];
+  oldest?: Date;
+  newest?: Date;
+}
+
+interface TelemetryState {
+  inventory: InventoryRecord[];
+  // Resolved view derived from the stack YAML content. Updated whenever the
+  // raw spec changes; consumers read `config` rather than re-parsing.
+  config: ResolvedTelemetry;
+  rawSpec: string | null;
+  // Last successful fetch — informational, used for spinner suppression
+  // and stale-data badges if the network drops.
+  lastFetchedAt: Date | null;
+  error: string | null;
+
+  setInventory: (records: InventoryRecord[]) => void;
+  setRawSpec: (content: string | null) => void;
+  setError: (error: string | null) => void;
+}
+
+const EMPTY_CONFIG: ResolvedTelemetry = { global: {}, servers: {} };
+
+export const useTelemetryStore = create<TelemetryState>()(
+  subscribeWithSelector((set) => ({
+    inventory: [],
+    config: EMPTY_CONFIG,
+    rawSpec: null,
+    lastFetchedAt: null,
+    error: null,
+
+    setInventory: (records) =>
+      set({ inventory: records ?? [], lastFetchedAt: new Date(), error: null }),
+
+    // The raw spec arrives as a YAML string; we parse it once on write so
+    // every read is a cheap object lookup. A nil/empty spec collapses to
+    // the empty resolved config — consistent with stackless mode.
+    setRawSpec: (content) => {
+      if (content === null) {
+        set({ rawSpec: null, config: EMPTY_CONFIG });
+        return;
+      }
+      set({ rawSpec: content, config: parseStackTelemetry(content) });
+    },
+
+    setError: (error) => set({ error }),
+  })),
+);
+
+// === Selectors ===
+//
+// These are plain functions (not hooks) so callers can use them in both
+// component bodies (via `useTelemetryStore` selectors) and in event
+// handlers (via `useTelemetryStore.getState()`).
+
+export function inventoryByServer(
+  inventory: InventoryRecord[],
+  serverName: string,
+): InventoryRecord[] {
+  return inventory.filter((r) => r.server === serverName);
+}
+
+export function totalSizeBytes(inventory: InventoryRecord[]): number {
+  return inventory.reduce((sum, r) => sum + r.sizeBytes, 0);
+}
+
+export function summarize(inventory: InventoryRecord[]): TelemetrySummary {
+  if (inventory.length === 0) {
+    return { totalBytes: 0, servers: 0, signals: [] };
+  }
+  const seenServers = new Set<string>();
+  const seenSignals = new Set<TelemetrySignal>();
+  let totalBytes = 0;
+  let oldest: Date | undefined;
+  let newest: Date | undefined;
+  for (const r of inventory) {
+    seenServers.add(r.server);
+    seenSignals.add(r.signal);
+    totalBytes += r.sizeBytes;
+    const o = new Date(r.oldestTime);
+    const n = new Date(r.newestTime);
+    if (!oldest || o < oldest) oldest = o;
+    if (!newest || n > newest) newest = n;
+  }
+  // Preserve the canonical signal order (logs, metrics, traces) rather than
+  // insertion order — keeps the wipe-modal enumeration stable across polls.
+  const order: TelemetrySignal[] = ['logs', 'metrics', 'traces'];
+  const signals = order.filter((s) => seenSignals.has(s));
+  return {
+    totalBytes,
+    servers: seenServers.size,
+    signals,
+    oldest,
+    newest,
+  };
+}
+
+// Hook variants for component subscriptions. They subscribe to inventory
+// only — the derived data is recomputed on each render but the inputs are
+// referentially stable so React skips work via memoization at the consumer
+// level if needed.
+export const useInventory = () => useTelemetryStore((s) => s.inventory);
+export const useTelemetryConfig = () => useTelemetryStore((s) => s.config);

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -523,3 +523,76 @@ export interface UpdateSummary {
   available: number;
   sources: SourceUpdateSummary[];
 }
+
+// --- Telemetry Persistence Types (Phase 4) ---
+
+// Three signal types persisted to disk. Lower-case wire shape matches the
+// Go struct's YAML tags so request bodies round-trip without renaming.
+export type TelemetrySignal = 'logs' | 'metrics' | 'traces';
+
+// Stack-global persist defaults are plain bools (binary on/off). Per-server
+// overrides use *bool semantics — see ServerPersistOverride below.
+export interface TelemetryPersistDefaults {
+  logs?: boolean;
+  metrics?: boolean;
+  traces?: boolean;
+}
+
+// One block per stack — per-signal retention is intentionally out of scope
+// at MVP. Defaults filled by SetDefaults: 100MB / 5 backups / 7d.
+export interface TelemetryRetention {
+  max_size_mb?: number;
+  max_backups?: number;
+  max_age_days?: number;
+}
+
+export interface TelemetryConfig {
+  persist?: TelemetryPersistDefaults;
+  retention?: TelemetryRetention;
+}
+
+// Per-server overrides are tri-state in the YAML: absent (inherit),
+// explicit true, explicit false. We keep null for "explicitly absent"
+// after the parser drops the key, so the UI can distinguish a freshly
+// cleared override from one that was never set.
+export type OverrideValue = boolean | null;
+
+export interface ServerPersistOverride {
+  logs?: OverrideValue;
+  metrics?: OverrideValue;
+  traces?: OverrideValue;
+}
+
+export interface MCPServerTelemetryOverride {
+  persist?: ServerPersistOverride;
+}
+
+// Inventory record from GET /api/telemetry/inventory. One entry per (server,
+// signal) pair where at least one file exists. SizeBytes/FileCount aggregate
+// the active jsonl plus rotated lumberjack siblings.
+export interface InventoryRecord {
+  server: string;
+  signal: TelemetrySignal;
+  path: string;
+  sizeBytes: number;
+  oldestTime: string; // RFC3339
+  newestTime: string; // RFC3339
+  fileCount: number;
+}
+
+// Standard envelope for PATCH/DELETE telemetry endpoints. The refreshed
+// inventory snapshot lets callers update the store in-place without an
+// extra round-trip.
+export interface TelemetryMutationResponse {
+  success: boolean;
+  inventory: InventoryRecord[];
+}
+
+// Resolved view derived from the parsed stack YAML. global is the
+// stack.telemetry block; servers maps server name → its (possibly empty)
+// override block. retention is the stack-wide retention config.
+export interface ResolvedTelemetry {
+  global: TelemetryPersistDefaults;
+  retention?: TelemetryRetention;
+  servers: Record<string, ServerPersistOverride>;
+}


### PR DESCRIPTION
## Description

Phase 4 of opt-in telemetry persistence: header pill + popover, sidebar tri-state per-server controls, graph node dot indicator, wipe modal with size/date enumeration, inventory polling, and persisted-from boundary markers on the Logs/Metrics/Traces tabs.

## Type of Change

- [x] New feature

## Changes Made

- `PATCH /api/stack/telemetry` and `PATCH /api/mcp-servers/{name}/telemetry` are now driven from a header popover (3 toggles + Wipe All) and a per-server sidebar section with tri-state controls cycling inherit → on → off → inherit.
- `GET /api/telemetry/inventory` polled every 3s alongside the existing status poll. Inventory drives the wipe modal's size/date enumeration, the graph node dot's three states (off/pending/active), and the boundary markers in the tab views.
- `DELETE /api/telemetry` invoked from both the header (global wipe) and sidebar (per-server wipe) via a shared `WipeTelemetryDialog` component built on the existing `ConfirmDialog` with `variant="danger"`.
- Stack YAML is parsed client-side (new `yaml` dep, ~50KB) so the UI can derive the global defaults plus per-server overrides without backend changes.
- 409 `stack_modified` envelope surfaces a typed `StackModifiedError` mapped to a warning toast with the structured hint.
- 22 new vitest cases cover YAML parsing edge cases, inheritance resolution, the tri-state state machine, header label formatting, wipe-modal scope formatting, and 409 surfacing.

## Testing

- `web && npx vitest run` — 493/493 pass.
- `web && npm run build` — clean.
- `make build` — Go binary embeds the new assets.

Manual: load a stack, click the header `Persistence: Off` pill → popover. Toggle Logs, observe pill turns emerald `Persistence: Logs`, stack YAML on disk gains the corresponding `telemetry.persist.logs: true`. Select an MCP server in the canvas, click rows in the new Telemetry sidebar section to cycle tri-state. Wait for files to accumulate, then verify the bottom-right node dot, the wipe modal's enumeration, and the `── persisted from <date> ──` marker on the Logs/Metrics/Traces tabs.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #550