### PR TITLE
fix: agent IDE null-nodes crash on first load

### DIFF
--- a/pkg/agent/dev/devserver/devserver.go
+++ b/pkg/agent/dev/devserver/devserver.go
@@ -109,6 +109,12 @@ func (s *Server) listSkillDirs() ([]SkillEntry, error) {
 		} else if _, err := os.Stat(filepath.Join(dir, "skill.ts")); err == nil {
 			lang = "ts"
 		}
+		// Skip markdown-only skills. The Agent IDE is the typed-skill
+		// graph view; md-only Claude Code skills have nothing to render
+		// and would auto-select on first load with a null graph.
+		if lang == "" {
+			return nil
+		}
 		rel, _ := filepath.Rel(s.root, dir)
 		if rel == "" {
 			rel = "."
@@ -118,12 +124,10 @@ func (s *Server) listSkillDirs() ([]SkillEntry, error) {
 			Lang: lang,
 			Dir:  rel,
 		}
-		if lang != "" {
-			g, err := parser.ParseSkill(name, dir)
-			if err == nil {
-				entry.NodeCount = len(g.Nodes)
-				entry.HasError = g.ParseError != ""
-			}
+		g, err := parser.ParseSkill(name, dir)
+		if err == nil {
+			entry.NodeCount = len(g.Nodes)
+			entry.HasError = g.ParseError != ""
 		}
 		entries = append(entries, entry)
 		return nil

--- a/pkg/agent/dev/devserver/devserver_test.go
+++ b/pkg/agent/dev/devserver/devserver_test.go
@@ -125,3 +125,41 @@ func TestNewServerRejectsMissingRoot(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+// TestListSkillsFiltersMdOnlySkills guards the Agent IDE sidebar: any
+// SKILL.md directory without a typed handler (skill.go / skill.ts)
+// must not appear in the listing. Otherwise the IDE auto-selects it
+// on first load and renders an empty graph.
+func TestListSkillsFiltersMdOnlySkills(t *testing.T) {
+	root := t.TempDir()
+	mdOnly := filepath.Join(root, "md-only")
+	writeFile(t, mdOnly, "SKILL.md", "---\nname: md-only\n---\n")
+
+	typed := filepath.Join(root, "typed")
+	writeFile(t, typed, "SKILL.md", "---\nname: typed\n---\n")
+	writeFile(t, typed, "skill.ts", "await tool(\"x\");\n")
+
+	srv, err := NewServer(root, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/dev/skills", nil)
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Skills []SkillEntry `json:"skills"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := len(body.Skills); got != 1 {
+		t.Fatalf("skills = %d, want 1: %+v", got, body.Skills)
+	}
+	if body.Skills[0].Name != "typed" {
+		t.Errorf("name = %q, want %q", body.Skills[0].Name, "typed")
+	}
+}

--- a/pkg/agent/dev/parser/parser.go
+++ b/pkg/agent/dev/parser/parser.go
@@ -139,7 +139,7 @@ func parseGoFile(skillName, path string) (Graph, error) {
 	if err != nil {
 		return Graph{}, fmt.Errorf("parser: read %s: %w", path, err)
 	}
-	g := Graph{Skill: skillName, Lang: LangGo, File: path}
+	g := Graph{Skill: skillName, Lang: LangGo, File: path, Nodes: []Node{}}
 
 	fset := token.NewFileSet()
 	f, parseErr := parser.ParseFile(fset, path, src, parser.AllErrors)
@@ -277,5 +277,5 @@ func ParseSkill(skillName, skillDir string) (Graph, error) {
 			return g, nil
 		}
 	}
-	return Graph{Skill: skillName, ParseError: "no typed handler (skill.go / skill.ts) found"}, nil
+	return Graph{Skill: skillName, Nodes: []Node{}, ParseError: "no typed handler (skill.go / skill.ts) found"}, nil
 }

--- a/pkg/agent/dev/parser/parser_test.go
+++ b/pkg/agent/dev/parser/parser_test.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -166,6 +168,67 @@ func TestParseSkillReportsMissingHandler(t *testing.T) {
 	}
 	if g.ParseError == "" {
 		t.Fatal("expected ParseError for missing handler")
+	}
+}
+
+// TestGraphNodesAlwaysSerializeAsArray guards the wire contract: the
+// frontend reads `graph.nodes.length` and crashes on `null`, so every
+// return path must yield a non-nil slice. Covers no-handler, valid
+// handler with zero recognised primitives, and a TS file with no
+// handler at all.
+func TestGraphNodesAlwaysSerializeAsArray(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+	}{
+		{
+			name:  "no-handler",
+			setup: func(_ *testing.T, _ string) {},
+		},
+		{
+			name: "go-handler-zero-nodes",
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "skill.go"),
+					[]byte("package x\nfunc Run(){}\n"), 0o644); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+			},
+		},
+		{
+			name: "ts-handler-zero-nodes",
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "skill.ts"),
+					[]byte("export default async function run(){}\n"), 0o644); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.setup(t, dir)
+			g, err := ParseSkill("noop", dir)
+			if err != nil {
+				t.Fatalf("ParseSkill: %v", err)
+			}
+			if g.Nodes == nil {
+				t.Fatal("Nodes is nil, want non-nil empty slice")
+			}
+			if len(g.Nodes) != 0 {
+				t.Fatalf("len(Nodes) = %d, want 0", len(g.Nodes))
+			}
+			body, err := json.Marshal(g)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !bytes.Contains(body, []byte(`"nodes":[]`)) {
+				t.Fatalf("JSON missing `\"nodes\":[]`: %s", body)
+			}
+			if bytes.Contains(body, []byte(`"nodes":null`)) {
+				t.Fatalf("JSON has `\"nodes\":null`: %s", body)
+			}
+		})
 	}
 }
 

--- a/pkg/agent/dev/parser/ts.go
+++ b/pkg/agent/dev/parser/ts.go
@@ -27,7 +27,7 @@ func parseTSFile(skillName, path string) (Graph, error) {
 	}
 	defer f.Close()
 
-	g := Graph{Skill: skillName, Lang: LangTS, File: path}
+	g := Graph{Skill: skillName, Lang: LangTS, File: path, Nodes: []Node{}}
 	idx := make(map[NodeKind]int)
 
 	sc := bufio.NewScanner(f)

--- a/web/src/__tests__/agent-api.test.ts
+++ b/web/src/__tests__/agent-api.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchSkill, fetchSkills } from '../lib/agent-api';
+
+function mockFetchResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'ERR',
+    json: async () => body,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchSkill', () => {
+  it('coerces a null `nodes` field to an empty array', async () => {
+    const stub = vi.fn().mockResolvedValue(
+      mockFetchResponse({
+        skill: 'blog',
+        lang: '',
+        file: '',
+        nodes: null,
+        parse_error: 'no typed handler (skill.go / skill.ts) found',
+      }),
+    );
+    vi.stubGlobal('fetch', stub);
+
+    const g = await fetchSkill('blog');
+    expect(g).not.toBeNull();
+    expect(g!.nodes).toEqual([]);
+    expect(Array.isArray(g!.nodes)).toBe(true);
+  });
+
+  it('preserves a populated `nodes` array', async () => {
+    const nodes = [
+      { id: 'tool:0', kind: 'tool' as const, label: 'x', file: 'skill.ts', line: 1, col: 1 },
+    ];
+    const stub = vi.fn().mockResolvedValue(
+      mockFetchResponse({ skill: 'x', lang: 'ts', file: 'skill.ts', nodes }),
+    );
+    vi.stubGlobal('fetch', stub);
+
+    const g = await fetchSkill('x');
+    expect(g!.nodes).toEqual(nodes);
+  });
+
+  it('returns null for 404 / 503', async () => {
+    const stub = vi.fn().mockResolvedValue(mockFetchResponse({}, 404));
+    vi.stubGlobal('fetch', stub);
+    expect(await fetchSkill('missing')).toBeNull();
+  });
+});
+
+describe('fetchSkills', () => {
+  it('returns the skills array', async () => {
+    const stub = vi.fn().mockResolvedValue(
+      mockFetchResponse({
+        skills: [{ name: 'x', lang: 'ts', dir: 'x', node_count: 1 }],
+      }),
+    );
+    vi.stubGlobal('fetch', stub);
+
+    const skills = await fetchSkills();
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('x');
+  });
+
+  it('returns [] on 503', async () => {
+    const stub = vi.fn().mockResolvedValue(mockFetchResponse({}, 503));
+    vi.stubGlobal('fetch', stub);
+    expect(await fetchSkills()).toEqual([]);
+  });
+});

--- a/web/src/lib/agent-api.ts
+++ b/web/src/lib/agent-api.ts
@@ -71,7 +71,11 @@ export async function fetchSkill(name: string): Promise<SkillGraph | null> {
   if (!res.ok) {
     throw new Error(`fetchSkill(${name}): ${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as SkillGraph;
+  // Coerce a stray `null` nodes field to `[]` — the Go backend
+  // guarantees `[]` on the wire, but the frontend null-derefs on
+  // `graph.nodes.length` so we belt-and-suspenders here too.
+  const g = (await res.json()) as SkillGraph;
+  return { ...g, nodes: g.nodes ?? [] };
 }
 
 // === Watcher events (SSE) ===


### PR DESCRIPTION
## Description

The Agent IDE auto-wired by `gridctl serve` (PR #615) crashed on first load with `Cannot read properties of null (reading 'length')` for any user whose registry contained markdown-only Claude Code skills alongside typed ones. This PR closes the entire class of the bug — Go nil slice → JSON null → JS null-deref — with a server-side guarantee, a server-side listing filter, and a defensive frontend coercion.

## Type of Change

- [x] Bug fix

## Changes Made

- `pkg/agent/dev/parser/parser.go` + `parser/ts.go` — initialize `Graph.Nodes` to `[]Node{}` in every return path so the JSON wire shape is always `"nodes": []`, never `"nodes": null`. Same pattern as #613.
- `pkg/agent/dev/devserver/devserver.go` — filter md-only skills (no `skill.go` / `skill.ts`) from `listSkillDirs` so the typed-graph IDE sidebar only shows skills it can actually render.
- `web/src/lib/agent-api.ts` — `fetchSkill` coerces `nodes ?? []` after JSON parse as belt-and-suspenders against future regressions.

## Testing

- `go test ./pkg/agent/... -race` — all packages pass, including new `TestGraphNodesAlwaysSerializeAsArray` (3 zero-node scenarios with JSON wire-shape assertions) and `TestListSkillsFiltersMdOnlySkills`.
- `golangci-lint run ./pkg/agent/dev/parser/... ./pkg/agent/dev/devserver/...` — 0 issues.
- `npx vitest run` — 491/491 frontend tests pass, including new `agent-api.test.ts` (null coercion, populated nodes, 404/503).
- `make build` — gridctl binary builds clean.
- Manual smoke against a mixed registry on a side-port daemon: `/api/agent/dev/skills` returns only typed entries (was 23 → 3), `/api/agent/dev/skills/<md-only>` returns 404, `/api/agent/dev/skills/<typed>` returns `nodes: [...]`. Opening `/agent` in the browser no longer throws.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #616