### PR TITLE
fix: wire agent IDE dev server in serve flag

### DIFF
--- a/cmd/gridctl/apply.go
+++ b/cmd/gridctl/apply.go
@@ -15,18 +15,19 @@ import (
 )
 
 var (
-	applyVerbose     bool
-	applyQuiet       bool
-	applyNoCache     bool
-	applyPort        int
-	applyBasePort    int
-	applyForeground  bool
-	applyDaemonChild bool
-	applyNoExpand    bool
-	applyWatch       bool
-	applyFlash       bool
-	applyCodeMode    bool
-	applyLogFile     string
+	applyVerbose      bool
+	applyQuiet        bool
+	applyNoCache      bool
+	applyPort         int
+	applyBasePort     int
+	applyForeground   bool
+	applyDaemonChild  bool
+	applyNoExpand     bool
+	applyWatch        bool
+	applyFlash        bool
+	applyCodeMode     bool
+	applyLogFile      string
+	applyAgentDevRoot string
 )
 
 var applyCmd = &cobra.Command{
@@ -66,16 +67,18 @@ func init() {
 	applyCmd.Flags().BoolVar(&applyFlash, "flash", false, "Auto-link detected LLM clients after apply")
 	applyCmd.Flags().BoolVar(&applyCodeMode, "code-mode", false, "Enable gateway code mode (replaces tools with search + execute meta-tools) (experimental)")
 	applyCmd.Flags().StringVar(&applyLogFile, "log-file", "", "Path to log file for structured JSON output with automatic rotation")
+	applyCmd.Flags().StringVar(&applyAgentDevRoot, "agent-dev-root", "", "Project root for the Agent IDE dev server (defaults to ~/.gridctl/registry/skills if present)")
 }
 
 // runServeStackless starts the API server and web UI without a stack file.
 // Vault and wizard endpoints are active; stack-dependent endpoints return 503.
 func runServeStackless() error {
 	ctrl := controller.New(controller.Config{
-		Port:        applyPort,
-		Foreground:  applyForeground,
-		DaemonChild: applyDaemonChild,
-		LogFile:     applyLogFile,
+		Port:         applyPort,
+		Foreground:   applyForeground,
+		DaemonChild:  applyDaemonChild,
+		LogFile:      applyLogFile,
+		AgentDevRoot: applyAgentDevRoot,
 	})
 	ctrl.SetVersion(version)
 	ctrl.SetWebFS(WebFS)
@@ -84,19 +87,20 @@ func runServeStackless() error {
 
 func runApply(stackPath string) error {
 	ctrl := controller.New(controller.Config{
-		StackPath:   stackPath,
-		Port:        applyPort,
-		BasePort:    applyBasePort,
-		Verbose:     applyVerbose,
-		Quiet:       applyQuiet,
-		NoCache:     applyNoCache,
-		NoExpand:    applyNoExpand,
-		Foreground:  applyForeground,
-		Watch:       applyWatch,
-		DaemonChild: applyDaemonChild,
-		CodeMode:    applyCodeMode,
-		Runtime:     runtimeFlag,
-		LogFile:     applyLogFile,
+		StackPath:    stackPath,
+		Port:         applyPort,
+		BasePort:     applyBasePort,
+		Verbose:      applyVerbose,
+		Quiet:        applyQuiet,
+		NoCache:      applyNoCache,
+		NoExpand:     applyNoExpand,
+		Foreground:   applyForeground,
+		Watch:        applyWatch,
+		DaemonChild:  applyDaemonChild,
+		CodeMode:     applyCodeMode,
+		Runtime:      runtimeFlag,
+		LogFile:      applyLogFile,
+		AgentDevRoot: applyAgentDevRoot,
 	})
 	ctrl.SetVersion(version)
 	ctrl.SetWebFS(WebFS)

--- a/cmd/gridctl/root.go
+++ b/cmd/gridctl/root.go
@@ -64,4 +64,5 @@ func init() {
 	serveCmd.Flags().BoolVarP(&applyForeground, "foreground", "f", false, "Run in foreground (don't daemonize)")
 	serveCmd.Flags().BoolVar(&applyDaemonChild, "daemon-child", false, "Internal flag for daemon process")
 	_ = serveCmd.Flags().MarkHidden("daemon-child")
+	serveCmd.Flags().StringVar(&applyAgentDevRoot, "agent-dev-root", "", "Project root for the Agent IDE dev server (defaults to ~/.gridctl/registry/skills if present)")
 }

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -61,7 +61,7 @@ Post-scaffold hint:
 run: gridctl agent dev --root "<dir>"
 ```
 
-The dev server (`gridctl agent dev`) gives you the IDE: a watcher that re-renders the graph on save in <300ms, click-to-`$EDITOR` jumps via `vscode://file/...:line`, and a trace overlay that shows the same status pills and latency the gateway records at runtime. The IDE is read-only — code is canon, the canvas never writes back.
+`gridctl agent dev` exposes the dev-server API (`/api/agent/dev/skills`, `/events`) for JSON/CLI use; the browser canvas is served by the daemon at `http://localhost:8180/agent` when you pass `--agent-dev-root <dir>` to `gridctl serve` (or place skills under `~/.gridctl/registry/skills`, which the daemon picks up by default). The canvas gives you a watcher that re-renders the graph on save in <300ms, click-to-`$EDITOR` jumps via `vscode://file/...:line`, and a trace overlay that shows the same status pills and latency the gateway records at runtime. The IDE is read-only — code is canon, the canvas never writes back.
 
 The TS sandbox's tool calls flow through the same `agent.ToolCaller` the gateway uses, so tracing, pricing, replica routing, vault auth, and tool whitelisting apply unchanged. `handoff()` resolves through the same `SkillCaller` interface the registry server uses, which means a TS skill calling a Go skill or a remote skill traverses the same dispatcher path an upstream client would — local execution and remote execution are one code path.
 

--- a/internal/api/agent_dev_test.go
+++ b/internal/api/agent_dev_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/agent/compose"
+	"github.com/gridctl/gridctl/pkg/agent/dev/devserver"
+	"github.com/gridctl/gridctl/pkg/agent/persist"
+	agentruntime "github.com/gridctl/gridctl/pkg/agent/runtime"
+	"github.com/gridctl/gridctl/pkg/agent/sandbox"
+)
+
+// agentDevSkillProject scaffolds a tmpdir with a single SKILL.md +
+// skill.ts pair so devserver.NewServer can parse a non-empty skill
+// list. Returns the absolute project root.
+func agentDevSkillProject(t *testing.T, skillName string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, skillName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: "+skillName+"\n---\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "skill.ts"), []byte("await tool(\"x\");\n"), 0o644); err != nil {
+		t.Fatalf("write skill.ts: %v", err)
+	}
+	return root
+}
+
+func TestHandleAgentDev_Unwired_Returns503(t *testing.T) {
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/dev/skills", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, want := body["error"], "agent dev server not configured"; got != want {
+		t.Errorf("error = %q, want %q", got, want)
+	}
+}
+
+func TestHandleAgentDev_LegacyWired_Delegates(t *testing.T) {
+	root := agentDevSkillProject(t, "legacy")
+	dev, err := devserver.NewServer(root, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	srv := newTestServer(t)
+	srv.SetAgentDevServer(dev)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/dev/skills", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Skills []devserver.SkillEntry `json:"skills"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Skills) != 1 || body.Skills[0].Name != "legacy" {
+		t.Fatalf("skills = %+v, want one skill named legacy", body.Skills)
+	}
+}
+
+func TestHandleAgentDev_RuntimeWired_PrefersRuntime(t *testing.T) {
+	runtimeRoot := agentDevSkillProject(t, "runtime-skill")
+	legacyRoot := agentDevSkillProject(t, "legacy-skill")
+
+	runtimeDev, err := devserver.NewServer(runtimeRoot, nil)
+	if err != nil {
+		t.Fatalf("runtime NewServer: %v", err)
+	}
+	legacyDev, err := devserver.NewServer(legacyRoot, nil)
+	if err != nil {
+		t.Fatalf("legacy NewServer: %v", err)
+	}
+
+	rt := agentruntime.NewRuntime(
+		persist.NewStore(t.TempDir()),
+		compose.NewRegistry(),
+		sandbox.New(0),
+	)
+	rt.SetDevServer(runtimeDev)
+
+	srv := newTestServer(t)
+	srv.SetAgentDevServer(legacyDev)
+	srv.SetAgentRuntime(rt)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/dev/skills", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Skills []devserver.SkillEntry `json:"skills"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Skills) != 1 || body.Skills[0].Name != "runtime-skill" {
+		t.Fatalf("skills = %+v, want runtime-skill (runtime aggregate must win over legacy setter)", body.Skills)
+	}
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -58,6 +58,12 @@ type Config struct {
 	Runtime     string // Explicit runtime selection (docker, podman)
 	Replace     bool   // Stop a running stack before deploying (used by plan apply)
 	LogFile     string // Path to log file (overrides stack.yaml logging.file)
+
+	// AgentDevRoot opts the daemon into the Agent IDE dev server. When set,
+	// /api/agent/dev/* serves the parsed skills under this project root and
+	// streams file-watcher events for the canvas. Empty falls back to
+	// ~/.gridctl/registry/skills if it exists; otherwise the routes 503.
+	AgentDevRoot string
 }
 
 // StackController orchestrates the full deploy lifecycle.

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -18,6 +19,8 @@ import (
 	"github.com/gridctl/gridctl/internal/probe"
 	"github.com/gridctl/gridctl/pkg/agent"
 	"github.com/gridctl/gridctl/pkg/agent/compose"
+	"github.com/gridctl/gridctl/pkg/agent/dev/devserver"
+	"github.com/gridctl/gridctl/pkg/agent/dev/watcher"
 	agentgateway "github.com/gridctl/gridctl/pkg/agent/gateway"
 	"github.com/gridctl/gridctl/pkg/agent/persist"
 	agentruntime "github.com/gridctl/gridctl/pkg/agent/runtime"
@@ -84,6 +87,11 @@ type GatewayBuilder struct {
 	// telemetry holds the opt-in disk-persistence writers wired at Build
 	// time. Nil when no server in the stack opts in.
 	telemetry *telemetryWiring
+
+	// agentDevWatcher is set when buildAPIServer wires the Agent IDE dev
+	// server. Run() starts its goroutine against the daemon's lifecycle
+	// context so the watcher exits cleanly on shutdown.
+	agentDevWatcher *watcher.Watcher
 }
 
 // telemetryWiring bundles the three per-signal writers + the otlptrace
@@ -381,6 +389,17 @@ func (b *GatewayBuilder) Run(ctx context.Context, inst *GatewayInstance, verbose
 		// Server started successfully
 	}
 
+	// Start the Agent IDE watcher (when wired). Its lifetime is bound to
+	// ctx so it exits cleanly on shutdown; errors are non-fatal so a
+	// failed watcher does not crash the daemon.
+	if b.agentDevWatcher != nil {
+		go func(w *watcher.Watcher) {
+			if err := w.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				slog.New(bufferHandler).Warn("agent IDE watcher exited", "error", err)
+			}
+		}(b.agentDevWatcher)
+	}
+
 	// Register MCP servers (after HTTP server is running for health checks)
 	registrar := NewServerRegistrar(gateway, b.config.NoExpand)
 	registrar.SetLogger(slog.New(bufferHandler))
@@ -541,6 +560,16 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 		}
 	}
 
+	// Agent IDE dev server (Phase F). When a project root is configured
+	// (or the default registry root exists), construct the watcher +
+	// devserver and wire them onto the runtime aggregate so the API
+	// server's /api/agent/dev/* handlers stop 503'ing. SetDevServer must
+	// run before SetAgentRuntime so the read accessor sees a non-nil
+	// devServer the first time a request lands.
+	if rt != nil {
+		b.wireAgentDevServer(rt)
+	}
+
 	// Agent runtime persistence (Phase E). The runtime aggregate already
 	// owns the JSONL run store and approval registry — wire it into the
 	// API server so /api/agent/runs/* handlers read from one source of
@@ -633,6 +662,58 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 	b.seedMetricsFromDisk(handler)
 
 	return server, nil
+}
+
+// wireAgentDevServer resolves the dev-root, constructs the watcher +
+// devserver, and installs them on the runtime aggregate. Each step is
+// best-effort: a missing root, an unreadable directory, or a fsnotify
+// failure logs a warning and leaves rt.DevServer() nil so the IDE
+// handlers fall back to 503 with the existing message. The watcher
+// goroutine is started later in Run() so it binds to the daemon's
+// lifecycle context.
+func (b *GatewayBuilder) wireAgentDevServer(rt *agentruntime.Runtime) {
+	root := b.resolveAgentDevRoot()
+	if root == "" {
+		return
+	}
+
+	logger := slog.Default()
+
+	w, err := watcher.New(root)
+	if err != nil {
+		logger.Warn("agent IDE dev server disabled", "root", root, "error", err)
+		return
+	}
+
+	srv, err := devserver.NewServer(root, w)
+	if err != nil {
+		logger.Warn("agent IDE dev server disabled", "root", root, "error", err)
+		return
+	}
+
+	rt.SetDevServer(srv)
+	b.agentDevWatcher = w
+	logger.Info("agent IDE wired", "root", root)
+}
+
+// resolveAgentDevRoot returns the effective dev-root for the Agent IDE,
+// preferring the explicit flag and falling back to ~/.gridctl/registry/skills
+// when that directory exists. Returns "" when no root resolves — callers
+// treat that as "leave the IDE backend unwired".
+func (b *GatewayBuilder) resolveAgentDevRoot() string {
+	if b.config.AgentDevRoot != "" {
+		return b.config.AgentDevRoot
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	candidate := filepath.Join(home, ".gridctl", "registry", "skills")
+	info, err := os.Stat(candidate)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+	return candidate
 }
 
 // applyTelemetryConfig walks the stack's MCP servers and registers per-


### PR DESCRIPTION
## Description

`gridctl serve` embeds the Agent IDE React UI but never wires the dev-server backend, so `/api/agent/dev/skills` 503s and the canvas renders an "EMPTY PROJECT" placeholder on a stock install. This PR adds `--agent-dev-root` to `serve`/`apply` and constructs the watcher + devserver inside `gateway_builder.buildAPIServer`, calling `rt.SetDevServer(srv)` before `server.SetAgentRuntime(rt)` so the existing accessor at `internal/api/api.go:279-286` sees a non-nil dev server on first request. With no flag set, the daemon falls back to `~/.gridctl/registry/skills` when that directory exists — making the IDE work out-of-the-box for anyone with installed skills.

## Type of Change

- [x] Bug fix

## Changes Made

- Add `--agent-dev-root <path>` flag to `gridctl serve` and `gridctl apply` (default empty; falls back to `~/.gridctl/registry/skills` when present).
- Add `AgentDevRoot` to `controller.Config` and plumb through `runServeStackless` / `runApply`.
- Construct `watcher.New` + `devserver.NewServer` in `gateway_builder.buildAPIServer`, wire via `rt.SetDevServer` before `SetAgentRuntime`. All failures are non-fatal (log + skip → existing 503 fallback).
- Bind watcher goroutine to the daemon's lifecycle context in `Run()` for clean shutdown.
- Emit `agent IDE wired root=<root>` log line so users can confirm the backend booted.
- Add `internal/api/agent_dev_test.go` covering the three relevant cases: unwired 503, legacy setter delegates, runtime aggregate wins over legacy.
- Clarify `docs/skills.md`: `gridctl agent dev` is the JSON/CLI surface; the browser canvas lives behind the daemon.

## Testing

Unit:

```
go test ./internal/api/... -run TestHandleAgentDev -v
# all 3 cases pass
```

Manual smoke (verified end-to-end):

```sh
# Explicit flag — HTTP 200 with scaffolded skill
gridctl serve --port 8780 --foreground --agent-dev-root /tmp/probe &
curl -s http://localhost:8780/api/agent/dev/skills
# {"skills":[{"name":"probe","lang":"ts","dir":"probe","node_count":2}]}

# Default fallback — HTTP 200, enumerates ~/.gridctl/registry/skills
gridctl serve --port 8781 --foreground &
curl -s http://localhost:8781/api/agent/dev/skills | jq '.skills | length'
# 21
```

Behavior preserved: with no flag and no fallback directory, `GET /api/agent/dev/skills` continues to return `503 {"error":"agent dev server not configured"}`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #614
