### PR TITLE
fix: telemetry persistence write and seed gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to gridctl will be documented in this file.
 
+## [Unreleased]
+
+
+### Bug Fixes
+
+
+- Telemetry persistence write and seed gaps (#550 follow-up)
+
 ## [0.1.0-beta.8] - 2026-05-05
 
 

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -277,6 +277,29 @@ func (b *GatewayBuilder) seedTracesFromDisk(handler slog.Handler) {
 	}
 }
 
+// seedMetricsFromDisk replays any existing per-server metrics.jsonl into the
+// accumulator's per-server totals AND the flusher's previous-snapshot map.
+// Called from buildAPIServer after the flusher is constructed but before any
+// Build phase can drive live tool calls — so seeded counters precede live
+// observations and the first post-restart flush computes a real diff against
+// the seeded baseline.
+func (b *GatewayBuilder) seedMetricsFromDisk(handler slog.Handler) {
+	if b.stack == nil || b.telemetry == nil || b.telemetry.metricsFlusher == nil {
+		return
+	}
+	logger := slog.New(handler)
+	for i := range b.stack.MCPServers {
+		srv := &b.stack.MCPServers[i]
+		if srv.Name == "" || !srv.PersistMetrics(b.stack) {
+			continue
+		}
+		path := state.TelemetryServerPath(b.stack.Name, srv.Name, "metrics")
+		if err := b.telemetry.metricsFlusher.SeedFromFile(path, telemetrySeedLimit); err != nil {
+			logger.Warn("telemetry: seed metrics failed", "server", srv.Name, "path", path, "error", err)
+		}
+	}
+}
+
 // Run starts the HTTP server, registers MCP servers, and blocks until shutdown.
 func (b *GatewayBuilder) Run(ctx context.Context, inst *GatewayInstance, verbose bool) error {
 	gateway := inst.Gateway
@@ -521,6 +544,14 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 
 	// Apply the current stack's per-server persistence settings.
 	b.applyTelemetryConfig(server, handler)
+
+	// Seed the metrics accumulator from disk after writers are registered
+	// (so per-server directories exist) and before the flusher goroutine
+	// starts in Run. The seed updates both the accumulator's per-server
+	// totals and the flusher's prev map atomically — so the first post-
+	// restart flush emits a real diff against the seeded baseline rather
+	// than a fresh reset.
+	b.seedMetricsFromDisk(handler)
 
 	return server, nil
 }

--- a/pkg/controller/gateway_builder_test.go
+++ b/pkg/controller/gateway_builder_test.go
@@ -1,9 +1,12 @@
 package controller
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +15,7 @@ import (
 	"github.com/gridctl/gridctl/pkg/logging"
 	"github.com/gridctl/gridctl/pkg/mcp"
 	"github.com/gridctl/gridctl/pkg/runtime"
+	"github.com/gridctl/gridctl/pkg/state"
 	"github.com/gridctl/gridctl/pkg/vault"
 )
 
@@ -401,6 +405,71 @@ func TestGatewayBuilder_Build_WebFSSuccess(t *testing.T) {
 	}
 }
 
+
+// TestGatewayBuilder_PersistedLogsArriveOnDisk drives a record through the
+// canonical pkg/mcp/gateway pattern (clientLogger := g.logger.With("server", name))
+// and asserts the per-server logs.jsonl receives the entry. Locks in the
+// router-side fix that recognizes "server" as a routing key.
+func TestGatewayBuilder_PersistedLogsArriveOnDisk(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	regDir := t.TempDir()
+	stack := &config.Stack{
+		Name: "teststack",
+		Telemetry: &config.TelemetryConfig{
+			Persist: config.TelemetryPersistence{Logs: true},
+		},
+		MCPServers: []config.MCPServer{
+			{Name: "github"},
+		},
+	}
+	cfg := Config{Port: 8181}
+	rt := runtime.NewOrchestrator(nil, nil)
+	builder := NewGatewayBuilder(cfg, stack, "/path/stack.yaml", rt, &runtime.UpResult{})
+	builder.registryDir = regDir
+
+	inst, err := builder.Build(false)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	// Mirror gateway.go:900: clientLogger := logger.With("server", name).
+	clientLogger := slog.New(inst.Handler).With("server", "github")
+	clientLogger.Info("server registered", "transport", "stdio")
+
+	// Lumberjack writes through synchronously inside slog handler, so the
+	// file should be non-empty by the time Handle returns. Read it and
+	// verify the message round-trips through JSON.
+	path := state.TelemetryServerPath(stack.Name, "github", "logs")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	var entries []map[string]any
+	for scanner.Scan() {
+		var rec map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &rec); err != nil {
+			t.Fatalf("malformed json line %q: %v", scanner.Text(), err)
+		}
+		entries = append(entries, rec)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("logs.jsonl is empty — record was not routed to disk via server attr")
+	}
+	if got := entries[0]["msg"]; got != "server registered" {
+		t.Errorf("msg = %v, want %q", got, "server registered")
+	}
+	if got := entries[0]["server"]; got != "github" {
+		t.Errorf("server attr lost on disk: %v", entries[0])
+	}
+}
 
 func TestNewGatewayBuilder_Fields(t *testing.T) {
 	cfg := Config{Port: 8080, NoExpand: true}

--- a/pkg/metrics/accumulator.go
+++ b/pkg/metrics/accumulator.go
@@ -481,10 +481,10 @@ func downsampleToHour(buckets []bucket) []DataPoint {
 // repopulate cumulative counters from a persisted metrics.jsonl file.
 //
 // Existing per-server counters are overwritten for any server present in the
-// map; servers absent from the map retain their current state. Replicas,
-// time-series buckets, and format-savings counters are not restored — those
-// carry no on-disk equivalent in the snapshot format and reset to zero
-// post-restart, accruing fresh data as live activity resumes.
+// map; servers absent from the map retain their current state. Replicas and
+// format-savings counters are not restored — those carry no on-disk
+// equivalent in the snapshot format. Time-series ring buckets are populated
+// separately via ReplaySnapshot.
 func (a *Accumulator) Restore(perServer map[string]TokenCounts) {
 	if len(perServer) == 0 {
 		return
@@ -510,6 +510,30 @@ func (a *Accumulator) Restore(perServer map[string]TokenCounts) {
 	}
 	a.sessionInput.Store(sessionIn)
 	a.sessionOutput.Store(sessionOut)
+}
+
+// ReplaySnapshot adds a historical observation to the time-series ring
+// buffers (aggregate + per-server) without touching cumulative counters.
+// Used by telemetry.MetricsFlusher.SeedFromFile to rehydrate per-minute
+// bucket history from each persisted Diff line — the chart shows pre-restart
+// activity continuously alongside live data instead of resetting to a single
+// post-restart point.
+//
+// Cumulative counters are restored separately via Restore. Calling both with
+// the same source data reproduces the on-disk state.
+//
+// ts is bucketed to the minute via the same key the live Record path uses,
+// so chronological replay produces one bucket per flush minute and live
+// observations after replay continue advancing the same ring naturally.
+func (a *Accumulator) ReplaySnapshot(serverName string, ts time.Time, inputTokens, outputTokens int64) {
+	if inputTokens == 0 && outputTokens == 0 {
+		return
+	}
+	bucket := bucketKey(ts)
+	a.addToBucket(bucket, inputTokens, outputTokens)
+	if serverName != "" {
+		a.addToServerBucket(serverName, bucket, inputTokens, outputTokens)
+	}
 }
 
 // Clear resets all metrics — session totals, per-server totals, and history.

--- a/pkg/metrics/accumulator.go
+++ b/pkg/metrics/accumulator.go
@@ -475,6 +475,43 @@ func downsampleToHour(buckets []bucket) []DataPoint {
 	return result
 }
 
+// Restore replaces per-server token totals with the supplied map and
+// recomputes session totals as the sum across all servers (matching the
+// invariant Record/RecordReplica maintains). Used on daemon startup to
+// repopulate cumulative counters from a persisted metrics.jsonl file.
+//
+// Existing per-server counters are overwritten for any server present in the
+// map; servers absent from the map retain their current state. Replicas,
+// time-series buckets, and format-savings counters are not restored — those
+// carry no on-disk equivalent in the snapshot format and reset to zero
+// post-restart, accruing fresh data as live activity resumes.
+func (a *Accumulator) Restore(perServer map[string]TokenCounts) {
+	if len(perServer) == 0 {
+		return
+	}
+
+	a.serverMu.Lock()
+	defer a.serverMu.Unlock()
+
+	for name, counts := range perServer {
+		sc, ok := a.servers[name]
+		if !ok {
+			sc = &serverCounters{}
+			a.servers[name] = sc
+		}
+		sc.inputTokens.Store(counts.InputTokens)
+		sc.outputTokens.Store(counts.OutputTokens)
+	}
+
+	var sessionIn, sessionOut int64
+	for _, sc := range a.servers {
+		sessionIn += sc.inputTokens.Load()
+		sessionOut += sc.outputTokens.Load()
+	}
+	a.sessionInput.Store(sessionIn)
+	a.sessionOutput.Store(sessionOut)
+}
+
 // Clear resets all metrics — session totals, per-server totals, and history.
 func (a *Accumulator) Clear() {
 	a.sessionInput.Store(0)

--- a/pkg/telemetry/logs.go
+++ b/pkg/telemetry/logs.go
@@ -16,14 +16,14 @@ import (
 
 // LogRouter is a slog.Handler that fans every record out to the inner handler
 // (the existing buffer/redact chain that powers the UI) AND, when a record's
-// resolved `component` attribute matches a configured server, to a per-server
-// lumberjack file. The component attribute is set today by every server-bound
-// logger via `logger.With("component", serverName)` — slog stores that on the
-// derived handler, not on the record, so this router tracks its own
-// accumulated attrs across WithAttrs/WithGroup the way BufferHandler does.
+// resolved server attribute matches a configured server, to a per-server
+// lumberjack file. The routing key is `component` when present and `server`
+// otherwise — gridctl's older subsystems (e.g. pkg/mcp/gateway) tag per-server
+// loggers with `.With("server", name)`, while newer code uses
+// `.With("component", name)`. Both shapes route correctly; `component` wins
+// when both are present in the same logger view.
 //
-// Records without a configured component pass through to the inner handler
-// only.
+// Records without a routing-key match pass through to the inner handler only.
 type LogRouter struct {
 	inner slog.Handler
 
@@ -190,10 +190,16 @@ func (r *LogRouter) Handle(ctx context.Context, record slog.Record) error {
 	return innerErr
 }
 
-// resolveComponent looks up `component` in accumulated handler-level attrs
+// resolveComponent looks up the routing key in accumulated handler-level attrs
 // first (set via .With at construction time on the per-server logger), then
 // falls back to the record's own attrs. The router-level value wins because
 // .With is the canonical way every gridctl component tags itself.
+//
+// Both `component` and `server` are accepted as routing keys; `component`
+// takes precedence when both appear in a single attr surface. This bridges
+// the convention used by pkg/mcp/gateway (`.With("server", name)`) with the
+// canonical `component` key used by newer code without forcing either side
+// to change.
 //
 // Records emitted by the router's own self logger are tagged `subsystem=
 // telemetry`; routing those would feed write-failure warnings back into the
@@ -205,15 +211,20 @@ func (r *LogRouter) resolveComponent(record slog.Record) string {
 	if r.component != "" {
 		return r.component
 	}
-	var component string
+	var componentVal, serverVal string
 	record.Attrs(func(a slog.Attr) bool {
-		if a.Key == "component" {
-			component = a.Value.String()
-			return false
+		switch a.Key {
+		case "component":
+			componentVal = a.Value.String()
+		case "server":
+			serverVal = a.Value.String()
 		}
 		return true
 	})
-	return component
+	if componentVal != "" {
+		return componentVal
+	}
+	return serverVal
 }
 
 // isSelfLog returns true when this record was produced by the router's own
@@ -239,7 +250,9 @@ func (r *LogRouter) isSelfLog(record slog.Record) bool {
 
 // WithAttrs implements slog.Handler. Returns a derived router that carries
 // the additional attrs alongside the inner-with-attrs handler. The shared
-// per-server map is unchanged.
+// per-server map is unchanged. Both `component` and `server` are recognized
+// as routing keys; `component` takes precedence when both appear in the same
+// attrs slice.
 func (r *LogRouter) WithAttrs(attrs []slog.Attr) slog.Handler {
 	derived := &LogRouter{
 		inner:     r.inner.WithAttrs(attrs),
@@ -248,10 +261,19 @@ func (r *LogRouter) WithAttrs(attrs []slog.Attr) slog.Handler {
 		servers:   r.servers,
 		selfLog:   r.selfLog,
 	}
+	var componentVal, serverVal string
 	for _, a := range attrs {
-		if a.Key == "component" {
-			derived.component = a.Value.String()
+		switch a.Key {
+		case "component":
+			componentVal = a.Value.String()
+		case "server":
+			serverVal = a.Value.String()
 		}
+	}
+	if componentVal != "" {
+		derived.component = componentVal
+	} else if serverVal != "" {
+		derived.component = serverVal
 	}
 	return derived
 }

--- a/pkg/telemetry/logs_test.go
+++ b/pkg/telemetry/logs_test.go
@@ -105,6 +105,87 @@ func TestLogRouter_RemoveServerStopsWriting(t *testing.T) {
 	}
 }
 
+// TestLogRouter_RoutesByServerAttribute exercises the `server` routing-key
+// fallback. pkg/mcp/gateway tags per-server loggers with `.With("server", name)`
+// rather than `component`; without this fallback those records would never
+// reach the per-server file fan-out.
+func TestLogRouter_RoutesByServerAttribute(t *testing.T) {
+	dir := t.TempDir()
+	githubPath := filepath.Join(dir, "github.jsonl")
+
+	buf := logging.NewLogBuffer(10)
+	router := NewLogRouter(logging.NewBufferHandler(buf, nil))
+	t.Cleanup(router.Close)
+	if err := router.AddServer("github", githubPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer github: %v", err)
+	}
+
+	// Mirror the pattern at pkg/mcp/gateway.go: clientLogger := logger.With("server", name).
+	logger := slog.New(router).With("server", "github")
+	logger.Info("hit github tool", "tool", "list_repos")
+
+	lines := readJSONLines(t, githubPath)
+	if len(lines) != 1 {
+		t.Errorf("github file got %d lines, want 1; lines=%v", len(lines), lines)
+	} else if msg := lines[0]["msg"]; msg != "hit github tool" {
+		t.Errorf("github line msg = %v, want %q", msg, "hit github tool")
+	}
+}
+
+// TestLogRouter_RoutesByRecordLevelServerAttr covers the case where `server`
+// arrives only on the record itself (not via .With) — the resolveComponent
+// record-attrs scan must pick it up.
+func TestLogRouter_RoutesByRecordLevelServerAttr(t *testing.T) {
+	dir := t.TempDir()
+	githubPath := filepath.Join(dir, "github.jsonl")
+
+	buf := logging.NewLogBuffer(10)
+	router := NewLogRouter(logging.NewBufferHandler(buf, nil))
+	t.Cleanup(router.Close)
+	if err := router.AddServer("github", githubPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	slog.New(router).Info("inline server attr", "server", "github")
+
+	lines := readJSONLines(t, githubPath)
+	if len(lines) != 1 {
+		t.Errorf("github file got %d lines, want 1; lines=%v", len(lines), lines)
+	}
+}
+
+// TestLogRouter_ComponentTakesPrecedenceOverServer verifies that when both
+// `component` and `server` are set, `component` wins. Belt-and-braces against
+// any caller that ever ends up tagging both.
+func TestLogRouter_ComponentTakesPrecedenceOverServer(t *testing.T) {
+	dir := t.TempDir()
+	githubPath := filepath.Join(dir, "github.jsonl")
+	weatherPath := filepath.Join(dir, "weather.jsonl")
+
+	buf := logging.NewLogBuffer(10)
+	router := NewLogRouter(logging.NewBufferHandler(buf, nil))
+	t.Cleanup(router.Close)
+	if err := router.AddServer("github", githubPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer github: %v", err)
+	}
+	if err := router.AddServer("weather", weatherPath, LogOpts{}); err != nil {
+		t.Fatalf("AddServer weather: %v", err)
+	}
+
+	// Both keys present in the same WithAttrs call — component must win.
+	logger := slog.New(router).With("component", "github", "server", "weather")
+	logger.Info("hi")
+
+	githubLines := readJSONLines(t, githubPath)
+	weatherLines := readJSONLines(t, weatherPath)
+	if len(githubLines) != 1 {
+		t.Errorf("github lines = %d, want 1 (component should win)", len(githubLines))
+	}
+	if len(weatherLines) != 0 {
+		t.Errorf("weather lines = %d, want 0 (component should win)", len(weatherLines))
+	}
+}
+
 func TestLogRouter_EnabledHandlesNilInner(t *testing.T) {
 	// Defensive — Enabled must not panic if a derived child handler ever
 	// has a nil inner. Today inner is always non-nil but the Handle path

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -1,10 +1,12 @@
 package telemetry
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -287,6 +289,82 @@ func isCounterReset(prev, current metrics.TokenCounts) bool {
 	return current.InputTokens < prev.InputTokens ||
 		current.OutputTokens < prev.OutputTokens ||
 		current.TotalTokens < prev.TotalTokens
+}
+
+// SeedFromFile reads up to the last n NDJSON entries from path and seeds
+// both the accumulator's per-server totals and this flusher's previous-
+// snapshot map. Both surfaces are updated atomically so the next flushOnce
+// computes a real diff against the seeded baseline rather than re-emitting
+// history as a fresh reset.
+//
+// On-disk format mirrors flushOnce's output: full MetricsSnapshotLine entries
+// plus lighter reset sentinels ({reset, ts, server} only). Reset sentinels
+// have a zero Total in the parsed line and are immediately followed by a full
+// reset line whose Total carries the post-reset state — so taking the most
+// recent Total per server yields the correct seed value in either case.
+//
+// Missing or empty files return nil (expected on first run with persistence
+// enabled). Malformed lines are skipped without aborting; a single corrupt
+// line should not lose the rest of the history.
+func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
+	if path == "" || f.acc == nil {
+		return nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("seed metrics from %q: %w", path, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("seed metrics scan %q: %w", path, err)
+	}
+
+	if n > 0 && len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+
+	// Latest Total per server. Reset sentinels parse with zero Total and are
+	// always followed by the matching full reset line — taking the most
+	// recent value lets the natural ordering produce the right answer.
+	latest := make(map[string]metrics.TokenCounts)
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec MetricsSnapshotLine
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec.Server == "" {
+			continue
+		}
+		latest[rec.Server] = rec.Total
+	}
+
+	if len(latest) == 0 {
+		return nil
+	}
+
+	// Seed accumulator and prev map under the same lock so the next
+	// flushOnce sees a consistent baseline.
+	f.mu.Lock()
+	for name, counts := range latest {
+		f.prev[name] = counts
+	}
+	f.mu.Unlock()
+	f.acc.Restore(latest)
+	return nil
 }
 
 // touchMode0600 ensures the file exists with mode 0600. lumberjack would

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -292,16 +292,22 @@ func isCounterReset(prev, current metrics.TokenCounts) bool {
 }
 
 // SeedFromFile reads up to the last n NDJSON entries from path and seeds
-// both the accumulator's per-server totals and this flusher's previous-
-// snapshot map. Both surfaces are updated atomically so the next flushOnce
-// computes a real diff against the seeded baseline rather than re-emitting
-// history as a fresh reset.
+// three surfaces atomically: cumulative per-server totals (via Restore),
+// per-minute time-series ring buckets (via ReplaySnapshot), and this
+// flusher's previous-snapshot map. The Token Usage Over Time chart in the
+// UI is backed by the time-series ring; without the bucket replay it would
+// show only a single post-restart point.
 //
-// On-disk format mirrors flushOnce's output: full MetricsSnapshotLine entries
-// plus lighter reset sentinels ({reset, ts, server} only). Reset sentinels
-// have a zero Total in the parsed line and are immediately followed by a full
+// On-disk format mirrors flushOnce's output: full MetricsSnapshotLine
+// entries plus lighter reset sentinels ({reset, ts, server} only). Reset
+// sentinels parse with a zero Total and are immediately followed by a full
 // reset line whose Total carries the post-reset state — so taking the most
 // recent Total per server yields the correct seed value in either case.
+//
+// For time-series, only non-reset lines are replayed: a Reset line's Diff
+// carries the carry-over from prior sessions (full snapshot), not a single
+// minute's activity, so replaying it would create a synthetic spike at the
+// reset boundary.
 //
 // Missing or empty files return nil (expected on first run with persistence
 // enabled). Malformed lines are skipped without aborting; a single corrupt
@@ -333,10 +339,18 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 		lines = lines[len(lines)-n:]
 	}
 
-	// Latest Total per server. Reset sentinels parse with zero Total and are
-	// always followed by the matching full reset line — taking the most
-	// recent value lets the natural ordering produce the right answer.
+	type seriesPoint struct {
+		server string
+		ts     time.Time
+		input  int64
+		output int64
+	}
+
+	// Latest Total per server feeds Restore + prev. Non-reset Diff entries
+	// feed ReplaySnapshot in chronological file order so per-minute buckets
+	// appear in the same shape they had during live operation.
 	latest := make(map[string]metrics.TokenCounts)
+	var series []seriesPoint
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -350,20 +364,37 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 			continue
 		}
 		latest[rec.Server] = rec.Total
+		if rec.Reset {
+			continue
+		}
+		if rec.Diff.InputTokens == 0 && rec.Diff.OutputTokens == 0 {
+			continue
+		}
+		series = append(series, seriesPoint{
+			server: rec.Server,
+			ts:     rec.Time,
+			input:  rec.Diff.InputTokens,
+			output: rec.Diff.OutputTokens,
+		})
 	}
 
 	if len(latest) == 0 {
 		return nil
 	}
 
-	// Seed accumulator and prev map under the same lock so the next
-	// flushOnce sees a consistent baseline.
+	// Replay time-series buckets first so the ring buffer fills in
+	// chronological order; then restore cumulative counters; then seed
+	// the flusher's prev map under the lock so the next flushOnce
+	// computes a real diff against the seeded baseline.
+	for _, p := range series {
+		f.acc.ReplaySnapshot(p.server, p.ts, p.input, p.output)
+	}
+	f.acc.Restore(latest)
 	f.mu.Lock()
 	for name, counts := range latest {
 		f.prev[name] = counts
 	}
 	f.mu.Unlock()
-	f.acc.Restore(latest)
 	return nil
 }
 

--- a/pkg/telemetry/metrics_test.go
+++ b/pkg/telemetry/metrics_test.go
@@ -333,6 +333,64 @@ func TestMetricsFlusher_SeedFromFile(t *testing.T) {
 		}
 	})
 
+	t.Run("non-reset diffs replay as time-series buckets", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		// Two flush windows, each with a real Diff. The first line is a
+		// Reset line (carry-over from previous session) — its Diff should
+		// NOT replay into the time-series. The next two lines are normal
+		// diffs and SHOULD show up in the per-minute ring.
+		base := time.Now().UTC().Truncate(time.Minute).Add(-3 * time.Minute)
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:   base,
+			Server: "github",
+			Reset:  true,
+			Diff:   metrics.TokenCounts{InputTokens: 10000, OutputTokens: 5000, TotalTokens: 15000},
+			Total:  metrics.TokenCounts{InputTokens: 10000, OutputTokens: 5000, TotalTokens: 15000},
+		})
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:   base.Add(time.Minute),
+			Server: "github",
+			Diff:   metrics.TokenCounts{InputTokens: 7, OutputTokens: 3, TotalTokens: 10},
+			Total:  metrics.TokenCounts{InputTokens: 10007, OutputTokens: 5003, TotalTokens: 15010},
+		})
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:   base.Add(2 * time.Minute),
+			Server: "github",
+			Diff:   metrics.TokenCounts{InputTokens: 11, OutputTokens: 5, TotalTokens: 16},
+			Total:  metrics.TokenCounts{InputTokens: 10018, OutputTokens: 5008, TotalTokens: 15026},
+		})
+
+		acc := metrics.NewAccumulator(100)
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.SeedFromFile(path, 100); err != nil {
+			t.Fatalf("SeedFromFile: %v", err)
+		}
+
+		ts := acc.Query(10 * time.Minute)
+		points, ok := ts.PerServer["github"]
+		if !ok {
+			t.Fatalf("github time-series missing from Query: %+v", ts.PerServer)
+		}
+		// The Reset line must NOT show up — only the two real diffs.
+		if len(points) != 2 {
+			t.Errorf("github points = %d; want 2 (Reset Diff should be skipped). points=%+v", len(points), points)
+		}
+		var totalIn, totalOut int64
+		for _, p := range points {
+			totalIn += p.InputTokens
+			totalOut += p.OutputTokens
+		}
+		if totalIn != 18 || totalOut != 8 {
+			t.Errorf("replayed totals = (%d,%d); want (18, 8) — only the two non-reset Diffs", totalIn, totalOut)
+		}
+		// Aggregate ring should also have the same minute-buckets.
+		if len(ts.Points) != 2 {
+			t.Errorf("aggregate points = %d; want 2", len(ts.Points))
+		}
+	})
+
 	t.Run("post-seed flush emits diff not reset", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "metrics.jsonl")

--- a/pkg/telemetry/metrics_test.go
+++ b/pkg/telemetry/metrics_test.go
@@ -213,6 +213,198 @@ func TestMetricsFlusher_StartStopFinalFlush(t *testing.T) {
 	}
 }
 
+func TestMetricsFlusher_SeedFromFile(t *testing.T) {
+	t.Run("missing file is no-op", func(t *testing.T) {
+		acc := metrics.NewAccumulator(100)
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.SeedFromFile(filepath.Join(t.TempDir(), "missing.jsonl"), 100); err != nil {
+			t.Errorf("missing file should not error: %v", err)
+		}
+		if got := acc.Snapshot().Session.TotalTokens; got != 0 {
+			t.Errorf("session total = %d after missing-file seed; want 0", got)
+		}
+	})
+
+	t.Run("empty file is no-op", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatalf("write empty file: %v", err)
+		}
+		acc := metrics.NewAccumulator(100)
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.SeedFromFile(path, 100); err != nil {
+			t.Errorf("empty file should not error: %v", err)
+		}
+		if got := acc.Snapshot().Session.TotalTokens; got != 0 {
+			t.Errorf("session total = %d after empty-file seed; want 0", got)
+		}
+	})
+
+	t.Run("single line seeds totals and prev", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		// Write a single full snapshot line for github.
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:   time.Now().UTC(),
+			Server: "github",
+			Reset:  true,
+			Diff:   metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+			Total:  metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+		})
+
+		acc := metrics.NewAccumulator(100)
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.SeedFromFile(path, 100); err != nil {
+			t.Fatalf("SeedFromFile: %v", err)
+		}
+
+		snap := acc.Snapshot()
+		if got := snap.Session.TotalTokens; got != 150 {
+			t.Errorf("session total = %d; want 150", got)
+		}
+		if got, ok := snap.PerServer["github"]; !ok || got.TotalTokens != 150 {
+			t.Errorf("per-server github = %+v; want total 150", got)
+		}
+
+		// prev must mirror the seeded total so the next flushOnce produces a
+		// real diff rather than a fresh reset.
+		f.mu.Lock()
+		prev, ok := f.prev["github"]
+		f.mu.Unlock()
+		if !ok || prev.TotalTokens != 150 {
+			t.Errorf("prev[github] = %+v (ok=%v); want total 150", prev, ok)
+		}
+	})
+
+	t.Run("reset sentinel mid-stream uses post-reset totals", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		// Pre-reset history.
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:   time.Now().UTC(),
+			Server: "github",
+			Reset:  true,
+			Diff:   metrics.TokenCounts{InputTokens: 1000, OutputTokens: 500, TotalTokens: 1500},
+			Total:  metrics.TokenCounts{InputTokens: 1000, OutputTokens: 500, TotalTokens: 1500},
+		})
+		// Reset sentinel (lightweight form — reset/ts/server only).
+		writeRawLine(t, path, `{"reset":true,"ts":"2026-05-06T00:00:00Z","server":"github"}`)
+		// Post-reset full line with smaller totals.
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:   time.Now().UTC(),
+			Server: "github",
+			Reset:  true,
+			Diff:   metrics.TokenCounts{InputTokens: 25, OutputTokens: 10, TotalTokens: 35},
+			Total:  metrics.TokenCounts{InputTokens: 25, OutputTokens: 10, TotalTokens: 35},
+		})
+
+		acc := metrics.NewAccumulator(100)
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.SeedFromFile(path, 100); err != nil {
+			t.Fatalf("SeedFromFile: %v", err)
+		}
+		got := acc.Snapshot().PerServer["github"]
+		if got.TotalTokens != 35 {
+			t.Errorf("github total = %d after post-reset seed; want 35", got.TotalTokens)
+		}
+	})
+
+	t.Run("malformed line is skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		writeRawLine(t, path, `{not json`)
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:   time.Now().UTC(),
+			Server: "github",
+			Total:  metrics.TokenCounts{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		})
+
+		acc := metrics.NewAccumulator(100)
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.SeedFromFile(path, 100); err != nil {
+			t.Fatalf("SeedFromFile: %v", err)
+		}
+		if got := acc.Snapshot().PerServer["github"].TotalTokens; got != 15 {
+			t.Errorf("github total = %d; want 15 (malformed line should not block valid one)", got)
+		}
+	})
+
+	t.Run("post-seed flush emits diff not reset", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		// Seed with a baseline.
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:   time.Now().UTC(),
+			Server: "github",
+			Reset:  true,
+			Diff:   metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+			Total:  metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+		})
+
+		acc := metrics.NewAccumulator(100)
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.AddServer("github", path, LogOpts{}); err != nil {
+			t.Fatalf("AddServer: %v", err)
+		}
+		if err := f.SeedFromFile(path, 100); err != nil {
+			t.Fatalf("SeedFromFile: %v", err)
+		}
+
+		// Live activity post-restart.
+		acc.Record("github", 25, 10)
+		f.flushOnce(time.Now())
+
+		lines := readMetricsLines(t, path)
+		// Expect exactly one new line appended (a non-reset diff). No
+		// extra reset sentinel — that would mean prev was not seeded.
+		// The seed line is the original one written; the new line is last.
+		if len(lines) < 2 {
+			t.Fatalf("expected at least 2 lines after post-seed flush, got %d: %v", len(lines), lines)
+		}
+		var last MetricsSnapshotLine
+		if err := json.Unmarshal([]byte(lines[len(lines)-1]), &last); err != nil {
+			t.Fatalf("unmarshal last line: %v", err)
+		}
+		if last.Reset {
+			t.Errorf("post-seed flush emitted reset=true; prev was not seeded correctly. line=%s", lines[len(lines)-1])
+		}
+		if last.Diff.InputTokens != 25 || last.Diff.OutputTokens != 10 {
+			t.Errorf("post-seed diff = %+v; want {25,10,35} (only the new activity)", last.Diff)
+		}
+		if last.Total.InputTokens != 125 || last.Total.OutputTokens != 60 {
+			t.Errorf("post-seed total = %+v; want {125,60,185} (seeded baseline + new activity)", last.Total)
+		}
+	})
+}
+
+// writeMetricsLine appends one MetricsSnapshotLine as NDJSON to path.
+func writeMetricsLine(t *testing.T, path string, line MetricsSnapshotLine) {
+	t.Helper()
+	data, err := json.Marshal(line)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	writeRawLine(t, path, string(data))
+}
+
+// writeRawLine appends a raw line + newline to path.
+func writeRawLine(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
 func readMetricsLines(t *testing.T, path string) []string {
 	t.Helper()
 	f, err := os.Open(path)

--- a/pkg/telemetry/seed_test.go
+++ b/pkg/telemetry/seed_test.go
@@ -199,6 +199,25 @@ func TestEndToEnd_MetricsPersistAndReseed(t *testing.T) {
 		t.Errorf("seeded session total = %d; want 185", got)
 	}
 
+	// Pre-restart time-series buckets should also come back so the Token
+	// Usage Over Time chart shows pre-restart history continuously rather
+	// than a single post-restart point. The first flush is a Reset line
+	// (carry-over) and is intentionally skipped; only the second flush's
+	// Diff (25 in / 10 out) replays into the per-minute ring.
+	ts := acc2.Query(time.Hour)
+	githubPoints := ts.PerServer["github"]
+	if len(githubPoints) == 0 {
+		t.Errorf("github time-series points = 0 after seed; chart would be empty")
+	}
+	var seriesIn, seriesOut int64
+	for _, p := range githubPoints {
+		seriesIn += p.InputTokens
+		seriesOut += p.OutputTokens
+	}
+	if seriesIn != 25 || seriesOut != 10 {
+		t.Errorf("seeded series totals = (%d,%d); want (25, 10) — only the non-reset Diff", seriesIn, seriesOut)
+	}
+
 	// Live activity post-restart. flushOnce must emit a non-reset diff
 	// against the seeded baseline rather than re-emitting the seeded
 	// totals as if they were fresh.

--- a/pkg/telemetry/seed_test.go
+++ b/pkg/telemetry/seed_test.go
@@ -2,13 +2,16 @@ package telemetry
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gridctl/gridctl/pkg/logging"
+	"github.com/gridctl/gridctl/pkg/metrics"
 	"github.com/gridctl/gridctl/pkg/tracing"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
@@ -147,6 +150,94 @@ func TestTracingBuffer_SeedFromFile_MissingFileNoError(t *testing.T) {
 	if got := buf.Count(); got != 0 {
 		t.Errorf("seeded buffer count = %d, want 0", got)
 	}
+}
+
+// TestEndToEnd_MetricsPersistAndReseed simulates a daemon restart with
+// metrics persistence enabled: record token usage, flush to disk, throw
+// away the accumulator + flusher, seed a fresh accumulator + flusher from
+// the same file, and verify the totals come back AND the very next live
+// flush emits a real diff (no reset, no double-counting).
+func TestEndToEnd_MetricsPersistAndReseed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+
+	// === Daemon "instance 1" ===
+	acc1 := metrics.NewAccumulator(100)
+	f1 := NewMetricsFlusher(acc1, time.Hour)
+	if err := f1.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	acc1.Record("github", 100, 50)
+	f1.flushOnce(time.Now())
+	acc1.Record("github", 25, 10)
+	f1.flushOnce(time.Now())
+
+	// "Restart": close instance 1's writers so the file is fully flushed.
+	f1.mu.Lock()
+	for _, lj := range f1.writers {
+		_ = lj.Close()
+	}
+	f1.mu.Unlock()
+
+	// === Daemon "instance 2" ===
+	acc2 := metrics.NewAccumulator(100)
+	f2 := NewMetricsFlusher(acc2, time.Hour)
+	if err := f2.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	if err := f2.SeedFromFile(path, 100); err != nil {
+		t.Fatalf("SeedFromFile: %v", err)
+	}
+
+	// Pre-restart totals should be visible immediately via the snapshot —
+	// this is the user-visible fix for "No token data yet" after restart.
+	snap := acc2.Snapshot()
+	if got := snap.PerServer["github"].TotalTokens; got != 185 {
+		t.Errorf("seeded github total = %d; want 185 (100+50+25+10)", got)
+	}
+	if got := snap.Session.TotalTokens; got != 185 {
+		t.Errorf("seeded session total = %d; want 185", got)
+	}
+
+	// Live activity post-restart. flushOnce must emit a non-reset diff
+	// against the seeded baseline rather than re-emitting the seeded
+	// totals as if they were fresh.
+	acc2.Record("github", 7, 3)
+	f2.flushOnce(time.Now())
+
+	// Read everything that's on disk and inspect the last full payload.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	lines := splitNonEmpty(string(data))
+	if len(lines) < 1 {
+		t.Fatalf("expected at least one line on disk, got 0")
+	}
+	var last MetricsSnapshotLine
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &last); err != nil {
+		t.Fatalf("unmarshal last line: %v", err)
+	}
+	if last.Reset {
+		t.Errorf("post-seed flush emitted reset=true; prev map was not seeded. line=%s", lines[len(lines)-1])
+	}
+	if last.Diff.InputTokens != 7 || last.Diff.OutputTokens != 3 {
+		t.Errorf("post-seed diff = %+v; want {7,3,10} (only post-restart activity)", last.Diff)
+	}
+	if last.Total.InputTokens != 132 || last.Total.OutputTokens != 63 {
+		t.Errorf("post-seed total = %+v; want {132,63,195} (seeded + live)", last.Total)
+	}
+}
+
+// splitNonEmpty splits on '\n' and discards empty entries.
+func splitNonEmpty(s string) []string {
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
 }
 
 // TestEndToEnd_PersistAndReseed simulates a daemon restart with persistence


### PR DESCRIPTION
## Description

Fixes two distinct defects in telemetry persistence shipped in v0.1.0-beta.8 (#550). Together they nullified the headline acceptance criterion: "Restart with persistence on seeds the Logs/Metrics/Traces tabs with pre-restart data on first load."

## Type of Change

- [x] Bug fix

## Changes Made

**Bug A — log write path (router-side fix only):**
- `pkg/mcp/gateway.go:900` tags per-server loggers with `.With("server", name)`, but `LogRouter.resolveComponent` only routed on `"component"` — every per-server `logs.jsonl` stayed at 0 bytes.
- `LogRouter.resolveComponent` and `WithAttrs` now accept either `component` or `server` as the routing key. `component` takes precedence when both are present.
- Producer (`pkg/mcp/gateway.go`) intentionally NOT modified — keeps any external log consumer parsing the existing `server` attr unaffected.

**Bug B — metrics seed gap:**
- No `SeedFromFile` for metrics, so the Metrics tab showed "No token data yet" after every restart even with persistence on.
- Added `Accumulator.Restore(perServer)` (totals-only, recomputes session sum from per-server totals).
- Added `Accumulator.ReplaySnapshot(server, ts, in, out)` to populate per-minute time-series ring buckets (aggregate + per-server) from the persisted `Diff` field of each NDJSON line. Without this, the Token Usage Over Time chart shows only a single post-restart point.
- Added `MetricsFlusher.SeedFromFile(path, n)` which combines all three surfaces: replays non-reset Diff entries into the time-series, restores cumulative Totals, and seeds the flusher's `prev` map. Reset lines (carry-over from prior sessions) are intentionally skipped for the time-series replay so they don't synthesize a spike at the reset boundary.
- Added `seedMetricsFromDisk` in `gateway_builder` after `applyTelemetryConfig`, before the flusher goroutine starts.
- Critical: seed atomically updates the accumulator AND the flusher's `prev` map so the first post-restart `flushOnce` emits a real diff against the seeded baseline (no Reset, no double-counting).

## Testing

- `go test -race ./...` — all packages pass
- `golangci-lint run ./...` — 0 issues

New tests:
- `pkg/telemetry/logs_test.go`: `TestLogRouter_RoutesByServerAttribute`, `TestLogRouter_RoutesByRecordLevelServerAttr`, `TestLogRouter_ComponentTakesPrecedenceOverServer`
- `pkg/telemetry/metrics_test.go`: `TestMetricsFlusher_SeedFromFile` covering missing/empty/single-line/reset-mid-stream/malformed/post-seed-flush AND time-series replay (Reset Diff is skipped, real Diffs become buckets)
- `pkg/telemetry/seed_test.go`: `TestEndToEnd_MetricsPersistAndReseed` (proves no double-counting on first post-restart flush AND that the Token Usage Over Time chart populates from disk)
- `pkg/controller/gateway_builder_test.go`: `TestGatewayBuilder_PersistedLogsArriveOnDisk` (drives the canonical `g.logger.With("server", name)` pattern through the real Build path and verifies JSON content on disk)

## Out of Scope

Per the investigation, these were intentionally not touched:
- `pkg/mcp/gateway.go` (producer-side `server` attr stays — fix is router-side only)
- `pkg/config/types.go` (resolvers are correct)
- Frontend, CLI

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #562