### PR TITLE
feat: cost KPI, cost-over-time chart, top clients panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to gridctl will be documented in this file.
 - Add `GET /api/metrics/cost?range={30m,1h,6h,24h,7d}&per_client=true` for cost-over-time time-series, mirroring the `/api/metrics/tokens` shape with optional per-client grouping.
 - Add `DELETE /api/metrics/cost`, which clears recorded cost data without touching the token counters or format-savings tally.
 - Extend `/api/status` with an additive, omitempty `cost` field carrying the session, per-server, per-client, and per-replica USD totals.
+- Surface cost in the Web UI Metrics tab: a session `$ Cost` KPI card beside Input/Output/Total tokens, a cost-over-time area chart that scales with the existing time-range selector, and a `Top Clients` panel summarizing per-client token and USD totals (sortable, default cost descending, hidden when no per-client attribution is present). Cost values render as `—` until the gateway has priced any calls, never a fabricated number.
 
 ### Bug Fixes
 

--- a/web/src/components/metrics/MetricsTab.tsx
+++ b/web/src/components/metrics/MetricsTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo, type ComponentType } from 'react';
 import {
   Pause,
   Play,
@@ -9,23 +9,27 @@ import {
   ArrowDown,
   AlertCircle,
   RefreshCw,
+  DollarSign,
+  Users,
 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { IconButton } from '../ui/IconButton';
 import { PopoutButton } from '../ui/PopoutButton';
 import { useUIStore } from '../../stores/useUIStore';
 import { useStackStore } from '../../stores/useStackStore';
-import { fetchTokenMetrics, clearTokenMetrics } from '../../lib/api';
+import { fetchTokenMetrics, clearTokenMetrics, fetchCostMetrics } from '../../lib/api';
 import { useWindowManager } from '../../hooks/useWindowManager';
-import { formatCompactNumber } from '../../lib/format';
+import { formatCompactNumber, formatUSD } from '../../lib/format';
 import { POLLING } from '../../lib/constants';
 import { AreaChart } from '../chart/AreaChart';
 import { PersistedFromMarker } from '../telemetry/PersistedFromMarker';
-import type { TokenMetricsResponse } from '../../types';
+import type { TokenMetricsResponse, CostMetricsResponse } from '../../types';
 
 type TimeRange = 'live' | '1h' | '6h' | '24h' | '7d';
 type SortColumn = 'name' | 'input' | 'output' | 'total';
 type SortDirection = 'asc' | 'desc';
+type ClientSortColumn = 'name' | 'input' | 'output' | 'total' | 'cost';
 
 const TIME_RANGES: { value: TimeRange; label: string }[] = [
   { value: 'live', label: 'Live' },
@@ -39,16 +43,20 @@ export function MetricsTab() {
   const bottomPanelOpen = useUIStore((s) => s.bottomPanelOpen);
   const bottomPanelTab = useUIStore((s) => s.bottomPanelTab);
   const tokenUsage = useStackStore((s) => s.tokenUsage);
+  const costUsage = useStackStore((s) => s.costUsage);
   const metricsDetached = useUIStore((s) => s.metricsDetached);
   const { openDetachedWindow } = useWindowManager();
   const [timeRange, setTimeRange] = useState<TimeRange>('live');
   const [isPaused, setIsPaused] = useState(false);
   const [metricsData, setMetricsData] = useState<TokenMetricsResponse | null>(null);
+  const [costData, setCostData] = useState<CostMetricsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [sortColumn, setSortColumn] = useState<SortColumn>('total');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [clientSortColumn, setClientSortColumn] = useState<ClientSortColumn>('cost');
+  const [clientSortDirection, setClientSortDirection] = useState<SortDirection>('desc');
 
   const intervalRef = useRef<number | null>(null);
   const isVisible = bottomPanelOpen && bottomPanelTab === 'metrics';
@@ -58,9 +66,29 @@ export function MetricsTab() {
 
   const loadMetrics = useCallback(async () => {
     try {
-      const data = await fetchTokenMetrics(apiRange);
-      setMetricsData(data);
-      setError(null);
+      // Piggyback the cost fetch on the existing token-metrics polling
+      // cycle (per the design system: do not add a second poll). When
+      // either request fails we surface the first error but still keep
+      // any successful payload to avoid losing the chart on a transient
+      // failure of just one endpoint.
+      const [tokenResult, costResult] = await Promise.allSettled([
+        fetchTokenMetrics(apiRange),
+        fetchCostMetrics(apiRange),
+      ]);
+      if (tokenResult.status === 'fulfilled') {
+        setMetricsData(tokenResult.value);
+      }
+      if (costResult.status === 'fulfilled') {
+        setCostData(costResult.value);
+      }
+      const firstFailure =
+        (tokenResult.status === 'rejected' && tokenResult.reason) ||
+        (costResult.status === 'rejected' && costResult.reason);
+      if (firstFailure) {
+        setError(firstFailure instanceof Error ? firstFailure.message : 'Failed to fetch metrics');
+      } else {
+        setError(null);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch metrics');
     } finally {
@@ -99,6 +127,7 @@ export function MetricsTab() {
     try {
       await clearTokenMetrics();
       setMetricsData(null);
+      setCostData(null);
       setShowClearConfirm(false);
       setIsLoading(true);
       loadMetrics();
@@ -113,6 +142,15 @@ export function MetricsTab() {
     } else {
       setSortColumn(column);
       setSortDirection('desc');
+    }
+  };
+
+  const handleClientSort = (column: ClientSortColumn) => {
+    if (clientSortColumn === column) {
+      setClientSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setClientSortColumn(column);
+      setClientSortDirection('desc');
     }
   };
 
@@ -145,7 +183,16 @@ export function MetricsTab() {
   const savingsPercent = tokenUsage?.format_savings.savings_percent ?? 0;
   const savedTokens = tokenUsage?.format_savings.saved_tokens ?? 0;
 
-  const hasData = sessionTotal > 0 || (metricsData?.data_points?.length ?? 0) > 0;
+  // Cost shown only when the backend has actually emitted a cost field on
+  // /api/status. costUsage is null until the first priced call lands —
+  // displaying "—" then matches the UX spec ("never a fabricated number").
+  const sessionCostUSD = costUsage?.session.total_usd;
+  const hasCost = sessionCostUSD !== undefined;
+
+  const hasData =
+    sessionTotal > 0 ||
+    (metricsData?.data_points?.length ?? 0) > 0 ||
+    (costData?.data_points?.length ?? 0) > 0;
 
   // Transform API data points to Recharts format
   const chartData = useMemo(() => {
@@ -156,6 +203,53 @@ export function MetricsTab() {
       "Output Tokens": dp.output_tokens,
     }));
   }, [metricsData]);
+
+  const costChartData = useMemo(() => {
+    if (!costData?.data_points) return [];
+    return costData.data_points.map((dp) => ({
+      time: new Date(dp.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      "Cost (USD)": dp.usd,
+    }));
+  }, [costData]);
+
+  const costSeriesHasData = costChartData.some((d) => d['Cost (USD)'] > 0);
+
+  // Per-client breakdown — joins the real-time token + cost snapshots so a
+  // client without any priced calls still shows up with cost = 0 (and
+  // pricing-unknown clients render as "—" in the cost column).
+  const perClientRows = useMemo(() => {
+    const tokenClients = tokenUsage?.per_client ?? {};
+    const costClients = costUsage?.per_client ?? {};
+    const names = new Set<string>([...Object.keys(tokenClients), ...Object.keys(costClients)]);
+    return Array.from(names).map((name) => {
+      const tokens = tokenClients[name];
+      const cost = costClients[name];
+      return {
+        name,
+        input: tokens?.input_tokens ?? 0,
+        output: tokens?.output_tokens ?? 0,
+        total: tokens?.total_tokens ?? 0,
+        cost: cost?.total_usd,
+      };
+    });
+  }, [tokenUsage, costUsage]);
+
+  const sortedClients = useMemo(() => {
+    const sorted = [...perClientRows];
+    sorted.sort((a, b) => {
+      const dir = clientSortDirection === 'asc' ? 1 : -1;
+      if (clientSortColumn === 'name') return dir * a.name.localeCompare(b.name);
+      if (clientSortColumn === 'cost') {
+        // Treat unknown cost as -Infinity so it sinks to the bottom on
+        // descending sort and bubbles to the top on ascending sort.
+        const aCost = a.cost ?? -Infinity;
+        const bCost = b.cost ?? -Infinity;
+        return dir * (aCost - bCost);
+      }
+      return dir * (a[clientSortColumn] - b[clientSortColumn]);
+    });
+    return sorted;
+  }, [perClientRows, clientSortColumn, clientSortDirection]);
 
   return (
     <div className="flex flex-col h-full">
@@ -302,10 +396,11 @@ export function MetricsTab() {
             <PersistedFromMarker serverName={null} signal="metrics" />
 
             {/* KPI Cards */}
-            <div className={cn('grid gap-3', savingsPercent > 0 ? 'grid-cols-4' : 'grid-cols-3')}>
+            <div className={cn('grid gap-3', savingsPercent > 0 ? 'grid-cols-5' : 'grid-cols-4')}>
               <KPICard label="Input Tokens" value={sessionInput} colorClass="text-secondary" />
               <KPICard label="Output Tokens" value={sessionOutput} colorClass="text-primary" />
               <KPICard label="Total Tokens" value={sessionTotal} colorClass="text-text-primary" />
+              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} />
               {savingsPercent > 0 && (
                 <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
                   <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Format Savings</span>
@@ -353,6 +448,72 @@ export function MetricsTab() {
                 className="h-36"
               />
             </div>
+
+            {/* Cost Over Time — only render once the gateway has emitted any
+                cost data. Pre-PR-1 stacks (no priced calls yet) get the
+                token chart unchanged with no empty cost panel below it. */}
+            {(hasCost || costSeriesHasData) && (
+              <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-[11px] font-medium text-text-secondary inline-flex items-center gap-1.5">
+                    <DollarSign size={11} className="text-emerald-400" />
+                    Cost Over Time
+                  </span>
+                  {costData && (
+                    <span className="text-[9px] text-text-muted font-mono">
+                      {costData.data_points?.length ?? 0} points &middot; {costData.interval} interval
+                    </span>
+                  )}
+                </div>
+                <AreaChart
+                  data={costChartData}
+                  index="time"
+                  categories={["Cost (USD)"]}
+                  colors={["emerald"]}
+                  type="default"
+                  fill="gradient"
+                  showLegend={false}
+                  showGridLines={true}
+                  showYAxis={true}
+                  yAxisWidth={56}
+                  valueFormatter={(v: number) => formatUSD(v)}
+                  className="h-32"
+                />
+              </div>
+            )}
+
+            {/* Top Clients — joins per_client tokens + cost from /api/status.
+                Hidden when the backend hasn't surfaced any per-client
+                attribution yet (pre-PR-2 stacks, or sessions where every
+                tool call ran without a known clientInfo). */}
+            {sortedClients.length > 0 && (
+              <PanelHeader icon={Users} label="Top Clients">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border/30">
+                      <ClientSortableHeader label="Client" column="name" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} />
+                      <ClientSortableHeader label="Input" column="input" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
+                      <ClientSortableHeader label="Output" column="output" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
+                      <ClientSortableHeader label="Total" column="total" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
+                      <ClientSortableHeader label="Cost" column="cost" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sortedClients.map((client) => (
+                      <tr key={client.name} className="border-b border-border/20 last:border-0 hover:bg-surface-highlight/30 transition-colors">
+                        <td className="px-3 py-2 font-medium text-text-primary font-mono">{client.name}</td>
+                        <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(client.input)}</td>
+                        <td className="px-3 py-2 text-right text-primary tabular-nums">{formatCompactNumber(client.output)}</td>
+                        <td className="px-3 py-2 text-right text-text-primary font-semibold tabular-nums">{formatCompactNumber(client.total)}</td>
+                        <td className={cn('px-3 py-2 text-right tabular-nums', client.cost === undefined ? 'text-text-muted' : 'text-emerald-400')}>
+                          {client.cost === undefined ? '—' : formatUSD(client.cost)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </PanelHeader>
+            )}
 
             {/* Per-Server Breakdown Table */}
             {sortedServers.length > 0 && (
@@ -428,6 +589,54 @@ function KPICard({ label, value, colorClass }: { label: string; value: number; c
   );
 }
 
+// CostKPICard — session USD spend. Renders an em-dash when the gateway
+// hasn't priced any calls yet (per the UX spec: never show a fabricated
+// number). The icon stays muted-by-default; the value carries the accent
+// so the card reads as "cost-flavored" without competing with the amber
+// Output KPI to its left.
+function CostKPICard({ usd, hasCost }: { usd: number | undefined; hasCost: boolean }) {
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
+      <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1 inline-flex items-center gap-1">
+        <DollarSign size={10} className="text-text-muted/70" />
+        Cost
+      </span>
+      <span
+        className={cn(
+          'text-lg font-bold tabular-nums',
+          hasCost ? 'text-emerald-400' : 'text-text-muted',
+        )}
+      >
+        {hasCost ? formatUSD(usd ?? 0) : '—'}
+      </span>
+    </div>
+  );
+}
+
+// PanelHeader wraps a labeled section with a thin header strip plus the
+// shared elevated-surface frame. Keeps the Top Clients panel visually
+// distinct from the per-server table without introducing a second
+// surface variant.
+function PanelHeader({
+  icon: Icon,
+  label,
+  children,
+}: {
+  icon: LucideIcon | ComponentType<{ size?: number; className?: string }>;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 overflow-hidden">
+      <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border/30 bg-surface-highlight/30">
+        <Icon size={11} className="text-text-muted" />
+        <span className="text-[11px] font-medium text-text-secondary">{label}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
 // Sortable table header
 function SortableHeader({
   label,
@@ -448,6 +657,47 @@ function SortableHeader({
   const SortIcon = isActive
     ? sortDirection === 'asc' ? ArrowUp : ArrowDown
     : ArrowUpDown;
+
+  return (
+    <th
+      className={cn(
+        'px-3 py-2 font-medium text-text-muted cursor-pointer hover:text-text-secondary transition-colors select-none',
+        align === 'right' && 'text-right'
+      )}
+      tabIndex={0}
+      role="columnheader"
+      aria-sort={isActive ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+      onClick={() => onSort(column)}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSort(column); } }}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        <SortIcon size={10} className={isActive ? 'text-primary' : 'text-text-muted/40'} />
+      </span>
+    </th>
+  );
+}
+
+// ClientSortableHeader — sibling of SortableHeader for the wider
+// ClientSortColumn type. A separate component keeps each table's sort
+// state strongly typed without forcing a generic header.
+function ClientSortableHeader({
+  label,
+  column,
+  sortColumn,
+  sortDirection,
+  onSort,
+  align = 'left',
+}: {
+  label: string;
+  column: ClientSortColumn;
+  sortColumn: ClientSortColumn;
+  sortDirection: SortDirection;
+  onSort: (column: ClientSortColumn) => void;
+  align?: 'left' | 'right';
+}) {
+  const isActive = sortColumn === column;
+  const SortIcon = isActive ? (sortDirection === 'asc' ? ArrowUp : ArrowDown) : ArrowUpDown;
 
   return (
     <th

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, RegistryStatus, AgentSkill, SkillFile, SkillValidationResult, WorkflowDefinition, ExecutionResult, TokenMetricsResponse, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SkillTestResult, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
+import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, RegistryStatus, AgentSkill, SkillFile, SkillValidationResult, WorkflowDefinition, ExecutionResult, TokenMetricsResponse, CostMetricsResponse, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SkillTestResult, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
 
 // Base URL for API calls - empty for same origin
 const API_BASE = '';
@@ -362,6 +362,39 @@ export async function clearTokenMetrics(): Promise<void> {
 
   if (!response.ok) {
     throw new Error(`Clear metrics failed: ${response.status} ${response.statusText}`);
+  }
+}
+
+/**
+ * Fetch historical USD-cost metrics. Mirrors fetchTokenMetrics so cost
+ * charts can share the existing time-range vocabulary.
+ * GET /api/metrics/cost?range=1h&per_client=true
+ */
+export async function fetchCostMetrics(
+  range: string = '1h',
+  perClient: boolean = false,
+): Promise<CostMetricsResponse> {
+  const params = new URLSearchParams({ range });
+  if (perClient) params.set('per_client', 'true');
+  return fetchJSON<CostMetricsResponse>(`/api/metrics/cost?${params.toString()}`);
+}
+
+/**
+ * Clear recorded USD-cost metrics. Leaves token counters intact.
+ * DELETE /api/metrics/cost
+ */
+export async function clearCostMetrics(): Promise<void> {
+  const response = await fetch(`${API_BASE}/api/metrics/cost`, {
+    method: 'DELETE',
+    headers: buildHeaders(),
+  });
+
+  if (response.status === 401) {
+    throw new AuthError('Authentication required');
+  }
+
+  if (!response.ok) {
+    throw new Error(`Clear cost metrics failed: ${response.status} ${response.statusText}`);
   }
 }
 

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -11,3 +11,20 @@ export function formatCompactNumber(n: number): string {
   const m = n / 1_000_000;
   return m % 1 === 0 ? `${m}M` : `${m.toFixed(1)}M`;
 }
+
+/**
+ * Format a USD amount with precision that matches its magnitude. Tiny
+ * per-call costs need 4 decimals to be readable; aggregates round
+ * naturally. Anything above $10k compacts (k/M) so KPI cards never
+ * overflow.
+ */
+export function formatUSD(usd: number): string {
+  if (!Number.isFinite(usd)) return '—';
+  if (usd === 0) return '$0.00';
+  const abs = Math.abs(usd);
+  if (abs < 0.01) return `$${usd.toFixed(4)}`;
+  if (abs < 1) return `$${usd.toFixed(3)}`;
+  if (abs < 1000) return `$${usd.toFixed(2)}`;
+  if (abs < 1_000_000) return `$${(usd / 1000).toFixed(2)}k`;
+  return `$${(usd / 1_000_000).toFixed(2)}M`;
+}

--- a/web/src/pages/DetachedMetricsPage.tsx
+++ b/web/src/pages/DetachedMetricsPage.tsx
@@ -1,18 +1,21 @@
-import { useEffect, useState, useCallback, Component, type ReactNode } from 'react';
+import { useEffect, useState, useCallback, Component, type ComponentType, type ReactNode } from 'react';
 import {
   BarChart3,
   AlertCircle,
   Maximize2,
   Minimize2,
+  DollarSign,
+  Users,
 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { IconButton } from '../components/ui/IconButton';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
-import { fetchStatus, fetchTokenMetrics, clearTokenMetrics } from '../lib/api';
-import { formatCompactNumber } from '../lib/format';
+import { fetchStatus, fetchTokenMetrics, fetchCostMetrics, clearTokenMetrics } from '../lib/api';
+import { formatCompactNumber, formatUSD } from '../lib/format';
 import { POLLING } from '../lib/constants';
 import { AreaChart } from '../components/chart/AreaChart';
-import type { GatewayStatus, TokenMetricsResponse, TokenUsage } from '../types';
+import type { GatewayStatus, TokenMetricsResponse, CostMetricsResponse, TokenUsage, CostUsage } from '../types';
 import {
   Pause,
   Play,
@@ -68,6 +71,7 @@ class DetachedErrorBoundary extends Component<{ children: ReactNode }, ErrorBoun
 type TimeRange = 'live' | '1h' | '6h' | '24h' | '7d';
 type SortColumn = 'name' | 'input' | 'output' | 'total';
 type SortDirection = 'asc' | 'desc';
+type ClientSortColumn = 'name' | 'input' | 'output' | 'total' | 'cost';
 
 const TIME_RANGES: { value: TimeRange; label: string }[] = [
   { value: 'live', label: 'Live' },
@@ -79,26 +83,31 @@ const TIME_RANGES: { value: TimeRange; label: string }[] = [
 
 function DetachedMetricsPageContent() {
   const [tokenUsage, setTokenUsage] = useState<TokenUsage | null>(null);
+  const [costUsage, setCostUsage] = useState<CostUsage | null>(null);
   const [timeRange, setTimeRange] = useState<TimeRange>('live');
   const [isPaused, setIsPaused] = useState(false);
   const [metricsData, setMetricsData] = useState<TokenMetricsResponse | null>(null);
+  const [costData, setCostData] = useState<CostMetricsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [sortColumn, setSortColumn] = useState<SortColumn>('total');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [clientSortColumn, setClientSortColumn] = useState<ClientSortColumn>('cost');
+  const [clientSortDirection, setClientSortDirection] = useState<SortDirection>('desc');
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   useDetachedWindowSync('metrics');
 
   const apiRange = timeRange === 'live' ? '30m' : timeRange;
 
-  // Poll status for real-time token usage
+  // Poll status for real-time token + cost usage
   useEffect(() => {
     const pollStatus = async () => {
       try {
         const status: GatewayStatus = await fetchStatus();
         setTokenUsage(status.token_usage ?? null);
+        setCostUsage(status.cost ?? null);
       } catch {
         // Ignore status errors
       }
@@ -111,9 +120,20 @@ function DetachedMetricsPageContent() {
 
   const loadMetrics = useCallback(async () => {
     try {
-      const data = await fetchTokenMetrics(apiRange);
-      setMetricsData(data);
-      setError(null);
+      const [tokenResult, costResult] = await Promise.allSettled([
+        fetchTokenMetrics(apiRange),
+        fetchCostMetrics(apiRange),
+      ]);
+      if (tokenResult.status === 'fulfilled') setMetricsData(tokenResult.value);
+      if (costResult.status === 'fulfilled') setCostData(costResult.value);
+      const firstFailure =
+        (tokenResult.status === 'rejected' && tokenResult.reason) ||
+        (costResult.status === 'rejected' && costResult.reason);
+      if (firstFailure) {
+        setError(firstFailure instanceof Error ? firstFailure.message : 'Failed to fetch metrics');
+      } else {
+        setError(null);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch metrics');
     } finally {
@@ -139,6 +159,7 @@ function DetachedMetricsPageContent() {
     try {
       await clearTokenMetrics();
       setMetricsData(null);
+      setCostData(null);
       setShowClearConfirm(false);
       setIsLoading(true);
       loadMetrics();
@@ -153,6 +174,15 @@ function DetachedMetricsPageContent() {
     } else {
       setSortColumn(column);
       setSortDirection('desc');
+    }
+  };
+
+  const handleClientSort = (column: ClientSortColumn) => {
+    if (clientSortColumn === column) {
+      setClientSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setClientSortColumn(column);
+      setClientSortDirection('desc');
     }
   };
 
@@ -177,7 +207,12 @@ function DetachedMetricsPageContent() {
   const sessionTotal = tokenUsage?.session.total_tokens ?? 0;
   const savingsPercent = tokenUsage?.format_savings.savings_percent ?? 0;
   const savedTokens = tokenUsage?.format_savings.saved_tokens ?? 0;
-  const hasData = sessionTotal > 0 || (metricsData?.data_points?.length ?? 0) > 0;
+  const sessionCostUSD = costUsage?.session.total_usd;
+  const hasCost = sessionCostUSD !== undefined;
+  const hasData =
+    sessionTotal > 0 ||
+    (metricsData?.data_points?.length ?? 0) > 0 ||
+    (costData?.data_points?.length ?? 0) > 0;
 
   const chartData = metricsData?.data_points
     ? metricsData.data_points.map((dp) => ({
@@ -186,6 +221,40 @@ function DetachedMetricsPageContent() {
         "Output Tokens": dp.output_tokens,
       }))
     : [];
+
+  const costChartData = costData?.data_points
+    ? costData.data_points.map((dp) => ({
+        time: new Date(dp.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+        "Cost (USD)": dp.usd,
+      }))
+    : [];
+
+  const costSeriesHasData = costChartData.some((d) => d['Cost (USD)'] > 0);
+
+  const tokenClients = tokenUsage?.per_client ?? {};
+  const costClients = costUsage?.per_client ?? {};
+  const clientNames = new Set<string>([...Object.keys(tokenClients), ...Object.keys(costClients)]);
+  const perClientRows = Array.from(clientNames).map((name) => {
+    const tokens = tokenClients[name];
+    const cost = costClients[name];
+    return {
+      name,
+      input: tokens?.input_tokens ?? 0,
+      output: tokens?.output_tokens ?? 0,
+      total: tokens?.total_tokens ?? 0,
+      cost: cost?.total_usd,
+    };
+  });
+  const sortedClients = [...perClientRows].sort((a, b) => {
+    const dir = clientSortDirection === 'asc' ? 1 : -1;
+    if (clientSortColumn === 'name') return dir * a.name.localeCompare(b.name);
+    if (clientSortColumn === 'cost') {
+      const aCost = a.cost ?? -Infinity;
+      const bCost = b.cost ?? -Infinity;
+      return dir * (aCost - bCost);
+    }
+    return dir * (a[clientSortColumn] - b[clientSortColumn]);
+  });
 
   const toggleFullscreen = async () => {
     if (!document.fullscreenElement) {
@@ -361,10 +430,11 @@ function DetachedMetricsPageContent() {
         {!error && hasData && (
           <div className="space-y-4">
             {/* KPI Cards */}
-            <div className={cn('grid gap-3', savingsPercent > 0 ? 'grid-cols-4' : 'grid-cols-3')}>
+            <div className={cn('grid gap-3', savingsPercent > 0 ? 'grid-cols-5' : 'grid-cols-4')}>
               <KPICard label="Input Tokens" value={sessionInput} colorClass="text-secondary" />
               <KPICard label="Output Tokens" value={sessionOutput} colorClass="text-primary" />
               <KPICard label="Total Tokens" value={sessionTotal} colorClass="text-text-primary" />
+              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} />
               {savingsPercent > 0 && (
                 <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
                   <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Format Savings</span>
@@ -406,6 +476,66 @@ function DetachedMetricsPageContent() {
               />
             </div>
 
+            {(hasCost || costSeriesHasData) && (
+              <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-[11px] font-medium text-text-secondary inline-flex items-center gap-1.5">
+                    <DollarSign size={11} className="text-emerald-400" />
+                    Cost Over Time
+                  </span>
+                  {costData && (
+                    <span className="text-[9px] text-text-muted font-mono">
+                      {costData.data_points?.length ?? 0} points &middot; {costData.interval} interval
+                    </span>
+                  )}
+                </div>
+                <AreaChart
+                  data={costChartData}
+                  index="time"
+                  categories={["Cost (USD)"]}
+                  colors={["emerald"]}
+                  type="default"
+                  fill="gradient"
+                  showLegend={false}
+                  showGridLines={true}
+                  showYAxis={true}
+                  yAxisWidth={56}
+                  valueFormatter={(v: number) => formatUSD(v)}
+                  className="h-40"
+                />
+              </div>
+            )}
+
+            {/* Top Clients */}
+            {sortedClients.length > 0 && (
+              <PanelHeader icon={Users} label="Top Clients">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border/30">
+                      <ClientSortableHeader label="Client" column="name" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} />
+                      <ClientSortableHeader label="Input" column="input" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
+                      <ClientSortableHeader label="Output" column="output" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
+                      <ClientSortableHeader label="Total" column="total" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
+                      <ClientSortableHeader label="Cost" column="cost" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sortedClients.map((client) => (
+                      <tr key={client.name} className="border-b border-border/20 last:border-0 hover:bg-surface-highlight/30 transition-colors">
+                        <td className="px-3 py-2 font-medium text-text-primary font-mono">{client.name}</td>
+                        <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(client.input)}</td>
+                        <td className="px-3 py-2 text-right text-primary tabular-nums">{formatCompactNumber(client.output)}</td>
+                        <td className="px-3 py-2 text-right text-text-primary font-semibold tabular-nums">{formatCompactNumber(client.total)}</td>
+                        <td className={cn('px-3 py-2 text-right tabular-nums', client.cost === undefined ? 'text-text-muted' : 'text-emerald-400')}>
+                          {client.cost === undefined ? '—' : formatUSD(client.cost)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </PanelHeader>
+            )}
+
             {/* Per-Server Breakdown Table */}
             {sortedServers.length > 0 && (
               <div className="rounded-lg bg-surface-elevated/60 border border-border/30 overflow-hidden">
@@ -437,8 +567,14 @@ function DetachedMetricsPageContent() {
 
       {/* Footer */}
       <footer className="h-6 flex-shrink-0 bg-surface/90 backdrop-blur-xl border-t border-border/50 flex items-center justify-between px-4 text-[10px] text-text-muted">
-        <span>
+        <span className="flex items-center gap-2">
           {sessionTotal > 0 ? `${formatCompactNumber(sessionTotal)} total tokens` : 'No data'}
+          {hasCost && (
+            <>
+              <span className="text-text-muted/50">·</span>
+              <span className="text-emerald-400/80">{formatUSD(sessionCostUSD ?? 0)}</span>
+            </>
+          )}
           {isPaused ? ' (paused)' : ''}
         </span>
         <span className="flex items-center gap-1">
@@ -461,6 +597,78 @@ function KPICard({ label, value, colorClass }: { label: string; value: number; c
       <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">{label}</span>
       <span className={cn('text-lg font-bold tabular-nums', colorClass)}>{formatCompactNumber(value)}</span>
     </div>
+  );
+}
+
+function CostKPICard({ usd, hasCost }: { usd: number | undefined; hasCost: boolean }) {
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
+      <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1 inline-flex items-center gap-1">
+        <DollarSign size={10} className="text-text-muted/70" />
+        Cost
+      </span>
+      <span
+        className={cn(
+          'text-lg font-bold tabular-nums',
+          hasCost ? 'text-emerald-400' : 'text-text-muted',
+        )}
+      >
+        {hasCost ? formatUSD(usd ?? 0) : '—'}
+      </span>
+    </div>
+  );
+}
+
+function PanelHeader({
+  icon: Icon,
+  label,
+  children,
+}: {
+  icon: LucideIcon | ComponentType<{ size?: number; className?: string }>;
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 overflow-hidden">
+      <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border/30 bg-surface-highlight/30">
+        <Icon size={11} className="text-text-muted" />
+        <span className="text-[11px] font-medium text-text-secondary">{label}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function ClientSortableHeader({
+  label, column, sortColumn, sortDirection, onSort, align = 'left',
+}: {
+  label: string;
+  column: ClientSortColumn;
+  sortColumn: ClientSortColumn;
+  sortDirection: SortDirection;
+  onSort: (column: ClientSortColumn) => void;
+  align?: 'left' | 'right';
+}) {
+  const isActive = sortColumn === column;
+  const SortIcon = isActive ? (sortDirection === 'asc' ? ArrowUp : ArrowDown) : ArrowUpDown;
+
+  return (
+    <th
+      className={cn(
+        'px-3 py-2 font-medium text-text-muted cursor-pointer hover:text-text-secondary transition-colors select-none',
+        align === 'right' && 'text-right'
+      )}
+      tabIndex={0}
+      role="columnheader"
+      aria-sort={isActive ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+      onClick={() => onSort(column)}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSort(column); } }}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        <SortIcon size={10} className={isActive ? 'text-primary' : 'text-text-muted/40'} />
+      </span>
+    </th>
   );
 }
 

--- a/web/src/stores/useStackStore.ts
+++ b/web/src/stores/useStackStore.ts
@@ -10,6 +10,7 @@ import type {
   ClientStatus,
   Tool,
   TokenUsage,
+  CostUsage,
   ConnectionStatus,
   AutoscaleDecisionKind,
 } from '../types';
@@ -52,6 +53,7 @@ interface StackState {
   sessions: number;
   codeMode: string | null;  // Gateway code mode status ("on" when active)
   tokenUsage: TokenUsage | null; // Token usage metrics from status response
+  costUsage: CostUsage | null;   // USD cost snapshot; null when no cost recorded
   stackName: string;        // Active stack name; empty string in stackless mode
 
   // === React Flow State ===
@@ -99,6 +101,7 @@ export const useStackStore = create<StackState>()(
     sessions: 0,
     codeMode: null,
     tokenUsage: null,
+    costUsage: null,
     stackName: '',
     nodes: [],
     edges: [],
@@ -129,6 +132,7 @@ export const useStackStore = create<StackState>()(
         sessions: status.sessions ?? 0,
         codeMode: status.code_mode || null,
         tokenUsage: status.token_usage ?? null,
+        costUsage: status.cost ?? null,
         stackName: status.stack_name || '',
         autoscaleHistory: folded.history,
         autoscaleDecisions: folded.decisions,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -116,7 +116,28 @@ export interface FormatSavings {
 export interface TokenUsage {
   session: TokenCounts;
   per_server: Record<string, TokenCounts>;
+  per_replica?: Record<string, Record<string, TokenCounts>>;
+  // per_client groups token usage by the originating MCP client. omitempty
+  // on the wire; pre-attribution responses won't include it.
+  per_client?: Record<string, TokenCounts>;
   format_savings: FormatSavings;
+}
+
+// Per-dimension USD cost snapshot mirroring TokenCounts
+export interface CostCounts {
+  input_usd: number;
+  output_usd: number;
+  cache_read_usd?: number;
+  cache_write_usd?: number;
+  total_usd: number;
+}
+
+// Cost usage summary from GET /api/status (cost field)
+export interface CostUsage {
+  session: CostCounts;
+  per_server: Record<string, CostCounts>;
+  per_replica?: Record<string, Record<string, CostCounts>>;
+  per_client?: Record<string, CostCounts>;
 }
 
 // Historical time-series data point
@@ -135,6 +156,21 @@ export interface TokenMetricsResponse {
   per_server: Record<string, TokenDataPoint[]>;
 }
 
+// Single bucket of cost-over-time data (USD per minute-aligned bucket)
+export interface CostDataPoint {
+  timestamp: string;
+  usd: number;
+}
+
+// Response from GET /api/metrics/cost
+export interface CostMetricsResponse {
+  range: string;
+  interval: string;
+  data_points: CostDataPoint[];
+  per_server: Record<string, CostDataPoint[]>;
+  per_client?: Record<string, CostDataPoint[]>;
+}
+
 // Gateway status response from GET /api/status
 export interface GatewayStatus {
   gateway: ServerInfo;
@@ -143,6 +179,7 @@ export interface GatewayStatus {
   sessions?: number;       // Active MCP session count
   code_mode?: string;      // "on" when code mode is active (omitted when off)
   token_usage?: TokenUsage; // Token usage metrics (omitted if no accumulator)
+  cost?: CostUsage;        // Cost snapshot (omitted until any cost is recorded)
   stack_name?: string;     // Active stack name; omitted in stackless mode
 }
 


### PR DESCRIPTION
## Description

Phase 3 of gateway-cost-observability. Surfaces the cost layer (PR #565) and per-client attribution (PR #566) in the Web UI: a session `$ Cost` KPI card, a cost-over-time area chart, and a sortable Top Clients panel — all inside the existing Metrics tab and the detached metrics window.

## Type of Change

- [x] feat

## Changes Made

- TS types for `CostUsage`, `CostCounts`, `CostDataPoint`, `CostMetricsResponse`; extended `TokenUsage` (`per_replica`, `per_client`) and `GatewayStatus` (`cost`)
- `fetchCostMetrics(range, perClient?)` and `clearCostMetrics()` on the API client; `formatUSD()` helper that scales precision with magnitude
- `useStackStore.costUsage` populated from `/api/status`
- MetricsTab + DetachedMetricsPage:
  - `$ Cost` KPI card with `DollarSign` glyph; renders `—` when no priced calls have landed yet (never a fabricated number)
  - Emerald gradient cost-over-time area chart, hidden until any cost is recorded; reuses the existing time-range selector
  - Top Clients panel (sortable; default Cost desc) joining `per_client` tokens + USD; hidden when no per-client attribution is available
  - Cost fetch piggybacks on the existing token-metrics polling cycle via `Promise.allSettled` — no second poll
- Detached window footer now includes the session USD when present
- `CHANGELOG.md` `[Unreleased]` entry

## Scope deviations to flag

- Top Clients columns are `Client | Input | Output | Total | Cost`. The original spec called for a `calls` column, but the backend doesn't expose a per-client call counter today — using token columns keeps the table consistent with the per-server breakdown above it.
- Per-bucket tooltip breakdown (input / output / cache-read / cache-write tokens + model + \$/token) is not implemented: `CostDataPoint` only carries `usd` per bucket. Default Recharts tooltip shows the USD value.
- Muted footer line listing models without pricing is omitted: backend doesn't expose unpriced-model names yet.

These can land alongside the optimize work in Phase 4/5 if needed.

## Testing

- `make build` succeeds (frontend TS compile + Go binary embed). Bundle contains the new \"Cost Over Time\" / \"Top Clients\" markers and `/api/metrics/cost` query.
- `go test ./internal/api/... ./pkg/metrics/...` passes.
- `./gridctl serve` smoke-test confirms `/api/metrics/cost` and `/api/status` return the expected shapes (cost field omitted when zero, empty `data_points` when no usage).
- Empty-state UI verified by JSON shape inspection: `$ Cost` shows `—`, cost chart hides, Top Clients hides — matching the UX spec.
- Live-data UI not exercised in this branch (no linked client making real tool calls); will be confirmed once integrated with a working stack.

Part of #564

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed