### PR TITLE
fix: emit [] not null for empty created/skipped arrays

### DIFF
--- a/cmd/gridctl/agent_test.go
+++ b/cmd/gridctl/agent_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -565,6 +566,73 @@ func RegisterSkill(reg *skill.Registry) error { return nil }
 
 	if err := runAgentValidate("valid-go"); err != nil {
 		t.Fatalf("validate clean go skill: %v", err)
+	}
+}
+
+// TestRunAgentInit_JSONContract_EmptyCreatedIsArray locks down the
+// `--format json` contract: when every starter file already exists,
+// `created` must serialize as `[]`, never `null`. The .([]any) type
+// assertion is the load-bearing check — a nil slice marshals to JSON
+// null and the assertion fails with ok=false.
+func TestRunAgentInit_JSONContract_EmptyCreatedIsArray(t *testing.T) {
+	resetAgentInitFlagsForTest(t)
+	t.Cleanup(func() { resetAgentInitFlagsForTest(t) })
+
+	dir := t.TempDir()
+
+	if err := runAgentInit(agentInitCmd, []string{dir}); err != nil {
+		t.Fatalf("first runAgentInit (populate): %v", err)
+	}
+
+	resetAgentInitFlagsForTest(t)
+	var buf bytes.Buffer
+	agentInitCmd.SetOut(&buf)
+	agentInitFormat = "json"
+	if err := runAgentInit(agentInitCmd, []string{dir}); err != nil {
+		t.Fatalf("second runAgentInit (json): %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal output %q: %v", buf.String(), err)
+	}
+
+	created, ok := got["created"].([]any)
+	if !ok {
+		t.Fatalf(`"created" must be a JSON array, got %T (value=%v) — null breaks consumer pipelines`, got["created"], got["created"])
+	}
+	if len(created) != 0 {
+		t.Errorf(`"created" must be empty when all files were skipped, got %v`, created)
+	}
+}
+
+// TestRunAgentInit_JSONContract_EmptySkippedIsArray is the symmetric
+// case: a fresh directory has nothing to skip, so `skipped` must
+// serialize as `[]`. Same nil-slice failure mode as the created case.
+func TestRunAgentInit_JSONContract_EmptySkippedIsArray(t *testing.T) {
+	resetAgentInitFlagsForTest(t)
+	t.Cleanup(func() { resetAgentInitFlagsForTest(t) })
+
+	dir := t.TempDir()
+
+	var buf bytes.Buffer
+	agentInitCmd.SetOut(&buf)
+	agentInitFormat = "json"
+	if err := runAgentInit(agentInitCmd, []string{dir}); err != nil {
+		t.Fatalf("runAgentInit (json, fresh dir): %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal output %q: %v", buf.String(), err)
+	}
+
+	skipped, ok := got["skipped"].([]any)
+	if !ok {
+		t.Fatalf(`"skipped" must be a JSON array, got %T (value=%v) — null breaks consumer pipelines`, got["skipped"], got["skipped"])
+	}
+	if len(skipped) != 0 {
+		t.Errorf(`"skipped" must be empty when all files were created, got %v`, skipped)
 	}
 }
 

--- a/pkg/agent/dev/scaffold/scaffold.go
+++ b/pkg/agent/dev/scaffold/scaffold.go
@@ -66,7 +66,7 @@ func Scaffold(root string, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("scaffold: mkdir %s: %w", root, err)
 	}
 	files := starterFiles(opts)
-	res := Result{}
+	res := Result{Created: []string{}, Skipped: []string{}}
 	for _, f := range files {
 		dst := filepath.Join(root, f.path)
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {


### PR DESCRIPTION
## Description

`gridctl agent init --format json` emitted `"created": null` (and symmetrically `"skipped": null`) instead of `[]` when the corresponding slice was empty. Initializes both slices at the scaffold layer so empty arrays serialize per the contract documented in `proto/agent-runtime/TEST.md`. Standard consumer pipelines like `jq '.created | length'` now work.

## Type of Change

- [x] Bug fix

## Changes Made

- `pkg/agent/dev/scaffold/scaffold.go`: initialize `Result.Created` and `Result.Skipped` to `[]string{}` (one-line fix at the data-structure source — every consumer benefits, no map-literal coercion needed at the CLI layer)
- `cmd/gridctl/agent_test.go`: add `TestRunAgentInit_JSONContract_EmptyCreatedIsArray` and `TestRunAgentInit_JSONContract_EmptySkippedIsArray` regression tests using `.([]any)` type assertions (the load-bearing check that distinguishes `[]` from `null`)

## Testing

- New tests fail descriptively without the fix (`"created" must be a JSON array, got <nil>`) and pass with it
- `go test ./...` green; no regressions
- `go vet ./...` and `golangci-lint run` clean on touched packages
- Manual repro:
  ```
  $ ./gridctl agent init --name hello-ts --format json /tmp/fresh
  {"created":[...],"dir":"/tmp/fresh","flavor":"ts","skipped":[]}
  $ ./gridctl agent init --name hello-ts --format json /tmp/populated
  {"created":[],"dir":"/tmp/populated","flavor":"ts","skipped":[...]}
  ```
- `jq '.created | length'` and `jq '.skipped | length'` return `0` for the respective empty cases

## Out of Scope

- Missing `"skill"` field in the JSON output (separate code-vs-doc divergence)
- Extra `"dir"` field (undocumented but functional)
- Refactor of the `map[string]any{}` literal into a typed report struct

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #612