### PR TITLE
fix: reload vault on read to pick up external writes

### DIFF
--- a/internal/api/vault_test.go
+++ b/internal/api/vault_test.go
@@ -492,3 +492,77 @@ func TestHandleVault_StatusShowsEncrypted(t *testing.T) {
 		t.Errorf("encrypted = %v, want true", result["encrypted"])
 	}
 }
+
+// TestHandleVault_List_ReflectsExternalWrites asserts that secrets written by
+// a separate Store instance against the same baseDir (i.e., a CLI
+// `gridctl vault import` run while the daemon is up) are visible to the
+// server's HTTP handler on the next request, without restarting the server.
+func TestHandleVault_List_ReflectsExternalWrites(t *testing.T) {
+	dir := t.TempDir()
+
+	// Server-side store, wired into the handler.
+	serverStore := vault.NewStore(dir)
+	if err := serverStore.Load(); err != nil {
+		t.Fatalf("server Load(): %v", err)
+	}
+	server := &Server{vaultStore: serverStore}
+	handler := server.Handler()
+
+	// First request returns an empty list.
+	req := httptest.NewRequest(http.MethodGet, "/api/vault", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("initial list status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var initial []map[string]string
+	_ = json.NewDecoder(w.Body).Decode(&initial)
+	if len(initial) != 0 {
+		t.Fatalf("initial list = %d entries, want 0", len(initial))
+	}
+
+	// CLI-side store writes through a separate instance.
+	cli := vault.NewStore(dir)
+	if err := cli.Load(); err != nil {
+		t.Fatalf("cli Load(): %v", err)
+	}
+	if _, err := cli.Import(map[string]string{"API_KEY": "abc", "DB_URL": "postgres://x"}); err != nil {
+		t.Fatalf("cli Import(): %v", err)
+	}
+
+	// Server's next request reflects the external writes.
+	req = httptest.NewRequest(http.MethodGet, "/api/vault", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("post-write list status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var entries []map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("post-write list = %d entries, want 2", len(entries))
+	}
+
+	keys := map[string]bool{}
+	for _, e := range entries {
+		keys[e["key"]] = true
+	}
+	if !keys["API_KEY"] || !keys["DB_URL"] {
+		t.Errorf("missing expected keys in list: %v", entries)
+	}
+
+	// Single-key Get should also pick up the external write.
+	req = httptest.NewRequest(http.MethodGet, "/api/vault/API_KEY", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var got map[string]string
+	_ = json.NewDecoder(w.Body).Decode(&got)
+	if got["value"] != "abc" {
+		t.Errorf("Get value = %q, want %q", got["value"], "abc")
+	}
+}

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -21,6 +21,10 @@ type Store struct {
 	locked     bool   // true when secrets.enc exists and vault is not unlocked
 	encrypted  bool   // true when vault was loaded from secrets.enc (re-encrypt on save)
 	passphrase string // held in memory for re-encryption after modifications
+	// Cached mtime/size of the backing file; gates reload-on-read so external
+	// writes (e.g. CLI vault commands while the daemon is up) are picked up.
+	mtime time.Time
+	size  int64
 }
 
 // NewStore creates a vault store rooted at the given directory.
@@ -42,12 +46,16 @@ func (s *Store) Load() error {
 	s.sets = make(map[string]Set)
 	s.locked = false
 	s.encrypted = false
+	s.mtime = time.Time{}
+	s.size = 0
 
 	// Check for encrypted vault first
 	encPath := s.encryptedPath()
-	if _, err := os.Stat(encPath); err == nil {
+	if info, err := os.Stat(encPath); err == nil {
 		s.locked = true
 		s.encrypted = true
+		s.mtime = info.ModTime()
+		s.size = info.Size()
 		return nil
 	}
 
@@ -60,39 +68,53 @@ func (s *Store) Load() error {
 		return fmt.Errorf("reading vault: %w", err)
 	}
 
-	return s.parseSecretsData(data)
+	secrets, sets, err := parseSecretsData(data)
+	if err != nil {
+		return err
+	}
+	s.secrets = secrets
+	s.sets = sets
+	s.stampMtimeLocked()
+	return nil
 }
 
-// parseSecretsData parses secrets JSON into the in-memory maps.
-func (s *Store) parseSecretsData(data []byte) error {
+// parseSecretsData parses secrets JSON and returns fresh maps. Returning
+// rather than mutating lets callers swap state in atomically — a parse error
+// must never wipe the live in-memory secrets.
+func parseSecretsData(data []byte) (map[string]Secret, map[string]Set, error) {
+	secrets := make(map[string]Secret)
+	sets := make(map[string]Set)
+
 	// Try new format first (object with secrets and sets)
 	var sd storeData
 	if err := json.Unmarshal(data, &sd); err == nil && (sd.Secrets != nil || sd.Sets != nil) {
 		for _, sec := range sd.Secrets {
-			s.secrets[sec.Key] = sec
+			secrets[sec.Key] = sec
 		}
 		for _, set := range sd.Sets {
-			s.sets[set.Name] = set
+			sets[set.Name] = set
 		}
-		return nil
+		return secrets, sets, nil
 	}
 
 	// Fall back to legacy flat array format
-	var secrets []Secret
-	if err := json.Unmarshal(data, &secrets); err != nil {
-		return fmt.Errorf("parsing vault: %w", err)
+	var legacy []Secret
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		return nil, nil, fmt.Errorf("parsing vault: %w", err)
 	}
 
-	for _, sec := range secrets {
-		s.secrets[sec.Key] = sec
+	for _, sec := range legacy {
+		secrets[sec.Key] = sec
 	}
-	return nil
+	return secrets, sets, nil
 }
 
-// Get returns a secret value and whether it exists.
+// Get returns a secret value and whether it exists. Read methods take the
+// write lock because reloadIfChanged may mutate state.
 func (s *Store) Get(key string) (string, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.reloadIfChanged()
 
 	sec, ok := s.secrets[key]
 	if !ok {
@@ -164,8 +186,9 @@ func (s *Store) Delete(key string) error {
 
 // List returns all secrets sorted by key.
 func (s *Store) List() []Secret {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.reloadIfChanged()
 
 	result := make([]Secret, 0, len(s.secrets))
 	for _, sec := range s.secrets {
@@ -197,8 +220,9 @@ func (s *Store) Import(secrets map[string]string) (int, error) {
 
 // Export returns all secrets as a key-value map.
 func (s *Store) Export() map[string]string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.reloadIfChanged()
 
 	result := make(map[string]string, len(s.secrets))
 	for k, sec := range s.secrets {
@@ -209,8 +233,9 @@ func (s *Store) Export() map[string]string {
 
 // Keys returns sorted key names only.
 func (s *Store) Keys() []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.reloadIfChanged()
 
 	keys := make([]string, 0, len(s.secrets))
 	for k := range s.secrets {
@@ -222,16 +247,18 @@ func (s *Store) Keys() []string {
 
 // Has checks existence without returning the value.
 func (s *Store) Has(key string) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.reloadIfChanged()
 	_, ok := s.secrets[key]
 	return ok
 }
 
 // Values returns all secret values (for redaction registration).
 func (s *Store) Values() []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.reloadIfChanged()
 
 	vals := make([]string, 0, len(s.secrets))
 	for _, sec := range s.secrets {
@@ -273,8 +300,9 @@ func (s *Store) SetSecretSet(key, setName string) error {
 
 // ListSets returns all sets with their member counts.
 func (s *Store) ListSets() []SetSummary {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.reloadIfChanged()
 
 	// Count members per set
 	counts := make(map[string]int)
@@ -344,8 +372,9 @@ func (s *Store) DeleteSet(name string) error {
 
 // GetSetSecrets returns all secrets belonging to a set, sorted by key.
 func (s *Store) GetSetSecrets(setName string) []Secret {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.reloadIfChanged()
 
 	var result []Secret
 	for _, sec := range s.secrets {
@@ -410,6 +439,7 @@ func (s *Store) Lock(passphrase string) error {
 		s.encrypted = true
 		s.locked = false
 		s.passphrase = passphrase
+		s.stampMtimeLocked()
 		return nil
 	})
 }
@@ -439,14 +469,15 @@ func (s *Store) Unlock(passphrase string) error {
 			return err
 		}
 
-		s.secrets = make(map[string]Secret)
-		s.sets = make(map[string]Set)
-		if err := s.parseSecretsData(plaintext); err != nil {
+		secrets, sets, err := parseSecretsData(plaintext)
+		if err != nil {
 			return err
 		}
-
+		s.secrets = secrets
+		s.sets = sets
 		s.locked = false
 		s.passphrase = passphrase
+		s.stampMtimeLocked()
 		return nil
 	})
 }
@@ -486,6 +517,7 @@ func (s *Store) ChangePassphrase(oldPass, newPass string) error {
 		}
 
 		s.passphrase = newPass
+		s.stampMtimeLocked()
 		return nil
 	})
 }
@@ -501,7 +533,8 @@ func (s *Store) encryptedPath() string {
 }
 
 // loadLocked reads from disk without acquiring the mutex (caller must hold it).
-// Supports plaintext, legacy, and encrypted formats.
+// Supports plaintext, legacy, and encrypted formats. Updates s.mtime/s.size
+// on success so subsequent reloadIfChanged calls have a fresh baseline.
 func (s *Store) loadLocked() error {
 	// If encrypted and unlocked, read from encrypted file
 	if s.encrypted && !s.locked && s.passphrase != "" {
@@ -523,9 +556,14 @@ func (s *Store) loadLocked() error {
 			return err
 		}
 
-		s.secrets = make(map[string]Secret)
-		s.sets = make(map[string]Set)
-		return s.parseSecretsData(plaintext)
+		secrets, sets, err := parseSecretsData(plaintext)
+		if err != nil {
+			return err
+		}
+		s.secrets = secrets
+		s.sets = sets
+		s.stampMtimeLocked()
+		return nil
 	}
 
 	path := s.secretsPath()
@@ -537,9 +575,58 @@ func (s *Store) loadLocked() error {
 		return fmt.Errorf("reading vault: %w", err)
 	}
 
-	s.secrets = make(map[string]Secret)
-	s.sets = make(map[string]Set)
-	return s.parseSecretsData(data)
+	secrets, sets, err := parseSecretsData(data)
+	if err != nil {
+		return err
+	}
+	s.secrets = secrets
+	s.sets = sets
+	s.stampMtimeLocked()
+	return nil
+}
+
+// activePathLocked returns the backing file path that matches the current
+// encryption state. Caller must hold the mutex.
+func (s *Store) activePathLocked() string {
+	if s.encrypted {
+		return s.encryptedPath()
+	}
+	return s.secretsPath()
+}
+
+// stampMtimeLocked records the current mtime and size of the active backing
+// file. A failed stat (e.g., file not yet written) leaves the baseline cleared
+// so the next reloadIfChanged is a no-op rather than a spurious reload.
+// Caller must hold the mutex.
+func (s *Store) stampMtimeLocked() {
+	info, err := os.Stat(s.activePathLocked())
+	if err != nil {
+		s.mtime = time.Time{}
+		s.size = 0
+		return
+	}
+	s.mtime = info.ModTime()
+	s.size = info.Size()
+}
+
+// reloadIfChanged re-reads from disk when the backing file's mtime or size
+// has advanced past the cached baseline. No-op when the file is missing
+// (preserve in-memory state) or when encrypted+locked (no passphrase). The
+// caller must hold the write lock — a reload mutates s.secrets/s.sets.
+func (s *Store) reloadIfChanged() error {
+	if s.encrypted && s.locked {
+		return nil
+	}
+	info, err := os.Stat(s.activePathLocked())
+	if err != nil {
+		return nil
+	}
+	// Size is a fallback for filesystems with coarse mtime resolution where a
+	// same-second rewrite could otherwise share an mtime with the prior file.
+	if !info.ModTime().After(s.mtime) && info.Size() == s.size {
+		return nil
+	}
+	return s.loadLocked()
 }
 
 // serializeSecrets returns the current secrets as JSON.
@@ -584,10 +671,18 @@ func (s *Store) saveLocked() error {
 			return err
 		}
 
-		return atomicWrite(s.encryptedPath(), encData, 0600)
+		if err := atomicWrite(s.encryptedPath(), encData, 0600); err != nil {
+			return err
+		}
+		s.stampMtimeLocked()
+		return nil
 	}
 
-	return atomicWrite(s.secretsPath(), data, 0600)
+	if err := atomicWrite(s.secretsPath(), data, 0600); err != nil {
+		return err
+	}
+	s.stampMtimeLocked()
+	return nil
 }
 
 // atomicWrite writes data to path via temp file + rename.

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -756,3 +756,188 @@ func TestStore_DeleteWhileEncrypted(t *testing.T) {
 		t.Error("kept key should exist")
 	}
 }
+
+// --- Cross-process reload tests ---
+//
+// These simulate the daemon + CLI scenario: two Store instances pointed at
+// the same baseDir, one writing and the other reading.
+
+func TestStore_ReloadsOnExternalWrite_Plaintext(t *testing.T) {
+	dir := t.TempDir()
+
+	// "server" loads an empty vault.
+	server := NewStore(dir)
+	if err := server.Load(); err != nil {
+		t.Fatalf("server Load(): %v", err)
+	}
+	if got := len(server.List()); got != 0 {
+		t.Fatalf("server List() before external write = %d, want 0", got)
+	}
+
+	// "cli" writes via a separate Store instance.
+	cli := NewStore(dir)
+	if err := cli.Load(); err != nil {
+		t.Fatalf("cli Load(): %v", err)
+	}
+	if err := cli.Set("API_KEY", "abc123"); err != nil {
+		t.Fatalf("cli Set(): %v", err)
+	}
+	if _, err := cli.Import(map[string]string{"DB_URL": "postgres://x", "TOKEN": "t1"}); err != nil {
+		t.Fatalf("cli Import(): %v", err)
+	}
+
+	// "server" reads should now reflect the cli writes.
+	secrets := server.List()
+	if len(secrets) != 3 {
+		t.Fatalf("server List() after external write = %d, want 3", len(secrets))
+	}
+
+	val, ok := server.Get("API_KEY")
+	if !ok || val != "abc123" {
+		t.Errorf("server Get(API_KEY) = %q, %v; want %q, true", val, ok, "abc123")
+	}
+	if !server.Has("DB_URL") {
+		t.Error("server Has(DB_URL) = false; want true")
+	}
+	if got := len(server.Keys()); got != 3 {
+		t.Errorf("server Keys() len = %d, want 3", got)
+	}
+
+	// Subsequent CLI delete should also propagate.
+	if err := cli.Delete("TOKEN"); err != nil {
+		t.Fatalf("cli Delete(): %v", err)
+	}
+	if server.Has("TOKEN") {
+		t.Error("server Has(TOKEN) after external delete = true; want false")
+	}
+}
+
+func TestStore_ReloadsOnExternalWrite_Encrypted(t *testing.T) {
+	dir := t.TempDir()
+	const pass = "test-passphrase"
+
+	// "server" creates an encrypted vault and holds the passphrase.
+	server := NewStore(dir)
+	if err := server.Load(); err != nil {
+		t.Fatalf("server Load(): %v", err)
+	}
+	if err := server.Set("INITIAL", "v0"); err != nil {
+		t.Fatalf("server Set(): %v", err)
+	}
+	if err := server.Lock(pass); err != nil {
+		t.Fatalf("server Lock(): %v", err)
+	}
+
+	// "cli" loads, unlocks with the same passphrase, writes.
+	cli := NewStore(dir)
+	if err := cli.Load(); err != nil {
+		t.Fatalf("cli Load(): %v", err)
+	}
+	if err := cli.Unlock(pass); err != nil {
+		t.Fatalf("cli Unlock(): %v", err)
+	}
+	if err := cli.Set("API_KEY", "abc123"); err != nil {
+		t.Fatalf("cli Set(): %v", err)
+	}
+
+	// Server reads should pick up the encrypted external write.
+	secrets := server.List()
+	if len(secrets) != 2 {
+		t.Fatalf("server List() after external encrypted write = %d, want 2", len(secrets))
+	}
+
+	val, ok := server.Get("API_KEY")
+	if !ok || val != "abc123" {
+		t.Errorf("server Get(API_KEY) = %q, %v; want %q, true", val, ok, "abc123")
+	}
+}
+
+func TestStore_LockedEncryptedReadIsNoop(t *testing.T) {
+	dir := t.TempDir()
+
+	// Set up an encrypted vault on disk.
+	writer := NewStore(dir)
+	if err := writer.Set("KEY", "val"); err != nil {
+		t.Fatalf("writer Set(): %v", err)
+	}
+	if err := writer.Lock("pass"); err != nil {
+		t.Fatalf("writer Lock(): %v", err)
+	}
+
+	// Fresh server starts with the vault locked (no passphrase known).
+	server := NewStore(dir)
+	if err := server.Load(); err != nil {
+		t.Fatalf("server Load(): %v", err)
+	}
+	if !server.IsLocked() {
+		t.Fatal("server should be locked after Load on encrypted vault")
+	}
+
+	// Reads should not error, should not unlock the vault, and should not
+	// surface secret values from disk.
+	for i := 0; i < 3; i++ {
+		_ = server.List()
+		_, _ = server.Get("KEY")
+		_ = server.Keys()
+		_ = server.Values()
+	}
+	if !server.IsLocked() {
+		t.Error("server became unlocked after reads; reload-on-read must be no-op while locked")
+	}
+}
+
+func TestStore_ReloadIgnoresCorruptFile(t *testing.T) {
+	// A corrupt external write (e.g. a half-flushed file or manual edit
+	// gone wrong) must not wipe the daemon's in-memory secrets. The parse
+	// error propagates inside loadLocked but the existing maps are
+	// preserved.
+	dir := t.TempDir()
+
+	store := NewStore(dir)
+	if err := store.Set("KEY", "val"); err != nil {
+		t.Fatalf("Set(): %v", err)
+	}
+	if got := len(store.List()); got != 1 {
+		t.Fatalf("List() before corruption = %d, want 1", got)
+	}
+
+	// Overwrite the backing file with garbage. Use a distinct mtime to
+	// guarantee the gate fires.
+	path := filepath.Join(dir, "secrets.json")
+	if err := os.WriteFile(path, []byte("not valid json {{{"), 0600); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+
+	val, ok := store.Get("KEY")
+	if !ok || val != "val" {
+		t.Errorf("Get(KEY) after corrupt overwrite = %q, %v; want %q, true", val, ok, "val")
+	}
+}
+
+func TestStore_ReloadIgnoresMissingFile(t *testing.T) {
+	// reloadIfChanged must treat a missing backing file as a no-op rather
+	// than wiping in-memory state — otherwise a transient stat error would
+	// surface as silent data loss to readers.
+	dir := t.TempDir()
+
+	store := NewStore(dir)
+	if err := store.Set("KEY", "val"); err != nil {
+		t.Fatalf("Set(): %v", err)
+	}
+
+	// Prime the cache with a read.
+	if got := len(store.List()); got != 1 {
+		t.Fatalf("List() before remove = %d, want 1", got)
+	}
+
+	// Remove the backing file. A correct reloadIfChanged treats a missing
+	// file as no-op (preserve in-memory state).
+	if err := os.Remove(filepath.Join(dir, "secrets.json")); err != nil {
+		t.Fatalf("remove secrets.json: %v", err)
+	}
+
+	val, ok := store.Get("KEY")
+	if !ok || val != "val" {
+		t.Errorf("Get(KEY) after file removal = %q, %v; want %q, true", val, ok, "val")
+	}
+}


### PR DESCRIPTION
## Description

The running gridctl daemon's `vault.Store` cached secrets in memory at startup and never refreshed them, so CLI vault writes (`gridctl vault import`, `vault set`, `vault rm`) silently failed to appear in the UI until the server was restarted. The same stale cache also fed skill-source credential resolution and `${vault:KEY}` expansion at runtime. This change adds an mtime+size-gated reload-on-read so the daemon picks up external writes on the next read with no goroutines, file watchers, or new endpoints.

## Type of Change

- [x] Bug fix

## Changes Made

- `pkg/vault/store.go`: cache `mtime`/`size` of the active backing file; new `reloadIfChanged`, `stampMtimeLocked`, `activePathLocked` helpers; switch read methods (`Get`, `List`, `Has`, `Values`, `Keys`, `Export`, `ListSets`, `GetSetSecrets`) from `RLock` to `Lock` + reload; refactor `parseSecretsData` to populate fresh maps and return them so a parse error never wipes in-memory state; mtime-stamp at every read/write site (`Load`, `loadLocked`, `saveLocked`, `Lock`, `Unlock`, `ChangePassphrase`).
- `pkg/vault/store_test.go`: multi-`Store` regression tests for plaintext and encrypted vaults; locked-encrypted reads stay no-op; corrupt-file and missing-file preserve in-memory state.
- `internal/api/vault_test.go`: handler-level test asserting `GET /api/vault` reflects writes performed via a separate `Store` instance.

## Testing

- `go test -race ./...` — green
- `golangci-lint run ./pkg/vault/... ./internal/api/...` — 0 issues
- Manual repro: `gridctl serve`, then `gridctl vault import .vars` from another shell, refresh browser — secrets now appear without restart.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #576