### PR TITLE
fix: vault encryption-state transitions not detected by daemon

### DIFF
--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -387,16 +387,22 @@ func (s *Store) GetSetSecrets(setName string) []Secret {
 }
 
 // IsLocked returns true when the vault is encrypted and not yet unlocked.
+// Takes the write lock so reloadIfChanged can pick up external lock/unlock
+// transitions before reporting state.
 func (s *Store) IsLocked() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.reloadIfChanged()
 	return s.locked
 }
 
 // IsEncrypted returns true when the vault has an encrypted backing file.
+// Takes the write lock so reloadIfChanged can pick up external lock/unlock
+// transitions before reporting state.
 func (s *Store) IsEncrypted() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.reloadIfChanged()
 	return s.encrypted
 }
 
@@ -609,24 +615,58 @@ func (s *Store) stampMtimeLocked() {
 	s.size = info.Size()
 }
 
-// reloadIfChanged re-reads from disk when the backing file's mtime or size
-// has advanced past the cached baseline. No-op when the file is missing
-// (preserve in-memory state) or when encrypted+locked (no passphrase). The
-// caller must hold the write lock — a reload mutates s.secrets/s.sets.
+// reloadIfChanged refreshes in-memory state to match the current shape of
+// the vault on disk. It detects three kinds of change in addition to plain
+// content edits: plaintext → encrypted (CLI lock while daemon is up),
+// encrypted → plaintext (manual restore or future "decrypt" command), and
+// same-file rewrites. When neither backing file exists, in-memory state is
+// preserved so an in-flight write (window between rename and stat) doesn't
+// surface as silent data loss. The caller must hold the write lock.
 func (s *Store) reloadIfChanged() error {
-	if s.encrypted && s.locked {
-		return nil
+	// secrets.enc takes precedence (matches Load()'s file ordering).
+	if info, err := os.Stat(s.encryptedPath()); err == nil {
+		if !s.encrypted {
+			// Plaintext → encrypted transition. The daemon doesn't know the
+			// new passphrase, so drop plaintext from memory and report
+			// locked. Done as one uninterrupted sequence so a panic between
+			// flag flip and map clear can't leave plaintext readable.
+			s.encrypted = true
+			s.locked = true
+			s.passphrase = ""
+			s.secrets = make(map[string]Secret)
+			s.sets = make(map[string]Set)
+			s.mtime = info.ModTime()
+			s.size = info.Size()
+			return nil
+		}
+		if s.locked {
+			return nil
+		}
+		// Size is a fallback for filesystems with coarse mtime resolution
+		// where a same-second rewrite could share an mtime with the prior
+		// file.
+		if !info.ModTime().After(s.mtime) && info.Size() == s.size {
+			return nil
+		}
+		return s.loadLocked()
 	}
-	info, err := os.Stat(s.activePathLocked())
-	if err != nil {
-		return nil
+	if info, err := os.Stat(s.secretsPath()); err == nil {
+		if s.encrypted {
+			// Encrypted → plaintext transition. Toggle flags first so
+			// loadLocked reads the plaintext path; on parse failure the
+			// atomic swap inside parseSecretsData leaves in-memory secrets
+			// intact (they were already empty if the daemon was locked).
+			s.encrypted = false
+			s.locked = false
+			s.passphrase = ""
+			return s.loadLocked()
+		}
+		if !info.ModTime().After(s.mtime) && info.Size() == s.size {
+			return nil
+		}
+		return s.loadLocked()
 	}
-	// Size is a fallback for filesystems with coarse mtime resolution where a
-	// same-second rewrite could otherwise share an mtime with the prior file.
-	if !info.ModTime().After(s.mtime) && info.Size() == s.size {
-		return nil
-	}
-	return s.loadLocked()
+	return nil
 }
 
 // serializeSecrets returns the current secrets as JSON.

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -914,6 +914,119 @@ func TestStore_ReloadIgnoresCorruptFile(t *testing.T) {
 	}
 }
 
+func TestStore_ReloadDetectsPlaintextToEncryptedTransition(t *testing.T) {
+	// Cross-process: while a "daemon" Store has the plaintext vault loaded,
+	// a "cli" Store calls Lock(). The daemon's next read must drop the
+	// in-memory plaintext, report locked, and not leak the previous values.
+	dir := t.TempDir()
+	const pass = "test-passphrase"
+
+	daemon := NewStore(dir)
+	if err := daemon.Load(); err != nil {
+		t.Fatalf("daemon Load(): %v", err)
+	}
+	if err := daemon.Set("API_KEY", "abc123"); err != nil {
+		t.Fatalf("daemon Set(): %v", err)
+	}
+	if daemon.IsLocked() {
+		t.Fatal("daemon IsLocked() before lock = true; want false")
+	}
+
+	cli := NewStore(dir)
+	if err := cli.Load(); err != nil {
+		t.Fatalf("cli Load(): %v", err)
+	}
+	if err := cli.Lock(pass); err != nil {
+		t.Fatalf("cli Lock(): %v", err)
+	}
+
+	if !daemon.IsLocked() {
+		t.Fatal("daemon IsLocked() after external lock = false; want true (plaintext leak)")
+	}
+	if got := daemon.List(); len(got) != 0 {
+		t.Errorf("daemon List() after external lock = %d secrets; want 0", len(got))
+	}
+	if val, ok := daemon.Get("API_KEY"); ok {
+		t.Errorf("daemon Get(API_KEY) after external lock = %q, true; want \"\", false", val)
+	}
+}
+
+func TestStore_ReloadDetectsEncryptedToPlaintextTransition(t *testing.T) {
+	// No CLI command performs encrypted → plaintext on disk today; the
+	// symmetric branch is exercised here by direct file manipulation, which
+	// also covers a manual restore-from-backup or future decrypt command.
+	dir := t.TempDir()
+	const pass = "test-passphrase"
+
+	writer := NewStore(dir)
+	if err := writer.Set("OLD_KEY", "old"); err != nil {
+		t.Fatalf("writer Set(): %v", err)
+	}
+	if err := writer.Lock(pass); err != nil {
+		t.Fatalf("writer Lock(): %v", err)
+	}
+
+	daemon := NewStore(dir)
+	if err := daemon.Load(); err != nil {
+		t.Fatalf("daemon Load(): %v", err)
+	}
+	if !daemon.IsLocked() {
+		t.Fatal("daemon IsLocked() on encrypted vault = false; want true")
+	}
+
+	plaintext := []byte(`{"secrets":[{"key":"NEW_KEY","value":"new"}]}`)
+	if err := os.WriteFile(filepath.Join(dir, "secrets.json"), plaintext, 0600); err != nil {
+		t.Fatalf("write secrets.json: %v", err)
+	}
+	if err := os.Remove(filepath.Join(dir, "secrets.enc")); err != nil {
+		t.Fatalf("remove secrets.enc: %v", err)
+	}
+
+	if daemon.IsLocked() {
+		t.Error("daemon IsLocked() after external decrypt = true; want false")
+	}
+	if daemon.IsEncrypted() {
+		t.Error("daemon IsEncrypted() after external decrypt = true; want false")
+	}
+	val, ok := daemon.Get("NEW_KEY")
+	if !ok || val != "new" {
+		t.Errorf("daemon Get(NEW_KEY) = %q, %v; want %q, true", val, ok, "new")
+	}
+	if _, ok := daemon.Get("OLD_KEY"); ok {
+		t.Error("daemon Get(OLD_KEY) returned ok=true after external decrypt swap")
+	}
+}
+
+func TestStore_IsLockedReflectsExternalLock(t *testing.T) {
+	// IsLocked() and IsEncrypted() must observe an external lock without
+	// a prior read call — handleVaultStatus reaches for them directly.
+	dir := t.TempDir()
+	const pass = "test-passphrase"
+
+	daemon := NewStore(dir)
+	if err := daemon.Load(); err != nil {
+		t.Fatalf("daemon Load(): %v", err)
+	}
+	if err := daemon.Set("API_KEY", "abc123"); err != nil {
+		t.Fatalf("daemon Set(): %v", err)
+	}
+
+	cli := NewStore(dir)
+	if err := cli.Load(); err != nil {
+		t.Fatalf("cli Load(): %v", err)
+	}
+	if err := cli.Lock(pass); err != nil {
+		t.Fatalf("cli Lock(): %v", err)
+	}
+
+	if !daemon.IsLocked() {
+		t.Fatal("daemon IsLocked() after external lock without prior read = false; want true")
+	}
+	if !daemon.IsEncrypted() {
+		t.Fatal("daemon IsEncrypted() after external lock without prior read = false; want true")
+	}
+}
+
 func TestStore_ReloadIgnoresMissingFile(t *testing.T) {
 	// reloadIfChanged must treat a missing backing file as a no-op rather
 	// than wiping in-memory state — otherwise a transient stat error would


### PR DESCRIPTION
## Description

The reload-on-read mechanism added in #576 picks up content changes to the active vault file but does not detect transitions between plaintext (`secrets.json`) and encrypted (`secrets.enc`). When `gridctl vault lock` runs while `gridctl serve` is up, the daemon retains `s.encrypted=false`, the previous plaintext stays in `s.secrets`, and `IsLocked()` keeps returning false — silently violating the lock the user just performed. This PR teaches the daemon to detect both transition directions on the next read.

## Type of Change

- [x] Bug fix

## Changes Made

- Rewrite `reloadIfChanged()` to stat both `secrets.enc` and `secrets.json` and detect plaintext↔encrypted transitions in addition to same-file rewrites. Plaintext→encrypted clears the in-memory secrets, sets `locked=true`, and drops the cached passphrase. Encrypted→plaintext toggles flags and reuses `loadLocked()` (atomic-swap pattern preserved on parse failure).
- Preserve the existing "neither file exists → no-op" behavior so in-flight write windows still don't surface as data loss.
- Update `IsLocked()` and `IsEncrypted()` to take the write lock and call `reloadIfChanged()` so callers like `handleVaultStatus` observe external transitions without needing a prior read.
- Add three regression tests: cross-process plaintext→encrypted transition, encrypted→plaintext transition (via direct file manipulation since no CLI command exercises that direction), and `IsLocked()` freshness without a prior read.

## Testing

- `go test -race ./pkg/vault/... ./internal/api/...` — all passing, including the existing `TestStore_ReloadIgnoresMissingFile` and `TestStore_ReloadIgnoresCorruptFile` resilience tests.
- `golangci-lint run` clean for touched packages.
- Manual reproduction: with the daemon running, `gridctl vault lock` from the CLI now causes the next vault read to return locked status; `IsLocked()` reflects the change immediately.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #578