### PR TITLE
feat: add telemetry persistence CLI

### DIFF
--- a/cmd/gridctl/telemetry.go
+++ b/cmd/gridctl/telemetry.go
@@ -1,0 +1,571 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	ossignal "os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/state"
+	"github.com/gridctl/gridctl/pkg/telemetry"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var (
+	telemetryStatusJSON bool
+	telemetryWipeServer string
+	telemetryWipeSignal string
+	telemetryWipeYes    bool
+	telemetryTailSignal string
+)
+
+var telemetryCmd = &cobra.Command{
+	Use:   "telemetry",
+	Short: "Inspect and manage persisted telemetry",
+	Long: `Inspect and manage opt-in telemetry persistence under ~/.gridctl/telemetry/.
+
+These commands operate directly on the on-disk files and do not require a
+running daemon. Persistence itself is configured per-stack and per-server in
+the stack YAML.`,
+}
+
+var telemetryStatusCmd = &cobra.Command{
+	Use:   "status [stack]",
+	Short: "Show persisted telemetry inventory",
+	Long: `Lists the on-disk footprint of persisted telemetry.
+
+With no argument, walks every stack under ~/.gridctl/telemetry/. Pass a stack
+name to scope the report. Use --json for machine-readable output.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		stack := ""
+		if len(args) == 1 {
+			stack = args[0]
+		}
+		return runTelemetryStatus(stack, telemetryStatusJSON)
+	},
+}
+
+var telemetryWipeCmd = &cobra.Command{
+	Use:   "wipe [stack]",
+	Short: "Delete persisted telemetry files",
+	Long: `Deletes persisted telemetry files. Without a stack argument or any flags,
+removes everything under ~/.gridctl/telemetry/.
+
+--server scopes the wipe to a single MCP server.
+--signal scopes the wipe to one signal type (logs, metrics, traces).
+-y / --yes skips the confirmation prompt.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		stack := ""
+		if len(args) == 1 {
+			stack = args[0]
+		}
+		return runTelemetryWipe(stack, telemetryWipeServer, telemetryWipeSignal, telemetryWipeYes)
+	},
+}
+
+var telemetryTailCmd = &cobra.Command{
+	Use:   "tail <stack> <server>",
+	Short: "Follow a persisted telemetry file (tail -f)",
+	Long: `Follows the active <signal>.jsonl file for the given stack and server,
+printing new NDJSON lines as they're written. Lumberjack rotations are
+detected automatically. Press Ctrl-C to exit.`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runTelemetryTail(args[0], args[1], telemetryTailSignal)
+	},
+}
+
+func init() {
+	telemetryStatusCmd.Flags().BoolVar(&telemetryStatusJSON, "json", false, "Output as JSON")
+
+	telemetryWipeCmd.Flags().StringVar(&telemetryWipeServer, "server", "", "Limit to a single MCP server")
+	telemetryWipeCmd.Flags().StringVar(&telemetryWipeSignal, "signal", "", "Limit to a single signal (logs, metrics, traces)")
+	telemetryWipeCmd.Flags().BoolVarP(&telemetryWipeYes, "yes", "y", false, "Skip confirmation prompt")
+
+	telemetryTailCmd.Flags().StringVar(&telemetryTailSignal, "signal", "", "Signal to follow (logs, metrics, traces)")
+	_ = telemetryTailCmd.MarkFlagRequired("signal")
+
+	telemetryCmd.AddCommand(telemetryStatusCmd)
+	telemetryCmd.AddCommand(telemetryWipeCmd)
+	telemetryCmd.AddCommand(telemetryTailCmd)
+	rootCmd.AddCommand(telemetryCmd)
+}
+
+// stackInventory pairs a stack name with its inventory records so the CLI can
+// render a multi-stack report without losing the parent stack on each row.
+type stackInventory struct {
+	Stack   string                       `json:"stack"`
+	Records []telemetry.InventoryRecord  `json:"records"`
+}
+
+// statusRow is the flat per-(stack, signal) row used for tables and JSON
+// output. Times are RFC3339 strings so the JSON form is consumable by jq
+// without a custom time decoder.
+type statusRow struct {
+	Stack     string `json:"stack"`
+	Server    string `json:"server"`
+	Signal    string `json:"signal"`
+	Path      string `json:"path"`
+	SizeBytes int64  `json:"sizeBytes"`
+	FileCount int    `json:"fileCount"`
+	Oldest    string `json:"oldest,omitempty"`
+	Newest    string `json:"newest,omitempty"`
+}
+
+// listTelemetryStacks returns the names of stacks that have a directory under
+// ~/.gridctl/telemetry/. A missing root returns an empty slice without error.
+func listTelemetryStacks() ([]string, error) {
+	root := state.TelemetryDir()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read telemetry root: %w", err)
+	}
+	stacks := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			stacks = append(stacks, e.Name())
+		}
+	}
+	sort.Strings(stacks)
+	return stacks, nil
+}
+
+// gatherInventories returns per-stack inventory records. When stack is empty,
+// every stack under TelemetryDir is walked.
+func gatherInventories(stack string) ([]stackInventory, error) {
+	stacks := []string{stack}
+	if stack == "" {
+		all, err := listTelemetryStacks()
+		if err != nil {
+			return nil, err
+		}
+		stacks = all
+	}
+	out := make([]stackInventory, 0, len(stacks))
+	for _, s := range stacks {
+		records, err := telemetry.Inventory(s, "")
+		if err != nil {
+			return nil, fmt.Errorf("inventory for %s: %w", s, err)
+		}
+		if len(records) == 0 {
+			continue
+		}
+		out = append(out, stackInventory{Stack: s, Records: records})
+	}
+	return out, nil
+}
+
+func runTelemetryStatus(stack string, asJSON bool) error {
+	invs, err := gatherInventories(stack)
+	if err != nil {
+		return err
+	}
+
+	rows := flattenInventories(invs)
+
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if rows == nil {
+			rows = []statusRow{}
+		}
+		return enc.Encode(rows)
+	}
+
+	if len(rows) == 0 {
+		if stack != "" {
+			fmt.Printf("No persisted telemetry for stack %q\n", stack)
+		} else {
+			fmt.Println("No persisted telemetry")
+		}
+		return nil
+	}
+
+	renderStatusTable(os.Stdout, rows)
+	return nil
+}
+
+// flattenInventories collapses per-stack inventory groups into the flat
+// statusRow shape used for both the table and JSON output.
+func flattenInventories(invs []stackInventory) []statusRow {
+	var rows []statusRow
+	for _, inv := range invs {
+		for _, r := range inv.Records {
+			rows = append(rows, statusRow{
+				Stack:     inv.Stack,
+				Server:    r.Server,
+				Signal:    r.Signal,
+				Path:      r.Path,
+				SizeBytes: r.SizeBytes,
+				FileCount: r.FileCount,
+				Oldest:    formatInventoryTime(r.OldestTime),
+				Newest:    formatInventoryTime(r.NewestTime),
+			})
+		}
+	}
+	return rows
+}
+
+func renderStatusTable(w io.Writer, rows []statusRow) {
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleRounded)
+	t.AppendHeader(table.Row{"STACK", "SERVER", "SIGNAL", "SIZE", "FILES", "OLDEST", "NEWEST"})
+	for _, r := range rows {
+		t.AppendRow(table.Row{
+			r.Stack,
+			r.Server,
+			r.Signal,
+			formatBytes(r.SizeBytes),
+			r.FileCount,
+			r.Oldest,
+			r.Newest,
+		})
+	}
+	t.Render()
+}
+
+func runTelemetryWipe(stack, server, signal string, yes bool) error {
+	if signal != "" && !telemetry.IsValidSignal(signal) {
+		return fmt.Errorf("invalid signal %q (expected logs, metrics, or traces)", signal)
+	}
+
+	invs, err := gatherInventories(stack)
+	if err != nil {
+		return err
+	}
+
+	// Filter the inventory by --server and --signal so the confirmation
+	// prompt enumerates exactly what Wipe will delete.
+	matching := filterInventories(invs, server, signal)
+	if isInventoryEmpty(matching) {
+		fmt.Println("Nothing to wipe — no matching telemetry found")
+		return nil
+	}
+
+	if !yes {
+		printWipeSummary(os.Stdout, matching, server, signal)
+		fmt.Print("Proceed? [y/N] ")
+		reader := bufio.NewReader(os.Stdin)
+		ans, _ := reader.ReadString('\n')
+		ans = strings.TrimSpace(strings.ToLower(ans))
+		if ans != "y" && ans != "yes" {
+			fmt.Println("Cancelled")
+			return nil
+		}
+	}
+
+	var wipeErrs []error
+	for _, inv := range matching {
+		if err := telemetry.Wipe(inv.Stack, server, signal); err != nil {
+			wipeErrs = append(wipeErrs, fmt.Errorf("wipe %s: %w", inv.Stack, err))
+		}
+	}
+	if len(wipeErrs) > 0 {
+		return errors.Join(wipeErrs...)
+	}
+
+	totalBytes, totalFiles, _ := summarizeInventories(matching)
+	fmt.Printf("Wiped %d %s (%s) across %d %s\n",
+		totalFiles, plural(totalFiles, "file", "files"),
+		formatBytes(totalBytes),
+		len(matching), plural(len(matching), "stack", "stacks"))
+	return nil
+}
+
+func plural(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}
+
+// filterInventories keeps only records that match the requested server and
+// signal, dropping any stack that ends up with no records. Empty filters act
+// as wildcards.
+func filterInventories(invs []stackInventory, server, signal string) []stackInventory {
+	if server == "" && signal == "" {
+		return invs
+	}
+	out := make([]stackInventory, 0, len(invs))
+	for _, inv := range invs {
+		var keep []telemetry.InventoryRecord
+		for _, r := range inv.Records {
+			if server != "" && r.Server != server {
+				continue
+			}
+			if signal != "" && r.Signal != signal {
+				continue
+			}
+			keep = append(keep, r)
+		}
+		if len(keep) > 0 {
+			out = append(out, stackInventory{Stack: inv.Stack, Records: keep})
+		}
+	}
+	return out
+}
+
+func isInventoryEmpty(invs []stackInventory) bool {
+	for _, inv := range invs {
+		if len(inv.Records) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// summarizeInventories returns total bytes, total file count, and the unique
+// set of servers across the supplied inventories. Used by both the wipe
+// confirmation summary and the post-wipe output.
+func summarizeInventories(invs []stackInventory) (int64, int, []string) {
+	var bytes int64
+	files := 0
+	seen := map[string]struct{}{}
+	var servers []string
+	for _, inv := range invs {
+		for _, r := range inv.Records {
+			bytes += r.SizeBytes
+			files += r.FileCount
+			if _, ok := seen[r.Server]; !ok {
+				seen[r.Server] = struct{}{}
+				servers = append(servers, r.Server)
+			}
+		}
+	}
+	sort.Strings(servers)
+	return bytes, files, servers
+}
+
+func printWipeSummary(w io.Writer, invs []stackInventory, server, signal string) {
+	totalBytes, totalFiles, servers := summarizeInventories(invs)
+
+	scope := "everything"
+	if signal != "" {
+		scope = signal
+	}
+	if server != "" {
+		scope = "server " + server
+		if signal != "" {
+			scope = signal + " for server " + server
+		}
+	}
+
+	stacks := make([]string, 0, len(invs))
+	for _, inv := range invs {
+		stacks = append(stacks, inv.Stack)
+	}
+
+	fmt.Fprintf(w, "About to delete %s persisted telemetry:\n", scope)
+	fmt.Fprintf(w, "  Stacks:  %s\n", strings.Join(stacks, ", "))
+	fmt.Fprintf(w, "  Servers: %s\n", strings.Join(servers, ", "))
+	fmt.Fprintf(w, "  Files:   %d\n", totalFiles)
+	fmt.Fprintf(w, "  Size:    %s\n", formatBytes(totalBytes))
+}
+
+func runTelemetryTail(stack, server, signal string) error {
+	if !telemetry.IsValidSignal(signal) {
+		return fmt.Errorf("invalid signal %q (expected logs, metrics, or traces)", signal)
+	}
+
+	path := state.TelemetryServerPath(stack, server, signal)
+	dir := filepath.Dir(path)
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no telemetry directory for stack %q server %q (enable persistence in the stack YAML and start the daemon)", stack, server)
+		}
+		return fmt.Errorf("stat %s: %w", dir, err)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("create watcher: %w", err)
+	}
+	defer watcher.Close()
+	if err := watcher.Add(dir); err != nil {
+		return fmt.Errorf("watch %s: %w", dir, err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	ossignal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer ossignal.Stop(sigCh)
+
+	t := newTailReader(path, os.Stdout)
+	if err := t.openAtEnd(); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer t.close()
+	t.drain()
+
+	target := filepath.Base(path)
+	for {
+		select {
+		case <-sigCh:
+			fmt.Println()
+			return nil
+		case ev, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			if filepath.Base(ev.Name) != target {
+				continue
+			}
+			switch {
+			case ev.Has(fsnotify.Create):
+				// Newly created (or recreated after rotation): read the whole
+				// file from the start so the user does not miss the first
+				// batch lumberjack flushes after rotating.
+				_ = t.openAtStart()
+				t.drain()
+			case ev.Has(fsnotify.Write):
+				if !t.isOpen() {
+					_ = t.openAtStart()
+				}
+				t.drain()
+			case ev.Has(fsnotify.Rename), ev.Has(fsnotify.Remove):
+				// Lumberjack rotated or wiped the active file. Drop our
+				// handle and wait for the Create event that brings the new
+				// file in.
+				t.close()
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "warning: watcher error: %v\n", err)
+		}
+	}
+}
+
+// tailReader wraps a single open file and exposes the operations the tail
+// loop needs — open at end (for the initial attach), open at start (after
+// rotation), drain pending bytes line-by-line, and close on rotation/exit.
+//
+// Partial trailing bytes (a half-flushed line) are held in `partial` until a
+// newline arrives; only complete lines are emitted. This matches `tail -f`
+// semantics and keeps NDJSON consumers from seeing torn JSON objects.
+type tailReader struct {
+	path    string
+	out     io.Writer
+	file    *os.File
+	reader  *bufio.Reader
+	partial []byte
+}
+
+func newTailReader(path string, out io.Writer) *tailReader {
+	return &tailReader{path: path, out: out}
+}
+
+func (t *tailReader) isOpen() bool { return t.file != nil }
+
+func (t *tailReader) close() {
+	if t.file != nil {
+		_ = t.file.Close()
+		t.file = nil
+		t.reader = nil
+	}
+	t.partial = t.partial[:0]
+}
+
+func (t *tailReader) openAtEnd() error {
+	t.close()
+	f, err := os.Open(t.path)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		_ = f.Close()
+		return err
+	}
+	t.file = f
+	t.reader = bufio.NewReader(f)
+	return nil
+}
+
+func (t *tailReader) openAtStart() error {
+	t.close()
+	f, err := os.Open(t.path)
+	if err != nil {
+		return err
+	}
+	t.file = f
+	t.reader = bufio.NewReader(f)
+	return nil
+}
+
+// drain reads complete lines from the underlying reader and writes them to
+// out. Partial trailing bytes are accumulated in t.partial and flushed only
+// when a newline arrives. Errors other than io.EOF are surfaced as a warning
+// so the tail loop never exits silently on a transient read failure.
+func (t *tailReader) drain() {
+	if t.reader == nil {
+		return
+	}
+	for {
+		chunk, err := t.reader.ReadString('\n')
+		if chunk != "" {
+			t.partial = append(t.partial, chunk...)
+		}
+		if err == nil {
+			// chunk ended in '\n' — flush the accumulated line.
+			fmt.Fprint(t.out, string(t.partial))
+			t.partial = t.partial[:0]
+			continue
+		}
+		if err != io.EOF {
+			fmt.Fprintf(os.Stderr, "warning: read %s: %v\n", t.path, err)
+		}
+		return
+	}
+}
+
+// formatBytes renders byte counts using binary multiples (KiB / MiB / GiB) to
+// match the frontend formatter in web/src/lib/format-bytes.ts. Operators
+// reading the wipe summary on the CLI and the wipe modal in the UI see the
+// same units for the same number.
+func formatBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	units := []string{"KiB", "MiB", "GiB", "TiB"}
+	if exp >= len(units) {
+		exp = len(units) - 1
+	}
+	value := float64(bytes) / float64(div)
+	if value < 10 {
+		return fmt.Sprintf("%.1f %s", value, units[exp])
+	}
+	return fmt.Sprintf("%d %s", int64(value+0.5), units[exp])
+}
+
+// formatInventoryTime renders an InventoryRecord timestamp as YYYY-MM-DD
+// HH:MM. Zero-valued times become "—" so the table column never reads
+// "0001-01-01 ..." for stacks with no rotated siblings yet.
+func formatInventoryTime(t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	return t.Format("2006-01-02 15:04")
+}

--- a/cmd/gridctl/telemetry_test.go
+++ b/cmd/gridctl/telemetry_test.go
@@ -1,0 +1,498 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/state"
+	"github.com/gridctl/gridctl/pkg/telemetry"
+)
+
+func setTempHomeTelemetry(t *testing.T) {
+	t.Helper()
+	orig := os.Getenv("HOME")
+	t.Cleanup(func() { os.Setenv("HOME", orig) })
+	os.Setenv("HOME", t.TempDir())
+}
+
+// seedTelemetry writes a telemetry file with the given content under
+// ~/.gridctl/telemetry/<stack>/<server>/<signal>.jsonl. The mtime is set so
+// inventory ordering tests are deterministic.
+func seedTelemetry(t *testing.T, stack, server, signal, content string, mtime time.Time) string {
+	t.Helper()
+	if err := state.EnsureTelemetryServerDir(stack, server); err != nil {
+		t.Fatalf("ensure dir: %v", err)
+	}
+	path := state.TelemetryServerPath(stack, server, signal)
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if !mtime.IsZero() {
+		if err := os.Chtimes(path, mtime, mtime); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+	}
+	return path
+}
+
+func TestFormatBytes(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{1, "1 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{1500, "1.5 KiB"},
+		{10 * 1024, "10 KiB"},
+		{1024 * 1024, "1.0 MiB"},
+		{1024 * 1024 * 1024, "1.0 GiB"},
+	}
+	for _, c := range cases {
+		got := formatBytes(c.in)
+		if got != c.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFormatInventoryTime(t *testing.T) {
+	if got := formatInventoryTime(time.Time{}); got != "—" {
+		t.Errorf("zero time = %q, want em-dash", got)
+	}
+	ts := time.Date(2026, 4, 30, 12, 5, 0, 0, time.UTC)
+	if got := formatInventoryTime(ts); got != "2026-04-30 12:05" {
+		t.Errorf("ts = %q", got)
+	}
+}
+
+func TestListTelemetryStacks(t *testing.T) {
+	setTempHomeTelemetry(t)
+
+	// No telemetry dir yet — should return nil without error.
+	stacks, err := listTelemetryStacks()
+	if err != nil {
+		t.Fatalf("listTelemetryStacks empty: %v", err)
+	}
+	if len(stacks) != 0 {
+		t.Errorf("expected no stacks, got %v", stacks)
+	}
+
+	// Seed two stacks; they should come back sorted.
+	seedTelemetry(t, "beta", "github", "logs", "{}\n", time.Time{})
+	seedTelemetry(t, "alpha", "slack", "metrics", "{}\n", time.Time{})
+
+	stacks, err = listTelemetryStacks()
+	if err != nil {
+		t.Fatalf("listTelemetryStacks: %v", err)
+	}
+	want := []string{"alpha", "beta"}
+	if len(stacks) != len(want) || stacks[0] != want[0] || stacks[1] != want[1] {
+		t.Errorf("stacks = %v, want %v", stacks, want)
+	}
+}
+
+func TestGatherInventories_AllStacks(t *testing.T) {
+	setTempHomeTelemetry(t)
+
+	now := time.Now()
+	seedTelemetry(t, "alpha", "github", "logs", `{"msg":"hi"}`+"\n", now)
+	seedTelemetry(t, "beta", "slack", "traces", `{"trace":1}`+"\n", now)
+
+	invs, err := gatherInventories("")
+	if err != nil {
+		t.Fatalf("gatherInventories: %v", err)
+	}
+	if len(invs) != 2 {
+		t.Fatalf("expected 2 stacks, got %d", len(invs))
+	}
+	// Ordering follows listTelemetryStacks (sorted) → alpha first.
+	if invs[0].Stack != "alpha" || invs[1].Stack != "beta" {
+		t.Errorf("stack order = %s,%s", invs[0].Stack, invs[1].Stack)
+	}
+}
+
+func TestGatherInventories_SkipsEmpty(t *testing.T) {
+	setTempHomeTelemetry(t)
+
+	// An empty server directory should not produce a stack record.
+	if err := state.EnsureTelemetryServerDir("alpha", "github"); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	invs, err := gatherInventories("")
+	if err != nil {
+		t.Fatalf("gatherInventories: %v", err)
+	}
+	if len(invs) != 0 {
+		t.Errorf("expected 0 stacks for empty dir, got %d", len(invs))
+	}
+}
+
+func TestFilterInventories(t *testing.T) {
+	invs := []stackInventory{
+		{
+			Stack: "alpha",
+			Records: []telemetry.InventoryRecord{
+				{Server: "github", Signal: "logs"},
+				{Server: "github", Signal: "traces"},
+				{Server: "slack", Signal: "logs"},
+			},
+		},
+		{
+			Stack: "beta",
+			Records: []telemetry.InventoryRecord{
+				{Server: "slack", Signal: "metrics"},
+			},
+		},
+	}
+
+	t.Run("no filters returns input", func(t *testing.T) {
+		got := filterInventories(invs, "", "")
+		if len(got) != 2 || len(got[0].Records) != 3 {
+			t.Errorf("expected pass-through, got %+v", got)
+		}
+	})
+
+	t.Run("filter by server drops non-matching stacks", func(t *testing.T) {
+		got := filterInventories(invs, "github", "")
+		if len(got) != 1 || got[0].Stack != "alpha" {
+			t.Fatalf("expected only alpha, got %+v", got)
+		}
+		if len(got[0].Records) != 2 {
+			t.Errorf("expected 2 github records, got %d", len(got[0].Records))
+		}
+	})
+
+	t.Run("filter by signal", func(t *testing.T) {
+		got := filterInventories(invs, "", "logs")
+		if len(got) != 1 || got[0].Stack != "alpha" {
+			t.Fatalf("expected only alpha (only stack with logs), got %+v", got)
+		}
+		if len(got[0].Records) != 2 {
+			t.Errorf("expected 2 logs records, got %d", len(got[0].Records))
+		}
+	})
+
+	t.Run("filter by both", func(t *testing.T) {
+		got := filterInventories(invs, "slack", "metrics")
+		if len(got) != 1 || got[0].Stack != "beta" {
+			t.Fatalf("expected beta, got %+v", got)
+		}
+		if len(got[0].Records) != 1 {
+			t.Errorf("expected 1 record, got %d", len(got[0].Records))
+		}
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		got := filterInventories(invs, "missing", "")
+		if len(got) != 0 {
+			t.Errorf("expected empty, got %+v", got)
+		}
+	})
+}
+
+func TestSummarizeInventories(t *testing.T) {
+	invs := []stackInventory{
+		{
+			Stack: "alpha",
+			Records: []telemetry.InventoryRecord{
+				{Server: "github", SizeBytes: 100, FileCount: 2},
+				{Server: "slack", SizeBytes: 200, FileCount: 1},
+			},
+		},
+		{
+			Stack: "beta",
+			Records: []telemetry.InventoryRecord{
+				{Server: "slack", SizeBytes: 50, FileCount: 1},
+			},
+		},
+	}
+	bytes, files, servers := summarizeInventories(invs)
+	if bytes != 350 {
+		t.Errorf("bytes = %d, want 350", bytes)
+	}
+	if files != 4 {
+		t.Errorf("files = %d, want 4", files)
+	}
+	if len(servers) != 2 || servers[0] != "github" || servers[1] != "slack" {
+		t.Errorf("servers = %v", servers)
+	}
+}
+
+func TestPrintWipeSummary(t *testing.T) {
+	invs := []stackInventory{
+		{
+			Stack: "alpha",
+			Records: []telemetry.InventoryRecord{
+				{Server: "github", Signal: "logs", SizeBytes: 1024 * 1024, FileCount: 2},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printWipeSummary(&buf, invs, "", "")
+	out := buf.String()
+	for _, want := range []string{"alpha", "github", "Files:", "1.0 MiB", "everything"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q:\n%s", want, out)
+		}
+	}
+
+	buf.Reset()
+	printWipeSummary(&buf, invs, "github", "logs")
+	out = buf.String()
+	if !strings.Contains(out, "logs for server github") {
+		t.Errorf("scoped summary missing 'logs for server github':\n%s", out)
+	}
+}
+
+func TestRunTelemetryStatus_Empty(t *testing.T) {
+	setTempHomeTelemetry(t)
+
+	stdout := captureStdout(t, func() {
+		if err := runTelemetryStatus("", false); err != nil {
+			t.Fatalf("runTelemetryStatus: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, "No persisted telemetry") {
+		t.Errorf("expected empty-state message, got: %q", stdout)
+	}
+
+	stdout = captureStdout(t, func() {
+		if err := runTelemetryStatus("missing", false); err != nil {
+			t.Fatalf("runTelemetryStatus: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, `stack "missing"`) {
+		t.Errorf("expected per-stack empty-state message, got: %q", stdout)
+	}
+}
+
+func TestRunTelemetryStatus_JSON(t *testing.T) {
+	setTempHomeTelemetry(t)
+
+	now := time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC)
+	seedTelemetry(t, "alpha", "github", "logs", `{"msg":"hi"}`+"\n", now)
+
+	stdout := captureStdout(t, func() {
+		if err := runTelemetryStatus("", true); err != nil {
+			t.Fatalf("runTelemetryStatus: %v", err)
+		}
+	})
+
+	var rows []statusRow
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, stdout)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].Stack != "alpha" || rows[0].Server != "github" || rows[0].Signal != "logs" {
+		t.Errorf("row = %+v", rows[0])
+	}
+	if rows[0].FileCount != 1 {
+		t.Errorf("file count = %d", rows[0].FileCount)
+	}
+}
+
+func TestRunTelemetryWipe_NothingToWipe(t *testing.T) {
+	setTempHomeTelemetry(t)
+
+	stdout := captureStdout(t, func() {
+		if err := runTelemetryWipe("", "", "", true); err != nil {
+			t.Fatalf("runTelemetryWipe: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, "Nothing to wipe") {
+		t.Errorf("expected 'Nothing to wipe', got: %q", stdout)
+	}
+}
+
+func TestRunTelemetryWipe_Wildcard(t *testing.T) {
+	setTempHomeTelemetry(t)
+
+	now := time.Now()
+	p1 := seedTelemetry(t, "alpha", "github", "logs", `{"a":1}`+"\n", now)
+	p2 := seedTelemetry(t, "beta", "slack", "traces", `{"b":2}`+"\n", now)
+
+	stdout := captureStdout(t, func() {
+		if err := runTelemetryWipe("", "", "", true); err != nil {
+			t.Fatalf("runTelemetryWipe: %v", err)
+		}
+	})
+	if !strings.Contains(stdout, "Wiped") {
+		t.Errorf("expected 'Wiped' summary, got: %q", stdout)
+	}
+	if _, err := os.Stat(p1); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed, stat err = %v", p1, err)
+	}
+	if _, err := os.Stat(p2); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed, stat err = %v", p2, err)
+	}
+}
+
+func TestRunTelemetryWipe_ScopedToServer(t *testing.T) {
+	setTempHomeTelemetry(t)
+
+	now := time.Now()
+	keep := seedTelemetry(t, "alpha", "github", "logs", `{"a":1}`+"\n", now)
+	drop := seedTelemetry(t, "alpha", "slack", "logs", `{"b":2}`+"\n", now)
+
+	if err := runTelemetryWipe("alpha", "slack", "", true); err != nil {
+		t.Fatalf("runTelemetryWipe: %v", err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Errorf("expected %s to survive, got: %v", keep, err)
+	}
+	if _, err := os.Stat(drop); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed, stat err = %v", drop, err)
+	}
+}
+
+func TestRunTelemetryWipe_InvalidSignal(t *testing.T) {
+	setTempHomeTelemetry(t)
+	err := runTelemetryWipe("", "", "bogus", true)
+	if err == nil || !strings.Contains(err.Error(), "invalid signal") {
+		t.Errorf("expected invalid-signal error, got: %v", err)
+	}
+}
+
+func TestRunTelemetryTail_MissingDir(t *testing.T) {
+	setTempHomeTelemetry(t)
+	err := runTelemetryTail("missing", "server", "logs")
+	if err == nil || !strings.Contains(err.Error(), "no telemetry directory") {
+		t.Errorf("expected missing-dir error, got: %v", err)
+	}
+}
+
+func TestRunTelemetryTail_InvalidSignal(t *testing.T) {
+	setTempHomeTelemetry(t)
+	err := runTelemetryTail("alpha", "github", "bogus")
+	if err == nil || !strings.Contains(err.Error(), "invalid signal") {
+		t.Errorf("expected invalid-signal error, got: %v", err)
+	}
+}
+
+func TestTailReader_DrainEmitsCompleteLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "logs.jsonl")
+	if err := os.WriteFile(path, []byte("first line\nsecond line\npartial"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var buf bytes.Buffer
+	tr := newTailReader(path, &buf)
+	if err := tr.openAtStart(); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer tr.close()
+	tr.drain()
+
+	got := buf.String()
+	if !strings.Contains(got, "first line\n") || !strings.Contains(got, "second line\n") {
+		t.Errorf("expected both complete lines, got: %q", got)
+	}
+	if strings.Contains(got, "partial") {
+		t.Errorf("partial trailing line should not have been emitted: %q", got)
+	}
+}
+
+func TestTailReader_HoldsPartialUntilNewline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "logs.jsonl")
+	if err := os.WriteFile(path, []byte("partial"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var buf bytes.Buffer
+	tr := newTailReader(path, &buf)
+	if err := tr.openAtStart(); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer tr.close()
+	tr.drain()
+	if buf.Len() != 0 {
+		t.Fatalf("partial line should not be emitted yet, got: %q", buf.String())
+	}
+
+	// Append the rest of the line plus a fully terminated next line.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		t.Fatalf("reopen for append: %v", err)
+	}
+	if _, err := f.WriteString(" rest\nnext line\n"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	_ = f.Close()
+
+	tr.drain()
+	got := buf.String()
+	if !strings.Contains(got, "partial rest\n") {
+		t.Errorf("partial line should have been completed: %q", got)
+	}
+	if !strings.Contains(got, "next line\n") {
+		t.Errorf("next line should have been emitted: %q", got)
+	}
+}
+
+func TestTailReader_OpenAtEndSkipsExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "logs.jsonl")
+	if err := os.WriteFile(path, []byte("preexisting line\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var buf bytes.Buffer
+	tr := newTailReader(path, &buf)
+	if err := tr.openAtEnd(); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer tr.close()
+	tr.drain()
+
+	if buf.Len() != 0 {
+		t.Errorf("openAtEnd should not have emitted preexisting content, got: %q", buf.String())
+	}
+
+	if err := os.WriteFile(path, []byte("preexisting line\nnew line\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	tr.drain()
+	if !strings.Contains(buf.String(), "new line") {
+		t.Errorf("expected new line in output, got: %q", buf.String())
+	}
+}
+
+// captureStdout swaps os.Stdout for a pipe, runs fn, and returns whatever fn
+// wrote. Used by the run* tests that print directly via fmt.Print rather
+// than through an injected writer.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = orig })
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	out := <-done
+	os.Stdout = orig
+	return out
+}


### PR DESCRIPTION
## Description

Adds Phase 5 (CLI parity) for opt-in telemetry persistence. Three new subcommands operate directly on `~/.gridctl/telemetry/` so operators can inspect, wipe, and follow persisted signals without a running daemon.

## Commands

- `gridctl telemetry status [stack] [--json]` — table or JSON inventory across one or all stacks.
- `gridctl telemetry wipe [stack] [--server X] [--signal logs|metrics|traces] [-y]` — enumerates scope before deleting; reuses `pkg/telemetry.Wipe` (already lock-protected).
- `gridctl telemetry tail <stack> <server> --signal X` — `tail -f`-style follow with fsnotify, lumberjack-rotation aware, partial trailing bytes held until newline.

## Changes Made

- `cmd/gridctl/telemetry.go` — subcommand wiring, multi-stack inventory walker, wipe summary/confirmation, fsnotify-based tail reader. Byte formatter mirrors `web/src/lib/format-bytes.ts` (KiB/MiB/GiB) so CLI and UI sizes match.
- `cmd/gridctl/telemetry_test.go` — unit tests for byte/time formatting, inventory gather/filter/summarize, status (empty/JSON), wipe (wildcard/scoped/invalid-signal), tail (missing dir / invalid signal / partial-line buffering / openAtEnd).

## Testing

- `go test -race ./...` — all green.
- `golangci-lint run ./cmd/gridctl/...` — 0 issues.
- Smoke-tested against a populated `~/.gridctl/telemetry/`: status (table + JSON), scoped wipe, tail signal validation.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] Commits follow conventional format and are signed
- [x] No secrets or credentials committed

Part of #550