### PR TITLE
fix: orphan daemon fallback in gridctl stop

### DIFF
--- a/cmd/gridctl/stop.go
+++ b/cmd/gridctl/stop.go
@@ -8,6 +8,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// findOrphan is a package-level seam over state.FindOrphan so tests
+// can simulate orphan and ambiguous outcomes without depending on
+// pgrep matching a real subprocess.
+var findOrphan = state.FindOrphan
+
+// stopForce, when true, allows runStop to terminate an orphan daemon
+// discovered via the port + process scan that runs when the state
+// file is missing.
+var stopForce bool
+
+// stopDefaultPort mirrors the default in serveCmd / applyCmd. Phase 3
+// of #618 deliberately hardcodes the port for stop fallback; adding a
+// --port flag here is out of scope.
+const stopDefaultPort = 8180
+
 var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the stackless gridctl daemon",
@@ -20,13 +35,18 @@ For stacks started with 'gridctl apply', use 'gridctl destroy <stack.yaml>' inst
 	},
 }
 
+func init() {
+	stopCmd.Flags().BoolVar(&stopForce, "force", false,
+		"Forcibly terminate an orphan daemon discovered via port and process scan when the state file is missing")
+}
+
 func runStop() error {
 	const name = "gridctl"
 
 	return state.WithLock(name, 5*time.Second, func() error {
 		st, err := state.Load(name)
 		if err != nil || st == nil {
-			return fmt.Errorf("no stackless daemon is running")
+			return runStopOrphanFallback()
 		}
 
 		if !state.IsRunning(st) {
@@ -43,4 +63,27 @@ func runStop() error {
 		fmt.Println("gridctl stopped")
 		return nil
 	})
+}
+
+// runStopOrphanFallback handles the missing-state-file case. If we
+// can identify a single orphan daemon listening on the default port,
+// either point the user at --force or terminate it (with --force).
+// Anything ambiguous falls through to the legacy "nothing to stop"
+// error so the user never sees us act on guesswork.
+func runStopOrphanFallback() error {
+	pid, ok, ferr := findOrphan(stopDefaultPort)
+	if ferr != nil || !ok {
+		return fmt.Errorf("no stackless daemon is running")
+	}
+
+	if !stopForce {
+		return fmt.Errorf("no state file found, but a gridctl process (pid %d) is listening on :%d — its /health endpoint is responding but it has no managed state; run 'gridctl stop --force' to terminate it", pid, stopDefaultPort)
+	}
+
+	orphan := &state.DaemonState{PID: pid, Port: stopDefaultPort, StackName: "gridctl"}
+	if err := state.KillDaemon(orphan); err != nil {
+		return fmt.Errorf("could not stop orphan daemon (pid %d): %w", pid, err)
+	}
+	fmt.Printf("Stopped orphan gridctl daemon (pid %d)\n", pid)
+	return nil
 }

--- a/cmd/gridctl/stop_test.go
+++ b/cmd/gridctl/stop_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +20,10 @@ func setTempHomeStop(t *testing.T) {
 
 func TestRunStop_NoDaemonRunning(t *testing.T) {
 	setTempHomeStop(t)
+	// Stub out the orphan scan: the developer's machine may have a
+	// real gridctl daemon running outside the test sandbox, and we
+	// don't want findOrphan to see it.
+	stubFindOrphan(t, func(int) (int, bool, error) { return 0, false, nil })
 
 	err := runStop()
 	if err == nil {
@@ -77,5 +83,74 @@ func TestRunStop_RunningDaemon(t *testing.T) {
 	// State file should be gone.
 	if _, err := state.Load("gridctl"); err == nil {
 		t.Error("expected state file to be deleted after stop")
+	}
+}
+
+// stubFindOrphan installs a test seam for findOrphan and restores the
+// real implementation on test cleanup.
+func stubFindOrphan(t *testing.T, fn func(int) (int, bool, error)) {
+	t.Helper()
+	orig := findOrphan
+	findOrphan = fn
+	t.Cleanup(func() { findOrphan = orig })
+}
+
+func TestRunStop_OrphanDaemon_NoForce(t *testing.T) {
+	setTempHomeStop(t)
+	stubFindOrphan(t, func(int) (int, bool, error) { return 4242, true, nil })
+
+	err := runStop()
+	if err == nil {
+		t.Fatal("expected error pointing at the orphan, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "pid 4242") || !strings.Contains(msg, ":"+strconv.Itoa(stopDefaultPort)) {
+		t.Errorf("expected error to mention pid and port; got: %q", msg)
+	}
+	if !strings.Contains(msg, "--force") {
+		t.Errorf("expected error to suggest --force; got: %q", msg)
+	}
+}
+
+func TestRunStop_OrphanDaemon_WithForce(t *testing.T) {
+	setTempHomeStop(t)
+
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting dummy orphan: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	stubFindOrphan(t, func(int) (int, bool, error) { return cmd.Process.Pid, true, nil })
+
+	stopForce = true
+	t.Cleanup(func() { stopForce = false })
+
+	if err := runStop(); err != nil {
+		t.Fatalf("expected runStop --force to succeed, got: %v", err)
+	}
+	// Reap the zombie so VerifyPID's signal-0 check is meaningful;
+	// without this, a freshly SIGKILLed-but-unreaped child still
+	// answers to signal 0 on macOS and the assertion flakes.
+	_ = cmd.Wait()
+	if state.VerifyPID(cmd.Process.Pid) {
+		t.Error("expected orphan process to be terminated")
+	}
+	// No state file should have been written.
+	if _, err := os.Stat(state.StatePath("gridctl")); !os.IsNotExist(err) {
+		t.Errorf("expected no state file, got err=%v", err)
+	}
+}
+
+func TestRunStop_OrphanDaemon_Ambiguous(t *testing.T) {
+	setTempHomeStop(t)
+	stubFindOrphan(t, func(int) (int, bool, error) { return 0, false, nil })
+
+	err := runStop()
+	if err == nil || err.Error() != "no stackless daemon is running" {
+		t.Errorf("expected legacy no-daemon error, got: %v", err)
 	}
 }

--- a/pkg/state/orphan_unix.go
+++ b/pkg/state/orphan_unix.go
@@ -1,0 +1,72 @@
+//go:build !windows
+
+package state
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// FindOrphan looks for an orphan gridctl daemon listening on port — a
+// process that owns the port but has no managed state file (because
+// e.g. an earlier shutdown deleted state mid-way, or the daemon was
+// started by a pre-fix binary).
+//
+// Returns (pid, true, nil) only when both signals agree: the /health
+// endpoint responds 200 AND pgrep -f finds exactly one matching
+// gridctl --daemon-child process for that port. Any ambiguity
+// (multiple matches, no /health response, no matching process)
+// returns ok=false so the caller can fall through to the legacy
+// behavior rather than acting on guesswork.
+//
+// The pgrep pattern requires --daemon-child, which the parent
+// gridctl stop process never sets, so this can never match the
+// caller itself.
+func FindOrphan(port int) (int, bool, error) {
+	if !probeHealth(port) {
+		return 0, false, nil
+	}
+	return runPgrep(port)
+}
+
+func probeHealth(port int) bool {
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	url := "http://127.0.0.1:" + strconv.Itoa(port) + "/health"
+	resp, err := client.Get(url)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func runPgrep(port int) (int, bool, error) {
+	pattern := fmt.Sprintf("gridctl.*--daemon-child.*--port %d", port)
+	out, err := exec.Command("pgrep", "-f", pattern).Output()
+	if err != nil {
+		// pgrep exit code 1 means "no matches" — not an error.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("pgrep: %w", err)
+	}
+
+	var pids []int
+	for _, line := range strings.Fields(strings.TrimSpace(string(out))) {
+		pid, convErr := strconv.Atoi(line)
+		if convErr != nil {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	if len(pids) != 1 {
+		return 0, false, nil
+	}
+	return pids[0], true, nil
+}

--- a/pkg/state/orphan_windows.go
+++ b/pkg/state/orphan_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package state
+
+// FindOrphan is a no-op on Windows; gridctl daemon mode is POSIX-only.
+func FindOrphan(port int) (int, bool, error) {
+	return 0, false, nil
+}


### PR DESCRIPTION
## Description

Phase 3 of 3 fixing #618 — the final phase. Adds a defense-in-depth fallback to `gridctl stop` so users facing a pre-fix orphan daemon (or any future shutdown regression that re-introduces the orphan condition) get an actionable error instead of the legacy `Error: no stackless daemon is running` lie. With `--force`, the command also terminates the discovered orphan.

## Type of Change

- [x] Bug fix

## Changes Made

- `pkg/state/orphan_unix.go` — new `state.FindOrphan(port int) (pid int, ok bool, err error)` helper. Returns `ok=true` only when both signals agree: the `/health` endpoint responds 200 AND `pgrep -f` finds exactly one matching `gridctl --daemon-child --port <port>` process. Any ambiguity returns `ok=false` so the caller never acts on guesswork. The `pgrep` pattern requires `--daemon-child`, which `gridctl stop` never sets, so it can never match the caller itself.
- `pkg/state/orphan_windows.go` — Windows stub returning `(0, false, nil)`. Gridctl daemon mode is POSIX-only by design.
- `cmd/gridctl/stop.go` — adds `--force` flag, a `findOrphan` test seam, and `runStopOrphanFallback`. When the state file is missing, the command probes for an orphan: ambiguous → legacy error, found without `--force` → actionable error naming the PID and port, found with `--force` → terminate via the existing `state.KillDaemon` (SIGTERM → wait 5s → SIGKILL). All fallback runs inside the existing `state.WithLock`, so it stays race-free with concurrent `gridctl serve`.
- `cmd/gridctl/stop_test.go` — three new tests: `TestRunStop_OrphanDaemon_NoForce` (actionable error shape), `TestRunStop_OrphanDaemon_WithForce` (terminates a real subprocess), `TestRunStop_OrphanDaemon_Ambiguous` (falls through to legacy error). Also stubs `findOrphan` in the existing `TestRunStop_NoDaemonRunning` so the test is deterministic on developer machines that may host real orphan daemons outside the test sandbox.

This is the last of three phases addressing #618. Phase 1 (#619) made the daemon actually exit on SIGTERM. Phase 2 (#620) made state-file lifetime equal process lifetime via a defer. Phase 3 is the user-facing safety net for the residual orphan case.

## Testing

- All six `TestRunStop_*` cases pass under `go test -race ./cmd/gridctl/...`.
- `go test -race ./...` passes (no regressions).
- `golangci-lint run`: 0 issues.
- `make build` succeeds.

Manual smoke test on macOS:
```sh
./gridctl serve                          # daemon starts on :8180, state file present
kill <pid>                               # daemon exits cleanly (post phases 1+2)
rm ~/.gridctl/state/gridctl.json         # simulate orphan: clear state, leave daemon alive
./gridctl serve &                        # restart daemon in background
rm ~/.gridctl/state/gridctl.json         # delete its state file again
./gridctl stop                           # → actionable error naming pid and :8180
./gridctl stop --force                   # → terminates the orphan
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #618