### PR TITLE
fix: defer state delete to daemon exit

### DIFF
--- a/cmd/gridctl/serve_integration_test.go
+++ b/cmd/gridctl/serve_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -71,6 +72,15 @@ func TestServe_ExitsOnSIGTERM(t *testing.T) {
 		// path on some platforms.
 	case <-time.After(20 * time.Second):
 		t.Fatalf("daemon did not exit within 20s of SIGTERM\n%s", out.String())
+	}
+
+	// State file must be gone after the daemon exits — proves the
+	// defer in runStacklessDaemonChild fired. If the file lingers, an
+	// orphan daemon would still be discoverable by `gridctl stop`, but
+	// this assertion specifically guards the happy-path lifecycle.
+	statePath := filepath.Join(os.Getenv("HOME"), ".gridctl", "state", "gridctl.json")
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("expected state file to be absent after exit, got err=%v", err)
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -163,6 +163,10 @@ func (sc *StackController) runStacklessDaemonChild(ctx context.Context) error {
 	if err := state.Save(st); err != nil {
 		return fmt.Errorf("failed to save state: %w", err)
 	}
+	// State-file lifetime tracks process lifetime: this defer is the
+	// only point where the file is removed, so an orphaned daemon
+	// remains discoverable until it actually exits.
+	defer func() { _ = state.Delete("gridctl") }()
 
 	return sc.buildAndRunStackless(ctx, false)
 }
@@ -382,6 +386,8 @@ func (sc *StackController) runDaemonChild(ctx context.Context, stack *config.Sta
 	if err := state.Save(st); err != nil {
 		return fmt.Errorf("failed to save state: %w", err)
 	}
+	// State-file lifetime tracks process lifetime; see runStacklessDaemonChild.
+	defer func() { _ = state.Delete(stack.Name) }()
 
 	builder := sc.newGatewayBuilder(stack, rt, result)
 	return builder.BuildAndRun(ctx, false)

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -1100,10 +1100,7 @@ func (b *GatewayBuilder) waitForShutdown(ctx context.Context, inst *GatewayInsta
 		if b.telemetry != nil && b.telemetry.logRouter != nil {
 			b.telemetry.logRouter.Close()
 		}
-
-		_ = state.Delete(b.stack.Name)
 	case err := <-serverErr:
-		_ = state.Delete(b.stack.Name)
 		return fmt.Errorf("server error: %w", err)
 	}
 


### PR DESCRIPTION
## Description

Phase 2 of 3 fixing #618. Makes the state-file lifetime equal the daemon process lifetime: the file is now deleted via a `defer` in the daemon-child entry, not mid-shutdown. An orphaned daemon (e.g., one whose shutdown sequence stalled or panicked) now keeps its state file until the process actually exits, so `gridctl stop` can still find it.

## Type of Change

- [x] Bug fix

## Changes Made

- `pkg/controller/controller.go` — `runStacklessDaemonChild` and `runDaemonChild` now register `defer state.Delete(...)` immediately after `state.Save(...)` succeeds. State-file cleanup is the daemon-child entry's responsibility, full stop.
- `pkg/controller/gateway_builder.go` — removed both `state.Delete` calls from `waitForShutdown` (the signal/ctx.Done branch and the serverErr branch). `waitForShutdown` is now purely shutdown-orchestration: HTTP, telemetry, tracing, logRouter.
- `cmd/gridctl/serve_integration_test.go` — extended `TestServe_ExitsOnSIGTERM` with a state-file-absent assertion. After the daemon exits, `~/.gridctl/state/gridctl.json` must be gone. Now the test guards both phase-1's process-exits invariant and phase-2's file-cleanup-via-defer invariant.

Phase 3 (orphan-discovery fallback in `gridctl stop`) lands separately.

## Testing

- `TestServe_ExitsOnSIGTERM` passes in ~4.4s (daemon exits, state file gone).
- `go test -race ./...` passes (no regressions).
- `golangci-lint run`: 0 issues.
- `make build` succeeds.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #618