### PR TITLE
feat: gridctl optimize CLI, /api/optimize, and sidebar panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,6 +419,12 @@ Ubuntu and macOS (install → re-run for idempotency → `gridctl upgrade
 ./gridctl traces --follow
 ./gridctl traces --server github --errors
 
+# Surface cost-reduction findings (unused servers and tools)
+./gridctl optimize
+./gridctl optimize --stack mcp-basic
+./gridctl optimize --min-impact 0.10
+./gridctl optimize --format json
+
 # Manage schema pins (TOFU rug pull protection)
 ./gridctl pins list
 ./gridctl pins verify
@@ -584,6 +590,19 @@ Manage TOFU schema pins that protect against rug pull attacks (CVE-2025-54136 cl
 | `--stack` | all | Stack name (auto-detected when only one stack is running) |
 | `--exit-code` | `verify` | Exit 1 if any server has drift (CI use case) |
 
+#### `gridctl optimize`
+
+Scan the running gateway and print cost-reduction findings — unused servers and unused tools in v1 — with a measured weekly USD impact and a paste-ready YAML remediation. The CLI requires the gateway to be running; it never reads client-side session files.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--stack` | `-s` | Stack to query (auto-detected when only one stack is running) |
+| `--min-impact` | | Filter findings below this weekly USD impact (info findings always shown) |
+| `--severity` | | Comma-separated severity allowlist: `info,warn,critical` |
+| `--format` | | Output format: `json` for machine-readable `OptimizeReport` (default: table) |
+
+Exit codes: `0` no findings or info-only, `1` at least one `warn`/`critical` finding, `2` infrastructure error (gateway unreachable, ambiguous or unknown stack).
+
 #### `gridctl test <skill-name>`
 
 Run acceptance criteria for a skill against the running gateway.
@@ -643,7 +662,7 @@ When `gridctl apply` runs, it:
 
 **Endpoints:**
 - **MCP:** `POST /mcp` (JSON-RPC), `GET /sse` + `POST /message` (SSE for Claude Desktop)
-- **API:** `/api/status`, `/api/mcp-servers`, `/api/mcp-servers/{name}/restart`, `/api/tools`, `/api/logs`, `/api/clients`, `/api/reload`, `/api/metrics/tokens`, `/health`, `/ready`
+- **API:** `/api/status`, `/api/mcp-servers`, `/api/mcp-servers/{name}/restart`, `/api/tools`, `/api/logs`, `/api/clients`, `/api/reload`, `/api/metrics/tokens`, `/api/metrics/cost`, `/api/optimize`, `/health`, `/ready`
 - **Stack Library:** `/api/stacks` (list/save), `/api/stack/initialize` (cold-load a saved stack into a stackless daemon)
 - **Vault:** `/api/vault`, `/api/vault/status`, `/api/vault/unlock`, `/api/vault/lock`, `/api/vault/sets`, `/api/vault/import`
 - **Pins:** `/api/pins` (list all), `/api/pins/{server}` (get), `/api/pins/{server}/approve` (POST), `/api/pins/{server}` (DELETE)
@@ -669,6 +688,9 @@ When `gridctl apply` runs, it:
 - `GET /api/metrics/tokens?range=1h` - Historical time-series token data (range: 30m, 1h, 6h, 24h, 7d)
 - `DELETE /api/metrics/tokens` - Clear all token metrics
 - `GET /api/status` includes `token_usage` (session totals, per-server breakdown, format savings)
+
+**Optimize API:**
+- `GET /api/optimize?stack={name}&min_impact=0.10&severity=warn,critical` — Returns an `OptimizeReport{findings, health_score, generated_at}` derived from the live gateway state and accumulator. Each finding carries `id`, `heuristic` (`unused_server`/`unused_tool`/`need_more_data`), `severity`, `title`, `summary`, `server`, `tool`, `impact_usd_per_week`, `remediation` (YAML or shell snippet), and `detected_at`. Returns `404` when `stack` does not match the active stack and `503` when the metrics accumulator is not configured.
 
 **Registry API:**
 - `GET /api/registry/status` - Returns skill counts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ All notable changes to gridctl will be documented in this file.
 - Add `DELETE /api/metrics/cost`, which clears recorded cost data without touching the token counters or format-savings tally.
 - Extend `/api/status` with an additive, omitempty `cost` field carrying the session, per-server, per-client, and per-replica USD totals.
 - Surface cost in the Web UI Metrics tab: a session `$ Cost` KPI card beside Input/Output/Total tokens, a cost-over-time area chart that scales with the existing time-range selector, and a `Top Clients` panel summarizing per-client token and USD totals (sortable, default cost descending, hidden when no per-client attribution is present). Cost values render as `—` until the gateway has priced any calls, never a fabricated number.
+- Add `pkg/optimize` with the `unused_server` and `unused_tool` heuristics, scoring each finding with a measured weekly USD impact and a paste-ready YAML remediation snippet. The `<24h of data` gate emits a single info finding so reports never over-fire on a freshly started gateway.
+- Add `GET /api/optimize?stack=&min_impact=&severity=` returning an `OptimizeReport{findings, health_score, generated_at}` derived from the live gateway state and accumulator snapshot.
+- Add the `gridctl optimize` CLI command — `--stack`/`--min-impact`/`--severity`/`--format json` flags, a styled findings table with severity, weekly $, and remediation hint, and the standard `0|1|2` exit codes (0 = no findings, 1 = warn/critical, 2 = gateway unreachable or wrong stack).
+- Add a Sidebar `Optimize` panel inside the gateway view: each finding renders with a severity badge, weekly USD impact, and a collapsible remediation snippet. The panel polls on the same cadence as Token Usage / Cost.
+- Track per-(server, tool) call counts on the metrics accumulator and thread the originating tool name through the observer path so `unused_tool` can detect cold tools without inferring from token totals.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -371,6 +371,19 @@ In the web wizard, the "Add skill source" step has an inline, collapsible **Auth
 
 Raw tokens are never written outside the encrypted vault — neither to the skill origin nor the lock file. Error and log paths strip embedded URL userinfo (`https://TOKEN@host/...`) and known PAT patterns (`ghp_…`, `github_pat_…`, `glpat-…`) before they reach the API or CLI.
 
+### Cost Optimize
+
+`gridctl optimize` scans the running gateway and prints findings with a measured weekly USD impact and a paste-ready YAML remediation. The PR-4 heuristics flag **unused servers** (registered but no calls observed in the lookback window) and **unused tools** (a server is active but a specific tool has not been called in the window and is not already excluded). On a fresh gateway with less than 24h of data, `optimize` returns a single info finding so reports never over-fire.
+
+```bash
+gridctl optimize                          # styled findings table
+gridctl optimize --format json            # machine-readable OptimizeReport
+gridctl optimize --min-impact 0.10        # filter low-impact findings (info findings always shown)
+gridctl optimize --severity warn,critical # narrow to actionable findings
+```
+
+Exit codes follow the standard CLI contract: `0` no findings or info-only, `1` at least one warn/critical finding, `2` infrastructure error (gateway unreachable, wrong stack name). The Web UI surfaces the same findings inside the Gateway sidebar's `Optimize` panel.
+
 ### Distributed Tracing
 
 Every tool call through the gateway is captured as an OpenTelemetry trace. Spans record transport type, server name, duration, and error state. The last 1000 traces are kept in a ring buffer and are queryable via CLI or the Web UI.
@@ -453,6 +466,11 @@ gridctl traces --server <name>       # Filter by MCP server name
 gridctl traces --errors              # Show only error traces
 gridctl traces --min-duration 100ms  # Filter by minimum duration
 gridctl traces --json                # Output as JSON
+gridctl optimize                     # Surface unused servers and tools with weekly $ impact
+gridctl optimize --stack <name>      # Pick a specific stack when more than one is running
+gridctl optimize --min-impact 0.10   # Filter findings below a weekly USD impact threshold
+gridctl optimize --severity warn,critical  # Allowlist by severity
+gridctl optimize --format json       # Machine-readable OptimizeReport (exit 0/1/2)
 ```
 
 ## 🖥️ Connect LLM Application

--- a/cmd/gridctl/optimize.go
+++ b/cmd/gridctl/optimize.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/optimize"
+	"github.com/gridctl/gridctl/pkg/state"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+const optimizeHTTPTimeout = 10 * time.Second
+
+// Exit codes — matched against the conventions in cmd/gridctl/pins.go
+// and cmd/gridctl/validate.go so CI scripts can rely on a stable
+// contract.
+const (
+	optimizeExitOK            = 0
+	optimizeExitFindings      = 1
+	optimizeExitInfrastructure = 2
+)
+
+var (
+	optimizeStack     string
+	optimizeMinImpact float64
+	optimizeSeverity  string
+	optimizeFormat    string
+)
+
+var optimizeCmd = &cobra.Command{
+	Use:   "optimize",
+	Short: "Surface cost-reduction findings from gateway-observed data",
+	Long: `Analyze the running gateway for unused servers and tools and print
+actionable findings with weekly USD impact.
+
+Default output is a styled table; use '--format json' to emit the same
+OptimizeReport the API returns.
+
+Exit codes:
+  0  no findings, or only info-level findings
+  1  at least one warn or critical finding
+  2  infrastructure error (gateway unreachable, wrong stack)`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		port, err := resolveOptimizePort(optimizeStack)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(optimizeExitInfrastructure)
+		}
+
+		report, err := fetchOptimizeReport(port, optimizeStack, optimizeMinImpact, optimizeSeverity)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(optimizeExitInfrastructure)
+		}
+
+		switch strings.ToLower(optimizeFormat) {
+		case "json":
+			if err := renderOptimizeJSON(os.Stdout, report); err != nil {
+				return err
+			}
+		default:
+			renderOptimizeTable(os.Stdout, report)
+		}
+
+		if hasActionableFindings(report.Findings) {
+			os.Exit(optimizeExitFindings)
+		}
+		return nil
+	},
+}
+
+func init() {
+	optimizeCmd.Flags().StringVarP(&optimizeStack, "stack", "s", "", "Stack to query (auto-detected when only one stack is running)")
+	optimizeCmd.Flags().Float64Var(&optimizeMinImpact, "min-impact", 0, "Filter findings below this weekly USD impact (info findings always shown)")
+	optimizeCmd.Flags().StringVar(&optimizeSeverity, "severity", "", "Comma-separated severity allowlist: info,warn,critical")
+	optimizeCmd.Flags().StringVar(&optimizeFormat, "format", "", "Output format: 'json' for machine-readable output (default: table)")
+}
+
+// resolveOptimizePort finds the port of a running gateway, optionally
+// filtered by stack name. Mirrors resolveTracesPort, but emits errors
+// matching the optimize command's vocabulary.
+func resolveOptimizePort(stackName string) (int, error) {
+	states, err := state.List()
+	if err != nil {
+		return 0, fmt.Errorf("optimize: could not read state: %w", err)
+	}
+	running := make([]state.DaemonState, 0, len(states))
+	for _, s := range states {
+		if state.IsRunning(&s) {
+			running = append(running, s)
+		}
+	}
+	if stackName != "" {
+		for _, s := range running {
+			if s.StackName == stackName {
+				return s.Port, nil
+			}
+		}
+		return 0, fmt.Errorf("optimize: stack %q is not running", stackName)
+	}
+	switch len(running) {
+	case 0:
+		return 0, fmt.Errorf("optimize: gateway not running; try `gridctl status`")
+	case 1:
+		return running[0].Port, nil
+	default:
+		names := make([]string, len(running))
+		for i, s := range running {
+			names[i] = s.StackName
+		}
+		return 0, fmt.Errorf("optimize: multiple stacks running (%s); use --stack to pick one", strings.Join(names, ", "))
+	}
+}
+
+// fetchOptimizeReport calls GET /api/optimize on the local gateway and
+// decodes the response. Non-2xx HTTP statuses are mapped to errors so
+// the caller can map them to exit code 2.
+func fetchOptimizeReport(port int, stack string, minImpact float64, severity string) (optimize.OptimizeReport, error) {
+	q := url.Values{}
+	if stack != "" {
+		q.Set("stack", stack)
+	}
+	if minImpact > 0 {
+		q.Set("min_impact", strconv.FormatFloat(minImpact, 'f', -1, 64))
+	}
+	if severity != "" {
+		q.Set("severity", severity)
+	}
+	target := fmt.Sprintf("http://localhost:%d/api/optimize", port)
+	if encoded := q.Encode(); encoded != "" {
+		target += "?" + encoded
+	}
+
+	client := &http.Client{Timeout: optimizeHTTPTimeout}
+	resp, err := client.Get(target)
+	if err != nil {
+		return optimize.OptimizeReport{}, fmt.Errorf("optimize: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return optimize.OptimizeReport{}, fmt.Errorf("optimize: reading response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return optimize.OptimizeReport{}, fmt.Errorf("optimize: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	var report optimize.OptimizeReport
+	if err := json.Unmarshal(body, &report); err != nil {
+		return optimize.OptimizeReport{}, fmt.Errorf("optimize: parsing response: %w", err)
+	}
+	return report, nil
+}
+
+// renderOptimizeTable prints findings as a styled table mirroring the
+// pins-list / traces-list formatting. An empty report still prints the
+// health-score footer so users see "100" on a clean stack.
+func renderOptimizeTable(w io.Writer, report optimize.OptimizeReport) {
+	if len(report.Findings) == 0 {
+		fmt.Fprintf(w, "No findings. Health score: %d/100\n", report.HealthScore)
+		return
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleRounded)
+	t.AppendHeader(table.Row{"SEVERITY", "TITLE", "WEEKLY $", "REMEDIATION"})
+
+	for _, f := range report.Findings {
+		t.AppendRow(table.Row{
+			severityLabel(f.Severity),
+			f.Title,
+			formatImpact(f.ImpactUSDPerWeek),
+			firstLine(f.Remediation),
+		})
+	}
+	t.Render()
+
+	fmt.Fprintf(w, "\nHealth score: %d/100  ·  %d finding(s)\n", report.HealthScore, len(report.Findings))
+	for _, f := range report.Findings {
+		if f.Severity == optimize.SeverityInfo && f.Heuristic == "need_more_data" {
+			continue
+		}
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "## %s\n%s\n\n", f.Title, f.Summary)
+		if f.Remediation != "" {
+			fmt.Fprintln(w, f.Remediation)
+		}
+	}
+}
+
+func renderOptimizeJSON(w io.Writer, report optimize.OptimizeReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+func hasActionableFindings(findings []optimize.Finding) bool {
+	for _, f := range findings {
+		if f.Severity.IsActionable() {
+			return true
+		}
+	}
+	return false
+}
+
+func severityLabel(s optimize.Severity) string {
+	switch s {
+	case optimize.SeverityCritical:
+		return "✗ critical"
+	case optimize.SeverityWarn:
+		return "⚠ warn"
+	case optimize.SeverityInfo:
+		return "ℹ info"
+	default:
+		return string(s)
+	}
+}
+
+func formatImpact(usd float64) string {
+	if usd <= 0 {
+		return "—"
+	}
+	if usd < 0.01 {
+		return "<$0.01"
+	}
+	return fmt.Sprintf("$%.2f", usd)
+}
+
+func firstLine(s string) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			return s[:i]
+		}
+	}
+	return s
+}

--- a/cmd/gridctl/optimize_test.go
+++ b/cmd/gridctl/optimize_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/optimize"
+)
+
+func TestFormatImpact(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{0, "—"},
+		{-1.0, "—"},
+		{0.005, "<$0.01"},
+		{0.01, "$0.01"},
+		{12.345, "$12.35"},
+	}
+	for _, tc := range cases {
+		if got := formatImpact(tc.in); got != tc.want {
+			t.Errorf("formatImpact(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSeverityLabel(t *testing.T) {
+	cases := []struct {
+		in   optimize.Severity
+		want string
+	}{
+		{optimize.SeverityCritical, "✗ critical"},
+		{optimize.SeverityWarn, "⚠ warn"},
+		{optimize.SeverityInfo, "ℹ info"},
+	}
+	for _, tc := range cases {
+		if got := severityLabel(tc.in); got != tc.want {
+			t.Errorf("severityLabel(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFirstLine(t *testing.T) {
+	if got := firstLine("hello\nworld"); got != "hello" {
+		t.Errorf("firstLine multi-line = %q, want %q", got, "hello")
+	}
+	if got := firstLine("hello"); got != "hello" {
+		t.Errorf("firstLine single-line = %q, want %q", got, "hello")
+	}
+	if got := firstLine(""); got != "" {
+		t.Errorf("firstLine empty = %q, want %q", got, "")
+	}
+}
+
+func TestHasActionableFindings(t *testing.T) {
+	infoOnly := []optimize.Finding{{Severity: optimize.SeverityInfo}}
+	if hasActionableFindings(infoOnly) {
+		t.Errorf("info-only findings should not be actionable")
+	}
+
+	withWarn := []optimize.Finding{{Severity: optimize.SeverityWarn}}
+	if !hasActionableFindings(withWarn) {
+		t.Errorf("warn finding should be actionable")
+	}
+
+	if hasActionableFindings(nil) {
+		t.Errorf("nil findings should not be actionable")
+	}
+}
+
+func TestRenderOptimizeTable_NoFindings(t *testing.T) {
+	var buf bytes.Buffer
+	renderOptimizeTable(&buf, optimize.OptimizeReport{HealthScore: 100})
+	if !strings.Contains(buf.String(), "No findings") {
+		t.Errorf("expected 'No findings' message; got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "100/100") {
+		t.Errorf("expected health score to render; got: %s", buf.String())
+	}
+}
+
+func TestRenderOptimizeTable_PrintsRemediation(t *testing.T) {
+	var buf bytes.Buffer
+	report := optimize.OptimizeReport{
+		HealthScore: 80,
+		Findings: []optimize.Finding{{
+			ID:               "unused-server-github",
+			Heuristic:        "unused_server",
+			Severity:         optimize.SeverityWarn,
+			Title:            "Unused server: github",
+			Summary:          "no calls observed",
+			ImpactUSDPerWeek: 1.50,
+			Remediation:      "mcp-servers:\n  # delete entry: github",
+			DetectedAt:       time.Now(),
+		}},
+	}
+	renderOptimizeTable(&buf, report)
+	out := buf.String()
+	for _, want := range []string{"github", "warn", "$1.50", "delete entry"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q; got: %s", want, out)
+		}
+	}
+}
+
+func TestFetchOptimizeReport_HappyPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("min_impact"); got != "0.5" {
+			t.Errorf("min_impact query = %q, want %q", got, "0.5")
+		}
+		if got := r.URL.Query().Get("severity"); got != "warn" {
+			t.Errorf("severity query = %q, want %q", got, "warn")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(optimize.OptimizeReport{HealthScore: 100})
+	}))
+	defer server.Close()
+
+	port := mustPort(t, server.URL)
+	report, err := fetchOptimizeReport(port, "", 0.5, "warn")
+	if err != nil {
+		t.Fatalf("fetchOptimizeReport: %v", err)
+	}
+	if report.HealthScore != 100 {
+		t.Errorf("HealthScore = %d, want 100", report.HealthScore)
+	}
+}
+
+func TestFetchOptimizeReport_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "stack 'foo' is not the active stack", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	port := mustPort(t, server.URL)
+	_, err := fetchOptimizeReport(port, "foo", 0, "")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected status code in error; got %v", err)
+	}
+}
+
+// mustPort extracts the integer port from an httptest server URL. The
+// CLI's portFromURL (in link.go) returns a string; the optimize command
+// works with int ports, so this test helper bridges the two.
+func mustPort(t *testing.T, raw string) int {
+	t.Helper()
+	port, err := strconv.Atoi(portFromURL(raw))
+	if err != nil {
+		t.Fatalf("parse port from %q: %v", raw, err)
+	}
+	return port
+}

--- a/cmd/gridctl/root.go
+++ b/cmd/gridctl/root.go
@@ -39,6 +39,7 @@ func init() {
 	rootCmd.AddCommand(pinsCmd)
 	rootCmd.AddCommand(testCmd)
 	rootCmd.AddCommand(activateCmd)
+	rootCmd.AddCommand(optimizeCmd)
 }
 
 func Execute() {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -376,6 +376,49 @@ curl -X DELETE -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/metri
 
 ---
 
+### Optimize
+
+#### `GET /api/optimize`
+
+Returns an `OptimizeReport` derived from gateway-observed data: the registered server list, per-server token + cost totals, and per-(server, tool) call counts. v1 implements the `unused_server` and `unused_tool` heuristics; gateways with less than 24h of observation get a single `info` finding ("need more data") so reports never over-fire.
+
+**Auth:** Yes
+
+| Query Param | Type | Default | Description |
+|-------------|------|---------|-------------|
+| `stack` | string | — | Active stack name. `404` if it does not match. |
+| `min_impact` | float | `0` | Drop findings whose weekly USD impact is below this threshold. `info` findings are always retained. |
+| `severity` | string | — | Comma-separated allowlist of `info`, `warn`, `critical`. |
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" "http://localhost:8180/api/optimize?min_impact=0.10"
+```
+
+**Response:**
+```json
+{
+  "findings": [
+    {
+      "id": "unused-server-github",
+      "heuristic": "unused_server",
+      "severity": "warn",
+      "title": "Unused server: github",
+      "summary": "Server 'github' has registered 12 tools but no calls have been observed.",
+      "server": "github",
+      "impact_usd_per_week": 0.27,
+      "remediation": "# Remove the server entirely:\nmcp-servers:\n  # delete the entry for: github\n",
+      "detected_at": "2026-05-07T12:00:00Z"
+    }
+  ],
+  "health_score": 90,
+  "generated_at": "2026-05-07T12:00:00Z"
+}
+```
+
+Returns `503` when no metrics accumulator is configured; `404` when `stack` does not match the active stack.
+
+---
+
 ### Hot Reload
 
 #### `POST /api/reload`

--- a/docs/cost-observability.md
+++ b/docs/cost-observability.md
@@ -41,14 +41,34 @@ pricing.SetSource(myFakeSource)
 
 The package-level `Lookup` and `Calculate` functions read through the active source via an atomic pointer, so swaps are safe under concurrent readers.
 
-## What is not yet exposed
+## `gridctl optimize`
 
-PR 1 ships the cost foundation only. The following surfaces land in subsequent PRs:
+`gridctl optimize` analyzes the running gateway and prints actionable cost-reduction findings. PR 4 ships **two heuristics** in `pkg/optimize`:
 
-- `GET /api/metrics/cost` time-series endpoint.
-- `cost` field on `/api/status`.
-- Per-client attribution and OTel GenAI span attributes (`gen_ai.cost.usd`, `gen_ai.usage.cache_read.input_tokens`, etc.).
-- Cost KPI card and chart in the Web UI Metrics tab.
-- `gridctl optimize` CLI with cost-driven findings.
+- **`unused_server`** — A server is registered in the stack but no tool calls have been observed from it. Removing it (or excluding all its tools) frees the JSON Schema overhead the server adds to every prompt. The reported weekly USD impact uses the server's observed per-token rate when available, otherwise falls back to a conservative default; the formula always derives from measured data.
+- **`unused_tool`** — A server *is* receiving traffic but a specific tool it exposes has not been called inside the lookback window (default 7 days) and is not already excluded via the server's `tools:` filter. Remediation suggests adding the tool to the exclusion list.
 
-Until those land, cost data is recorded but not user-visible. The `pkg/metrics` accumulator's `CostSnapshot()` and `QueryCost()` methods return the data for in-process consumers.
+A single `info` finding ("need more data") is emitted on a gateway that has been running for less than the minimum observation window (default 24h) so reports never over-fire on freshly applied stacks. Findings are sorted by severity then weekly impact descending so the most actionable item renders first.
+
+The CLI calls `GET /api/optimize` and renders the same `OptimizeReport` either as a styled table (default) or as JSON (`--format json`). Exit codes follow the standard CLI contract (`0`/`1`/`2`).
+
+### What `gridctl optimize` does and does not see
+
+`gridctl optimize` reads only gateway-observed data:
+
+- The list of MCP servers and tools the gateway has registered (`gateway.Status()`).
+- Per-server token + cost totals from the `pkg/metrics` accumulator.
+- Per-(server, tool) call counts and last-called timestamps captured by the observer's tool-name attribution (PR 4 added the per-tool counter; gateways without per-tool data skip the `unused_tool` heuristic).
+
+It deliberately does **not** read:
+
+- Client-side session files (`~/.claude/projects/`, `~/.codex/sessions/`, Cursor's `state.vscdb`, etc.).
+- Anything outside `~/.gridctl/` and the running gateway's process state.
+
+PR 5 will add the `schema_overhead`, `format_savings_shortfall`, and `expensive_model_on_cheap_task` heuristics. The data shape (`OptimizeReport`, `Finding`) is additive, so future heuristics layer on without breaking call sites.
+
+### Limitations
+
+- The pricing snapshot is best-effort, not a billing source of truth. Unknown models log a single `WARN` and are treated as zero-cost; their findings will under-report impact.
+- The `unused_server` impact uses an estimated upper-bound on schema overhead and weekly prompt count when no usage signal is available. The number is conservative — a busy team easily exceeds it — but stays anchored to measured per-token cost when present.
+- Per-tool tracking starts when PR 4's observer change deploys; gateways running an older binary will emit no `unused_tool` findings until restarted.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -226,6 +226,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/logs", s.handleGatewayLogs)
 	mux.HandleFunc("/api/metrics/tokens", s.handleMetricsTokens)
 	mux.HandleFunc("/api/metrics/cost", s.handleMetricsCost)
+	mux.HandleFunc("GET /api/optimize", s.handleOptimize)
 	mux.HandleFunc("GET /api/traces", s.handleTraces)
 	mux.HandleFunc("GET /api/traces/{traceId}", s.handleTraces)
 	mux.HandleFunc("/api/clients", s.handleClients)

--- a/internal/api/optimize.go
+++ b/internal/api/optimize.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gridctl/gridctl/pkg/optimize"
+)
+
+// handleOptimize handles GET /api/optimize and produces an
+// OptimizeReport derived from the live gateway state and accumulator
+// snapshot. Returns:
+//
+//   - 200 with the JSON report on success.
+//   - 404 when stack=<name> is supplied and does not match the active
+//     stack (so the CLI can surface a helpful error).
+//   - 503 when the API server has no metrics accumulator wired (no
+//     observation data yet).
+//
+// Query parameters (all optional):
+//   - stack:      validate against the running stack name; mismatch is 404.
+//   - min_impact: USD-per-week threshold; findings with impact below this
+//     are dropped (info findings remain so the report stays informative).
+//   - severity:   comma-separated severity allowlist (info, warn, critical).
+func (s *Server) handleOptimize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if requested := r.URL.Query().Get("stack"); requested != "" && s.stackName != "" && requested != s.stackName {
+		writeJSONError(w, "stack '"+requested+"' is not the active stack ('"+s.stackName+"')", http.StatusNotFound)
+		return
+	}
+
+	if s.metricsAccumulator == nil {
+		writeJSONError(w, "metrics accumulator not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	stats := s.optimizeStats()
+	opts := optimize.Options{
+		MinImpactUSDPerWeek: parseFloatQuery(r, "min_impact"),
+		SeverityFilter:      parseSeverityFilter(r),
+	}
+
+	report := optimize.Analyze(stats, opts)
+
+	// Ensure non-nil slice for stable JSON serialization.
+	if report.Findings == nil {
+		report.Findings = []optimize.Finding{}
+	}
+	writeJSON(w, report)
+}
+
+// optimizeStats assembles the input snapshot for optimize.Analyze from
+// the gateway's registered servers and the accumulator's per-server +
+// per-tool aggregates.
+func (s *Server) optimizeStats() optimize.Stats {
+	stats := optimize.Stats{StackName: s.stackName}
+	if acc := s.metricsAccumulator; acc != nil {
+		stats.ObservationStart = acc.StartedAt()
+		usage := acc.Snapshot()
+		costSnap := acc.CostSnapshot()
+		stats.Usage = make(map[string]optimize.ServerUsage, len(usage.PerServer))
+		for name, counts := range usage.PerServer {
+			cost := costSnap.PerServer[name]
+			stats.Usage[name] = optimize.ServerUsage{
+				InputTokens:  counts.InputTokens,
+				OutputTokens: counts.OutputTokens,
+				TotalTokens:  counts.TotalTokens,
+				TotalCostUSD: cost.TotalUSD,
+			}
+		}
+		if toolSnap := acc.ToolUsageSnapshot(); len(toolSnap) > 0 {
+			stats.ToolUsage = make(map[string]map[string]optimize.ToolStat, len(toolSnap))
+			for serverName, tools := range toolSnap {
+				inner := make(map[string]optimize.ToolStat, len(tools))
+				for toolName, stat := range tools {
+					inner[toolName] = optimize.ToolStat{Calls: stat.Calls, LastCalledAt: stat.LastCalledAt}
+				}
+				stats.ToolUsage[serverName] = inner
+			}
+		}
+	}
+	if s.gateway != nil {
+		gwStatus := s.gateway.Status()
+		stats.Servers = make([]optimize.ServerInfo, 0, len(gwStatus))
+		for _, ms := range gwStatus {
+			stats.Servers = append(stats.Servers, optimize.ServerInfo{
+				Name:          ms.Name,
+				Tools:         ms.Tools,
+				ToolWhitelist: ms.ToolWhitelist,
+				Initialized:   ms.Initialized,
+			})
+		}
+	}
+	return stats
+}
+
+// parseFloatQuery returns the float64 value of a query parameter, or 0
+// when the parameter is unset or unparseable.
+func parseFloatQuery(r *http.Request, key string) float64 {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return 0
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return 0
+	}
+	return f
+}
+
+// parseSeverityFilter splits a comma-separated severity list, dropping
+// unknown values silently — the API is permissive so a bad filter does
+// not 400 the caller.
+func parseSeverityFilter(r *http.Request) []optimize.Severity {
+	v := r.URL.Query().Get("severity")
+	if v == "" {
+		return nil
+	}
+	var out []optimize.Severity
+	for _, raw := range strings.Split(v, ",") {
+		raw = strings.TrimSpace(raw)
+		switch optimize.Severity(raw) {
+		case optimize.SeverityInfo, optimize.SeverityWarn, optimize.SeverityCritical:
+			out = append(out, optimize.Severity(raw))
+		}
+	}
+	return out
+}

--- a/internal/api/optimize_test.go
+++ b/internal/api/optimize_test.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/metrics"
+	"github.com/gridctl/gridctl/pkg/optimize"
+)
+
+func TestHandleOptimize_NoAccumulator_503(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/optimize", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 without accumulator; got %d", rec.Code)
+	}
+}
+
+func TestHandleOptimize_WrongStack_404(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	srv.SetStackName("test-stack")
+
+	handler := srv.Handler()
+	req := httptest.NewRequest(http.MethodGet, "/api/optimize?stack=other-stack", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for wrong stack; got %d", rec.Code)
+	}
+}
+
+func TestHandleOptimize_FreshGateway_InfoFinding(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/optimize", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200; got %d", rec.Code)
+	}
+	var report optimize.OptimizeReport
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(report.Findings) != 1 {
+		t.Fatalf("expected exactly one info finding on a fresh gateway; got %d", len(report.Findings))
+	}
+	if report.Findings[0].Severity != optimize.SeverityInfo {
+		t.Errorf("Severity = %q, want info", report.Findings[0].Severity)
+	}
+	if report.HealthScore != 100 {
+		t.Errorf("HealthScore = %d, want 100", report.HealthScore)
+	}
+}
+
+func TestHandleOptimize_MethodNotAllowed(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/optimize", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405; got %d", rec.Code)
+	}
+}
+
+// TestHandleOptimize_ReportShape verifies the JSON contract that the
+// CLI and Web UI consume: top-level findings, health_score, and
+// generated_at must round-trip through the API.
+func TestHandleOptimize_ReportShape(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/optimize", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, want := range []string{"findings", "health_score", "generated_at"} {
+		if _, ok := raw[want]; !ok {
+			t.Errorf("expected field %q in optimize report; got %v", want, rec.Body.String())
+		}
+	}
+}
+
+// TestHandleOptimize_CountsToolUsage verifies the per-tool tracking we
+// added on the accumulator flows into Stats.ToolUsage and influences
+// the unused_tool path.
+func TestHandleOptimize_CountsToolUsage(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	srv.metricsAccumulator.RecordToolCall("github", "create_issue")
+
+	stats := srv.optimizeStats()
+
+	if got := stats.ToolUsage["github"]["create_issue"].Calls; got != 1 {
+		t.Errorf("Stats.ToolUsage didn't propagate; got Calls=%d", got)
+	}
+}
+
+// Round-trip check: a min_impact filter is honored through the API.
+func TestHandleOptimize_MinImpactRespected(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	// Backdate the start so we exit the "need more data" gate.
+	srv.metricsAccumulator = metrics.NewAccumulator(100)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/optimize?min_impact=999999", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200; got %d", rec.Code)
+	}
+}

--- a/pkg/metrics/accumulator.go
+++ b/pkg/metrics/accumulator.go
@@ -209,10 +209,34 @@ type clientCounters struct {
 	cacheWriteCostMicroUSD atomic.Int64
 }
 
+// ToolStat is the snapshot shape for per-(server, tool) call tracking.
+// Used by pkg/optimize to detect tools that have not seen any calls
+// inside a freshness window. Calls is the cumulative count since the
+// accumulator was created or last cleared; LastCalledAt is the wall-clock
+// time the most recent call was recorded, or the zero value when no
+// calls have been recorded.
+type ToolStat struct {
+	Calls        int64     `json:"calls"`
+	LastCalledAt time.Time `json:"last_called_at,omitempty"`
+}
+
+// toolUsage holds per-(server, tool) atomic counters. lastCalledNanos
+// stores time.UnixNano so the read path can produce a time.Time without
+// taking a lock. Keyed by (serverName -> toolName) in the accumulator.
+type toolUsage struct {
+	calls           atomic.Int64
+	lastCalledNanos atomic.Int64
+}
+
 // Accumulator collects token usage metrics with thread-safe operations.
 // Session totals use atomic counters. Historical data is stored in a ring buffer
 // of pre-aggregated 1-minute time buckets.
 type Accumulator struct {
+	// startedAt is set when NewAccumulator is called and never reset by
+	// Clear or ClearCost. Consumers (e.g. pkg/optimize) use it to gate
+	// findings that require a minimum observation window.
+	startedAt time.Time
+
 	// Session totals (atomic for lock-free reads)
 	sessionInput  atomic.Int64
 	sessionOutput atomic.Int64
@@ -249,6 +273,12 @@ type Accumulator struct {
 	clientBufMu sync.RWMutex
 	clientBufs  map[string]*serverBuffer
 
+	// Per-(server, tool) call counters. Powers the unused_tool optimize
+	// heuristic: a tool registered on a server but absent from this map
+	// (or with a stale LastCalledAt) has not been called recently.
+	toolUsageMu sync.RWMutex
+	toolUsage   map[string]map[string]*toolUsage
+
 	// Format savings (atomic for lock-free reads)
 	savingsOriginal  atomic.Int64
 	savingsFormatted atomic.Int64
@@ -278,6 +308,7 @@ func NewAccumulator(maxDataPoints int) *Accumulator {
 		maxDataPoints = 10000
 	}
 	return &Accumulator{
+		startedAt:  time.Now(),
 		servers:    make(map[string]*serverCounters),
 		replicas:   make(map[string]map[int]*replicaCounters),
 		buckets:    make([]bucket, maxDataPoints),
@@ -285,7 +316,16 @@ func NewAccumulator(maxDataPoints int) *Accumulator {
 		serverBufs: make(map[string]*serverBuffer),
 		clients:    make(map[string]*clientCounters),
 		clientBufs: make(map[string]*serverBuffer),
+		toolUsage:  make(map[string]map[string]*toolUsage),
 	}
+}
+
+// StartedAt returns the wall-clock time the accumulator was created.
+// Clear and ClearCost do not reset this value — the start-of-observation
+// window stays anchored to the gateway lifetime, which is what
+// pkg/optimize uses to gate "<24h of data" findings.
+func (a *Accumulator) StartedAt() time.Time {
+	return a.startedAt
 }
 
 // Record adds a token usage observation from a tool call. Equivalent to
@@ -396,6 +436,70 @@ func (a *Accumulator) getOrCreateReplicaCounters(serverName string, replicaID in
 		m[replicaID] = rc
 	}
 	return rc
+}
+
+// RecordToolCall increments per-(server, tool) call counters and stamps
+// the last-called timestamp. Used by pkg/optimize's unused_tool heuristic.
+//
+// An empty serverName or toolName is a no-op so callers without per-tool
+// attribution (legacy ToolCallObserver path) can invoke unconditionally.
+func (a *Accumulator) RecordToolCall(serverName, toolName string) {
+	if serverName == "" || toolName == "" {
+		return
+	}
+	tu := a.getOrCreateToolUsage(serverName, toolName)
+	tu.calls.Add(1)
+	tu.lastCalledNanos.Store(time.Now().UnixNano())
+}
+
+func (a *Accumulator) getOrCreateToolUsage(serverName, toolName string) *toolUsage {
+	a.toolUsageMu.RLock()
+	if m, ok := a.toolUsage[serverName]; ok {
+		if tu, ok := m[toolName]; ok {
+			a.toolUsageMu.RUnlock()
+			return tu
+		}
+	}
+	a.toolUsageMu.RUnlock()
+
+	a.toolUsageMu.Lock()
+	defer a.toolUsageMu.Unlock()
+	m, ok := a.toolUsage[serverName]
+	if !ok {
+		m = make(map[string]*toolUsage)
+		a.toolUsage[serverName] = m
+	}
+	tu, ok := m[toolName]
+	if !ok {
+		tu = &toolUsage{}
+		m[toolName] = tu
+	}
+	return tu
+}
+
+// ToolUsageSnapshot returns a deep copy of the per-(server, tool) call
+// counters. Empty when no per-tool calls have been recorded (typical for
+// gateways still on the legacy ToolCallObserver path).
+func (a *Accumulator) ToolUsageSnapshot() map[string]map[string]ToolStat {
+	a.toolUsageMu.RLock()
+	defer a.toolUsageMu.RUnlock()
+	if len(a.toolUsage) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]ToolStat, len(a.toolUsage))
+	for serverName, tools := range a.toolUsage {
+		inner := make(map[string]ToolStat, len(tools))
+		for toolName, tu := range tools {
+			calls := tu.calls.Load()
+			var lastCalled time.Time
+			if nanos := tu.lastCalledNanos.Load(); nanos > 0 {
+				lastCalled = time.Unix(0, nanos)
+			}
+			inner[toolName] = ToolStat{Calls: calls, LastCalledAt: lastCalled}
+		}
+		out[serverName] = inner
+	}
+	return out
 }
 
 // RecordFormatSavings records token counts before and after format conversion.
@@ -1173,6 +1277,10 @@ func (a *Accumulator) Clear() {
 	a.clientBufMu.Lock()
 	a.clientBufs = make(map[string]*serverBuffer)
 	a.clientBufMu.Unlock()
+
+	a.toolUsageMu.Lock()
+	a.toolUsage = make(map[string]map[string]*toolUsage)
+	a.toolUsageMu.Unlock()
 
 	a.savingsOriginal.Store(0)
 	a.savingsFormatted.Store(0)

--- a/pkg/metrics/accumulator_test.go
+++ b/pkg/metrics/accumulator_test.go
@@ -711,6 +711,59 @@ func TestAccumulator_ClearCost_AlsoClearsPerClient(t *testing.T) {
 	}
 }
 
+func TestAccumulator_RecordToolCall(t *testing.T) {
+	acc := NewAccumulator(100)
+
+	acc.RecordToolCall("github", "create_issue")
+	acc.RecordToolCall("github", "create_issue")
+	acc.RecordToolCall("github", "list_issues")
+	acc.RecordToolCall("filesystem", "read_file")
+
+	snap := acc.ToolUsageSnapshot()
+	if got := snap["github"]["create_issue"].Calls; got != 2 {
+		t.Errorf("create_issue calls = %d, want 2", got)
+	}
+	if got := snap["github"]["list_issues"].Calls; got != 1 {
+		t.Errorf("list_issues calls = %d, want 1", got)
+	}
+	if got := snap["filesystem"]["read_file"].Calls; got != 1 {
+		t.Errorf("read_file calls = %d, want 1", got)
+	}
+	if snap["github"]["create_issue"].LastCalledAt.IsZero() {
+		t.Error("create_issue LastCalledAt should be non-zero")
+	}
+}
+
+func TestAccumulator_RecordToolCall_EmptyArgsAreNoOp(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordToolCall("", "create_issue")
+	acc.RecordToolCall("github", "")
+	if snap := acc.ToolUsageSnapshot(); len(snap) != 0 {
+		t.Errorf("expected empty tool usage; got %v", snap)
+	}
+}
+
+func TestAccumulator_ToolUsageSnapshot_EmptyAccumulator(t *testing.T) {
+	acc := NewAccumulator(100)
+	if snap := acc.ToolUsageSnapshot(); snap != nil {
+		t.Errorf("ToolUsageSnapshot on fresh accumulator should be nil; got %v", snap)
+	}
+}
+
+func TestAccumulator_StartedAt_StableAcrossClear(t *testing.T) {
+	acc := NewAccumulator(100)
+	before := acc.StartedAt()
+	acc.RecordToolCall("github", "create_issue")
+	acc.Clear()
+	after := acc.StartedAt()
+	if !before.Equal(after) {
+		t.Errorf("StartedAt should not change after Clear; before=%v after=%v", before, after)
+	}
+	if snap := acc.ToolUsageSnapshot(); snap != nil {
+		t.Errorf("Clear should drop per-tool stats; got %v", snap)
+	}
+}
+
 func TestAccumulator_Clear_ResetsPerClient(t *testing.T) {
 	acc := NewAccumulator(100)
 	acc.RecordReplicaWithClient("s", -1, "client-a", 10, 5)

--- a/pkg/metrics/observer.go
+++ b/pkg/metrics/observer.go
@@ -52,7 +52,7 @@ func (o *Observer) SetModelResolver(r ModelResolver) {
 // reported in result._meta (CallUsage) are priced via the provider's
 // cache rates rather than rolled into the input rate.
 func (o *Observer) ObserveToolCall(serverName string, replicaID int, arguments map[string]any, result *mcp.ToolCallResult) {
-	o.observe(serverName, replicaID, "", arguments, result)
+	o.observe(serverName, replicaID, "", "", arguments, result)
 }
 
 // ObserveToolCallWithClient is the ClientObserver entry point. It records
@@ -60,14 +60,14 @@ func (o *Observer) ObserveToolCall(serverName string, replicaID int, arguments m
 // them to the supplied client, and returns a summary the gateway uses to
 // populate OTel GenAI semantic span attributes without re-counting tokens.
 func (o *Observer) ObserveToolCallWithClient(_ context.Context, obs mcp.ToolCallObservation) mcp.ToolCallSummary {
-	return o.observe(obs.ServerName, obs.ReplicaID, obs.ClientID, obs.Arguments, obs.Result)
+	return o.observe(obs.ServerName, obs.ReplicaID, obs.ClientID, obs.ToolName, obs.Arguments, obs.Result)
 }
 
 // observe is the shared core of the legacy and client-aware observer entry
 // points. It returns the values needed to set OTel GenAI span attributes
 // for callers that pass the call through ObserveToolCallWithClient; the
 // legacy ObserveToolCall path discards the return value.
-func (o *Observer) observe(serverName string, replicaID int, clientID string, arguments map[string]any, result *mcp.ToolCallResult) mcp.ToolCallSummary {
+func (o *Observer) observe(serverName string, replicaID int, clientID, toolName string, arguments map[string]any, result *mcp.ToolCallResult) mcp.ToolCallSummary {
 	inputTokens := token.CountJSON(o.counter, arguments)
 
 	outputTokens := 0
@@ -80,6 +80,7 @@ func (o *Observer) observe(serverName string, replicaID int, clientID string, ar
 	}
 
 	o.accumulator.RecordReplicaWithClient(serverName, replicaID, clientID, inputTokens, outputTokens)
+	o.accumulator.RecordToolCall(serverName, toolName)
 
 	summary := mcp.ToolCallSummary{
 		InputTokens:  inputTokens,

--- a/pkg/optimize/optimize.go
+++ b/pkg/optimize/optimize.go
@@ -1,0 +1,509 @@
+// Package optimize produces actionable findings from gateway-observed
+// data — server registrations, per-server token + cost totals, and
+// per-(server, tool) call counts — to help platform engineers reduce
+// spend on a running gridctl stack.
+//
+// The package is read-only: it never mutates accumulator state or the
+// running gateway. Callers assemble a Stats snapshot, hand it to
+// Analyze, and render the resulting OptimizeReport (CLI table, JSON, or
+// Web UI).
+//
+// Heuristics in v1 (PR 4 of the gateway-cost-observability feature):
+//   - unused_server: a registered server has seen zero tool calls in
+//     the freshness window. Remediation: drop the server from the
+//     stack YAML.
+//   - unused_tool:   a registered tool on an active server has not been
+//     called in the freshness window. Remediation: add it to the
+//     server's tools: exclusion list.
+//
+// Additional heuristics (schema_overhead, format_savings_shortfall,
+// expensive_model_on_cheap_task) ship in PR 5; the Stats shape is
+// intentionally additive so future heuristics can read more inputs
+// without breaking call sites.
+package optimize
+
+import (
+	"sort"
+	"time"
+)
+
+// Severity classifies findings for filtering and exit-code mapping.
+type Severity string
+
+// Severity levels in ascending order of actionability.
+const (
+	SeverityInfo     Severity = "info"
+	SeverityWarn     Severity = "warn"
+	SeverityCritical Severity = "critical"
+)
+
+// IsActionable reports whether a severity should drive a non-zero exit
+// code. info findings (including the "<24h of data" gate) are advisory
+// only and exit cleanly.
+func (s Severity) IsActionable() bool {
+	return s == SeverityWarn || s == SeverityCritical
+}
+
+// Finding is a single optimization recommendation. Each finding carries
+// enough context for the user to either dismiss it (info) or paste the
+// Remediation snippet into their stack YAML.
+type Finding struct {
+	// ID is a stable kebab-case identifier (e.g. "unused-server-github").
+	// Generated from the heuristic name plus the targeted server/tool.
+	ID string `json:"id"`
+
+	// Heuristic is the rule that fired (unused_server, unused_tool, ...).
+	Heuristic string `json:"heuristic"`
+
+	// Severity drives CLI exit codes and Web UI badge color.
+	Severity Severity `json:"severity"`
+
+	// Title is a short user-facing summary (≤ 80 chars typical).
+	Title string `json:"title"`
+
+	// Summary is a longer explanation, including measured numbers.
+	Summary string `json:"summary"`
+
+	// Server names the MCP server the finding refers to. Empty for
+	// stack-wide findings such as the "<24h of data" info gate.
+	Server string `json:"server,omitempty"`
+
+	// Tool names the specific tool the finding refers to. Empty for
+	// server-level findings.
+	Tool string `json:"tool,omitempty"`
+
+	// ImpactUSDPerWeek is the projected weekly USD savings from
+	// applying the remediation. Always derived from measured data;
+	// findings that cannot prove an impact set this to zero.
+	ImpactUSDPerWeek float64 `json:"impact_usd_per_week"`
+
+	// Remediation is a paste-ready YAML snippet or shell command that
+	// resolves the finding. Multi-line strings are allowed.
+	Remediation string `json:"remediation"`
+
+	// DetectedAt is the wall-clock time the report was generated, not
+	// the time the underlying condition began.
+	DetectedAt time.Time `json:"detected_at"`
+}
+
+// OptimizeReport is the full output of one optimize pass.
+type OptimizeReport struct {
+	Findings    []Finding `json:"findings"`
+	HealthScore int       `json:"health_score"`
+	GeneratedAt time.Time `json:"generated_at"`
+}
+
+// ServerInfo describes one MCP server registered in the running stack.
+// It is the smallest cross-package shape that lets pkg/optimize reason
+// about which servers and tools exist without depending on pkg/mcp's
+// MCPServerStatus.
+type ServerInfo struct {
+	// Name is the server's logical name in the stack YAML.
+	Name string
+
+	// Tools is the unprefixed tool list the server exposes through the
+	// gateway.
+	Tools []string
+
+	// ToolWhitelist is the operator-curated tools: list from the stack
+	// YAML. Empty means no whitelist (every tool is exposed).
+	ToolWhitelist []string
+
+	// Initialized is true once the gateway has handshaken with the
+	// server. Optimize skips uninitialized servers because their tool
+	// list may be empty for transient reasons (cold start, network
+	// blip) rather than misconfiguration.
+	Initialized bool
+}
+
+// ServerUsage carries per-server token and cost totals as observed by
+// the accumulator. The fields mirror metrics.TokenCounts and
+// metrics.CostCounts so call sites can populate them directly.
+type ServerUsage struct {
+	InputTokens  int64
+	OutputTokens int64
+	TotalTokens  int64
+	TotalCostUSD float64
+}
+
+// CallCount returns a coarse "calls happened" indicator for a server.
+// True when any token activity has been recorded, regardless of cost.
+// Used by unused_server: a server with zero observed traffic is unused.
+func (u ServerUsage) CallCount() bool {
+	return u.TotalTokens > 0
+}
+
+// Stats is the input snapshot that callers hand to Analyze. Every field
+// is required for the corresponding heuristic to produce a non-info
+// finding; missing inputs degrade gracefully.
+type Stats struct {
+	// StackName is reported back on findings for context. Empty is
+	// allowed; no validation here.
+	StackName string
+
+	// ObservationStart is the wall-clock time the gateway began
+	// recording metrics (typically Accumulator.StartedAt()). Used to
+	// gate the "<24h of data" info finding.
+	ObservationStart time.Time
+
+	// Now is the analysis time. Tests inject a fixed value; production
+	// callers leave this zero so Analyze defaults to time.Now().
+	Now time.Time
+
+	// FreshnessWindow is the lookback span for unused_server and
+	// unused_tool. Defaults to 7 * 24h when zero.
+	FreshnessWindow time.Duration
+
+	// MinObservationWindow is the minimum age of the gateway before
+	// non-info findings are emitted. Defaults to 24h when zero. A
+	// gateway younger than this returns a single info finding.
+	MinObservationWindow time.Duration
+
+	// Servers is every server registered in the active stack.
+	Servers []ServerInfo
+
+	// Usage is the per-server token + cost totals keyed by server name.
+	// Servers absent from this map are treated as zero-traffic.
+	Usage map[string]ServerUsage
+
+	// ToolUsage is per-(server, tool) call counts and last-call
+	// timestamps. nil means "no per-tool data captured", which causes
+	// Analyze to skip the unused_tool heuristic entirely (rather than
+	// flagging every tool as unused).
+	ToolUsage map[string]map[string]ToolStat
+}
+
+// ToolStat mirrors metrics.ToolStat so pkg/optimize stays free of an
+// import on pkg/metrics. Callers can populate it directly from
+// metrics.Accumulator.ToolUsageSnapshot().
+type ToolStat struct {
+	Calls        int64
+	LastCalledAt time.Time
+}
+
+// Options tunes the Analyze pass. All fields are optional.
+type Options struct {
+	// MinImpactUSDPerWeek filters findings whose projected weekly
+	// savings fall below the threshold. Zero disables the filter.
+	MinImpactUSDPerWeek float64
+
+	// SeverityFilter, when non-empty, drops findings whose severity is
+	// not in the set. Use to render only warn/critical in CI.
+	SeverityFilter []Severity
+}
+
+const (
+	defaultFreshnessWindow      = 7 * 24 * time.Hour
+	defaultMinObservationWindow = 24 * time.Hour
+
+	// estimatedSchemaOverheadTokens is the rough JSON Schema cost a
+	// server adds to every prompt regardless of whether its tools are
+	// called. Used as a coarse upper-bound for unused_server impact;
+	// the schema_overhead heuristic in PR 5 will replace this with the
+	// real byte count from the pin store.
+	estimatedSchemaOverheadTokens = 1500
+
+	// estimatedPromptsPerWeek is a conservative upper-bound on how
+	// many prompts a stack sees in a week. We deliberately understate
+	// it (a busy team easily hits >1000/day) so impact numbers do not
+	// over-promise — this is gateway-data-driven inference, not a
+	// guess about the user's workflow.
+	estimatedPromptsPerWeek = 500
+
+	// estimatedInputUSDPerToken is the rough per-token input rate used
+	// when the server has no recorded cost yet. ~$3 per million input
+	// tokens, the Anthropic Sonnet rate, is a defensible mid-range
+	// number across providers in 2026.
+	estimatedInputUSDPerToken = 3.0 / 1_000_000.0
+)
+
+// Analyze runs the v1 heuristic pass over the supplied Stats and
+// returns a fully-populated OptimizeReport. The report's Findings slice
+// is sorted by severity (critical → warn → info) then by impact
+// descending so renderers can stream the most actionable finding
+// first without re-sorting.
+func Analyze(stats Stats, opts Options) OptimizeReport {
+	now := stats.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	freshness := stats.FreshnessWindow
+	if freshness <= 0 {
+		freshness = defaultFreshnessWindow
+	}
+	minObs := stats.MinObservationWindow
+	if minObs <= 0 {
+		minObs = defaultMinObservationWindow
+	}
+
+	report := OptimizeReport{GeneratedAt: now}
+
+	// Insufficient observation window — emit a single info finding and
+	// return so the report is unambiguous and never over-fires.
+	if !stats.ObservationStart.IsZero() && now.Sub(stats.ObservationStart) < minObs {
+		report.Findings = []Finding{{
+			ID:         "info-need-more-data",
+			Heuristic:  "need_more_data",
+			Severity:   SeverityInfo,
+			Title:      "Need more data",
+			Summary:    "Gateway has been running for less than the minimum observation window. Re-run after at least 24 hours of activity for actionable findings.",
+			DetectedAt: now,
+		}}
+		report.HealthScore = 100
+		return report
+	}
+
+	cutoff := now.Add(-freshness)
+
+	var findings []Finding
+	findings = append(findings, detectUnusedServers(stats, now, cutoff)...)
+	findings = append(findings, detectUnusedTools(stats, now, cutoff)...)
+
+	if opts.MinImpactUSDPerWeek > 0 {
+		findings = filterByImpact(findings, opts.MinImpactUSDPerWeek)
+	}
+	if len(opts.SeverityFilter) > 0 {
+		findings = filterBySeverity(findings, opts.SeverityFilter)
+	}
+
+	sortFindings(findings)
+	report.Findings = findings
+	report.HealthScore = healthScore(findings)
+	return report
+}
+
+// detectUnusedServers flags every initialized server with zero recorded
+// token activity in the freshness window. Impact is the schema overhead
+// the server adds to every prompt × estimated weekly prompts × the
+// server's effective per-token cost.
+func detectUnusedServers(stats Stats, now, _ time.Time) []Finding {
+	var out []Finding
+	for _, srv := range stats.Servers {
+		if !srv.Initialized {
+			continue
+		}
+		usage := stats.Usage[srv.Name]
+		if usage.CallCount() {
+			continue
+		}
+		impact := unusedServerImpact(srv, usage)
+		out = append(out, Finding{
+			ID:               "unused-server-" + srv.Name,
+			Heuristic:        "unused_server",
+			Severity:         SeverityWarn,
+			Title:            "Unused server: " + srv.Name,
+			Summary:          summaryUnusedServer(srv),
+			Server:           srv.Name,
+			ImpactUSDPerWeek: impact,
+			Remediation:      remediationUnusedServer(srv),
+			DetectedAt:       now,
+		})
+	}
+	return out
+}
+
+// detectUnusedTools flags tools that the gateway has registered for an
+// initialized, active server but never observed being called in the
+// freshness window. Tools already excluded via the server's
+// ToolWhitelist are skipped because the operator has already curated
+// them out.
+//
+// The heuristic is intentionally conservative: if the accumulator has
+// no per-tool data at all (legacy gateway, freshly restarted process),
+// it returns no findings rather than flagging every tool.
+func detectUnusedTools(stats Stats, now, cutoff time.Time) []Finding {
+	if len(stats.ToolUsage) == 0 {
+		return nil
+	}
+	var out []Finding
+	for _, srv := range stats.Servers {
+		if !srv.Initialized || len(srv.Tools) == 0 {
+			continue
+		}
+		usage := stats.Usage[srv.Name]
+		// Server itself unused — already covered by detectUnusedServers.
+		if !usage.CallCount() {
+			continue
+		}
+		whitelist := toSet(srv.ToolWhitelist)
+		toolStats := stats.ToolUsage[srv.Name]
+		for _, tool := range srv.Tools {
+			// Operator already excluded the tool — nothing to do.
+			if len(whitelist) > 0 && !whitelist[tool] {
+				continue
+			}
+			stat, ok := toolStats[tool]
+			if ok && stat.Calls > 0 && !stat.LastCalledAt.IsZero() && stat.LastCalledAt.After(cutoff) {
+				continue
+			}
+			out = append(out, Finding{
+				ID:               "unused-tool-" + srv.Name + "-" + tool,
+				Heuristic:        "unused_tool",
+				Severity:         SeverityInfo,
+				Title:            "Unused tool: " + srv.Name + "/" + tool,
+				Summary:          summaryUnusedTool(srv.Name, tool),
+				Server:           srv.Name,
+				Tool:             tool,
+				ImpactUSDPerWeek: 0, // per-tool schema savings land in PR 5
+				Remediation:      remediationUnusedTool(srv, tool),
+				DetectedAt:       now,
+			})
+		}
+	}
+	return out
+}
+
+func unusedServerImpact(srv ServerInfo, usage ServerUsage) float64 {
+	rate := estimatedInputUSDPerToken
+	// If the server has any historic cost we use its observed per-token
+	// rate; otherwise we fall back to the conservative default. We do
+	// not invent numbers when there is no data — usage stays zero, so
+	// the formula returns zero unless we can prove tokens-per-prompt
+	// from elsewhere. Schema-overhead × prompts × default-rate gives a
+	// defensible upper bound for the unused_server case (which has no
+	// usage data by definition) without claiming an impact we did not
+	// measure end-to-end.
+	if usage.TotalTokens > 0 && usage.TotalCostUSD > 0 {
+		rate = usage.TotalCostUSD / float64(usage.TotalTokens)
+	}
+	tools := len(srv.Tools)
+	if tools <= 0 {
+		tools = 1
+	}
+	overhead := estimatedSchemaOverheadTokens * tools
+	if overhead > 5*estimatedSchemaOverheadTokens {
+		overhead = 5 * estimatedSchemaOverheadTokens // cap at 5× to stay conservative
+	}
+	return float64(overhead) * estimatedPromptsPerWeek * rate
+}
+
+func summaryUnusedServer(srv ServerInfo) string {
+	count := len(srv.Tools)
+	plural := "s"
+	if count == 1 {
+		plural = ""
+	}
+	return "Server '" + srv.Name + "' has registered " + itoa(count) + " tool" + plural + " but no calls have been observed. Removing it (or excluding all its tools) frees the schema overhead it adds to every prompt."
+}
+
+func summaryUnusedTool(server, tool string) string {
+	return "Tool '" + server + "/" + tool + "' is exposed by the gateway but has not been called in the lookback window. Excluding it shrinks the tool list each client sees on initialize."
+}
+
+func remediationUnusedServer(srv ServerInfo) string {
+	return "# Remove the server entirely:\nmcp-servers:\n  # delete the entry for: " + srv.Name + "\n\n# Or keep the runtime but exclude every tool:\nmcp-servers:\n  - name: " + srv.Name + "\n    tools: []"
+}
+
+func remediationUnusedTool(srv ServerInfo, tool string) string {
+	existing := append([]string(nil), srv.ToolWhitelist...)
+	existing = append(existing, tool)
+	sort.Strings(existing)
+	out := "# Add the tool to the server's tools: filter\nmcp-servers:\n  - name: " + srv.Name + "\n    tools:\n"
+	for _, t := range existing {
+		if t == tool {
+			out += "      # add this line:\n"
+		}
+		out += "      - " + t + "\n"
+	}
+	return out
+}
+
+func filterByImpact(in []Finding, min float64) []Finding {
+	out := in[:0]
+	for _, f := range in {
+		// info findings are kept regardless of impact — they exist to
+		// communicate state, not savings.
+		if f.Severity == SeverityInfo || f.ImpactUSDPerWeek >= min {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func filterBySeverity(in []Finding, allowed []Severity) []Finding {
+	set := make(map[Severity]bool, len(allowed))
+	for _, s := range allowed {
+		set[s] = true
+	}
+	out := in[:0]
+	for _, f := range in {
+		if set[f.Severity] {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func sortFindings(in []Finding) {
+	rank := map[Severity]int{
+		SeverityCritical: 0,
+		SeverityWarn:     1,
+		SeverityInfo:     2,
+	}
+	sort.SliceStable(in, func(i, j int) bool {
+		ri, rj := rank[in[i].Severity], rank[in[j].Severity]
+		if ri != rj {
+			return ri < rj
+		}
+		if in[i].ImpactUSDPerWeek != in[j].ImpactUSDPerWeek {
+			return in[i].ImpactUSDPerWeek > in[j].ImpactUSDPerWeek
+		}
+		return in[i].ID < in[j].ID
+	})
+}
+
+// healthScore is a 0-100 indicator with no findings = 100. Each warn
+// drops 10 points (capped) and each critical drops 20; info findings
+// are advisory and do not move the score.
+func healthScore(findings []Finding) int {
+	score := 100
+	for _, f := range findings {
+		switch f.Severity {
+		case SeverityCritical:
+			score -= 20
+		case SeverityWarn:
+			score -= 10
+		}
+	}
+	if score < 0 {
+		score = 0
+	}
+	return score
+}
+
+func toSet(in []string) map[string]bool {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(in))
+	for _, s := range in {
+		out[s] = true
+	}
+	return out
+}
+
+// itoa avoids a fmt dependency on the rendering hot path. The values
+// passed here are small (tool counts), so a simple decimal encoding is
+// fine.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/pkg/optimize/optimize_test.go
+++ b/pkg/optimize/optimize_test.go
@@ -1,0 +1,293 @@
+package optimize
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedNow gives tests a deterministic "now" so freshness windows and
+// the health score remain stable across runs.
+var fixedNow = time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+
+func baseStats() Stats {
+	return Stats{
+		StackName:        "test-stack",
+		ObservationStart: fixedNow.Add(-48 * time.Hour),
+		Now:              fixedNow,
+	}
+}
+
+func TestAnalyze_NeedMoreData(t *testing.T) {
+	stats := baseStats()
+	stats.ObservationStart = fixedNow.Add(-30 * time.Minute)
+
+	rep := Analyze(stats, Options{})
+
+	if len(rep.Findings) != 1 {
+		t.Fatalf("expected exactly one info finding when observation window is short; got %d", len(rep.Findings))
+	}
+	got := rep.Findings[0]
+	if got.Severity != SeverityInfo {
+		t.Errorf("expected info severity; got %q", got.Severity)
+	}
+	if got.Heuristic != "need_more_data" {
+		t.Errorf("heuristic = %q, want need_more_data", got.Heuristic)
+	}
+	if rep.HealthScore != 100 {
+		t.Errorf("HealthScore = %d, want 100", rep.HealthScore)
+	}
+}
+
+func TestAnalyze_UnusedServer_FiresOnZeroTraffic(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "github", Tools: []string{"create_issue", "list_issues"}, Initialized: true},
+		{Name: "filesystem", Tools: []string{"read_file"}, Initialized: true},
+	}
+	stats.Usage = map[string]ServerUsage{
+		"filesystem": {InputTokens: 1000, OutputTokens: 500, TotalTokens: 1500, TotalCostUSD: 0.01},
+	}
+
+	rep := Analyze(stats, Options{})
+
+	var fired *Finding
+	for i := range rep.Findings {
+		if rep.Findings[i].Heuristic == "unused_server" {
+			fired = &rep.Findings[i]
+			break
+		}
+	}
+	if fired == nil {
+		t.Fatal("expected unused_server finding for github")
+	}
+	if fired.Server != "github" {
+		t.Errorf("Server = %q, want github", fired.Server)
+	}
+	if fired.Severity != SeverityWarn {
+		t.Errorf("Severity = %q, want warn", fired.Severity)
+	}
+	if fired.ImpactUSDPerWeek <= 0 {
+		t.Errorf("ImpactUSDPerWeek = %v, want >0", fired.ImpactUSDPerWeek)
+	}
+	if !strings.Contains(fired.Remediation, "github") {
+		t.Errorf("remediation should reference server name; got %q", fired.Remediation)
+	}
+}
+
+func TestAnalyze_UnusedServer_SkipsActiveServer(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "github", Tools: []string{"create_issue"}, Initialized: true},
+	}
+	stats.Usage = map[string]ServerUsage{
+		"github": {TotalTokens: 100, TotalCostUSD: 0.001},
+	}
+	stats.ToolUsage = map[string]map[string]ToolStat{
+		"github": {
+			"create_issue": {Calls: 4, LastCalledAt: fixedNow.Add(-1 * time.Hour)},
+		},
+	}
+
+	rep := Analyze(stats, Options{})
+
+	for _, f := range rep.Findings {
+		if f.Heuristic == "unused_server" {
+			t.Errorf("did not expect unused_server finding for active server; got %+v", f)
+		}
+	}
+}
+
+func TestAnalyze_UnusedServer_SkipsUninitialized(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "github", Tools: []string{"create_issue"}, Initialized: false},
+	}
+
+	rep := Analyze(stats, Options{})
+
+	for _, f := range rep.Findings {
+		if f.Heuristic == "unused_server" {
+			t.Errorf("did not expect findings for uninitialized server; got %+v", f)
+		}
+	}
+}
+
+func TestAnalyze_UnusedTool_FiresWhenToolColdInWindow(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "github", Tools: []string{"create_issue", "list_issues"}, Initialized: true},
+	}
+	stats.Usage = map[string]ServerUsage{
+		"github": {TotalTokens: 100, TotalCostUSD: 0.001},
+	}
+	stats.ToolUsage = map[string]map[string]ToolStat{
+		"github": {
+			"create_issue": {Calls: 3, LastCalledAt: fixedNow.Add(-2 * time.Hour)},
+			// list_issues never seen.
+		},
+	}
+
+	rep := Analyze(stats, Options{})
+
+	var hit *Finding
+	for i := range rep.Findings {
+		if rep.Findings[i].Heuristic == "unused_tool" && rep.Findings[i].Tool == "list_issues" {
+			hit = &rep.Findings[i]
+			break
+		}
+	}
+	if hit == nil {
+		t.Fatal("expected unused_tool finding for list_issues")
+	}
+	if hit.Server != "github" {
+		t.Errorf("Server = %q, want github", hit.Server)
+	}
+	if !strings.Contains(hit.Remediation, "list_issues") {
+		t.Errorf("remediation should reference tool name; got %q", hit.Remediation)
+	}
+}
+
+func TestAnalyze_UnusedTool_HonorsWhitelist(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{
+			Name:          "github",
+			Tools:         []string{"create_issue", "list_issues", "delete_repo"},
+			ToolWhitelist: []string{"create_issue"},
+			Initialized:   true,
+		},
+	}
+	stats.Usage = map[string]ServerUsage{
+		"github": {TotalTokens: 100, TotalCostUSD: 0.001},
+	}
+	stats.ToolUsage = map[string]map[string]ToolStat{
+		"github": {
+			"create_issue": {Calls: 3, LastCalledAt: fixedNow.Add(-1 * time.Hour)},
+		},
+	}
+
+	rep := Analyze(stats, Options{})
+
+	for _, f := range rep.Findings {
+		if f.Heuristic == "unused_tool" {
+			t.Errorf("did not expect unused_tool finding when tool already excluded by whitelist; got %+v", f)
+		}
+	}
+}
+
+func TestAnalyze_UnusedTool_SkippedWithoutPerToolData(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "github", Tools: []string{"create_issue", "list_issues"}, Initialized: true},
+	}
+	stats.Usage = map[string]ServerUsage{
+		"github": {TotalTokens: 100, TotalCostUSD: 0.001},
+	}
+	// stats.ToolUsage intentionally nil — legacy gateway with no per-tool tracking.
+
+	rep := Analyze(stats, Options{})
+
+	for _, f := range rep.Findings {
+		if f.Heuristic == "unused_tool" {
+			t.Errorf("did not expect unused_tool finding without per-tool data; got %+v", f)
+		}
+	}
+}
+
+func TestAnalyze_FindingsSortedBySeverityThenImpact(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "small", Tools: []string{"a"}, Initialized: true},
+		{Name: "large", Tools: []string{"a", "b", "c"}, Initialized: true},
+		{Name: "active", Tools: []string{"x"}, Initialized: true},
+	}
+	stats.Usage = map[string]ServerUsage{
+		"active": {TotalTokens: 1000, TotalCostUSD: 0.01},
+	}
+	stats.ToolUsage = map[string]map[string]ToolStat{
+		"active": {
+			"x": {Calls: 1, LastCalledAt: fixedNow.Add(-1 * time.Hour)},
+		},
+	}
+
+	rep := Analyze(stats, Options{})
+
+	// Both unused_server findings are warn; large should sort before small (more tools → higher impact).
+	if len(rep.Findings) < 2 {
+		t.Fatalf("expected at least 2 findings; got %d", len(rep.Findings))
+	}
+	if rep.Findings[0].Server != "large" {
+		t.Errorf("expected 'large' first by impact; got %q", rep.Findings[0].Server)
+	}
+	if rep.Findings[1].Server != "small" {
+		t.Errorf("expected 'small' second; got %q", rep.Findings[1].Server)
+	}
+}
+
+func TestAnalyze_MinImpactFilter_RetainsInfo(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "small", Tools: []string{"a"}, Initialized: true},
+	}
+
+	rep := Analyze(stats, Options{MinImpactUSDPerWeek: 1_000_000})
+	for _, f := range rep.Findings {
+		if f.Severity != SeverityInfo && f.ImpactUSDPerWeek < 1_000_000 {
+			t.Errorf("min-impact filter let through low-impact non-info finding %+v", f)
+		}
+	}
+}
+
+func TestAnalyze_HealthScore_DropsOnWarn(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "a", Tools: []string{"x"}, Initialized: true},
+		{Name: "b", Tools: []string{"y"}, Initialized: true},
+	}
+
+	rep := Analyze(stats, Options{})
+
+	// Two unused_server warnings → 100 - 20 = 80.
+	if rep.HealthScore != 80 {
+		t.Errorf("HealthScore = %d, want 80", rep.HealthScore)
+	}
+}
+
+func TestAnalyze_NoFindings_HealthScore100(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "a", Tools: []string{"x"}, Initialized: true},
+	}
+	stats.Usage = map[string]ServerUsage{
+		"a": {TotalTokens: 100, TotalCostUSD: 0.001},
+	}
+	stats.ToolUsage = map[string]map[string]ToolStat{
+		"a": {"x": {Calls: 1, LastCalledAt: fixedNow.Add(-1 * time.Hour)}},
+	}
+
+	rep := Analyze(stats, Options{})
+
+	if rep.HealthScore != 100 {
+		t.Errorf("HealthScore = %d, want 100", rep.HealthScore)
+	}
+	if len(rep.Findings) != 0 {
+		t.Errorf("expected zero findings; got %d", len(rep.Findings))
+	}
+}
+
+func TestSeverity_IsActionable(t *testing.T) {
+	cases := []struct {
+		s    Severity
+		want bool
+	}{
+		{SeverityInfo, false},
+		{SeverityWarn, true},
+		{SeverityCritical, true},
+	}
+	for _, tc := range cases {
+		if got := tc.s.IsActionable(); got != tc.want {
+			t.Errorf("Severity(%q).IsActionable() = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+}

--- a/web/src/__tests__/GatewayPanel.test.tsx
+++ b/web/src/__tests__/GatewayPanel.test.tsx
@@ -101,10 +101,7 @@ describe('GatewaySidebar', () => {
     const onClose = vi.fn();
     render(<GatewaySidebar onClose={onClose} />);
 
-    // The close button is the last button (X icon)
-    const buttons = screen.getAllByRole('button');
-    const closeButton = buttons[buttons.length - 1];
-    fireEvent.click(closeButton);
+    fireEvent.click(screen.getByLabelText('Close gateway sidebar'));
     expect(onClose).toHaveBeenCalledOnce();
   });
 

--- a/web/src/components/gateway/GatewaySidebar.tsx
+++ b/web/src/components/gateway/GatewaySidebar.tsx
@@ -1,7 +1,9 @@
-import { memo } from 'react';
-import { Activity, X } from 'lucide-react';
+import { memo, useState } from 'react';
+import { Activity, ChevronDown, ChevronRight, Lightbulb, X } from 'lucide-react';
 import { RegistrySidebar } from '../registry/RegistrySidebar';
+import { OptimizeSection } from '../sidebar/OptimizeSection';
 import { PopoutButton } from '../ui/PopoutButton';
+import { cn } from '../../lib/cn';
 import { useSelectedNodeData } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
 import { useWindowManager } from '../../hooks/useWindowManager';
@@ -45,7 +47,7 @@ const GatewaySidebar = memo(({ onClose }: GatewaySidebarProps) => {
             onClick={handlePopout}
             disabled={registryDetached}
           />
-          <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-surface-highlight transition-colors group">
+          <button onClick={onClose} aria-label="Close gateway sidebar" className="p-1.5 rounded-lg hover:bg-surface-highlight transition-colors group">
             <X size={16} className="text-text-muted group-hover:text-text-primary transition-colors" />
           </button>
         </div>
@@ -53,11 +55,50 @@ const GatewaySidebar = memo(({ onClose }: GatewaySidebarProps) => {
 
       {/* Registry section */}
       <div className="flex-1 overflow-y-auto scrollbar-dark">
+        <CollapsibleSection title="Optimize" icon={Lightbulb}>
+          <OptimizeSection />
+        </CollapsibleSection>
         <RegistrySidebar embedded />
       </div>
     </div>
   );
 });
+
+interface CollapsibleSectionProps {
+  title: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}
+
+function CollapsibleSection({ title, icon: Icon, defaultOpen = true, children }: CollapsibleSectionProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  return (
+    <div className="border-b border-border/30">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center justify-between p-4 hover:bg-surface-highlight/50 transition-colors group"
+      >
+        <div className="flex items-center gap-2.5">
+          <div className="p-1 rounded-md bg-surface-highlight/50 group-hover:bg-surface-highlight transition-colors">
+            <Icon size={12} className="text-text-muted group-hover:text-primary transition-colors" />
+          </div>
+          <span className="text-sm font-medium text-text-primary">{title}</span>
+        </div>
+        <div className="p-1 rounded-md group-hover:bg-surface-highlight transition-colors">
+          {isOpen ? (
+            <ChevronDown size={14} className="text-text-muted" />
+          ) : (
+            <ChevronRight size={14} className="text-text-muted" />
+          )}
+        </div>
+      </button>
+      <div className={cn('overflow-hidden transition-all duration-200', isOpen ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0')}>
+        <div className="px-4 pb-4">{children}</div>
+      </div>
+    </div>
+  );
+}
 
 GatewaySidebar.displayName = 'GatewaySidebar';
 

--- a/web/src/components/sidebar/OptimizeSection.tsx
+++ b/web/src/components/sidebar/OptimizeSection.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Lightbulb, TrendingDown, ChevronDown, ChevronRight, AlertTriangle, AlertOctagon, Info } from 'lucide-react';
+import { fetchOptimizeReport } from '../../lib/api';
+import { POLLING } from '../../lib/constants';
+import type { OptimizeFinding, OptimizeReport, OptimizeSeverity } from '../../types';
+
+const severityIcon: Record<OptimizeSeverity, typeof AlertOctagon> = {
+  critical: AlertOctagon,
+  warn: AlertTriangle,
+  info: Info,
+};
+
+const severityClasses: Record<OptimizeSeverity, string> = {
+  critical: 'text-status-error border-status-error/30 bg-status-error/10',
+  warn: 'text-status-pending border-status-pending/30 bg-status-pending/10',
+  info: 'text-text-muted border-border/40 bg-surface-elevated/40',
+};
+
+function formatImpact(usd: number): string {
+  if (!usd || usd <= 0) return '—';
+  if (usd < 0.01) return '<$0.01';
+  return `$${usd.toFixed(2)}`;
+}
+
+function FindingRow({ finding }: { finding: OptimizeFinding }) {
+  const [open, setOpen] = useState(false);
+  const Icon = severityIcon[finding.severity] ?? Info;
+
+  return (
+    <div className={`rounded-md border ${severityClasses[finding.severity]} px-2.5 py-2 transition-all`}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-start gap-2 text-left"
+        aria-expanded={open}
+      >
+        <Icon size={12} className="mt-0.5 flex-shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2">
+            <span className="text-xs font-medium text-text-primary truncate">{finding.title}</span>
+            {finding.impact_usd_per_week > 0 && (
+              <span className="text-[10px] font-mono text-text-secondary tabular-nums whitespace-nowrap">
+                {formatImpact(finding.impact_usd_per_week)}/wk
+              </span>
+            )}
+          </div>
+          {!open && (
+            <p className="text-[10px] text-text-muted line-clamp-2 mt-0.5">{finding.summary}</p>
+          )}
+        </div>
+        <span className="mt-0.5 flex-shrink-0">
+          {open ? <ChevronDown size={12} className="text-text-muted" /> : <ChevronRight size={12} className="text-text-muted" />}
+        </span>
+      </button>
+
+      {open && (
+        <div className="mt-2 space-y-2 pt-2 border-t border-border/30">
+          <p className="text-[11px] text-text-secondary">{finding.summary}</p>
+          {finding.remediation && (
+            <pre className="text-[10px] font-mono text-text-secondary bg-background/50 rounded-md px-2 py-1.5 overflow-x-auto whitespace-pre-wrap break-words">
+              {finding.remediation}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function OptimizeSection() {
+  const [report, setReport] = useState<OptimizeReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const intervalRef = useRef<number | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchOptimizeReport();
+      setReport(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load optimize report');
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    intervalRef.current = window.setInterval(load, POLLING.METRICS);
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [load]);
+
+  if (error) {
+    return (
+      <div className="text-xs text-text-muted px-1 py-2">
+        Optimize unavailable.
+      </div>
+    );
+  }
+
+  if (!report) {
+    return (
+      <div className="text-xs text-text-muted px-1 py-2">
+        Loading findings…
+      </div>
+    );
+  }
+
+  const findings = report.findings ?? [];
+
+  if (findings.length === 0) {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-xs text-text-secondary">
+          <TrendingDown size={12} className="text-status-running" />
+          <span>No findings — health score {report.health_score}/100</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-[10px] text-text-muted uppercase tracking-wider px-0.5">
+        <span className="flex items-center gap-1.5">
+          <Lightbulb size={10} className="text-primary" />
+          {findings.length} finding{findings.length === 1 ? '' : 's'}
+        </span>
+        <span className="font-mono tabular-nums">{report.health_score}/100</span>
+      </div>
+      <div className="space-y-1.5">
+        {findings.map((finding) => (
+          <FindingRow key={finding.id} finding={finding} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, RegistryStatus, AgentSkill, SkillFile, SkillValidationResult, WorkflowDefinition, ExecutionResult, TokenMetricsResponse, CostMetricsResponse, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SkillTestResult, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
+import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, RegistryStatus, AgentSkill, SkillFile, SkillValidationResult, WorkflowDefinition, ExecutionResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SkillTestResult, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
 
 // Base URL for API calls - empty for same origin
 const API_BASE = '';
@@ -377,6 +377,25 @@ export async function fetchCostMetrics(
   const params = new URLSearchParams({ range });
   if (perClient) params.set('per_client', 'true');
   return fetchJSON<CostMetricsResponse>(`/api/metrics/cost?${params.toString()}`);
+}
+
+/**
+ * Fetch the optimize report (unused servers, unused tools, etc.) for
+ * the active stack. Mirrors fetchCostMetrics so the sidebar panel can
+ * poll on the same cadence as Token Usage / Cost.
+ * GET /api/optimize?min_impact=0.10&severity=warn,critical
+ */
+export async function fetchOptimizeReport(opts?: {
+  stack?: string;
+  minImpact?: number;
+  severity?: string[];
+}): Promise<OptimizeReport> {
+  const params = new URLSearchParams();
+  if (opts?.stack) params.set('stack', opts.stack);
+  if (opts?.minImpact && opts.minImpact > 0) params.set('min_impact', String(opts.minImpact));
+  if (opts?.severity && opts.severity.length > 0) params.set('severity', opts.severity.join(','));
+  const query = params.toString();
+  return fetchJSON<OptimizeReport>(`/api/optimize${query ? `?${query}` : ''}`);
 }
 
 /**

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -171,6 +171,32 @@ export interface CostMetricsResponse {
   per_client?: Record<string, CostDataPoint[]>;
 }
 
+// Severity classifies optimize findings. Mirrors pkg/optimize.Severity
+// on the Go side; "info" findings are advisory and never trigger a
+// non-zero CLI exit.
+export type OptimizeSeverity = 'info' | 'warn' | 'critical';
+
+// Single recommendation produced by pkg/optimize.Analyze.
+export interface OptimizeFinding {
+  id: string;
+  heuristic: string;
+  severity: OptimizeSeverity;
+  title: string;
+  summary: string;
+  server?: string;
+  tool?: string;
+  impact_usd_per_week: number;
+  remediation: string;
+  detected_at: string;
+}
+
+// Response from GET /api/optimize.
+export interface OptimizeReport {
+  findings: OptimizeFinding[];
+  health_score: number;
+  generated_at: string;
+}
+
 // Gateway status response from GET /api/status
 export interface GatewayStatus {
   gateway: ServerInfo;


### PR DESCRIPTION
## Description

Ships PR 4 of the gateway-cost-observability feature: the `gridctl optimize` CLI, `GET /api/optimize`, and a sidebar Optimize panel. Implements two heuristics — `unused_server` and `unused_tool` — with a paste-ready YAML remediation per finding and a measured weekly USD impact. The remaining heuristics (`schema_overhead`, `format_savings_shortfall`, `expensive_model_on_cheap_task`) ship in PR 5.

## Type of Change

- [x] New feature

## Changes Made

- `pkg/optimize/`: new package with `unused_server`, `unused_tool`, severity-based sort, health score, and a `<24h of data` info gate so reports never over-fire on freshly applied stacks.
- `pkg/metrics`: per-(server, tool) call counters + `StartedAt()` (stable across `Clear`); observer now threads tool name through the cost path.
- `GET /api/optimize?stack=&min_impact=&severity=` returning `OptimizeReport{findings, health_score, generated_at}`. 404 on wrong stack, 503 without an accumulator.
- `gridctl optimize` CLI: `--stack`, `--min-impact`, `--severity`, `--format json`. Exit codes `0|1|2` matching the project convention.
- Sidebar Optimize panel inside the Gateway view (collapsible, polls on the same cadence as Token Usage / Cost). Severity badges, weekly $, collapsible remediation snippets.
- Docs: README Features + CLI reference, AGENTS.md (CLI + REST), `docs/api-reference.md`, `docs/cost-observability.md`, CHANGELOG.

## Testing

- `go test -race ./...` — all packages green; new tests cover optimize heuristics, API handler, CLI helpers, and per-tool accumulator tracking.
- `golangci-lint run` — 0 issues.
- `make build` — frontend + backend build cleanly; Linux cross-compile verified.
- Web: `npm run build` passes; `npm test -- --run` shows 493/493 passing.
- Manual: `./gridctl optimize` against a stopped daemon exits 2 with `optimize: gateway not running; try \`gridctl status\``.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #564