### PR TITLE
constitutional amendment: relax dependency posture and clarify YAML scope

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -6,11 +6,11 @@ This document contains the immutable governance articles for the gridctl project
 
 ## Article I — Library-First Architecture
 
-Gridctl MUST prefer the Go standard library over external dependencies. A new external dependency MUST NOT be introduced when the standard library can achieve the same result with reasonable code. Every external dependency is a supply-chain risk and a maintenance burden; its introduction requires explicit justification in the PR that adds it.
+Gridctl prefers mature, permissively-licensed (Apache 2.0 or MIT) Go libraries over bespoke implementations for foundational concerns where the alternative is reinventing a graph runtime, sandbox, or schema validator. The standard library remains the default for incidental utilities. Justification for each new top-level dependency still belongs in the PR that adds it.
 
 ## Article II — Dependency Minimalism
 
-External dependencies MUST be justified by functionality that the standard library demonstrably cannot provide. Dependencies MUST NOT be added for convenience, style preference, or to reduce line count when equivalent stdlib patterns exist. Transitive dependencies count toward this obligation.
+External dependencies MUST be justified by functionality, maturity, or correctness gains the project would otherwise have to reproduce. Transitive footprint and license posture remain part of the review criteria.
 
 ## Article III — Test-First Development
 
@@ -38,7 +38,7 @@ The public CLI interface and stack YAML schema are versioned artifacts. Breaking
 
 ## Article IX — Stack YAML Backward Compatibility
 
-Every new field added to the stack YAML schema MUST be optional with a documented default that preserves existing behavior. A stack file valid against version N MUST remain valid and produce equivalent behavior under version N+1 unless the major version has been incremented. Removing or renaming a field is a breaking change.
+Every new field added to the `stack.yaml` schema (MCP servers, transports, networks, vault, pins) MUST be optional with a documented default that preserves existing behavior. A stack file valid against version N MUST remain valid and produce equivalent behavior under version N+1 unless the major version has been incremented. Removing or renaming a field is a breaking change. This guarantee covers the `stack.yaml` schema only — skill definition formats are not in scope. The `workflow:` block in `SKILL.md` is no longer supported.
 
 ## Article X — Machine-Parseable CLI Output
 


### PR DESCRIPTION
## Summary

Amend three constitutional articles to unblock upcoming work without committing to a runtime that does not exist yet. The other twelve articles are byte-identical.

- **Article I (Library-First Architecture)** — replace the stdlib-only mandate. Prefer mature, permissively-licensed (Apache 2.0 or MIT) Go libraries for foundational concerns (graph runtime, sandbox, schema validator) rather than reinventing them. Stdlib remains the default for incidental utilities. Per-PR justification still required.
- **Article II (Dependency Minimalism)** — soften the stdlib-can-do-it test. Dependencies must be justified by functionality, maturity, or correctness gains the project would otherwise have to reproduce. Transitive footprint and license posture stay in review criteria.
- **Article IX (Stack YAML Backward Compatibility)** — narrow scope to the `stack.yaml` schema (MCP servers, transports, networks, vault, pins). Skill definition formats are not covered. The `workflow:` block in `SKILL.md` is no longer supported.

## Scope

- One file changed: `CONSTITUTION.md`.
- Three articles amended; numbering unchanged.
- Articles III–VIII and X–XV are byte-identical.
- No README, AGENTS, docs/, or SECURITY changes — those are deferred until there is something concrete to point at.
- No new articles. The "Skills Are Code" / "Code Mode is Default" / "Typed Boundaries" articles previously discussed describe a runtime that does not exist yet; they belong in a follow-up amendment when the runtime lands.

## Test plan

- [ ] Reviewer reads the diff in under five minutes
- [ ] Articles III–VIII and X–XV verified byte-identical to prior version (`git diff` shows only Articles I, II, IX changed)
- [ ] No other files touched (`git diff --stat` shows one file)