### PR TITLE
fix: cancel daemon ctx on signal

### DIFF
--- a/cmd/gridctl/apply.go
+++ b/cmd/gridctl/apply.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/gridctl/gridctl/pkg/controller"
 	"github.com/gridctl/gridctl/pkg/output"
@@ -82,7 +85,14 @@ func runServeStackless() error {
 	})
 	ctrl.SetVersion(version)
 	ctrl.SetWebFS(WebFS)
-	return ctrl.Serve(context.Background())
+
+	// Cancel ctx on SIGINT/SIGTERM so all ctx-bound goroutines in the gateway
+	// (health monitor, autoscaler, agent IDE watcher, file watcher) actually
+	// exit; without this the daemon child receives the signal but never exits.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return ctrl.Serve(ctx)
 }
 
 func runApply(stackPath string) error {
@@ -105,7 +115,11 @@ func runApply(stackPath string) error {
 	ctrl.SetVersion(version)
 	ctrl.SetWebFS(WebFS)
 
-	if err := ctrl.Deploy(context.Background()); err != nil {
+	// Cancel ctx on SIGINT/SIGTERM so daemon goroutines exit cleanly.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := ctrl.Deploy(ctx); err != nil {
 		return err
 	}
 

--- a/cmd/gridctl/serve_integration_test.go
+++ b/cmd/gridctl/serve_integration_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"net"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestServe_ExitsOnSIGTERM forks a real `gridctl serve --daemon-child` and
+// asserts that SIGTERM causes the process to exit within the graceful
+// shutdown window. This guards against regressions where ctx-bound
+// goroutines (health monitor, autoscaler, agent IDE watcher, file watcher)
+// hold the process alive after the signal is received.
+func TestServe_ExitsOnSIGTERM(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("daemon mode and SIGTERM semantics are POSIX-specific")
+	}
+
+	// Build the binary before redirecting HOME so `go build` resolves its
+	// real module cache rather than poisoning the test's tempdir with
+	// read-only mod-cache files that t.TempDir() RemoveAll can't clean.
+	binPath := filepath.Join(t.TempDir(), "gridctl")
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	build.Stderr = &bytes.Buffer{}
+	if err := build.Run(); err != nil {
+		t.Fatalf("building gridctl: %v\n%s", err, build.Stderr.(*bytes.Buffer).String())
+	}
+
+	t.Setenv("HOME", t.TempDir())
+
+	port := freePort(t)
+
+	var out bytes.Buffer
+	cmd := exec.Command(binPath, "serve", "--daemon-child", "--port", strconv.Itoa(port))
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting daemon: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	})
+
+	if !waitHealth(port, 10*time.Second) {
+		t.Fatalf("daemon never reached healthy state on :%d\n%s", port, out.String())
+	}
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("sending SIGTERM: %v", err)
+	}
+
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
+
+	select {
+	case <-waitDone:
+		// Process exited — that's the expected outcome. We don't assert
+		// on the exit error since cmd.Wait() returns non-nil for any
+		// non-zero exit including the SIGTERM-driven graceful shutdown
+		// path on some platforms.
+	case <-time.After(20 * time.Second):
+		t.Fatalf("daemon did not exit within 20s of SIGTERM\n%s", out.String())
+	}
+}
+
+// freePort finds an unused TCP port by binding to :0 and closing the
+// listener. There is an unavoidable race between close and the daemon's
+// bind, but it is acceptable for an integration test.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("finding free port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// waitHealth polls /health until it returns 200 or the deadline expires.
+func waitHealth(port int, timeout time.Duration) bool {
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	url := "http://127.0.0.1:" + strconv.Itoa(port) + "/health"
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			ok := resp.StatusCode == http.StatusOK
+			resp.Body.Close()
+			if ok {
+				return true
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -8,9 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
@@ -432,7 +430,7 @@ func (b *GatewayBuilder) Run(ctx context.Context, inst *GatewayInstance, verbose
 	}
 
 	// Wait for shutdown signal or server error
-	return b.waitForShutdown(inst, bufferHandler, serverErr, verbose)
+	return b.waitForShutdown(ctx, inst, bufferHandler, serverErr, verbose)
 }
 
 // buildLogging creates or reuses the log buffer and handler.
@@ -1061,15 +1059,15 @@ func (b *GatewayBuilder) printEndpoints(inst *GatewayInstance) {
 	fmt.Println("\nPress Ctrl+C to stop...")
 }
 
-// waitForShutdown blocks until a shutdown signal or server error, then cleans up.
-func (b *GatewayBuilder) waitForShutdown(inst *GatewayInstance, handler slog.Handler, serverErr <-chan error, verbose bool) error {
-	done := make(chan os.Signal, 1)
-	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
-
+// waitForShutdown blocks until ctx is canceled (signal-driven) or the server
+// errors, then cleans up. Listening on ctx.Done() rather than a local signal
+// channel ensures all ctx-bound goroutines in the gateway see the same
+// cancellation and exit cleanly.
+func (b *GatewayBuilder) waitForShutdown(ctx context.Context, inst *GatewayInstance, handler slog.Handler, serverErr <-chan error, verbose bool) error {
 	select {
-	case sig := <-done:
+	case <-ctx.Done():
 		logger := slog.New(handler)
-		logger.Info("received signal, shutting down", "signal", sig)
+		logger.Info("received shutdown signal")
 
 		if verbose {
 			fmt.Println("\nShutting down...")
@@ -1079,7 +1077,9 @@ func (b *GatewayBuilder) waitForShutdown(inst *GatewayInstance, handler slog.Han
 		// HTTP connections are still alive, then closes gateway clients.
 		inst.APIServer.Close()
 
-		// Graceful HTTP shutdown with timeout
+		// Graceful HTTP shutdown with timeout. Parent is Background, not
+		// ctx — ctx is already canceled at this point, so a child of it
+		// would expire immediately.
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer shutdownCancel()
 


### PR DESCRIPTION
## Description

Phase 1 of 3 fixing #618. Wires `signal.NotifyContext` into the daemon entry points so SIGINT/SIGTERM cancels the root context threaded through all background goroutines (health monitor, autoscaler, agent IDE watcher, file watcher). Without this, the daemon receives the signal but never actually exits — leaving an orphan process bound to the port.

## Type of Change

- [x] Bug fix

## Changes Made

- `cmd/gridctl/apply.go` — `runServeStackless` and `runApply` now derive ctx via `signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)` instead of passing `context.Background()` directly. Matches the existing pattern at `cmd/gridctl/agent.go:113`.
- `pkg/controller/gateway_builder.go` — `waitForShutdown` now listens on `<-ctx.Done()` instead of a local `signal.Notify` channel. Same cancellation signal as the rest of the gateway, so all ctx-bound goroutines exit cleanly.
- `cmd/gridctl/serve_integration_test.go` — new `TestServe_ExitsOnSIGTERM` integration test that forks a real `gridctl serve --daemon-child`, sends SIGTERM, and asserts the process exits within 20s.

Scope is deliberately limited to context propagation + regression test. Two follow-up changes remain for separate PRs:
1. Move `state.Delete` to a `defer` in the daemon-child entry so state-file lifetime equals process lifetime.
2. Add an orphan-discovery fallback to `gridctl stop` so a missing state file plus a live daemon produces an actionable error.

## Testing

- `TestServe_ExitsOnSIGTERM` passes in ~4.4s (daemon exits within seconds of SIGTERM).
- `go test -race ./...` passes (no regressions).
- `golangci-lint run`: 0 issues.
- `make build` succeeds.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #618