### PR TITLE
refactor: muted-by-default color hierarchy for Skills Registry

### DIFF
--- a/web/src/components/registry/RegistrySidebar.tsx
+++ b/web/src/components/registry/RegistrySidebar.tsx
@@ -494,7 +494,7 @@ function SkillItem({
     <div
       ref={rowRef}
       className={cn(
-        'rounded-lg bg-surface-elevated/50 border overflow-hidden transition-colors',
+        'group rounded-lg bg-surface-elevated/50 border overflow-hidden transition-colors',
         isSelected ? 'border-primary/40 shadow-[0_0_0_1px_rgba(245,158,11,0.25)]' : 'border-border-subtle',
       )}
     >

--- a/web/src/components/registry/SkillActions.tsx
+++ b/web/src/components/registry/SkillActions.tsx
@@ -27,7 +27,13 @@ export function SkillActions({
   className,
 }: SkillActionsProps) {
   return (
-    <div className={cn('flex items-center gap-0.5', className)}>
+    <div
+      className={cn(
+        'flex items-center gap-0.5 opacity-60 transition-opacity duration-200',
+        'group-hover:opacity-100 group-focus-within:opacity-100 hover:opacity-100',
+        className,
+      )}
+    >
       {showToggle && (
         skill.state === 'active' ? (
           <IconButton

--- a/web/src/components/registry/SkillCard.tsx
+++ b/web/src/components/registry/SkillCard.tsx
@@ -36,22 +36,22 @@ export const SkillCard = memo(({
     <div
       style={style}
       className={cn(
-        'relative rounded-xl overflow-hidden flex flex-col',
+        'group relative rounded-xl overflow-hidden flex flex-col',
         'backdrop-blur-xl border transition-all duration-200 ease-out',
         'bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.02]',
-        'border-border/60 hover:border-primary/40 hover:shadow-node-hover',
+        'border-white/[0.08] hover:border-primary/40 focus-within:border-primary/40 hover:shadow-node-hover',
         className,
       )}
     >
-      {/* Top accent line */}
-      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
+      {/* Top accent line — muted at rest, warms on hover/focus */}
+      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 group-hover:via-primary/40 group-focus-within:via-primary/40 to-transparent transition-colors duration-200" />
 
       {/* Card body */}
       <div className="p-3 flex flex-col gap-2 flex-1">
         {/* Header: icon + name + state badge */}
         <div className="flex items-start gap-2">
-          <div className="p-1.5 rounded-md border bg-primary/10 border-primary/20 flex-shrink-0 mt-0.5">
-            <BookOpen size={14} className="text-primary/70" />
+          <div className="p-1.5 rounded-md border bg-surface-highlight/60 border-border/40 flex-shrink-0 mt-0.5 transition-colors duration-200 group-hover:bg-primary/10 group-hover:border-primary/20 group-focus-within:bg-primary/10 group-focus-within:border-primary/20">
+            <BookOpen size={14} className="text-text-muted transition-colors duration-200 group-hover:text-primary/70 group-focus-within:text-primary/70" />
           </div>
           <span className="font-semibold log-text text-text-primary truncate flex-1 min-w-0 leading-tight mt-0.5">
             {skill.name}

--- a/web/src/components/registry/SkillCardSkeleton.tsx
+++ b/web/src/components/registry/SkillCardSkeleton.tsx
@@ -2,9 +2,9 @@ import { memo } from 'react';
 
 export const SkillCardSkeleton = memo(() => {
   return (
-    <div className="relative rounded-xl overflow-hidden flex flex-col backdrop-blur-xl border border-border/60 bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.02]">
-      {/* Top accent line */}
-      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-primary/20 to-transparent" />
+    <div className="relative rounded-xl overflow-hidden flex flex-col backdrop-blur-xl border border-white/[0.08] bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.02]">
+      {/* Top accent line — neutral to match the new muted card resting state */}
+      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
 
       {/* Card body */}
       <div className="p-3 flex flex-col gap-2 flex-1">

--- a/web/src/components/registry/TestStatusBadge.tsx
+++ b/web/src/components/registry/TestStatusBadge.tsx
@@ -30,7 +30,7 @@ export function TestStatusBadge({
   if (untested) {
     icon = <Minus size={11} />;
     label = 'untested';
-    color = 'text-amber-400/80 bg-amber-400/8 border-amber-400/20';
+    color = 'text-text-muted bg-surface-highlight/60 border-border/40';
     title = 'No test run yet';
   } else if (failed) {
     icon = <XCircle size={11} />;


### PR DESCRIPTION
## Description

Refactors the Skills Registry styling to a muted-by-default color strategy. Demotes static metadata (the `untested` badge, idle card borders, top accent line, internal book icon, utility icons) to neutral greys; reserves the brand orange for primary actions, the active filter tab, and interactive feedback (hover / focus). Pure CSS-class changes — no API, type, state, or behavior changes.

## Type of Change

- [x] Refactor (no functional change)

## Changes Made

- `TestStatusBadge`: `untested` color from `amber-400` palette to neutral `text-text-muted bg-surface-highlight/60 border-border/40`. `passing` (emerald) and `failing` (rose) untouched.
- `SkillCard`: added `group` to wrapper; resting border `border-white/[0.08]`, orange on `:hover` and `:focus-within`. Top accent line muted at rest, warms via `group-hover` / `group-focus-within`. Internal book-icon container and icon muted at rest, warm via the same group selectors.
- `SkillActions`: wrapper renders at `opacity-60` at rest, returns to full opacity on `group-hover`, `group-focus-within`, or direct `hover` of the cluster.
- `SkillCardSkeleton`: matched to the new muted card resting border so the load → loaded transition is visually coherent.
- `RegistrySidebar`: added `group` to the `SkillItem` outer wrapper so the new `SkillActions` opacity behavior also activates on the sidebar surface (spot-fix; no layout/interaction changes).

Brand-color affordances kept intact: `+ New Skill` button, `Library` brand icon, active filter tab, and the sidebar selected-row highlight.

## Testing

- `npm run build` (tsc + vite) passes cleanly.
- Visual QA: open `/registry` (or pop out the detached registry window) and confirm:
  - Untested badge reads as quiet grey, not amber.
  - Card border barely-there at rest, orange on hover/focus.
  - Top accent gradient muted at rest, warms on hover/focus.
  - Trash/edit/power icons dim at rest, full-bright on card hover.
  - `+ New Skill` is the strongest primary affordance in the toolbar.
  - Active filter tab is the only orange tab.
  - Passing (emerald) and failing (rose) badges unchanged.
  - Sidebar `SkillItem` expanded actions also dim/brighten correctly.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #558