### PR TITLE
fix: stack cost KPI label above value

### DIFF
--- a/web/src/components/metrics/MetricsTab.tsx
+++ b/web/src/components/metrics/MetricsTab.tsx
@@ -597,7 +597,7 @@ function KPICard({ label, value, colorClass }: { label: string; value: number; c
 function CostKPICard({ usd, hasCost }: { usd: number | undefined; hasCost: boolean }) {
   return (
     <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-      <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1 inline-flex items-center gap-1">
+      <span className="text-[10px] text-text-muted uppercase tracking-wider flex items-center gap-1 mb-1">
         <DollarSign size={10} className="text-text-muted/70" />
         Cost
       </span>

--- a/web/src/pages/DetachedMetricsPage.tsx
+++ b/web/src/pages/DetachedMetricsPage.tsx
@@ -603,7 +603,7 @@ function KPICard({ label, value, colorClass }: { label: string; value: number; c
 function CostKPICard({ usd, hasCost }: { usd: number | undefined; hasCost: boolean }) {
   return (
     <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-      <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1 inline-flex items-center gap-1">
+      <span className="text-[10px] text-text-muted uppercase tracking-wider flex items-center gap-1 mb-1">
         <DollarSign size={10} className="text-text-muted/70" />
         Cost
       </span>


### PR DESCRIPTION
## Description

The Cost KPI card on the Metrics tab and the detached metrics window rendered the `$ COST` label and the value on the same line, breaking visual consistency with the three sibling cards (Input/Output/Total Tokens). This PR fixes the label span so it stacks above the value, matching the rest of the row.

## Type of Change

- [x] Bug fix

## Changes Made

- Replace conflicting `block ... inline-flex` classes on the Cost label span with `flex items-center gap-1 mb-1` in `web/src/components/metrics/MetricsTab.tsx`.
- Apply the matching change to the duplicated component in `web/src/pages/DetachedMetricsPage.tsx`.

## Testing

- `npm run build` (tsc + vite) succeeds with no new errors.
- Visual check: open a server detail page → Metrics tab and confirm the Cost card stacks `$ COST` above the value, matching the other three KPI cards. Also verify the detached metrics window.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #570