### PR TITLE
refactor: Focus-First styling pass for Topology view

### DIFF
--- a/web/src/components/graph/ClientNode.tsx
+++ b/web/src/components/graph/ClientNode.tsx
@@ -24,7 +24,7 @@ const ClientNode = memo(({ data, selected }: ClientNodeProps) => {
           'bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.03]',
           'flex items-center px-2.5 gap-2',
           selected && 'border-primary shadow-glow-primary ring-2 ring-primary/20',
-          !selected && 'border-primary/25 hover:shadow-node-hover hover:border-primary/40'
+          !selected && 'border-border hover:shadow-node-hover hover:border-primary/60'
         )}
         style={{ height: LAYOUT.CLIENT_HEIGHT_COMPACT }}
       >
@@ -83,10 +83,10 @@ const ClientNode = memo(({ data, selected }: ClientNodeProps) => {
       </span>
 
       {/* Status */}
-      <div className="flex items-center gap-1">
+      <span className="inline-flex items-center gap-1.5 text-[10px] px-1.5 py-0.5 rounded font-medium border bg-status-running/10 border-status-running/25 text-status-running">
         <StatusDot status={data.status} />
-        <span className="text-[10px] text-status-running font-medium">Linked</span>
-      </div>
+        Linked
+      </span>
 
       {/* Source handle (connects to gateway on the right) */}
       <Handle

--- a/web/src/components/graph/CustomNode.tsx
+++ b/web/src/components/graph/CustomNode.tsx
@@ -55,14 +55,16 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
         'w-64 rounded-xl relative',
         'backdrop-blur-xl border transition-all duration-200 ease-out',
         isServer
-          ? 'bg-gradient-to-br from-surface/95 to-violet-500/[0.03] border-violet-500/30'
-          : 'bg-gradient-to-br from-surface/95 to-secondary/[0.02] border-border/50',
-        selected && isServer && 'border-violet-500 shadow-[0_0_15px_rgba(139,92,246,0.3)] ring-1 ring-violet-500/30',
-        selected && !isServer && 'border-secondary shadow-glow-secondary ring-1 ring-secondary/30',
+          ? 'bg-gradient-to-br from-surface/95 to-violet-500/[0.03] border-border'
+          : 'bg-gradient-to-br from-surface/95 to-secondary/[0.02] border-border',
+        selected && isServer && 'border-violet-500 shadow-[0_0_15px_rgba(139,92,246,0.3)] ring-2 ring-violet-500/30',
+        selected && !isServer && 'border-secondary shadow-glow-secondary ring-2 ring-secondary/30',
         // Autoscale decision ring: inset so it does not fight selection highlighting.
         autoscale?.lastDecision === 'up' && 'ring-2 ring-inset ring-primary/40 animate-pulse-glow',
         autoscale?.lastDecision === 'down' && 'ring-2 ring-inset ring-secondary/40',
-        !selected && 'hover:shadow-node-hover hover:border-text-muted/30'
+        !selected && 'hover:shadow-node-hover',
+        !selected && isServer && 'hover:border-violet-400/60',
+        !selected && !isServer && 'hover:border-secondary/70'
       )}
       style={{
         height: isCompact ? LAYOUT.NODE_HEIGHT_COMPACT : undefined,
@@ -289,9 +291,16 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
 
           {/* Status Badge + Type indicator */}
           <div className="pt-1 flex items-center gap-2">
-            <Badge status={data.status}>
-              <span className="capitalize">{data.status}</span>
-            </Badge>
+            {data.status === 'running' ? (
+              <span className="inline-flex items-center gap-1.5 text-[10px] px-1.5 py-0.5 rounded font-medium border bg-status-running/10 border-status-running/25 text-status-running capitalize">
+                <span className="w-1.5 h-1.5 rounded-full bg-status-running" />
+                {data.status}
+              </span>
+            ) : (
+              <Badge status={data.status}>
+                <span className="capitalize">{data.status}</span>
+              </Badge>
+            )}
             {isServer && !isExternal && !isLocalProcess && !isSSH && !isOpenAPI && (
               <div className={cn(
                 'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border',

--- a/web/src/components/graph/CustomNode.tsx
+++ b/web/src/components/graph/CustomNode.tsx
@@ -146,7 +146,7 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
               {toolCount}t
             </span>
           )}
-          <StatusDot status={data.status} />
+          <StatusDot status={data.status} pulse={!isCompact} />
         </div>
       </div>
 

--- a/web/src/components/graph/GatewayNode.tsx
+++ b/web/src/components/graph/GatewayNode.tsx
@@ -19,10 +19,10 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
       className={cn(
         'w-60 rounded-2xl',
         'bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.03]',
-        'backdrop-blur-xl border border-primary/20',
+        'backdrop-blur-xl border border-border',
         'shadow-lg transition-all duration-300 ease-out',
         selected && 'border-primary shadow-glow-primary ring-2 ring-primary/20',
-        !selected && 'hover:shadow-node-hover hover:border-primary/40'
+        !selected && 'hover:shadow-node-hover hover:border-primary/60'
       )}
     >
       {/* Top accent gradient */}
@@ -53,7 +53,7 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
         <div className="flex items-center justify-between group">
           <div className="flex items-center gap-2.5">
             <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-              <Server size={12} className="text-primary" />
+              <Server size={12} className="text-primary/70" />
             </div>
             <span className="text-xs text-text-secondary font-medium">MCP Servers</span>
           </div>
@@ -67,7 +67,7 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
           <div className="flex items-center justify-between group">
             <div className="flex items-center gap-2.5">
               <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-                <Database size={12} className="text-primary" />
+                <Database size={12} className="text-primary/70" />
               </div>
               <span className="text-xs text-text-secondary font-medium">Resources</span>
             </div>
@@ -82,7 +82,7 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
           <div className="flex items-center justify-between group">
             <div className="flex items-center gap-2.5">
               <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-                <Radio size={12} className="text-primary" />
+                <Radio size={12} className="text-primary/70" />
               </div>
               <span className="text-xs text-text-secondary font-medium">Sessions</span>
             </div>
@@ -97,7 +97,7 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
           <div className="flex items-center justify-between group">
             <div className="flex items-center gap-2.5">
               <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-                <Monitor size={12} className="text-primary" />
+                <Monitor size={12} className="text-primary/70" />
               </div>
               <span className="text-xs text-text-secondary font-medium">Clients</span>
             </div>
@@ -111,7 +111,7 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
         <div className="flex items-center justify-between group">
           <div className="flex items-center gap-2.5">
             <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-              <Wrench size={12} className="text-primary" />
+              <Wrench size={12} className="text-primary/70" />
             </div>
             <span className="text-xs text-text-secondary font-medium">Total Tools</span>
           </div>
@@ -129,7 +129,7 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
           >
             <div className="flex items-center gap-2.5">
               <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-                <Library size={12} className="text-primary" />
+                <Library size={12} className="text-primary/70" />
               </div>
               <span className="text-xs text-text-secondary font-medium">Skills</span>
             </div>
@@ -152,12 +152,10 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
 
         {/* Status indicator */}
         <div className="flex items-center gap-2.5 pt-2 mt-1 border-t border-border/50">
-          <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-full bg-status-running/10 border border-status-running/20">
+          <span className="inline-flex items-center gap-1.5 text-[10px] px-1.5 py-0.5 rounded font-medium border bg-status-running/10 border-status-running/25 text-status-running">
             <StatusDot status="running" />
-            <span className="text-[11px] text-status-running font-semibold tracking-wide">
-              Gateway Active
-            </span>
-          </div>
+            Gateway Active
+          </span>
           <Zap size={14} className="text-primary animate-pulse" style={{ animationDuration: '2s' }} />
         </div>
       </div>

--- a/web/src/components/graph/SkillGroupNode.tsx
+++ b/web/src/components/graph/SkillGroupNode.tsx
@@ -52,7 +52,7 @@ const SkillGroupNode = memo(({ data, selected }: SkillGroupNodeProps) => {
           'bg-gradient-to-b from-surface/95 via-surface/90 to-tertiary/[0.03]',
           'flex items-center px-2.5 gap-2',
           selected && 'border-tertiary shadow-glow-tertiary ring-2 ring-tertiary/20',
-          !selected && 'border-tertiary/25 hover:shadow-node-hover hover:border-tertiary/40'
+          !selected && 'border-border hover:shadow-node-hover hover:border-tertiary-light/60'
         )}
         style={{ height: LAYOUT.NODE_HEIGHT_COMPACT }}
       >

--- a/web/src/components/graph/SkillNode.tsx
+++ b/web/src/components/graph/SkillNode.tsx
@@ -62,7 +62,7 @@ const SkillNode = memo(({ data, selected }: SkillNodeProps) => {
           'bg-gradient-to-b from-surface/95 via-surface/90 to-tertiary/[0.03]',
           'flex items-center px-2.5 gap-2',
           selected && 'border-tertiary shadow-glow-tertiary ring-2 ring-tertiary/20',
-          !selected && 'border-tertiary/25 hover:shadow-node-hover hover:border-tertiary/40'
+          !selected && 'border-border hover:shadow-node-hover hover:border-tertiary-light/60'
         )}
         style={{ height: LAYOUT.NODE_HEIGHT_COMPACT }}
       >

--- a/web/src/components/telemetry/TelemetryNodeDot.tsx
+++ b/web/src/components/telemetry/TelemetryNodeDot.tsx
@@ -1,17 +1,18 @@
 // 12px dot anchored to the bottom-right of an MCP server graph node,
-// indicating telemetry persistence state. Three visual states map onto
-// the (config, inventory) cross-product:
+// indicating telemetry persistence state. Surfaces only when something
+// needs attention; the healthy steady state renders nothing so it does
+// not compete visually with the running-status indicator.
 //
 //   off       — gray solid: no signal effectively persisted for this server.
 //   pending   — outlined emerald: at least one signal is on but no files
 //               yet exist on disk. Useful for spotting silent failures
 //               (e.g., persistence enabled but the writer can't write).
-//   active    — filled emerald with glow: at least one signal is on AND
-//               inventory has files.
+//   active    — hidden: signals on AND inventory has files. Healthy steady
+//               state needs no marker; details remain reachable via the
+//               telemetry sidebar.
 //
-// Tooltip enumerates the per-signal status and total disk footprint.
+// Tooltip (when rendered) enumerates the per-signal status and total disk footprint.
 import { useMemo } from 'react';
-import { cn } from '../../lib/cn';
 import { formatBytes } from '../../lib/format-bytes';
 import { effectiveSignal } from '../../lib/telemetry-config';
 import {
@@ -52,6 +53,12 @@ export function TelemetryNodeDot({ serverName }: Props) {
     return { state, tooltip };
   }, [config, inventory, serverName]);
 
+  // Hidden when active so a healthy steady state stays visually quiet;
+  // the dot only surfaces when something needs attention (pending/off).
+  if (view.state === 'active') {
+    return null;
+  }
+
   if (view.state === 'off') {
     return (
       <span
@@ -66,12 +73,7 @@ export function TelemetryNodeDot({ serverName }: Props) {
     <span
       aria-label={view.tooltip}
       title={view.tooltip}
-      className={cn(
-        'absolute bottom-1.5 right-1.5 w-3 h-3 rounded-full border transition-all duration-200',
-        view.state === 'active'
-          ? 'bg-status-running border-status-running shadow-[0_0_8px_rgba(16,185,129,0.55)]'
-          : 'border-status-running/70 bg-transparent',
-      )}
+      className="absolute bottom-1.5 right-1.5 w-3 h-3 rounded-full border border-status-running/70 bg-transparent transition-all duration-200"
     />
   );
 }

--- a/web/src/components/ui/StatusDot.tsx
+++ b/web/src/components/ui/StatusDot.tsx
@@ -4,6 +4,7 @@ import type { NodeStatus } from '../../types';
 interface StatusDotProps {
   status: NodeStatus;
   size?: 'sm' | 'md';
+  pulse?: boolean;
 }
 
 const dotStyles: Record<NodeStatus, string> = {
@@ -14,7 +15,7 @@ const dotStyles: Record<NodeStatus, string> = {
   idle: 'bg-status-idle',
 };
 
-export function StatusDot({ status, size = 'sm' }: StatusDotProps) {
+export function StatusDot({ status, size = 'sm', pulse = true }: StatusDotProps) {
   const sizeClasses = {
     sm: 'w-2 h-2',
     md: 'w-2.5 h-2.5',
@@ -30,7 +31,7 @@ export function StatusDot({ status, size = 'sm' }: StatusDotProps) {
         )}
       />
       {/* Pulse ring for running status */}
-      {status === 'running' && (
+      {pulse && status === 'running' && (
         <span
           className={cn(
             'absolute inset-0 rounded-full bg-status-running animate-ping opacity-40',


### PR DESCRIPTION
## Description

Extends the muted-by-default direction set by PR #559 (Skills Registry) into the Topology view. Idle nodes recede; selection becomes the only fully-saturated element on screen. Steady-state-good badges (Linked / Gateway Active / Running) unify to the Registry's low-profile recipe; abnormal-state badges (error/stopped/pending) keep full saturation.

## Changes Made

- **Idle border** unified to `border-border` (existing `#27272a` token, full opacity) across `GatewayNode`, `ClientNode`, `CustomNode`, `SkillNode`, `SkillGroupNode`. Visually unifies idle nodes with edge strokes.
- **Hover border** previews the selection color at WCAG-clearing intensity:
  - Amber nodes: `hover:border-primary/60` (~3.7:1)
  - Server (violet): `hover:border-violet-400/60` (~3.45:1)
  - Resource (teal): `hover:border-secondary/70` (~3.26:1)
  - Skill (tertiary): `hover:border-tertiary-light/60` (~3.45:1)
- **Selection** keeps existing brand-color border + glow + ring. `CustomNode` ring bumped from `ring-1` → `ring-2` for parity with other nodes (non-color signal per WCAG SC 2.4.13).
- **Status badges** restyled to Registry recipe (`text-[10px] px-1.5 py-0.5 rounded font-medium border bg-{tone}/10 border-{tone}/25`):
  - `ClientNode` "Linked"
  - `GatewayNode` "Gateway Active"
  - `CustomNode` running status (rendered conditionally; abnormal statuses keep the existing saturated `<Badge>`)
- **Gateway metric icons** dimmed to 70% (`text-primary/70`) for Server / Database / Radio / Monitor / Wrench / Library so the white numerical values become the primary read. Header logo, Code Mode badge icon, and Zap flourish kept at full opacity.

## Out of Scope

- Edge stroke styling (`.react-flow__edge-path` in `index.css`) — left untouched per evaluation.
- `<Badge>` primitive extraction — deferred until a third muted-badge consumer emerges.
- Live traffic / edge animation as a focus driver — separate concern.
- `prefers-reduced-motion` block — global rule at `index.css:684–692` already covers all transitions and animations.

## Accessibility

| Surface | Value | Contrast vs `#08080a` |
|---|---|---|
| Idle border | `border-border` (#27272a) | 1.36:1 (decorative tier) |
| Hover border (amber) | `border-primary/60` | ~3.7:1 |
| Hover border (violet-400) | `border-violet-400/60` | ~3.45:1 |
| Hover border (teal) | `border-secondary/70` | ~3.26:1 |
| Hover border (tertiary-light) | `border-tertiary-light/60` | ~3.45:1 |
| Selected border (amber) | `border-primary` | 9.32:1 |
| Selected border (violet) | `border-violet-500` | ~4.5:1 |
| Selected border (teal) | `border-secondary` | ~5.3:1 |
| Selected border (tertiary) | `border-tertiary` | ~4.5:1 |
| Gateway metric icon @ 70% | `text-primary/70` on `bg-primary/10` panel | ~4.68:1 |

**Honest note:** the idle border at 1.36:1 is below WCAG SC 1.4.11's 3:1 minimum for interactive UI components. This matches the project's de facto standard set by PR #559 (which uses `border-white/[0.08]` for Skills Registry cards, even lower contrast). Selected, hover, and badge boundaries all clear 3:1. Promoting idle borders to a strict-3:1 baseline would be a project-wide tone shift outside this PR's scope.

## Testing

- `tsc -b --noEmit` — clean
- `npm run lint` — 0 new errors / warnings in touched files
- `npm run test` — 493/493 passing
- `npm run build` — production build succeeds

Manual QA:
- [ ] Idle scan: all node types render with neutral structural border
- [ ] Hover preview: each node type previews its accent color at lower intensity
- [ ] Click-to-select: brand-color border + glow + 2px ring on selected; unrelated nodes/edges dim via existing `usePathHighlight`
- [ ] Selected state visible without color (verify via DevTools grayscale)
- [ ] Linked / Gateway Active / Running badges visually align with Registry `StateBadge` / `TestStatusBadge`
- [ ] Abnormal-state badges (error/stopped/pending) retain saturation
- [ ] Heat glow on `CustomNode` still appears under load
- [ ] `prefers-reduced-motion` disables animations (existing global rule)

## Type of Change

- [x] Refactor

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #560