### PR TITLE
fix: wire agent runtime, TS dispatcher, and require shim

### DIFF
--- a/internal/api/agent_dev.go
+++ b/internal/api/agent_dev.go
@@ -6,16 +6,20 @@ import (
 	"github.com/gridctl/gridctl/pkg/agent/dev/devserver"
 )
 
-// SetAgentDevServer wires the agent IDE dev-server endpoints into
-// the daemon's API surface. When set, /api/agent/dev/* routes serve
-// parsed skill graphs and file-watcher events from the configured
-// project root. Passing nil disables the routes — they 503.
+// SetAgentDevServer wires the agent IDE dev-server endpoints into the
+// daemon's API surface. When set, /api/agent/dev/* routes serve parsed
+// skill graphs and file-watcher events from the configured project
+// root. Passing nil disables the routes — they 503.
 //
-// The daemon path is convenience: `gridctl agent dev` already
-// stands up its own listener on port 8181 for standalone authoring.
-// When the operator wants the project-aware IDE inside the same web
-// UI as the gateway dashboard, they can wire a dev server here at
-// apply time (or via a future serve flag).
+// The daemon path is convenience: `gridctl agent dev` already stands
+// up its own listener on port 8181 for standalone authoring. When the
+// operator wants the project-aware IDE inside the same web UI as the
+// gateway dashboard, they can wire a dev server here at apply time
+// (or via a future serve flag).
+//
+// SetAgentRuntime takes precedence over this setter at read time;
+// retained for test fixtures and the current daemon path that builds
+// the dev server out-of-band.
 func (s *Server) SetAgentDevServer(dev *devserver.Server) {
 	s.agentDevServer = dev
 }
@@ -25,9 +29,10 @@ func (s *Server) SetAgentDevServer(dev *devserver.Server) {
 // with a clear "not configured" message so frontend clients can
 // gracefully degrade rather than silently fail.
 func (s *Server) handleAgentDev(w http.ResponseWriter, r *http.Request) {
-	if s.agentDevServer == nil {
+	dev := s.devServer()
+	if dev == nil {
 		writeJSONError(w, "agent dev server not configured", http.StatusServiceUnavailable)
 		return
 	}
-	s.agentDevServer.Handler().ServeHTTP(w, r)
+	dev.Handler().ServeHTTP(w, r)
 }

--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -13,16 +13,18 @@ import (
 )
 
 // SetAgentRunStore wires the persist.Store the /api/agent/runs/*
-// handlers read from. The daemon constructs the store once per
-// process at apply time so concurrent run-loop writers and HTTP
-// readers share the same on-disk layout.
+// handlers fall back to when no runtime aggregate is installed.
+// Production callers should use SetAgentRuntime, which takes precedence
+// over this setter at read time. Retained for tests that need only one
+// slice of runtime state.
 func (s *Server) SetAgentRunStore(store *persist.Store) {
 	s.agentRunStore = store
 }
 
-// SetAgentApprovalRegistry wires the in-process approval registry.
-// Approvals issued by the runtime register here; the
-// /api/agent/runs/{id}/approve handler resolves them by ID.
+// SetAgentApprovalRegistry wires the in-process approval registry the
+// /api/agent/runs/{id}/approve handler falls back to when no runtime
+// aggregate is installed. SetAgentRuntime takes precedence at read
+// time. Retained for test-fixture wiring.
 func (s *Server) SetAgentApprovalRegistry(reg *compose.Registry) {
 	s.agentApprovalRegistry = reg
 }
@@ -46,7 +48,7 @@ type agentRunListItem struct {
 
 // handleAgentRunsList returns a paginated list of recent runs.
 func (s *Server) handleAgentRunsList(w http.ResponseWriter, r *http.Request) {
-	store := s.agentRunStore
+	store := s.runStore()
 	if store == nil {
 		writeJSONError(w, "agent runtime not configured", http.StatusServiceUnavailable)
 		return
@@ -74,7 +76,7 @@ func (s *Server) handleAgentRunsList(w http.ResponseWriter, r *http.Request) {
 // payload list is returned in one shot — for streaming, see
 // handleAgentRunEvents (SSE).
 func (s *Server) handleAgentRunGet(w http.ResponseWriter, r *http.Request) {
-	store := s.agentRunStore
+	store := s.runStore()
 	if store == nil {
 		writeJSONError(w, "agent runtime not configured", http.StatusServiceUnavailable)
 		return
@@ -109,7 +111,7 @@ func (s *Server) handleAgentRunGet(w http.ResponseWriter, r *http.Request) {
 // The handler streams the complete ledger then closes the connection;
 // live tailing lands when the runtime exposes an event-bus surface.
 func (s *Server) handleAgentRunEvents(w http.ResponseWriter, r *http.Request) {
-	store := s.agentRunStore
+	store := s.runStore()
 	if store == nil {
 		writeJSONError(w, "agent runtime not configured", http.StatusServiceUnavailable)
 		return
@@ -162,7 +164,7 @@ type agentResumeRequest struct {
 // projection over the JSONL so CLI/web clients see the same
 // rehydrated state.
 func (s *Server) handleAgentRunResume(w http.ResponseWriter, r *http.Request) {
-	store := s.agentRunStore
+	store := s.runStore()
 	if store == nil {
 		writeJSONError(w, "agent runtime not configured", http.StatusServiceUnavailable)
 		return
@@ -199,11 +201,12 @@ type agentApproveRequest struct {
 // can be supplied explicitly or inferred from the run's pending
 // approval (most CLIs use the run-id-only form for convenience).
 func (s *Server) handleAgentRunApprove(w http.ResponseWriter, r *http.Request) {
-	if s.agentApprovalRegistry == nil {
+	registry := s.approvalRegistry()
+	if registry == nil {
 		writeJSONError(w, "agent runtime not configured", http.StatusServiceUnavailable)
 		return
 	}
-	store := s.agentRunStore
+	store := s.runStore()
 	if store == nil {
 		writeJSONError(w, "agent runtime not configured", http.StatusServiceUnavailable)
 		return
@@ -238,7 +241,7 @@ func (s *Server) handleAgentRunApprove(w http.ResponseWriter, r *http.Request) {
 	if source == "" {
 		source = "api"
 	}
-	if err := s.agentApprovalRegistry.Resolve(approvalID, req.Approved, req.Reason, source); err != nil {
+	if err := registry.Resolve(approvalID, req.Approved, req.Reason, source); err != nil {
 		switch {
 		case errors.Is(err, compose.ErrApprovalNotFound):
 			writeJSONError(w, err.Error(), http.StatusNotFound)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gridctl/gridctl/pkg/agent/compose"
 	"github.com/gridctl/gridctl/pkg/agent/dev/devserver"
 	"github.com/gridctl/gridctl/pkg/agent/persist"
+	agentruntime "github.com/gridctl/gridctl/pkg/agent/runtime"
 	"github.com/gridctl/gridctl/pkg/dockerclient"
 	"github.com/gridctl/gridctl/pkg/logging"
 	"github.com/gridctl/gridctl/pkg/mcp"
@@ -92,6 +93,12 @@ type Server struct {
 	// devserver.Server that powers the /api/agent/dev/* endpoints
 	// (skills list, AST graphs, file-watcher SSE). Nil → 503.
 	agentDevServer *devserver.Server
+
+	// agentRuntime is the unified runtime aggregate; when non-nil,
+	// /api/agent/* and /api/playground/* handlers prefer it over the
+	// per-component fields above. SetAgentRuntime installs it; the
+	// per-component setters are retained as test-fixture wrappers.
+	agentRuntime *agentruntime.Runtime
 }
 
 // NewServer creates a new API server.
@@ -219,8 +226,63 @@ func (s *Server) SetSkillSourcePaths(lockPath, configPath string) {
 // (the chat endpoint returns a clear error). The provider is typically
 // the prefix-routing agent/llm/gateway.Provider built at apply-time by
 // pkg/controller from the vault keys present.
+//
+// SetAgentRuntime takes precedence over this setter at read time;
+// retained for test fixtures.
 func (s *Server) SetPlaygroundProvider(p agent.ChatModel) {
 	s.playgroundProvider = p
+}
+
+// SetAgentRuntime installs the unified runtime aggregate. When set, the
+// per-component setters below are ignored at read time. Wire-time only:
+// the controller calls this once during apply before HTTP serving
+// starts; field access is unsynchronised to match the rest of the
+// per-server setter pattern.
+func (s *Server) SetAgentRuntime(rt *agentruntime.Runtime) {
+	s.agentRuntime = rt
+}
+
+// The four accessors below all share the same shape: prefer the runtime
+// aggregate's component when set, otherwise fall back to the legacy
+// per-field value the matching setter wrote. Production wiring goes
+// through SetAgentRuntime; the per-field setters survive for tests
+// that need to wire a single component without building a full
+// Runtime.
+
+func (s *Server) runStore() *persist.Store {
+	if s.agentRuntime != nil {
+		if store := s.agentRuntime.RunStore(); store != nil {
+			return store
+		}
+	}
+	return s.agentRunStore
+}
+
+func (s *Server) approvalRegistry() *compose.Registry {
+	if s.agentRuntime != nil {
+		if reg := s.agentRuntime.ApprovalRegistry(); reg != nil {
+			return reg
+		}
+	}
+	return s.agentApprovalRegistry
+}
+
+func (s *Server) chatProvider() agent.ChatModel {
+	if s.agentRuntime != nil {
+		if m := s.agentRuntime.ChatModel(); m != nil {
+			return m
+		}
+	}
+	return s.playgroundProvider
+}
+
+func (s *Server) devServer() *devserver.Server {
+	if s.agentRuntime != nil {
+		if d := s.agentRuntime.DevServer(); d != nil {
+			return d
+		}
+	}
+	return s.agentDevServer
 }
 
 // RegistryServer returns the registry server.

--- a/internal/api/optimize.go
+++ b/internal/api/optimize.go
@@ -113,7 +113,7 @@ func (s *Server) optimizeStats() optimize.Stats {
 		stats.ServerCallCount = computeServerCallCount(acc.ToolUsageSnapshot())
 	}
 	stats.ModelStats = lookupModelStats(stats.Servers)
-	stats.RunStats = collectRunStats(s.agentRunStore)
+	stats.RunStats = collectRunStats(s.runStore())
 	return stats
 }
 

--- a/internal/api/playground.go
+++ b/internal/api/playground.go
@@ -214,11 +214,11 @@ func (s *Server) handlePlaygroundChat(w http.ResponseWriter, r *http.Request) {
 // a chat request. When the requested model has no matching provider,
 // the function returns an error the handler surfaces verbatim.
 func (s *Server) resolveProvider(model string) (agent.ChatModel, string, string, error) {
-	if s.playgroundProvider != nil {
+	if provider := s.chatProvider(); provider != nil {
 		// The injected provider may be a router (llm/gateway.Provider)
 		// that itself dispatches by prefix; otherwise the provider
 		// honors whatever model the request specifies.
-		return s.playgroundProvider, model, providerNameFromModel(model), nil
+		return provider, model, providerNameFromModel(model), nil
 	}
 	return nil, "", "", errors.New("playground: no LLM provider is configured (set ANTHROPIC_API_KEY in the vault and restart)")
 }

--- a/pkg/agent/dev/scaffold/scaffold.go
+++ b/pkg/agent/dev/scaffold/scaffold.go
@@ -118,6 +118,13 @@ canvas reflects the change in <300ms.
 `, name, name)
 }
 
+// HelloSkillTS returns the body of the scaffolded skill.ts as bytes
+// the regression suite can run through the sandbox verbatim. Exporting
+// the helper means a future change to the scaffold immediately re-tests
+// runtime compatibility — there's no parallel copy of the source to
+// drift out of sync.
+func HelloSkillTS(name string) string { return helloSkillTS(name) }
+
 // helloSkillTS renders a runnable TS skill exercising the recognised
 // primitives. Authors edit this file, the watcher fires, the IDE
 // re-renders.
@@ -155,7 +162,7 @@ export default async function run(input: HelloInput): Promise<HelloOutput> {
     ],
   });
 
-  return { greeting: reply.text };
+  return { greeting: reply.content };
 }
 `
 }

--- a/pkg/agent/runtime/runtime.go
+++ b/pkg/agent/runtime/runtime.go
@@ -1,0 +1,113 @@
+// Package runtime aggregates the agent runtime's process-wide state into
+// a single handle the gateway hangs off via SetAgentRuntime. Centralising
+// the run store, approval registry, sandbox, dev server, and active LLM
+// provider lets downstream consumers (HTTP API, CLI, dispatcher) pull
+// every collaborator from one place rather than threading four setters
+// through the API server.
+//
+// The package lives below pkg/agent (rather than alongside it) because
+// pkg/agent already imports pkg/mcp; placing Runtime here lets us
+// import pkg/agent/sandbox + compose + persist + dev/devserver without
+// taking pkg/mcp into the closure of those packages. The gateway
+// holds *Runtime as an opaque mcp.AgentRuntime — consumers type-assert
+// to read the components.
+package runtime
+
+import (
+	"sync"
+
+	"github.com/gridctl/gridctl/pkg/agent"
+	"github.com/gridctl/gridctl/pkg/agent/compose"
+	"github.com/gridctl/gridctl/pkg/agent/dev/devserver"
+	"github.com/gridctl/gridctl/pkg/agent/persist"
+	"github.com/gridctl/gridctl/pkg/agent/sandbox"
+)
+
+// Runtime is the agent runtime aggregate. Construct with NewRuntime;
+// late-binding components (ChatModel, DevServer) plug in via setters
+// once their upstream factories have run. All accessors are safe for
+// concurrent use.
+type Runtime struct {
+	mu sync.RWMutex
+
+	runStore         *persist.Store
+	approvalRegistry *compose.Registry
+	sandbox          *sandbox.Sandbox
+
+	chatModel agent.ChatModel
+	devServer *devserver.Server
+}
+
+// NewRuntime constructs a Runtime with the load-bearing components the
+// dispatcher and HTTP handlers need at process start. The ChatModel and
+// DevServer plug in later once the API server has resolved them.
+func NewRuntime(store *persist.Store, reg *compose.Registry, sb *sandbox.Sandbox) *Runtime {
+	return &Runtime{
+		runStore:         store,
+		approvalRegistry: reg,
+		sandbox:          sb,
+	}
+}
+
+// AgentRuntimeMarker satisfies the mcp.AgentRuntime interface so the
+// Gateway can hold *Runtime opaquely without the agent → mcp → agent
+// import cycle. The method is intentionally empty — the marker exists
+// purely to keep the Gateway's accessor type-safe.
+func (*Runtime) AgentRuntimeMarker() {}
+
+// RunStore returns the JSONL run-event ledger. Nil only when NewRuntime
+// was called without one (defensive — callers should always pass a real
+// store).
+func (r *Runtime) RunStore() *persist.Store {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.runStore
+}
+
+// ApprovalRegistry returns the in-process approval-gate registry.
+func (r *Runtime) ApprovalRegistry() *compose.Registry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.approvalRegistry
+}
+
+// Sandbox returns the goja sandbox used to execute TypeScript skills.
+func (r *Runtime) Sandbox() *sandbox.Sandbox {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.sandbox
+}
+
+// SetChatModel installs (or replaces) the LLM provider exposed to skills
+// via the sandbox's llm() binding. Plumbed late because the provider is
+// built by the API-server stage of gateway construction, after the
+// runtime aggregate already exists.
+func (r *Runtime) SetChatModel(m agent.ChatModel) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.chatModel = m
+}
+
+// ChatModel returns the active LLM provider, or nil if none is wired.
+// Callers should treat nil as "llm() unavailable" and surface a clear
+// error rather than panicking.
+func (r *Runtime) ChatModel() agent.ChatModel {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.chatModel
+}
+
+// SetDevServer installs the agent IDE dev server. nil disables the
+// /api/agent/dev/* routes, which then return 503.
+func (r *Runtime) SetDevServer(d *devserver.Server) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.devServer = d
+}
+
+// DevServer returns the agent IDE dev server, or nil when not wired.
+func (r *Runtime) DevServer() *devserver.Server {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.devServer
+}

--- a/pkg/agent/runtime/runtime_test.go
+++ b/pkg/agent/runtime/runtime_test.go
@@ -1,0 +1,75 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/agent"
+	"github.com/gridctl/gridctl/pkg/agent/compose"
+	"github.com/gridctl/gridctl/pkg/agent/persist"
+	"github.com/gridctl/gridctl/pkg/agent/sandbox"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// stubChatModel satisfies agent.ChatModel without exercising any real
+// LLM provider — Runtime only stores and returns the value, so no
+// methods are called in this test.
+type stubChatModel struct{}
+
+func (stubChatModel) Generate(_ context.Context, _ agent.ChatRequest) (agent.ChatResponse, error) {
+	return agent.ChatResponse{}, nil
+}
+func (stubChatModel) Stream(_ context.Context, _ agent.ChatRequest) (*agent.StreamReader[agent.ChatChunk], error) {
+	return nil, nil
+}
+
+func TestRuntime_NewRuntimeStoresLoadBearingComponents(t *testing.T) {
+	t.Parallel()
+	store := persist.NewStore(t.TempDir())
+	reg := compose.NewRegistry()
+	sb := sandbox.New(0)
+
+	rt := NewRuntime(store, reg, sb)
+
+	if got := rt.RunStore(); got != store {
+		t.Errorf("RunStore() = %p, want %p", got, store)
+	}
+	if got := rt.ApprovalRegistry(); got != reg {
+		t.Errorf("ApprovalRegistry() = %p, want %p", got, reg)
+	}
+	if got := rt.Sandbox(); got != sb {
+		t.Errorf("Sandbox() = %p, want %p", got, sb)
+	}
+	if got := rt.ChatModel(); got != nil {
+		t.Errorf("ChatModel() = %v, want nil before SetChatModel", got)
+	}
+	if got := rt.DevServer(); got != nil {
+		t.Errorf("DevServer() = %v, want nil before SetDevServer", got)
+	}
+}
+
+func TestRuntime_SetChatModelLatePlugIn(t *testing.T) {
+	t.Parallel()
+	rt := NewRuntime(persist.NewStore(t.TempDir()), compose.NewRegistry(), sandbox.New(0))
+
+	model := stubChatModel{}
+	rt.SetChatModel(model)
+	if got := rt.ChatModel(); got != model {
+		t.Errorf("ChatModel() = %v, want stub model after SetChatModel", got)
+	}
+
+	// Replace with nil so consumers can detach a stale provider.
+	rt.SetChatModel(nil)
+	if got := rt.ChatModel(); got != nil {
+		t.Errorf("ChatModel() = %v after SetChatModel(nil), want nil", got)
+	}
+}
+
+func TestRuntime_AgentRuntimeMarkerSatisfiesGatewayContract(t *testing.T) {
+	t.Parallel()
+	// Asserting against the real mcp.AgentRuntime interface (rather
+	// than a local copy) means a future signature drift fails this
+	// test at compile time — even though the gateway also enforces it.
+	rt := NewRuntime(persist.NewStore(t.TempDir()), compose.NewRegistry(), sandbox.New(0))
+	var _ mcp.AgentRuntime = rt
+}

--- a/pkg/agent/sandbox/dispatcher.go
+++ b/pkg/agent/sandbox/dispatcher.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -34,6 +35,74 @@ func FileSourceLoader(lookup func(name string) (string, bool)) SourceLoader {
 		}
 		return string(data), nil
 	}
+}
+
+// BindingsProvider returns the Bindings the dispatcher uses for one
+// invocation. The closure is called per Dispatch so a long-lived
+// dispatcher can hand each call request-scoped collaborators (a fresh
+// ToolCaller, the current ChatModel, the run's Approver) without
+// caching state across calls.
+type BindingsProvider func(ctx context.Context, skillName string) Bindings
+
+// Dispatcher implements registry.TSDispatcher: each Dispatch reads the
+// TS skill source from disk and runs it through the sandbox using the
+// per-call Bindings. The struct is constructed once at gateway-build
+// time and registered on the registry server via SetTSDispatcher; all
+// per-call collaborators flow through the BindingsProvider closure.
+type Dispatcher struct {
+	sb       *Sandbox
+	bindings BindingsProvider
+}
+
+// NewDispatcher constructs a Dispatcher. Passing a nil sandbox is
+// rejected — the caller is expected to construct a Sandbox with the
+// timeout it wants enforced for skill execution. A nil bindings
+// provider is allowed; calls then run with empty Bindings (no tool(),
+// no llm(), etc.) and any binding access from the skill raises a JS
+// error at call time.
+func NewDispatcher(sb *Sandbox, bp BindingsProvider) (*Dispatcher, error) {
+	if sb == nil {
+		return nil, errors.New("sandbox: dispatcher requires a non-nil sandbox")
+	}
+	return &Dispatcher{sb: sb, bindings: bp}, nil
+}
+
+// Dispatch runs `name`'s TS source through the sandbox and wraps the
+// returned value in an mcp.ToolCallResult shaped the way a typed-skill
+// MCP tool reply does. The marshaling matches NewInvoker's so the
+// bytes-on-the-wire are the same whether the gateway calls the skill
+// via the dispatcher (external MCP clients) or via the typed-skill
+// registry (handoff() inside another skill).
+func (d *Dispatcher) Dispatch(ctx context.Context, name, sourcePath string, arguments map[string]any) (*mcp.ToolCallResult, error) {
+	if d == nil || d.sb == nil {
+		return nil, errors.New("sandbox: dispatcher not initialized")
+	}
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("ts skill %q: reading source: %w", name, err)
+	}
+	var b Bindings
+	if d.bindings != nil {
+		b = d.bindings(ctx, name)
+	}
+	result, err := d.sb.Execute(ctx, string(source), arguments, b)
+	if err != nil {
+		return nil, err
+	}
+	text := result.Value
+	if text == "" {
+		text = "null"
+	}
+	// Validate the value is JSON; if it isn't (the skill returned a
+	// non-serialisable value), wrap it in a JSON string so the upstream
+	// caller still receives a syntactically valid content block.
+	var probe any
+	if err := json.Unmarshal([]byte(text), &probe); err != nil {
+		text = fmt.Sprintf("%q", result.Value)
+	}
+	return &mcp.ToolCallResult{
+		Content: []mcp.Content{mcp.NewTextContent(text)},
+	}, nil
 }
 
 // NewInvoker builds a skill.Invoker that runs `name`'s TS source

--- a/pkg/agent/sandbox/dispatcher_test.go
+++ b/pkg/agent/sandbox/dispatcher_test.go
@@ -1,0 +1,139 @@
+package sandbox
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// TestDispatcher_DispatchReadsSourceAndWrapsResult is the unit-test
+// proof that the concrete Dispatcher reads the TS source from the
+// supplied path, runs it under the sandbox with per-call Bindings, and
+// wraps the resolved value in an mcp.ToolCallResult shaped the way an
+// MCP tool reply does. This is the path the gateway hands to external
+// MCP clients calling a TS skill by name.
+func TestDispatcher_DispatchReadsSourceAndWrapsResult(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "echo.ts")
+	src := `export default async function (i: any) { return { echoed: i }; }`
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatalf("writing skill source: %v", err)
+	}
+
+	sb := New(2 * time.Second)
+	disp, err := NewDispatcher(sb, func(_ context.Context, _ string) Bindings { return Bindings{} })
+	if err != nil {
+		t.Fatalf("NewDispatcher: %v", err)
+	}
+
+	res, err := disp.Dispatch(context.Background(), "echo", path, map[string]any{"v": 7})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(res.Content) != 1 {
+		t.Fatalf("expected one content block, got %d", len(res.Content))
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, `"echoed":`) || !strings.Contains(text, `"v":7`) {
+		t.Errorf("content text = %q, want JSON containing echoed.v=7", text)
+	}
+}
+
+// TestDispatcher_BindingsProviderReceivesContextAndName confirms the
+// per-call BindingsProvider hook is invoked with the run's context and
+// skill name on every Dispatch — that is the surface long-lived
+// dispatchers use to scope ToolCaller/ChatModel/Approver to one call.
+func TestDispatcher_BindingsProviderReceivesContextAndName(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "noop.ts")
+	if err := os.WriteFile(path, []byte(`export default async function () { return null; }`), 0o600); err != nil {
+		t.Fatalf("writing skill source: %v", err)
+	}
+
+	type captured struct {
+		ctx  context.Context
+		name string
+	}
+	calls := []captured{}
+	sb := New(2 * time.Second)
+	disp, err := NewDispatcher(sb, func(ctx context.Context, name string) Bindings {
+		calls = append(calls, captured{ctx: ctx, name: name})
+		return Bindings{}
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher: %v", err)
+	}
+
+	type ctxKey string
+	parentCtx := context.WithValue(context.Background(), ctxKey("trace"), "abc")
+	if _, err := disp.Dispatch(parentCtx, "skill-name", path, nil); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("BindingsProvider invoked %d times, want 1", len(calls))
+	}
+	if calls[0].name != "skill-name" {
+		t.Errorf("BindingsProvider got name=%q, want skill-name", calls[0].name)
+	}
+	if got := calls[0].ctx.Value(ctxKey("trace")); got != "abc" {
+		t.Errorf("BindingsProvider context lost trace value: got %v", got)
+	}
+}
+
+// TestDispatcher_DispatchReportsMissingSource confirms a missing source
+// file surfaces as a structured error rather than a panic.
+func TestDispatcher_DispatchReportsMissingSource(t *testing.T) {
+	t.Parallel()
+	sb := New(2 * time.Second)
+	disp, err := NewDispatcher(sb, nil)
+	if err != nil {
+		t.Fatalf("NewDispatcher: %v", err)
+	}
+	_, err = disp.Dispatch(context.Background(), "ghost", filepath.Join(t.TempDir(), "missing.ts"), nil)
+	if err == nil {
+		t.Fatal("expected error for missing source")
+	}
+	if !strings.Contains(err.Error(), `ts skill "ghost"`) {
+		t.Errorf("err = %v, want skill-named error", err)
+	}
+}
+
+// TestDispatcher_NewDispatcherRejectsNilSandbox locks in the
+// constructor's contract: a nil sandbox is a programmer error caught
+// at wire time, not at first call.
+func TestDispatcher_NewDispatcherRejectsNilSandbox(t *testing.T) {
+	t.Parallel()
+	_, err := NewDispatcher(nil, nil)
+	if err == nil {
+		t.Fatal("expected error for nil sandbox")
+	}
+	if !strings.Contains(err.Error(), "non-nil sandbox") {
+		t.Errorf("err = %v, want explanation that sandbox is required", err)
+	}
+}
+
+// TestDispatcher_SatisfiesRegistryTSDispatcherShape is a structural
+// check: the concrete Dispatcher implements the dispatch contract the
+// registry server consumes (Dispatch(ctx, name, path, args) → result).
+// The registry interface lives in pkg/registry; we mirror its shape
+// here so a future signature change in either package fails this test
+// rather than a downstream integration.
+func TestDispatcher_SatisfiesRegistryTSDispatcherShape(t *testing.T) {
+	t.Parallel()
+	type tsDispatcher interface {
+		Dispatch(ctx context.Context, name, sourcePath string, arguments map[string]any) (*mcp.ToolCallResult, error)
+	}
+	sb := New(time.Second)
+	disp, err := NewDispatcher(sb, nil)
+	if err != nil {
+		t.Fatalf("NewDispatcher: %v", err)
+	}
+	var _ tsDispatcher = disp
+}

--- a/pkg/agent/sandbox/sandbox.go
+++ b/pkg/agent/sandbox/sandbox.go
@@ -200,6 +200,9 @@ func (s *Sandbox) Execute(ctx context.Context, source string, input any, b Bindi
 		installParallelBinding(vm, loop, b)
 		installHandoffBinding(vm, loop, runCtx, s.timeout, b)
 		installApprovalBinding(vm, loop, runCtx, s.timeout, b)
+		// Install the require() shim after the bindings so it can read
+		// their global values into the @gridctl/agent module object.
+		installRequireShim(vm)
 
 		// Run the transpiled skill source first; this populates
 		// module.exports.default with the handler the harness then
@@ -320,5 +323,46 @@ func installModuleHarness(vm *goja.Runtime) {
 	_ = module.Set("exports", exports)
 	_ = vm.Set("module", module)
 	_ = vm.Set("exports", exports)
+}
+
+// agentModuleName is the only module specifier the require() shim
+// resolves. Skills that author against the gridctl SDK import from this
+// package; everything else fails fast so authors notice unsupported
+// imports at runtime rather than getting a silently-empty module.
+const agentModuleName = "@gridctl/agent"
+
+// agentModuleExports lists the names the @gridctl/agent module re-exports
+// — they map 1:1 onto the bindings each install* function registers as a
+// JS global. Keeping this in one place ensures a new binding is exposed
+// through both the global path and the import path with one change.
+var agentModuleExports = []string{"tool", "llm", "parallel", "handoff", "approval"}
+
+// installRequireShim wires a minimal CommonJS-style require() that
+// resolves the @gridctl/agent specifier the scaffold (and esbuild's
+// CommonJS output) emits. The shim returns an object whose properties
+// are the goja values the binding installs already registered as
+// globals — that's why this call MUST run after every install* binding.
+//
+// Any other module name throws so unexpected imports surface as a
+// runtime error rather than a silently-undefined member access.
+func installRequireShim(vm *goja.Runtime) {
+	_ = vm.Set("require", func(call goja.FunctionCall) goja.Value {
+		if len(call.Arguments) < 1 {
+			panic(vm.NewGoError(fmt.Errorf("require: missing module name")))
+		}
+		name := call.Arguments[0].String()
+		if name != agentModuleName {
+			panic(vm.NewGoError(fmt.Errorf("require: unknown module %q", name)))
+		}
+		mod := vm.NewObject()
+		for _, export := range agentModuleExports {
+			// A goja Set on a property whose binding is missing yields
+			// `undefined`; copying the live value preserves the function
+			// identity so esbuild's `(0, mod.tool)(...)` indirect-call
+			// form still dispatches to the binding closure.
+			_ = mod.Set(export, vm.Get(export))
+		}
+		return vm.ToValue(mod)
+	})
 }
 

--- a/pkg/agent/sandbox/sandbox_test.go
+++ b/pkg/agent/sandbox/sandbox_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gridctl/gridctl/pkg/agent"
+	"github.com/gridctl/gridctl/pkg/agent/dev/scaffold"
 	"github.com/gridctl/gridctl/pkg/mcp"
 )
 
@@ -428,6 +429,99 @@ func TestApprovalBinding_HonorsCustomApprover(t *testing.T) {
 	}
 	if app.prompt != "ship?" {
 		t.Errorf("approver got prompt %q, want ship?", app.prompt)
+	}
+}
+
+// TestExecute_ScaffoldOutputRunsThroughRequireShim is the regression
+// test for the gap that shipped in the Code-First Agent Runtime slice:
+// `gridctl agent init` scaffolds a skill.ts that imports from
+// "@gridctl/agent", esbuild lowers that to require("@gridctl/agent"),
+// and the sandbox previously had no require global. The test runs the
+// literal scaffold body so any future scaffold change re-exercises the
+// runtime contract automatically.
+func TestExecute_ScaffoldOutputRunsThroughRequireShim(t *testing.T) {
+	t.Parallel()
+	src := scaffold.HelloSkillTS("hello-ts")
+	caller := &fakeToolCaller{
+		respond: func(_ string, _ map[string]any) (*mcp.ToolCallResult, error) {
+			return &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent(`"casual"`)}}, nil
+		},
+	}
+	model := &fakeChatModel{
+		resp: agent.ChatResponse{
+			Model:   "claude-sonnet-4-6",
+			Content: "Hi, world!",
+		},
+	}
+	sb := New(2 * time.Second)
+	res, err := sb.Execute(context.Background(),
+		src,
+		map[string]any{"name": "world"},
+		Bindings{
+			ToolCaller:   caller,
+			AllowedTools: []mcp.Tool{{Name: "gridctl__greeting_style"}},
+			ChatModel:    model,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Value, "Hi, world!") {
+		t.Errorf("value = %s, want greeting from chat model", res.Value)
+	}
+	if len(caller.calls) != 1 || caller.calls[0].name != "gridctl__greeting_style" {
+		t.Errorf("expected one tool call to gridctl__greeting_style, got %+v", caller.calls)
+	}
+}
+
+// TestExecute_RequireShim_GridctlAgent verifies that an explicit import
+// of the agent SDK transpiles into a working require("@gridctl/agent")
+// call and the resulting module object exposes the binding globals.
+// This is the smaller, focused mirror of the scaffold-output test —
+// useful when debugging because it isolates require() resolution from
+// the broader scaffold path.
+func TestExecute_RequireShim_GridctlAgent(t *testing.T) {
+	t.Parallel()
+	src := `
+		import { tool } from "@gridctl/agent";
+		export default async function (i: { x: number }) {
+			return await tool("svc__op", { x: i.x });
+		}
+	`
+	caller := &fakeToolCaller{
+		respond: func(_ string, args map[string]any) (*mcp.ToolCallResult, error) {
+			payload, _ := json.Marshal(map[string]any{"ok": true, "x": args["x"]})
+			return &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent(string(payload))}}, nil
+		},
+	}
+	sb := New(2 * time.Second)
+	res, err := sb.Execute(context.Background(), src, map[string]any{"x": 1}, Bindings{
+		ToolCaller:   caller,
+		AllowedTools: []mcp.Tool{{Name: "svc__op"}},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Value, `"ok":true`) {
+		t.Errorf("value = %s, want ok:true", res.Value)
+	}
+}
+
+// TestExecute_RequireShim_RejectsUnknownModule guards against the
+// require shim accidentally returning empty modules for arbitrary names.
+// Unknown imports must surface as a clear runtime error so authors
+// notice unsupported imports immediately rather than getting
+// undefined-method failures deep inside their handler.
+func TestExecute_RequireShim_RejectsUnknownModule(t *testing.T) {
+	t.Parallel()
+	src := `import * as fs from "fs"; export default async function () { return fs; };`
+	sb := New(2 * time.Second)
+	_, err := sb.Execute(context.Background(), src, nil, Bindings{})
+	if err == nil {
+		t.Fatal("expected unknown-module error, got nil")
+	}
+	if !strings.Contains(err.Error(), `unknown module "fs"`) {
+		t.Errorf("err = %v, want unknown-module error", err)
 	}
 }
 

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -16,8 +16,12 @@ import (
 
 	"github.com/gridctl/gridctl/internal/api"
 	"github.com/gridctl/gridctl/internal/probe"
+	"github.com/gridctl/gridctl/pkg/agent"
 	"github.com/gridctl/gridctl/pkg/agent/compose"
+	agentgateway "github.com/gridctl/gridctl/pkg/agent/gateway"
 	"github.com/gridctl/gridctl/pkg/agent/persist"
+	agentruntime "github.com/gridctl/gridctl/pkg/agent/runtime"
+	"github.com/gridctl/gridctl/pkg/agent/sandbox"
 	"github.com/gridctl/gridctl/pkg/config"
 	"github.com/gridctl/gridctl/pkg/logging"
 	"github.com/gridctl/gridctl/pkg/mcp"
@@ -179,6 +183,42 @@ func (b *GatewayBuilder) Build(verbose bool) (*GatewayInstance, error) {
 	registryStore := registry.NewStore(regDir)
 	registryServer := registry.New(registryStore)
 	inst.RegistryServer = registryServer
+
+	// Phase 1c: Build the agent runtime aggregate. The gateway hangs off
+	// SetAgentRuntime so HTTP handlers, the dispatcher, and the IDE all
+	// pull from one place. RunStore + ApprovalRegistry + Sandbox are
+	// available from the start so the dispatcher can register against
+	// the registry server before the router exposes its tools; the
+	// ChatModel plugs in later inside buildAPIServer once the vault has
+	// resolved provider keys.
+	agentSandbox := sandbox.New(0)
+	agentRuntime := agentruntime.NewRuntime(
+		persist.NewStore(persist.DefaultRunsDir()),
+		compose.NewRegistry(),
+		agentSandbox,
+	)
+	inst.Gateway.SetAgentRuntime(agentRuntime)
+
+	// Wire the TS dispatcher onto the registry server. The bindings
+	// provider closes over the gateway so per-call collaborators
+	// (current AllowedTools snapshot, the runtime's ChatModel) reflect
+	// the daemon's live state rather than a snapshot frozen at build
+	// time. The ToolCaller is built once here because its only failure
+	// mode is a nil gateway — a programmer error we want to surface at
+	// build time, not as a silently-disabled tool() binding at first
+	// call. SetTSDispatcher MUST run before the router adds the
+	// registry server below — Router.RefreshTools queries the
+	// registry's Tools(), which only surfaces TS skills when a
+	// dispatcher is wired.
+	toolCaller, err := agentgateway.NewToolCaller(inst.Gateway)
+	if err != nil {
+		return nil, fmt.Errorf("agent tool caller: %w", err)
+	}
+	dispatcher, err := sandbox.NewDispatcher(agentSandbox, makeDispatcherBindings(inst.Gateway, registryServer, toolCaller))
+	if err != nil {
+		return nil, fmt.Errorf("agent dispatcher: %w", err)
+	}
+	registryServer.SetTSDispatcher(dispatcher)
 
 	// Phase 2: Configure logging
 	var logErr error
@@ -470,15 +510,29 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 		server.SetPinStore(b.pinStore)
 	}
 
+	// Resolve the agent runtime aggregate the gateway holds (built in
+	// Phase 1c above). Every API handler that needs runtime components
+	// reads them from this aggregate rather than from per-field setters.
+	rt, _ := gateway.AgentRuntime().(*agentruntime.Runtime)
+
 	if provider := buildPlaygroundProvider(b.vaultStore); provider != nil {
 		server.SetPlaygroundProvider(provider)
+		// Wire the same provider into the runtime so the TS dispatcher's
+		// llm() binding sees it. The dispatcher's bindings closure
+		// re-reads ChatModel on every call, so plugging it in here
+		// retroactively makes earlier-registered TS skills work.
+		if rt != nil {
+			rt.SetChatModel(provider)
+		}
 	}
 
-	// Agent runtime persistence (Phase E). Runs land as JSONL at
-	// ~/.gridctl/runs/<run_id>.jsonl; the registry tracks approval
-	// gates so the API and CLI can resolve them by ID.
-	server.SetAgentRunStore(persist.NewStore(persist.DefaultRunsDir()))
-	server.SetAgentApprovalRegistry(compose.NewRegistry())
+	// Agent runtime persistence (Phase E). The runtime aggregate already
+	// owns the JSONL run store and approval registry — wire it into the
+	// API server so /api/agent/runs/* handlers read from one source of
+	// truth and can never get out of step with the dispatcher's view.
+	if rt != nil {
+		server.SetAgentRuntime(rt)
+	}
 
 	// Wire token usage metrics
 	counter, err := b.buildTokenCounter()
@@ -713,6 +767,33 @@ func (b *GatewayBuilder) tokenizerName() string {
 		return b.stack.Gateway.Tokenizer
 	}
 	return "embedded"
+}
+
+// makeDispatcherBindings returns a sandbox.BindingsProvider that builds
+// per-call collaborators from the live gateway state. Closing over gw
+// (rather than snapshotting Bindings at build time) means later changes
+// — a freshly-set ChatModel after vault auth completes, an autoscaled
+// MCP server adding new tools — show up in subsequent dispatches
+// without a rewire. The ToolCaller is constructed once at wire time
+// (it depends only on the gateway pointer, which is stable) so a
+// per-call construction failure is impossible by design.
+//
+// Approver is left nil so the sandbox's auto-approve stub stays in
+// effect for the dispatcher path. Orchestrator-driven runs construct a
+// real compose.Gate (which needs a per-run recorder) and supply it via
+// their own bindings.
+func makeDispatcherBindings(gw *mcp.Gateway, skillCaller sandbox.SkillCaller, toolCaller agent.ToolCaller) sandbox.BindingsProvider {
+	return func(_ context.Context, _ string) sandbox.Bindings {
+		b := sandbox.Bindings{
+			AllowedTools: gw.Router().AggregatedTools(),
+			SkillCaller:  skillCaller,
+			ToolCaller:   toolCaller,
+		}
+		if rt, ok := gw.AgentRuntime().(*agentruntime.Runtime); ok && rt != nil {
+			b.ChatModel = rt.ChatModel()
+		}
+		return b
+	}
 }
 
 // buildTokenCounter creates the token counter based on the stack gateway config.

--- a/pkg/controller/gateway_builder_test.go
+++ b/pkg/controller/gateway_builder_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gridctl/gridctl/pkg/config"
@@ -90,6 +91,90 @@ func TestGatewayBuilder_Build_WithEmptyRegistry(t *testing.T) {
 	// API server should have the registry server
 	if inst.APIServer.RegistryServer() == nil {
 		t.Error("expected API server to have registry server set")
+	}
+}
+
+// TestGatewayBuilder_Build_WiresTSDispatcherForExternalCallers is the
+// regression test for the wiring gap that hid TypeScript skills from
+// MCP clients. Before the fix, the registry server's TSDispatcher was
+// never installed by the builder, so a skill.ts dropped on disk loaded
+// into the registry's store but produced "not a registered tool" when
+// any external client called it. The test drops the minimal
+// SKILL.md + skill.ts pair the registry walker recognises, builds the
+// gateway, and asserts:
+//
+//  1. Gateway.Router().AggregatedTools() lists the skill (proves
+//     SetTSDispatcher ran before the router refreshed its tool list).
+//  2. Calling RegistryServer.CallTool dispatches into the sandbox and
+//     returns the skill's resolved value (proves the dispatcher's
+//     bindings provider produces a usable Bindings struct).
+//
+// The skill itself does not call llm() / tool(), so the dispatcher's
+// nil-when-unwired ChatModel is fine.
+func TestGatewayBuilder_Build_WiresTSDispatcherForExternalCallers(t *testing.T) {
+	regDir := t.TempDir()
+	skillDir := filepath.Join(regDir, "skills", "echo")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("creating skill dir: %v", err)
+	}
+	skillMD := `---
+name: echo
+description: ts echo skill
+state: active
+---
+
+Echo input back.
+`
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillMD), 0o644); err != nil {
+		t.Fatalf("writing SKILL.md: %v", err)
+	}
+	skillTS := `export default async function (i: any) { return { echoed: i }; }`
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.ts"), []byte(skillTS), 0o644); err != nil {
+		t.Fatalf("writing skill.ts: %v", err)
+	}
+
+	cfg := Config{Port: 8180}
+	stack := &config.Stack{Name: "test"}
+	rt := runtime.NewOrchestrator(nil, nil)
+	builder := NewGatewayBuilder(cfg, stack, "/path/stack.yaml", rt, &runtime.UpResult{})
+	builder.registryDir = regDir
+
+	inst, err := builder.Build(false)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	// Surface check: the TS skill must appear in the aggregated tool
+	// list under the gateway's "registry__" prefix. Before the fix, the
+	// registry's Tools() filtered TS skills out when the dispatcher was
+	// nil — so the absence of this entry was the load-bearing user-
+	// visible bug.
+	wantPrefixed := mcp.PrefixTool("registry", "echo")
+	found := false
+	for _, tl := range inst.Gateway.Router().AggregatedTools() {
+		if tl.Name == wantPrefixed {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("aggregated tools missing %q (TS dispatcher not wired)", wantPrefixed)
+	}
+
+	// Execution check: dispatch through the registry server's CallTool
+	// — this is the path Gateway.HandleToolCall hits for an external
+	// MCP client. A successful echo proves the sandbox+dispatcher chain
+	// is reachable end-to-end.
+	res, err := inst.RegistryServer.CallTool(context.Background(), "echo", map[string]any{"v": 7})
+	if err != nil {
+		t.Fatalf("RegistryServer.CallTool(echo): %v", err)
+	}
+	if len(res.Content) == 0 {
+		t.Fatal("CallTool returned no content")
+	}
+	got := res.Content[0].Text
+	if !strings.Contains(got, `"echoed":`) || !strings.Contains(got, `"v":7`) {
+		t.Errorf("CallTool result = %q, want JSON containing echoed.v=7", got)
 	}
 }
 

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -115,6 +115,16 @@ type HealthStatus struct {
 // DefaultHealthCheckInterval is the default interval between health checks.
 const DefaultHealthCheckInterval = 30 * time.Second
 
+// AgentRuntime is the opaque agent-runtime aggregate stored on the
+// Gateway via SetAgentRuntime. The concrete type lives in
+// pkg/agent/runtime to avoid the import cycle (pkg/agent already
+// depends on pkg/mcp). Consumers that need the underlying components
+// type-assert to *agent/runtime.Runtime; the marker method keeps
+// arbitrary types from accidentally satisfying the interface.
+type AgentRuntime interface {
+	AgentRuntimeMarker()
+}
+
 // Gateway aggregates multiple MCP servers into a single endpoint.
 type Gateway struct {
 	router    *Router
@@ -123,11 +133,12 @@ type Gateway struct {
 	logger    *slog.Logger
 	cancel    context.CancelFunc
 
-	mu          sync.RWMutex
-	serverInfo  ServerInfo
-	serverMeta  map[string]MCPServerConfig // name -> config for status reporting
-	codeMode    *CodeMode                  // nil when code mode is off
-	codeModeStr string                           // "off", "on" — for status reporting
+	mu           sync.RWMutex
+	serverInfo   ServerInfo
+	serverMeta   map[string]MCPServerConfig // name -> config for status reporting
+	codeMode     *CodeMode                  // nil when code mode is off
+	codeModeStr  string                     // "off", "on" — for status reporting
+	agentRuntime AgentRuntime               // nil until SetAgentRuntime wires the runtime aggregate
 
 	healthMu      sync.RWMutex
 	health        map[string]*HealthStatus         // name -> rollup health (public API)
@@ -207,6 +218,24 @@ func (g *Gateway) SetCodeMode(timeout time.Duration) {
 	cm.SetLogger(g.logger)
 	g.codeMode = cm
 	g.codeModeStr = "on"
+}
+
+// SetAgentRuntime installs the agent runtime aggregate the gateway hangs
+// off. Consumers (HTTP handlers, dispatcher bindings) read the runtime
+// via AgentRuntime() and type-assert to *agent/runtime.Runtime to access
+// the underlying components. Pass nil to detach.
+func (g *Gateway) SetAgentRuntime(rt AgentRuntime) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.agentRuntime = rt
+}
+
+// AgentRuntime returns the agent runtime aggregate previously installed
+// via SetAgentRuntime, or nil when none is wired.
+func (g *Gateway) AgentRuntime() AgentRuntime {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.agentRuntime
 }
 
 // SetDefaultOutputFormat sets the gateway-level default output format.

--- a/pkg/mcp/gateway_test.go
+++ b/pkg/mcp/gateway_test.go
@@ -3406,3 +3406,38 @@ func TestGateway_HandleInitialize_NormalizesClientID(t *testing.T) {
 	}
 }
 
+// stubAgentRuntime is a minimal AgentRuntime impl used by the
+// round-trip test. The real implementation lives in
+// pkg/agent/runtime — importing it here would re-create the
+// agent → mcp → agent cycle the marker interface exists to break, so
+// we declare a local type and assert the gateway round-trips it.
+type stubAgentRuntime struct{ id string }
+
+func (*stubAgentRuntime) AgentRuntimeMarker() {}
+
+// TestGateway_AgentRuntimeRoundTrip locks in the SetAgentRuntime /
+// AgentRuntime contract: a value installed via the setter is returned
+// verbatim by the accessor, and the zero state is nil.
+func TestGateway_AgentRuntimeRoundTrip(t *testing.T) {
+	g := NewGateway()
+	if got := g.AgentRuntime(); got != nil {
+		t.Fatalf("zero-value AgentRuntime = %v, want nil", got)
+	}
+
+	rt := &stubAgentRuntime{id: "fixture"}
+	g.SetAgentRuntime(rt)
+
+	got, ok := g.AgentRuntime().(*stubAgentRuntime)
+	if !ok {
+		t.Fatalf("AgentRuntime returned %T, want *stubAgentRuntime", g.AgentRuntime())
+	}
+	if got != rt {
+		t.Errorf("AgentRuntime returned a different pointer (%p vs %p)", got, rt)
+	}
+
+	g.SetAgentRuntime(nil)
+	if got := g.AgentRuntime(); got != nil {
+		t.Errorf("after SetAgentRuntime(nil), AgentRuntime() = %v, want nil", got)
+	}
+}
+


### PR DESCRIPTION
## Description

Addresses three coupled wiring gaps in the Code-First Agent Runtime feature (PRs #598–#601) that together rendered the advertised end-to-end demo non-functional.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **TSDispatcher wired** — adds a concrete `sandbox.Dispatcher` and registers it on the registry server from `pkg/controller/gateway_builder.go`. TS skills now appear in `tools/list` and dispatch through the sandbox when called by external MCP clients.
- **`require` shim in sandbox** — esbuild's CommonJS output emits `require("@gridctl/agent")` for the scaffolded `import { tool, llm } from "@gridctl/agent"` line; the goja runtime now installs a `require` global that resolves the SDK module to the existing binding globals and panics with a clear error for unknown module names.
- **`Gateway.SetAgentRuntime`** — adds a new `mcp.AgentRuntime` marker interface and `SetAgentRuntime`/`AgentRuntime()` accessors parallel to `SetCodeMode`. The concrete `*runtime.Runtime` aggregate (new package `pkg/agent/runtime`) holds the run store, approval registry, sandbox, chat model, and dev server in one place.
- **API server refactor** — `internal/api/api.go` reads runtime components from the aggregate via four new helpers (`runStore`, `approvalRegistry`, `chatProvider`, `devServer`); the four legacy per-component setters remain as test-fixture wrappers and now document the precedence relationship.
- **Scaffold polish** — exports `HelloSkillTS` so regression tests can run the verbatim scaffold output through the sandbox, and fixes a separate latent typo where the scaffolded skill referenced `reply.text` instead of `reply.content` on the chat response.

## Testing

- `go test -race ./...` — all packages pass
- `golangci-lint run ./...` — 0 issues
- `make build` and `cd web && npm run build` — both succeed
- Eight new tests cover: scaffold output round-trip, require shim known/unknown module, Dispatcher round-trip + bindings provider hooks + nil rejection + structural conformance, Runtime constructor + late-bound ChatModel + marker contract, Gateway runtime round-trip, gateway-builder integration test that drops a `SKILL.md`+`skill.ts` pair and asserts the skill appears in `Router().AggregatedTools()` and dispatches successfully.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #602