### PR TITLE
fix: persist and replay cost data across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to gridctl will be documented in this file.
 
 
 - Telemetry persistence write and seed gaps (#550 follow-up)
+- Persist and replay cost data across daemon restarts. Previously the cost KPI and Cost Over Time chart silently reset to $0 after a restart even when pre-restart cost was non-zero — token persistence had this path; cost did not. The on-disk `metrics.jsonl` schema is extended additively (cost fields are pointer + `omitempty`) and remains forward- and backward-compatible with files written by older versions.
 
 ## [0.1.0-beta.8] - 2026-05-05
 

--- a/pkg/metrics/accumulator.go
+++ b/pkg/metrics/accumulator.go
@@ -25,17 +25,17 @@ type FormatSavings struct {
 
 // TokenUsage is the top-level token usage snapshot returned by the API.
 type TokenUsage struct {
-	Session       TokenCounts                        `json:"session"`
-	PerServer     map[string]TokenCounts             `json:"per_server"`
-	PerReplica    map[string]map[int]TokenCounts     `json:"per_replica,omitempty"`
+	Session    TokenCounts                    `json:"session"`
+	PerServer  map[string]TokenCounts         `json:"per_server"`
+	PerReplica map[string]map[int]TokenCounts `json:"per_replica,omitempty"`
 	// PerClient groups token usage by the originating MCP client (for example
 	// "claude-code", "cursor"). The field is omitempty so consumers built
 	// before per-client attribution shipped continue to see the same JSON
 	// shape. Future per-user / per-team dimensions land as sibling fields
 	// (per_user, per_team) under this same shape rather than reshaping
 	// per_client.
-	PerClient     map[string]TokenCounts             `json:"per_client,omitempty"`
-	FormatSavings FormatSavings                      `json:"format_savings"`
+	PerClient     map[string]TokenCounts `json:"per_client,omitempty"`
+	FormatSavings FormatSavings          `json:"format_savings"`
 }
 
 // CostBreakdown is the per-call USD cost split passed to RecordCost. Cache
@@ -81,15 +81,38 @@ type CostCounts struct {
 	TotalUSD      float64 `json:"total_usd"`
 }
 
+// CostMicroUSDCounts is the int64 micro-USD shape used by the persistence
+// layer to round-trip the four cost components without float precision
+// loss. Mirrors the in-memory atomic representation on serverCounters.
+type CostMicroUSDCounts struct {
+	InputMicroUSD      int64 `json:"input_micro_usd,omitempty"`
+	OutputMicroUSD     int64 `json:"output_micro_usd,omitempty"`
+	CacheReadMicroUSD  int64 `json:"cache_read_micro_usd,omitempty"`
+	CacheWriteMicroUSD int64 `json:"cache_write_micro_usd,omitempty"`
+}
+
+// IsZero reports whether all four cost components are zero.
+func (c CostMicroUSDCounts) IsZero() bool {
+	return c.InputMicroUSD == 0 && c.OutputMicroUSD == 0 &&
+		c.CacheReadMicroUSD == 0 && c.CacheWriteMicroUSD == 0
+}
+
+// TotalMicroUSD returns the rolled-up sum of the four components — the
+// shape ReplaySnapshot stores per bucket, matching addCostToBucket's live
+// behavior of writing a single total per minute.
+func (c CostMicroUSDCounts) TotalMicroUSD() int64 {
+	return c.InputMicroUSD + c.OutputMicroUSD + c.CacheReadMicroUSD + c.CacheWriteMicroUSD
+}
+
 // CostUsage is the top-level cost snapshot. The shape mirrors TokenUsage so
 // API consumers can render cost charts beside token charts.
 type CostUsage struct {
-	Session    CostCounts                       `json:"session"`
-	PerServer  map[string]CostCounts            `json:"per_server"`
-	PerReplica map[string]map[int]CostCounts    `json:"per_replica,omitempty"`
+	Session    CostCounts                    `json:"session"`
+	PerServer  map[string]CostCounts         `json:"per_server"`
+	PerReplica map[string]map[int]CostCounts `json:"per_replica,omitempty"`
 	// PerClient groups USD cost by the originating MCP client. omitempty so
 	// pre-attribution consumers keep their existing JSON shape.
-	PerClient  map[string]CostCounts            `json:"per_client,omitempty"`
+	PerClient map[string]CostCounts `json:"per_client,omitempty"`
 }
 
 // CostDataPoint is the time-series shape for cost-over-time queries.
@@ -102,15 +125,15 @@ type CostDataPoint struct {
 // `Range` and `Interval` strings reuse the same vocabulary as the token
 // time-series so charts can share a time-range selector.
 type CostTimeSeriesResponse struct {
-	Range     string                       `json:"range"`
-	Interval  string                       `json:"interval"`
-	Points    []CostDataPoint              `json:"data_points"`
-	PerServer map[string][]CostDataPoint   `json:"per_server"`
+	Range     string                     `json:"range"`
+	Interval  string                     `json:"interval"`
+	Points    []CostDataPoint            `json:"data_points"`
+	PerServer map[string][]CostDataPoint `json:"per_server"`
 	// PerClient groups cost over time by originating MCP client. Populated
 	// only when the API caller requests per-client grouping (the
 	// `per_client=true` query parameter on /api/metrics/cost) so the JSON
 	// stays compact for the common per-server view.
-	PerClient map[string][]CostDataPoint   `json:"per_client,omitempty"`
+	PerClient map[string][]CostDataPoint `json:"per_client,omitempty"`
 }
 
 // costScale converts the public USD float64 values to the int64
@@ -144,10 +167,10 @@ type DataPoint struct {
 
 // TimeSeriesResponse is returned by the historical metrics endpoint.
 type TimeSeriesResponse struct {
-	Range     string                       `json:"range"`
-	Interval  string                       `json:"interval"`
-	Points    []DataPoint                  `json:"data_points"`
-	PerServer map[string][]DataPoint       `json:"per_server"`
+	Range     string                 `json:"range"`
+	Interval  string                 `json:"interval"`
+	Points    []DataPoint            `json:"data_points"`
+	PerServer map[string][]DataPoint `json:"per_server"`
 }
 
 // bucketKey returns the minute-aligned key for a timestamp.
@@ -160,10 +183,10 @@ func bucketKey(t time.Time) time.Time {
 // addition is a plain integer write under the bucket mutex; precision below
 // nano-USD is irrelevant for any realistic call.
 type bucket struct {
-	timestamp     time.Time
-	inputTokens   int64
-	outputTokens  int64
-	costMicroUSD  int64
+	timestamp    time.Time
+	inputTokens  int64
+	outputTokens int64
+	costMicroUSD int64
 }
 
 // serverCounters holds atomic counters for a single server.
@@ -874,6 +897,29 @@ func (a *Accumulator) Snapshot() TokenUsage {
 	}
 }
 
+// CostMicroSnapshot returns per-server cumulative cost in the int64
+// micro-USD shape used by the persistence layer. Skipping the float USD
+// round-trip avoids any precision loss between the in-memory atomics and
+// the on-disk schema. Used by telemetry.MetricsFlusher.flushOnce to
+// compute a cost diff against prevCost in the same units that get written
+// to metrics.jsonl, and consumed symmetrically by SeedFromFile via
+// RestoreCost. Session totals are not returned — they are derivable as
+// the sum across servers, which RestoreCost re-derives on rehydrate.
+func (a *Accumulator) CostMicroSnapshot() map[string]CostMicroUSDCounts {
+	a.serverMu.RLock()
+	defer a.serverMu.RUnlock()
+	out := make(map[string]CostMicroUSDCounts, len(a.servers))
+	for name, sc := range a.servers {
+		out[name] = CostMicroUSDCounts{
+			InputMicroUSD:      sc.inputCostMicroUSD.Load(),
+			OutputMicroUSD:     sc.outputCostMicroUSD.Load(),
+			CacheReadMicroUSD:  sc.cacheReadCostMicroUSD.Load(),
+			CacheWriteMicroUSD: sc.cacheWriteCostMicroUSD.Load(),
+		}
+	}
+	return out
+}
+
 // CostSnapshot returns the current cost usage summary in USD. The shape
 // mirrors Snapshot()'s TokenUsage so API responses can carry both side by
 // side. Cache fields are non-zero only when RecordCost recorded cache
@@ -1223,6 +1269,56 @@ func (a *Accumulator) Restore(perServer map[string]TokenCounts) {
 	a.sessionOutput.Store(sessionOut)
 }
 
+// RestoreCost is the cost analogue of Restore: it overwrites per-server
+// cost component atomics with the supplied map and recomputes session
+// cost totals as the sum across all servers (matching the invariant
+// RecordCost maintains). Used on daemon startup by
+// telemetry.MetricsFlusher.SeedFromFile to repopulate cumulative cost
+// counters from a persisted metrics.jsonl file so the Cost KPI card
+// reflects pre-restart spend the moment the UI loads.
+//
+// Per-component splitting (input / output / cache-read / cache-write) is
+// preserved on the cumulative atomics so CostSnapshot.Session can render
+// the breakdown without recomputing — same trade-off live RecordCost
+// makes. The time-series ring buffers are populated separately via
+// ReplaySnapshot, which carries only the rolled-up total per bucket.
+//
+// Servers absent from the map retain their current cost state. Replicas,
+// format-savings, and per-client cost have no on-disk equivalent in the
+// snapshot format and are not restored.
+func (a *Accumulator) RestoreCost(perServer map[string]CostMicroUSDCounts) {
+	if len(perServer) == 0 {
+		return
+	}
+
+	a.serverMu.Lock()
+	defer a.serverMu.Unlock()
+
+	for name, counts := range perServer {
+		sc, ok := a.servers[name]
+		if !ok {
+			sc = &serverCounters{}
+			a.servers[name] = sc
+		}
+		sc.inputCostMicroUSD.Store(counts.InputMicroUSD)
+		sc.outputCostMicroUSD.Store(counts.OutputMicroUSD)
+		sc.cacheReadCostMicroUSD.Store(counts.CacheReadMicroUSD)
+		sc.cacheWriteCostMicroUSD.Store(counts.CacheWriteMicroUSD)
+	}
+
+	var sessionIn, sessionOut, sessionCR, sessionCW int64
+	for _, sc := range a.servers {
+		sessionIn += sc.inputCostMicroUSD.Load()
+		sessionOut += sc.outputCostMicroUSD.Load()
+		sessionCR += sc.cacheReadCostMicroUSD.Load()
+		sessionCW += sc.cacheWriteCostMicroUSD.Load()
+	}
+	a.sessionInputCostMicroUSD.Store(sessionIn)
+	a.sessionOutputCostMicroUSD.Store(sessionOut)
+	a.sessionCacheReadCostMicroUSD.Store(sessionCR)
+	a.sessionCacheWriteCostMicroUSD.Store(sessionCW)
+}
+
 // ReplaySnapshot adds a historical observation to the time-series ring
 // buffers (aggregate + per-server) without touching cumulative counters.
 // Used by telemetry.MetricsFlusher.SeedFromFile to rehydrate per-minute
@@ -1230,20 +1326,36 @@ func (a *Accumulator) Restore(perServer map[string]TokenCounts) {
 // activity continuously alongside live data instead of resetting to a single
 // post-restart point.
 //
-// Cumulative counters are restored separately via Restore. Calling both with
-// the same source data reproduces the on-disk state.
+// costMicro is the rolled-up total cost for the minute (sum of the four
+// CostBreakdown components) in int64 micro-USD, matching the live
+// RecordCost path which also calls addCostToBucket(now, totalMicro). Pass 0
+// for token-only replays (legacy persistence files predate the cost field).
+// Cost-only replays — non-zero costMicro with zero token counts — are
+// supported so a minute that recorded a priced fixture without token
+// attribution still hydrates its cost bucket on seed.
+//
+// Cumulative counters are restored separately via Restore + RestoreCost.
+// Calling both with the same source data reproduces the on-disk state.
 //
 // ts is bucketed to the minute via the same key the live Record path uses,
 // so chronological replay produces one bucket per flush minute and live
 // observations after replay continue advancing the same ring naturally.
-func (a *Accumulator) ReplaySnapshot(serverName string, ts time.Time, inputTokens, outputTokens int64) {
-	if inputTokens == 0 && outputTokens == 0 {
+func (a *Accumulator) ReplaySnapshot(serverName string, ts time.Time, inputTokens, outputTokens, costMicro int64) {
+	if inputTokens == 0 && outputTokens == 0 && costMicro == 0 {
 		return
 	}
 	bucket := bucketKey(ts)
-	a.addToBucket(bucket, inputTokens, outputTokens)
-	if serverName != "" {
-		a.addToServerBucket(serverName, bucket, inputTokens, outputTokens)
+	if inputTokens != 0 || outputTokens != 0 {
+		a.addToBucket(bucket, inputTokens, outputTokens)
+		if serverName != "" {
+			a.addToServerBucket(serverName, bucket, inputTokens, outputTokens)
+		}
+	}
+	if costMicro != 0 {
+		a.addCostToBucket(bucket, costMicro)
+		if serverName != "" {
+			a.addCostToServerBucket(serverName, bucket, costMicro)
+		}
 	}
 }
 

--- a/pkg/metrics/accumulator_test.go
+++ b/pkg/metrics/accumulator_test.go
@@ -780,3 +780,187 @@ func TestAccumulator_Clear_ResetsPerClient(t *testing.T) {
 		t.Errorf("Clear should drop per-client cost; got %v", cost.PerClient)
 	}
 }
+
+// TestAccumulator_RestoreCost_PerServerAndSessionTotals covers the cost
+// analogue of Restore: it overwrites per-server cost component atomics
+// from the supplied map and recomputes session totals as the sum across
+// servers. After RestoreCost the CostSnapshot KPI surfaces should reflect
+// pre-restart spend, matching what telemetry.MetricsFlusher.SeedFromFile
+// reads from disk.
+func TestAccumulator_RestoreCost_PerServerAndSessionTotals(t *testing.T) {
+	acc := NewAccumulator(100)
+
+	acc.RestoreCost(map[string]CostMicroUSDCounts{
+		"github": {
+			InputMicroUSD:      50_000,  // $0.05
+			OutputMicroUSD:     100_000, // $0.10
+			CacheReadMicroUSD:  20_000,  // $0.02
+			CacheWriteMicroUSD: 5_000,   // $0.005
+		},
+		"gitlab": {
+			InputMicroUSD:  300_000, // $0.30
+			OutputMicroUSD: 400_000, // $0.40
+		},
+	})
+
+	snap := acc.CostSnapshot()
+	if !approxCostEq(snap.PerServer["github"].TotalUSD, 0.175) {
+		t.Errorf("github total = %v, want 0.175", snap.PerServer["github"].TotalUSD)
+	}
+	if !approxCostEq(snap.PerServer["github"].CacheReadUSD, 0.02) {
+		t.Errorf("github cache-read = %v, want 0.02", snap.PerServer["github"].CacheReadUSD)
+	}
+	if !approxCostEq(snap.PerServer["gitlab"].TotalUSD, 0.70) {
+		t.Errorf("gitlab total = %v, want 0.70", snap.PerServer["gitlab"].TotalUSD)
+	}
+	// Session totals = sum across all per-server components (matches
+	// Restore's invariant on tokens — per-server is the source of truth,
+	// session is derived).
+	if !approxCostEq(snap.Session.TotalUSD, 0.875) {
+		t.Errorf("session total = %v, want 0.875", snap.Session.TotalUSD)
+	}
+	if !approxCostEq(snap.Session.InputUSD, 0.35) {
+		t.Errorf("session input = %v, want 0.35", snap.Session.InputUSD)
+	}
+}
+
+// TestAccumulator_RestoreCost_EmptyMapIsNoop guards against an
+// edge case where the persistence file has no cost data (legacy or
+// no-priced-calls file). RestoreCost must leave the accumulator's cost
+// state untouched in that case so live RecordCost calls are not erased.
+func TestAccumulator_RestoreCost_EmptyMapIsNoop(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordCost("github", -1, CostBreakdown{Input: 0.10})
+
+	acc.RestoreCost(nil)
+	acc.RestoreCost(map[string]CostMicroUSDCounts{})
+
+	snap := acc.CostSnapshot()
+	if !approxCostEq(snap.Session.InputUSD, 0.10) {
+		t.Errorf("RestoreCost(empty) erased cost; session input = %v, want 0.10", snap.Session.InputUSD)
+	}
+}
+
+// TestAccumulator_ReplaySnapshot_CostBucket verifies that ReplaySnapshot
+// populates the cost bucket at the correct minute key and that QueryCost
+// returns the rolled-up total. Mirrors the token-only assertion already
+// implicit in TestEndToEnd_MetricsPersistAndReseed but pinned at the
+// accumulator surface.
+func TestAccumulator_ReplaySnapshot_CostBucket(t *testing.T) {
+	acc := NewAccumulator(100)
+
+	ts := time.Now().Add(-30 * time.Minute)            // within the 1h query window
+	acc.ReplaySnapshot("github", ts, 100, 50, 250_000) // $0.25 rolled-up
+
+	resp := acc.QueryCost(time.Hour)
+	var total float64
+	for _, p := range resp.Points {
+		total += p.USD
+	}
+	if !approxCostEq(total, 0.25) {
+		t.Errorf("aggregate cost from replay = %v, want 0.25", total)
+	}
+	per := resp.PerServer["github"]
+	if len(per) == 0 {
+		t.Fatalf("expected per-server cost points after replay; got 0")
+	}
+	var perTotal float64
+	for _, p := range per {
+		perTotal += p.USD
+	}
+	if !approxCostEq(perTotal, 0.25) {
+		t.Errorf("per-server cost from replay = %v, want 0.25", perTotal)
+	}
+}
+
+// TestAccumulator_ReplaySnapshot_CostOnly covers the cost-only replay
+// path: zero token counts plus a non-zero cost. Without explicit
+// handling the early-return guard would silently drop the line; that
+// would lose any priced fixture minute (rare in production, common in
+// tests) on rehydrate.
+func TestAccumulator_ReplaySnapshot_CostOnly(t *testing.T) {
+	acc := NewAccumulator(100)
+	ts := time.Now().Add(-10 * time.Minute)
+
+	acc.ReplaySnapshot("github", ts, 0, 0, 100_000) // tokens=0, cost=$0.10
+
+	resp := acc.QueryCost(time.Hour)
+	var total float64
+	for _, p := range resp.Points {
+		total += p.USD
+	}
+	if !approxCostEq(total, 0.10) {
+		t.Errorf("cost-only replay aggregate = %v, want 0.10", total)
+	}
+}
+
+// TestAccumulator_ReplaySnapshot_AllZeroIsNoop guards the early-return
+// guard: a line with zero tokens and zero cost is genuinely empty and
+// should not allocate a bucket.
+func TestAccumulator_ReplaySnapshot_AllZeroIsNoop(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.ReplaySnapshot("github", time.Now(), 0, 0, 0)
+
+	resp := acc.Query(time.Hour)
+	if len(resp.Points) != 0 {
+		t.Errorf("all-zero replay created %d points; want 0", len(resp.Points))
+	}
+	costResp := acc.QueryCost(time.Hour)
+	if len(costResp.Points) != 0 {
+		t.Errorf("all-zero replay created %d cost points; want 0", len(costResp.Points))
+	}
+}
+
+// TestCostMicroUSDCounts_TotalAndIsZero pins the helper math the
+// flusher and seed paths rely on.
+func TestCostMicroUSDCounts_TotalAndIsZero(t *testing.T) {
+	zero := CostMicroUSDCounts{}
+	if !zero.IsZero() {
+		t.Error("zero value IsZero = false")
+	}
+	if zero.TotalMicroUSD() != 0 {
+		t.Errorf("zero total = %d, want 0", zero.TotalMicroUSD())
+	}
+
+	cc := CostMicroUSDCounts{
+		InputMicroUSD:      1,
+		OutputMicroUSD:     2,
+		CacheReadMicroUSD:  3,
+		CacheWriteMicroUSD: 4,
+	}
+	if cc.IsZero() {
+		t.Error("non-zero value IsZero = true")
+	}
+	if cc.TotalMicroUSD() != 10 {
+		t.Errorf("total = %d, want 10", cc.TotalMicroUSD())
+	}
+}
+
+// TestAccumulator_CostMicroSnapshot_PerServer asserts the persistence-
+// shaped snapshot exposed for flushOnce contains the same per-component
+// values the public CostSnapshot does, just in the int64 micro-USD shape
+// that round-trips losslessly through the on-disk schema.
+func TestAccumulator_CostMicroSnapshot_PerServer(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordCost("github", -1, CostBreakdown{
+		Input: 0.10, Output: 0.20, CacheRead: 0.01, CacheWrite: 0.005,
+	})
+
+	got := acc.CostMicroSnapshot()
+	gh, ok := got["github"]
+	if !ok {
+		t.Fatalf("expected github entry in CostMicroSnapshot; got %v", got)
+	}
+	if gh.InputMicroUSD != 100_000 {
+		t.Errorf("input micro = %d, want 100000", gh.InputMicroUSD)
+	}
+	if gh.OutputMicroUSD != 200_000 {
+		t.Errorf("output micro = %d, want 200000", gh.OutputMicroUSD)
+	}
+	if gh.CacheReadMicroUSD != 10_000 {
+		t.Errorf("cache-read micro = %d, want 10000", gh.CacheReadMicroUSD)
+	}
+	if gh.CacheWriteMicroUSD != 5_000 {
+		t.Errorf("cache-write micro = %d, want 5000", gh.CacheWriteMicroUSD)
+	}
+}

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -21,15 +21,22 @@ const DefaultMetricsFlushInterval = 60 * time.Second
 
 // MetricsSnapshotLine is the on-disk schema for one NDJSON entry in
 // metrics.jsonl. Time, Server, and Diff are populated for every line; Reset
-// is true on the first line written after a counter reset (server restart,
-// Accumulator.Clear) and the diff for that line is the *full* snapshot, not
-// a negative delta.
+// is true on the first line written after a token counter reset (server
+// restart, Accumulator.Clear) and the diff for that line is the *full*
+// snapshot. CostReset signals an independent cost-side reset (e.g.
+// Accumulator.ClearCost between flushes) — the two flags are independent
+// so a cost-only clear does not invalidate the token diff on the same
+// line. Cost fields are pointer + omitempty so token-only minutes emit
+// lines byte-identical to the pre-cost-persistence schema.
 type MetricsSnapshotLine struct {
-	Time   time.Time            `json:"ts"`
-	Server string               `json:"server"`
-	Reset  bool                 `json:"reset,omitempty"`
-	Diff   metrics.TokenCounts  `json:"diff"`
-	Total  metrics.TokenCounts  `json:"total"`
+	Time      time.Time                   `json:"ts"`
+	Server    string                      `json:"server"`
+	Reset     bool                        `json:"reset,omitempty"`
+	CostReset bool                        `json:"cost_reset,omitempty"`
+	Diff      metrics.TokenCounts         `json:"diff"`
+	Total     metrics.TokenCounts         `json:"total"`
+	CostDiff  *metrics.CostMicroUSDCounts `json:"cost_diff,omitempty"`
+	CostTotal *metrics.CostMicroUSDCounts `json:"cost_total,omitempty"`
 }
 
 // MetricsFlusher periodically serializes per-server token counters from a
@@ -42,9 +49,10 @@ type MetricsFlusher struct {
 	interval time.Duration
 	logger   *slog.Logger
 
-	mu      sync.Mutex
-	writers map[string]*lumberjack.Logger  // serverName -> writer
-	prev    map[string]metrics.TokenCounts // serverName -> last snapshot
+	mu       sync.Mutex
+	writers  map[string]*lumberjack.Logger         // serverName -> writer
+	prev     map[string]metrics.TokenCounts        // serverName -> last token snapshot
+	prevCost map[string]metrics.CostMicroUSDCounts // serverName -> last cost snapshot (parallel to prev)
 
 	stop     chan struct{}
 	done     chan struct{}
@@ -63,6 +71,7 @@ func NewMetricsFlusher(acc *metrics.Accumulator, interval time.Duration) *Metric
 		interval: interval,
 		writers:  make(map[string]*lumberjack.Logger),
 		prev:     make(map[string]metrics.TokenCounts),
+		prevCost: make(map[string]metrics.CostMicroUSDCounts),
 		stop:     make(chan struct{}),
 		done:     make(chan struct{}),
 	}
@@ -128,6 +137,7 @@ func (f *MetricsFlusher) RemoveServer(name string) {
 		delete(f.writers, name)
 	}
 	delete(f.prev, name)
+	delete(f.prevCost, name)
 }
 
 // ConfiguredServers returns the names currently persisting metrics.
@@ -199,7 +209,10 @@ func (f *MetricsFlusher) run() {
 }
 
 // flushOnce snapshots the accumulator and writes one NDJSON line per
-// configured server with a non-zero delta vs the previous snapshot. The
+// configured server with a non-zero delta vs the previous snapshot. A
+// "non-zero delta" means *either* the token diff or the cost diff is
+// non-zero — a minute that records a priced fixture without token
+// attribution still emits a line so its cost reaches disk. The
 // per-server writer map is snapshotted under the mutex; disk I/O happens
 // outside the lock so a slow writer can't block AddServer/RemoveServer.
 func (f *MetricsFlusher) flushOnce(now time.Time) {
@@ -207,6 +220,7 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 		return
 	}
 	snap := f.acc.Snapshot()
+	costSnap := f.acc.CostMicroSnapshot()
 
 	type planned struct {
 		writer *lumberjack.Logger
@@ -220,34 +234,88 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 		if !ok {
 			continue
 		}
+		// Cost may legitimately be missing from the cost snapshot when no
+		// priced call has hit the server yet — treat a missing entry as
+		// the zero CostMicroUSDCounts so the diff math stays uniform.
+		currentCost := costSnap[name]
 		prev, hadPrev := f.prev[name]
+		prevCost, hadPrevCost := f.prevCost[name]
 		line := MetricsSnapshotLine{
 			Time:   now.UTC(),
 			Server: name,
 			Total:  current,
 		}
-		switch {
-		case !hadPrev:
+		// Reset detection runs independently per dimension. A token reset
+		// (first flush, or strictly-decreasing component) writes the full
+		// token snapshot in Diff and sets Reset=true. A cost reset
+		// (ClearCost between flushes — only flagged when prior cost
+		// existed) writes the full cost snapshot in CostDiff and sets
+		// CostReset=true. Splitting the flags is what lets a cost-only
+		// clear preserve the token Diff on the same line; conflating
+		// them would silently drop the token activity for that minute on
+		// SeedFromFile replay.
+		tokenReset := !hadPrev || isCounterReset(prev, current)
+		costReset := hadPrevCost && isCostCounterReset(prevCost, currentCost)
+
+		var tokenDiff metrics.TokenCounts
+		if tokenReset {
 			line.Reset = true
-			line.Diff = current
-		case isCounterReset(prev, current):
-			line.Reset = true
-			line.Diff = current
-		default:
-			line.Diff = metrics.TokenCounts{
+			tokenDiff = current
+		} else {
+			tokenDiff = metrics.TokenCounts{
 				InputTokens:  current.InputTokens - prev.InputTokens,
 				OutputTokens: current.OutputTokens - prev.OutputTokens,
 				TotalTokens:  current.TotalTokens - prev.TotalTokens,
 			}
-			if line.Diff.InputTokens == 0 && line.Diff.OutputTokens == 0 && line.Diff.TotalTokens == 0 {
-				continue
+		}
+		line.Diff = tokenDiff
+
+		var costDiff metrics.CostMicroUSDCounts
+		switch {
+		case costReset:
+			line.CostReset = true
+			costDiff = currentCost
+		case tokenReset:
+			// Token reset implies a fresh-server boundary. Match the
+			// existing token contract by carrying the full cost
+			// snapshot in CostDiff so the post-restart cumulative
+			// reconstruction reads the same way for both dimensions.
+			costDiff = currentCost
+		default:
+			costDiff = metrics.CostMicroUSDCounts{
+				InputMicroUSD:      currentCost.InputMicroUSD - prevCost.InputMicroUSD,
+				OutputMicroUSD:     currentCost.OutputMicroUSD - prevCost.OutputMicroUSD,
+				CacheReadMicroUSD:  currentCost.CacheReadMicroUSD - prevCost.CacheReadMicroUSD,
+				CacheWriteMicroUSD: currentCost.CacheWriteMicroUSD - prevCost.CacheWriteMicroUSD,
 			}
 		}
+
+		// Skip lines whose every dimension is empty: token diff zero AND
+		// cost diff zero AND neither dimension reset. A reset line always
+		// emits because it carries the post-reset boundary signal even
+		// when the post-reset state is zero.
+		tokenDiffZero := tokenDiff.InputTokens == 0 && tokenDiff.OutputTokens == 0 && tokenDiff.TotalTokens == 0
+		if !line.Reset && !line.CostReset && tokenDiffZero && costDiff.IsZero() {
+			continue
+		}
+
+		if !costDiff.IsZero() || line.CostReset {
+			cd := costDiff
+			line.CostDiff = &cd
+		}
+		if !currentCost.IsZero() {
+			ct := currentCost
+			line.CostTotal = &ct
+		}
+
 		plan = append(plan, planned{writer: writer, line: line})
-		// Update prev under the lock — even if the write fails the in-memory
-		// state advances; lumberjack rotates rather than retaining failed
-		// writes, so retry would emit the same delta on the next tick anyway.
+		// Update prev / prevCost under the lock — even if the write fails
+		// the in-memory state advances; lumberjack rotates rather than
+		// retaining failed writes, so retry would emit the same delta on
+		// the next tick anyway. Both maps advance together so a partial
+		// failure cannot leave them out of sync for the next tick's diff.
 		f.prev[name] = current
+		f.prevCost[name] = currentCost
 	}
 	f.mu.Unlock()
 
@@ -291,12 +359,28 @@ func isCounterReset(prev, current metrics.TokenCounts) bool {
 		current.TotalTokens < prev.TotalTokens
 }
 
+// isCostCounterReset is the cost analogue of isCounterReset. ClearCost
+// can produce a strictly-decreasing cost component without touching tokens;
+// flushOnce records that as a CostReset (independent of token Reset) so
+// SeedFromFile knows to skip the line's CostDiff for time-series replay
+// while still consuming its token Diff normally.
+func isCostCounterReset(prev, current metrics.CostMicroUSDCounts) bool {
+	return current.InputMicroUSD < prev.InputMicroUSD ||
+		current.OutputMicroUSD < prev.OutputMicroUSD ||
+		current.CacheReadMicroUSD < prev.CacheReadMicroUSD ||
+		current.CacheWriteMicroUSD < prev.CacheWriteMicroUSD
+}
+
 // SeedFromFile reads up to the last n NDJSON entries from path and seeds
-// three surfaces atomically: cumulative per-server totals (via Restore),
-// per-minute time-series ring buckets (via ReplaySnapshot), and this
-// flusher's previous-snapshot map. The Token Usage Over Time chart in the
-// UI is backed by the time-series ring; without the bucket replay it would
-// show only a single post-restart point.
+// four surfaces atomically: cumulative per-server token totals (via
+// Restore), cumulative per-server cost totals (via RestoreCost), per-minute
+// time-series ring buckets — both tokens and cost — (via ReplaySnapshot),
+// and this flusher's previous-snapshot maps (prev + prevCost). The Token
+// Usage Over Time and Cost Over Time charts are backed by the time-series
+// ring; without the bucket replay each would show only a single post-restart
+// point. The Cost KPI card is backed by the cumulative atomics; without
+// RestoreCost it would silently read $0 even when pre-restart cost was
+// non-zero.
 //
 // On-disk format mirrors flushOnce's output: full MetricsSnapshotLine
 // entries plus lighter reset sentinels ({reset, ts, server} only). Reset
@@ -307,7 +391,13 @@ func isCounterReset(prev, current metrics.TokenCounts) bool {
 // For time-series, only non-reset lines are replayed: a Reset line's Diff
 // carries the carry-over from prior sessions (full snapshot), not a single
 // minute's activity, so replaying it would create a synthetic spike at the
-// reset boundary.
+// reset boundary. The same skip applies to cost replay.
+//
+// Legacy files predating cost persistence have no CostDiff / CostTotal
+// fields; they unmarshal with nil pointers, the cost diff sums to zero,
+// the cost replay no-ops, and RestoreCost is invoked with an empty map
+// (which itself no-ops). Token state restores normally — the file remains
+// fully readable with no warning.
 //
 // Missing or empty files return nil (expected on first run with persistence
 // enabled). Malformed lines are skipped without aborting; a single corrupt
@@ -344,13 +434,16 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 		ts     time.Time
 		input  int64
 		output int64
+		cost   int64 // rolled-up micro-USD total for the bucket
 	}
 
-	// Latest Total per server feeds Restore + prev. Non-reset Diff entries
-	// feed ReplaySnapshot in chronological file order so per-minute buckets
-	// appear in the same shape they had during live operation.
+	// Latest Total / CostTotal per server feeds Restore + RestoreCost +
+	// prev / prevCost. Non-reset Diff entries feed ReplaySnapshot in
+	// chronological file order so per-minute buckets appear in the same
+	// shape they had during live operation.
 	latest := make(map[string]metrics.TokenCounts)
-	var series []seriesPoint
+	latestCost := make(map[string]metrics.CostMicroUSDCounts)
+	series := make([]seriesPoint, 0, len(lines))
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -364,17 +457,35 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 			continue
 		}
 		latest[rec.Server] = rec.Total
-		if rec.Reset {
-			continue
+		if rec.CostTotal != nil {
+			latestCost[rec.Server] = *rec.CostTotal
 		}
-		if rec.Diff.InputTokens == 0 && rec.Diff.OutputTokens == 0 {
+		// Reset and CostReset are independent: a token-reset line skips
+		// token replay (Diff is the full carryover, replaying would spike
+		// the bucket) but its cost diff may still be a real per-minute
+		// delta. Symmetrically, a cost-reset-only line keeps its real
+		// token diff but skips the cost component.
+		var input, output, costMicro int64
+		if !rec.Reset {
+			input = rec.Diff.InputTokens
+			output = rec.Diff.OutputTokens
+		}
+		if !rec.CostReset && !rec.Reset && rec.CostDiff != nil {
+			// Token-reset lines carry CostDiff = currentCost as a
+			// fresh-server boundary marker, not a per-minute delta —
+			// skip cost replay for those too so we don't emit a
+			// synthetic spike alongside the token reset.
+			costMicro = rec.CostDiff.TotalMicroUSD()
+		}
+		if input == 0 && output == 0 && costMicro == 0 {
 			continue
 		}
 		series = append(series, seriesPoint{
 			server: rec.Server,
 			ts:     rec.Time,
-			input:  rec.Diff.InputTokens,
-			output: rec.Diff.OutputTokens,
+			input:  input,
+			output: output,
+			cost:   costMicro,
 		})
 	}
 
@@ -384,15 +495,19 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 
 	// Replay time-series buckets first so the ring buffer fills in
 	// chronological order; then restore cumulative counters; then seed
-	// the flusher's prev map under the lock so the next flushOnce
-	// computes a real diff against the seeded baseline.
+	// the flusher's prev / prevCost maps under the lock so the next
+	// flushOnce computes a real diff against the seeded baseline.
 	for _, p := range series {
-		f.acc.ReplaySnapshot(p.server, p.ts, p.input, p.output)
+		f.acc.ReplaySnapshot(p.server, p.ts, p.input, p.output, p.cost)
 	}
 	f.acc.Restore(latest)
+	f.acc.RestoreCost(latestCost)
 	f.mu.Lock()
 	for name, counts := range latest {
 		f.prev[name] = counts
+	}
+	for name, counts := range latestCost {
+		f.prevCost[name] = counts
 	}
 	f.mu.Unlock()
 	return nil

--- a/pkg/telemetry/metrics_test.go
+++ b/pkg/telemetry/metrics_test.go
@@ -440,6 +440,109 @@ func TestMetricsFlusher_SeedFromFile(t *testing.T) {
 	})
 }
 
+// TestSeedFromFile_LegacyTokenOnly verifies that metrics.jsonl files
+// written before cost persistence shipped (no cost_diff / cost_total
+// fields) continue to load cleanly. Token state restores; cost state
+// stays zero. Backward compatibility is the entire reason the cost
+// fields are pointer + omitempty.
+func TestSeedFromFile_LegacyTokenOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+
+	// Hand-write the legacy on-disk format: a reset sentinel followed by
+	// a reset payload, then a non-reset diff. No cost_diff / cost_total
+	// fields anywhere — exactly what a pre-cost-persistence daemon would
+	// have produced.
+	writeRawLine(t, path, `{"reset":true,"ts":"2026-05-05T12:00:00Z","server":"github"}`)
+	writeRawLine(t, path,
+		`{"ts":"2026-05-05T12:00:00Z","server":"github","reset":true,`+
+			`"diff":{"input_tokens":100,"output_tokens":50,"total_tokens":150},`+
+			`"total":{"input_tokens":100,"output_tokens":50,"total_tokens":150}}`)
+	writeRawLine(t, path,
+		`{"ts":"2026-05-05T12:01:00Z","server":"github",`+
+			`"diff":{"input_tokens":25,"output_tokens":10,"total_tokens":35},`+
+			`"total":{"input_tokens":125,"output_tokens":60,"total_tokens":185}}`)
+
+	acc := metrics.NewAccumulator(100)
+	f := NewMetricsFlusher(acc, time.Hour)
+	if err := f.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	if err := f.SeedFromFile(path, 100); err != nil {
+		t.Fatalf("SeedFromFile of legacy file: %v", err)
+	}
+
+	// Tokens restore as if nothing changed.
+	snap := acc.Snapshot()
+	if got := snap.PerServer["github"].TotalTokens; got != 185 {
+		t.Errorf("legacy seed token total = %d; want 185", got)
+	}
+	if got := snap.Session.TotalTokens; got != 185 {
+		t.Errorf("legacy seed session token total = %d; want 185", got)
+	}
+
+	// Cost stays zero — nothing on disk to restore.
+	cost := acc.CostSnapshot()
+	if cost.Session.TotalUSD != 0 {
+		t.Errorf("legacy seed produced non-zero session cost = %v; want 0", cost.Session.TotalUSD)
+	}
+	if got, ok := cost.PerServer["github"]; ok && got.TotalUSD != 0 {
+		t.Errorf("legacy seed produced non-zero github cost = %v; want 0", got.TotalUSD)
+	}
+}
+
+// TestMetricsSnapshotLine_OmitsCostFieldsWhenZero pins the wire format
+// guarantee: a token-only flush (no priced calls in the minute)
+// serializes byte-identically to the pre-cost-persistence schema, so
+// older daemons reading new files round-trip token state without any
+// surprises.
+func TestMetricsSnapshotLine_OmitsCostFieldsWhenZero(t *testing.T) {
+	line := MetricsSnapshotLine{
+		Time:   time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC),
+		Server: "github",
+		Diff:   metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+		Total:  metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+	}
+	data, err := json.Marshal(line)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, "cost_diff") {
+		t.Errorf("token-only line carried cost_diff field: %s", got)
+	}
+	if strings.Contains(got, "cost_total") {
+		t.Errorf("token-only line carried cost_total field: %s", got)
+	}
+}
+
+// TestMetricsSnapshotLine_IncludesCostFieldsWhenPresent is the inverse —
+// once cost is non-zero, the new fields appear with the documented JSON
+// names so the seed path can find them.
+func TestMetricsSnapshotLine_IncludesCostFieldsWhenPresent(t *testing.T) {
+	cd := metrics.CostMicroUSDCounts{InputMicroUSD: 50_000}
+	ct := metrics.CostMicroUSDCounts{InputMicroUSD: 100_000}
+	line := MetricsSnapshotLine{
+		Time:      time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC),
+		Server:    "github",
+		Diff:      metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+		Total:     metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+		CostDiff:  &cd,
+		CostTotal: &ct,
+	}
+	data, err := json.Marshal(line)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `"cost_diff":{"input_micro_usd":50000}`) {
+		t.Errorf("line missing cost_diff: %s", got)
+	}
+	if !strings.Contains(got, `"cost_total":{"input_micro_usd":100000}`) {
+		t.Errorf("line missing cost_total: %s", got)
+	}
+}
+
 // writeMetricsLine appends one MetricsSnapshotLine as NDJSON to path.
 func writeMetricsLine(t *testing.T, path string, line MetricsSnapshotLine) {
 	t.Helper()

--- a/pkg/telemetry/seed_test.go
+++ b/pkg/telemetry/seed_test.go
@@ -248,6 +248,282 @@ func TestEndToEnd_MetricsPersistAndReseed(t *testing.T) {
 	}
 }
 
+// TestEndToEnd_CostPersistAndReseed mirrors TestEndToEnd_MetricsPersistAndReseed
+// for cost. After a daemon restart, both cumulative cost (the Cost KPI on
+// the Metrics tab) and the cost time-series ring (the Cost Over Time
+// chart) should reflect pre-restart spend. Without RestoreCost +
+// ReplaySnapshot's cost replay, both surfaces silently read $0 even when
+// the persisted file carries non-zero cost.
+func TestEndToEnd_CostPersistAndReseed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+
+	// === Daemon "instance 1" ===
+	acc1 := metrics.NewAccumulator(100)
+	f1 := NewMetricsFlusher(acc1, time.Hour)
+	if err := f1.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	acc1.Record("github", 100, 50)
+	acc1.RecordCost("github", -1, metrics.CostBreakdown{Input: 0.05, Output: 0.10})
+	f1.flushOnce(time.Now())
+
+	acc1.Record("github", 25, 10)
+	acc1.RecordCost("github", -1, metrics.CostBreakdown{
+		Input: 0.02, Output: 0.04, CacheRead: 0.01,
+	})
+	f1.flushOnce(time.Now())
+
+	// "Restart": close instance 1's writers so the file is fully flushed.
+	f1.mu.Lock()
+	for _, lj := range f1.writers {
+		_ = lj.Close()
+	}
+	f1.mu.Unlock()
+
+	// === Daemon "instance 2" ===
+	acc2 := metrics.NewAccumulator(100)
+	f2 := NewMetricsFlusher(acc2, time.Hour)
+	if err := f2.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	if err := f2.SeedFromFile(path, 100); err != nil {
+		t.Fatalf("SeedFromFile: %v", err)
+	}
+
+	// Cumulative cost: every component restored, session = sum across
+	// servers (here, single server). Total = 0.05+0.10+0.02+0.04+0.01 = 0.22.
+	cs := acc2.CostSnapshot()
+	wantTotal := 0.22
+	if !approxCostEq(cs.Session.TotalUSD, wantTotal) {
+		t.Errorf("seeded session cost = %.6f; want %.6f", cs.Session.TotalUSD, wantTotal)
+	}
+	if !approxCostEq(cs.PerServer["github"].TotalUSD, wantTotal) {
+		t.Errorf("seeded github cost = %.6f; want %.6f", cs.PerServer["github"].TotalUSD, wantTotal)
+	}
+	// Component breakdown survives — micro-USD round-trip is exact.
+	if !approxCostEq(cs.PerServer["github"].CacheReadUSD, 0.01) {
+		t.Errorf("seeded github cache-read cost = %.6f; want 0.01", cs.PerServer["github"].CacheReadUSD)
+	}
+
+	// Time-series cost: only the second flush's diff replays (Reset is
+	// skipped to avoid a synthetic spike). The first flush is the
+	// per-server reset and its CostDiff carries the full carry-over —
+	// 0.05+0.10 = 0.15 — which does NOT enter the ring. The second flush
+	// diff is 0.02+0.04+0.01 = 0.07, which is the only value that should
+	// appear in the time-series.
+	ts := acc2.QueryCost(time.Hour)
+	points := ts.PerServer["github"]
+	if len(points) == 0 {
+		t.Fatal("github cost time-series points = 0 after seed; chart would be empty")
+	}
+	var seriesUSD float64
+	for _, p := range points {
+		seriesUSD += p.USD
+	}
+	wantSeries := 0.07
+	if !approxCostEq(seriesUSD, wantSeries) {
+		t.Errorf("seeded cost series total = %.6f; want %.6f (only the non-reset Diff)", seriesUSD, wantSeries)
+	}
+
+	// Live cost activity post-restart: next flush emits a real cost diff,
+	// not a reset — proving f.prevCost was seeded so the diff math is
+	// against the seeded baseline rather than against zero.
+	acc2.RecordCost("github", -1, metrics.CostBreakdown{Input: 0.001, Output: 0.002})
+	f2.flushOnce(time.Now())
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	lines := splitNonEmpty(string(data))
+	var last MetricsSnapshotLine
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &last); err != nil {
+		t.Fatalf("unmarshal last line: %v", err)
+	}
+	if last.Reset {
+		t.Errorf("post-seed cost flush emitted reset=true; prevCost map was not seeded. line=%s", lines[len(lines)-1])
+	}
+	if last.CostDiff == nil {
+		t.Fatalf("post-seed cost flush has nil CostDiff; want $0.003 diff. line=%s", lines[len(lines)-1])
+	}
+	wantDiffMicro := int64(3_000) // $0.003 = input 0.001 + output 0.002
+	if got := last.CostDiff.TotalMicroUSD(); got != wantDiffMicro {
+		t.Errorf("post-seed cost diff total = %d micro; want %d", got, wantDiffMicro)
+	}
+}
+
+// TestEndToEnd_CostOnlyFlushWritesLine guards the skip-zero gate change:
+// a minute with no token activity but non-zero priced cost must still
+// emit a flush line so the cost reaches disk. Pre-fix the gate looked at
+// tokens only and a cost-only minute would be silently dropped.
+func TestEndToEnd_CostOnlyFlushWritesLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+
+	acc := metrics.NewAccumulator(100)
+	f := NewMetricsFlusher(acc, time.Hour)
+	if err := f.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	// First flush emits a Reset (full snapshot) — counts as one payload.
+	acc.RecordCost("github", -1, metrics.CostBreakdown{Input: 0.05})
+	f.flushOnce(time.Now())
+
+	// More cost, zero new tokens. Pre-fix this would be a no-op.
+	acc.RecordCost("github", -1, metrics.CostBreakdown{Output: 0.07})
+	beforeLines := readLineCount(t, path)
+	f.flushOnce(time.Now())
+	afterLines := readLineCount(t, path)
+
+	if afterLines <= beforeLines {
+		t.Fatalf("cost-only flush did not append a line: before=%d after=%d", beforeLines, afterLines)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	all := splitNonEmpty(string(data))
+	var last MetricsSnapshotLine
+	if err := json.Unmarshal([]byte(all[len(all)-1]), &last); err != nil {
+		t.Fatalf("unmarshal last: %v", err)
+	}
+	if last.Reset {
+		t.Error("cost-only follow-up flush emitted reset=true")
+	}
+	if last.CostDiff == nil || last.CostDiff.OutputMicroUSD != 70_000 {
+		t.Errorf("cost-only diff = %+v; want OutputMicroUSD=70000 ($0.07)", last.CostDiff)
+	}
+	// Token diff zero is the explicit signal the line was written for cost.
+	if last.Diff.InputTokens != 0 || last.Diff.OutputTokens != 0 {
+		t.Errorf("cost-only diff carried token deltas; got %+v", last.Diff)
+	}
+}
+
+// TestEndToEnd_CostOnlyResetPreservesTokenDiff guards the high-severity
+// edge case where ClearCost runs between flushes without a token Clear.
+// Before the CostReset/Reset split, the resulting line was marked Reset
+// with Diff = current (full token snapshot) — and SeedFromFile skipped
+// Reset lines from time-series replay, silently dropping that minute's
+// token activity from the Token Over Time chart on the next restart.
+func TestEndToEnd_CostOnlyResetPreservesTokenDiff(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+
+	acc1 := metrics.NewAccumulator(100)
+	f1 := NewMetricsFlusher(acc1, time.Hour)
+	if err := f1.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	// First flush: prime token + cost state.
+	acc1.Record("github", 100, 50)
+	acc1.RecordCost("github", -1, metrics.CostBreakdown{Input: 0.05})
+	f1.flushOnce(time.Now())
+
+	// Cost-only reset: ClearCost wipes cost atomics, but tokens advance
+	// monotonically. This is exactly the user-facing "DELETE
+	// /api/metrics/cost" path while a session is running.
+	acc1.ClearCost()
+	acc1.Record("github", 25, 10)
+	f1.flushOnce(time.Now())
+
+	// Inspect the on-disk line: must be CostReset=true, Reset=false, and
+	// Diff carries the real token delta (25/10) rather than a full
+	// snapshot.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lines := splitNonEmpty(string(data))
+	var last MetricsSnapshotLine
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &last); err != nil {
+		t.Fatalf("unmarshal last: %v", err)
+	}
+	if last.Reset {
+		t.Errorf("cost-only reset emitted Reset=true; that conflates dimensions and drops the token diff on replay")
+	}
+	if !last.CostReset {
+		t.Errorf("cost-only reset did not emit CostReset=true; SeedFromFile cannot tell to skip cost replay")
+	}
+	if last.Diff.InputTokens != 25 || last.Diff.OutputTokens != 10 {
+		t.Errorf("cost-only reset Diff = %+v; want real token delta {25,10,35}", last.Diff)
+	}
+
+	// Restart simulation: fresh accumulator, seed from disk. The token
+	// time-series ring should contain the 25/10 delta — proving the
+	// CostReset/Reset split prevented the silent drop.
+	f1.mu.Lock()
+	for _, lj := range f1.writers {
+		_ = lj.Close()
+	}
+	f1.mu.Unlock()
+
+	acc2 := metrics.NewAccumulator(100)
+	f2 := NewMetricsFlusher(acc2, time.Hour)
+	if err := f2.AddServer("github", path, LogOpts{}); err != nil {
+		t.Fatalf("AddServer 2: %v", err)
+	}
+	if err := f2.SeedFromFile(path, 100); err != nil {
+		t.Fatalf("SeedFromFile: %v", err)
+	}
+
+	ts := acc2.Query(time.Hour)
+	var seriesIn, seriesOut int64
+	for _, p := range ts.PerServer["github"] {
+		seriesIn += p.InputTokens
+		seriesOut += p.OutputTokens
+	}
+	if seriesIn != 25 || seriesOut != 10 {
+		t.Errorf("seeded token series = (%d,%d); want (25,10) — the cost-only reset's token activity must survive replay", seriesIn, seriesOut)
+	}
+
+	// Cumulative tokens reflect both pre- and post-reset activity.
+	if got := acc2.Snapshot().PerServer["github"].TotalTokens; got != 185 {
+		t.Errorf("seeded github token total = %d; want 185 (full carryover via Total)", got)
+	}
+
+	// Cost time-series should NOT replay across the cost-only reset
+	// boundary — the post-reset cost is zero, and the line carries
+	// CostDiff = currentCost as the boundary marker, not a per-minute
+	// delta. SeedFromFile skips it for cost replay.
+	costTS := acc2.QueryCost(time.Hour)
+	var seriesUSD float64
+	for _, p := range costTS.PerServer["github"] {
+		seriesUSD += p.USD
+	}
+	if !approxCostEq(seriesUSD, 0) {
+		t.Errorf("post-cost-reset cost series = %v; want 0", seriesUSD)
+	}
+}
+
+// readLineCount returns the number of non-empty lines currently in path.
+// Used to assert the flusher appended (or did not append) a line on a
+// given tick.
+func readLineCount(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return len(splitNonEmpty(string(data)))
+}
+
+// approxCostEq is a 1-micro-USD tolerance compare for the seeded-cost
+// assertions. Mirrors the helper in pkg/metrics/accumulator_test.go;
+// duplicated here because the telemetry tests are a different package.
+func approxCostEq(a, b float64) bool {
+	const eps = 1e-6
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < eps
+}
+
 // splitNonEmpty splits on '\n' and discards empty entries.
 func splitNonEmpty(s string) []string {
 	var out []string


### PR DESCRIPTION
## Description

Cost data was never written to `metrics.jsonl` and never rehydrated on daemon restart, so the Cost KPI and Cost Over Time chart silently reset to $0 after every restart even when pre-restart cost was non-zero. Token persistence (#563) shipped this path; cost did not. This PR mirrors the token path symmetrically.

## Type of Change

- [x] Bug fix

## Changes Made

- **Schema (additive, backward-compatible):** `MetricsSnapshotLine` gains optional `cost_diff` / `cost_total` pointer fields plus an independent `cost_reset` flag. Token-only minutes emit lines byte-identical to the pre-cost-persistence schema; legacy files load with no warning.
- **Accumulator:** new `RestoreCost` mirrors `Restore` for cumulative per-server cost atomics; new `CostMicroSnapshot` exposes the persistence-shaped int64 micro-USD view; `ReplaySnapshot` extended with a `costMicro` parameter to populate cost buckets and supports cost-only replay.
- **Flusher:** `flushOnce` now reads `CostMicroSnapshot` alongside `Snapshot`, computes a cost diff against a parallel `prevCost` map, and emits the line when *either* token or cost diff is non-zero. `SeedFromFile` parses cost fields, calls `RestoreCost` after `Restore`, seeds `prevCost` so the first post-seed flush produces a clean diff.
- **Reset semantics split:** `Reset` and `CostReset` are independent flags. A cost-only clear (e.g. `DELETE /api/metrics/cost` between flush cycles) sets `CostReset=true` but leaves `Reset=false` — preserving the real per-minute token diff on the same line. Without the split, `SeedFromFile` would skip the line and silently drop that minute's token activity from the Token Over Time chart on replay.
- **Precision:** cost is persisted as int64 micro-USD per component (Input / Output / CacheRead / CacheWrite), matching the in-memory atomics. No float64 round-trip.
- **Tests:** `TestEndToEnd_CostPersistAndReseed`, `TestEndToEnd_CostOnlyFlushWritesLine`, `TestEndToEnd_CostOnlyResetPreservesTokenDiff`, `TestSeedFromFile_LegacyTokenOnly`, plus accumulator-level `TestAccumulator_RestoreCost*` and `TestAccumulator_ReplaySnapshot_*` coverage.

## Testing

- `go test ./... -race -count=1` — all packages green
- `golangci-lint run ./...` — 0 issues
- `npm run build` (web) — clean (no web changes)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #572