### PR TITLE
feat: add agent skill launch endpoint

### DIFF
--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gridctl/gridctl/pkg/agent/compose"
 	"github.com/gridctl/gridctl/pkg/agent/persist"
+	"github.com/gridctl/gridctl/pkg/agent/runner"
 )
 
 // SetAgentRunStore wires the persist.Store the /api/agent/runs/*
@@ -257,6 +258,91 @@ func (s *Server) handleAgentRunApprove(w http.ResponseWriter, r *http.Request) {
 		"approval_id": approvalID,
 		"approved":    req.Approved,
 	})
+}
+
+// agentRunLaunchRequest is the body accepted by POST /api/agent/runs.
+type agentRunLaunchRequest struct {
+	SkillName string          `json:"skill_name"`
+	Input     json.RawMessage `json:"input,omitempty"`
+}
+
+// agentRunLaunchResponse is the body returned by POST /api/agent/runs.
+type agentRunLaunchResponse struct {
+	RunID     string    `json:"run_id"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// handleAgentRunsLaunch validates the request and dispatches a new run
+// via the daemon's wired registry server. EventRunStarted is recorded
+// synchronously before the response returns so SSE subscribers polling
+// the new run see the head of the ledger without racing the first
+// event. Execution flows through registry.Server.CallTool so
+// tool()/llm()/approval() bindings (vault, gateway routing, approval
+// registry) apply unchanged.
+//
+// Initial scope is TS-handler skills only — Go and prompt-only handlers
+// are rejected with 422 and an actionable message.
+func (s *Server) handleAgentRunsLaunch(w http.ResponseWriter, r *http.Request) {
+	store := s.runStore()
+	if store == nil || s.registryServer == nil {
+		writeJSONError(w, "agent runtime not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req agentRunLaunchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, fmt.Sprintf("decoding body: %v", err), http.StatusBadRequest)
+		return
+	}
+	if req.SkillName == "" {
+		writeJSONError(w, "skill_name is required", http.StatusBadRequest)
+		return
+	}
+
+	// Default input to {} when absent. When present, it must be a
+	// JSON object — a top-level array, scalar, or null is rejected so
+	// the dispatcher receives a stable shape.
+	input := map[string]any{}
+	rawInput := json.RawMessage(`{}`)
+	if len(req.Input) > 0 {
+		if err := json.Unmarshal(req.Input, &input); err != nil || input == nil {
+			writeJSONError(w, "input must be a JSON object", http.StatusBadRequest)
+			return
+		}
+		rawInput = req.Input
+	}
+
+	sk, err := s.registryServer.Store().GetSkill(req.SkillName)
+	if err != nil {
+		writeJSONError(w, fmt.Sprintf("skill %q not found", req.SkillName), http.StatusNotFound)
+		return
+	}
+
+	switch sk.HandlerLanguage {
+	case "ts":
+		// proceed
+	case "go":
+		writeJSONError(w, fmt.Sprintf("skill %q has a Go handler; the launcher does not yet support Go plugins — invoke via `gridctl run` after `gridctl agent build`", req.SkillName), http.StatusUnprocessableEntity)
+		return
+	case "":
+		writeJSONError(w, fmt.Sprintf("skill %q is prompt-only and surfaces as an MCP prompt, not an invocable tool", req.SkillName), http.StatusUnprocessableEntity)
+		return
+	default:
+		writeJSONError(w, fmt.Sprintf("skill %q has unsupported handler language %q", req.SkillName, sk.HandlerLanguage), http.StatusUnprocessableEntity)
+		return
+	}
+
+	runID, startedAt, err := runner.Start(r.Context(), store, s.registryServer, runner.StartOptions{
+		Skill:    req.SkillName,
+		Flavor:   sk.HandlerLanguage,
+		Input:    input,
+		RawInput: rawInput,
+	})
+	if err != nil {
+		writeJSONError(w, fmt.Sprintf("starting run: %v", err), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, agentRunLaunchResponse{RunID: runID, StartedAt: startedAt})
 }
 
 // summaryToListItem strips the on-disk path off a persist.RunSummary

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gridctl/gridctl/pkg/agent/compose"
 	"github.com/gridctl/gridctl/pkg/agent/persist"
+	"github.com/gridctl/gridctl/pkg/registry"
 )
 
 func newAgentRunsTestServer(t *testing.T) (*Server, *persist.Store, *compose.Registry) {
@@ -234,6 +235,200 @@ func TestAgentRunsRoutes503WithoutStore(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/agent/runs", nil)
 	rr := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rr.Code)
+	}
+}
+
+// newAgentRunLaunchTestServer wires the same per-component fixtures as
+// newAgentRunsTestServer plus a registry server seeded with TS, Go, and
+// prompt-only skills. The skills are written to a temp directory so the
+// handler can read the cached AgentSkill metadata; no on-disk handler
+// source is required because the test does not wait for the async
+// dispatch to succeed.
+func newAgentRunLaunchTestServer(t *testing.T) (*Server, *persist.Store, *registry.Server) {
+	t.Helper()
+	srv, store, _ := newAgentRunsTestServer(t)
+	regStore := registry.NewStore(t.TempDir())
+	regServer := registry.New(regStore)
+	if err := regServer.Initialize(context.Background()); err != nil {
+		t.Fatalf("registry init: %v", err)
+	}
+	srv.SetRegistryServer(regServer)
+	return srv, store, regServer
+}
+
+func seedTypedSkill(t *testing.T, regServer *registry.Server, name, handler string) {
+	t.Helper()
+	sk := &registry.AgentSkill{
+		Name:            name,
+		Description:     "Test skill: " + name,
+		State:           registry.StateActive,
+		Body:            "# " + name + "\n\nSkill instructions.",
+		HandlerLanguage: handler,
+	}
+	if err := regServer.Store().SaveSkill(sk); err != nil {
+		t.Fatalf("SaveSkill %q: %v", name, err)
+	}
+}
+
+func postLaunch(t *testing.T, srv *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/runs", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	return rr
+}
+
+func TestAgentRunsLaunch_ReturnsRunIDForTSSkill(t *testing.T) {
+	srv, store, regServer := newAgentRunLaunchTestServer(t)
+	seedTypedSkill(t, regServer, "demo-ts", "ts")
+
+	rr := postLaunch(t, srv, `{"skill_name":"demo-ts","input":{"q":"hi"}}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	var body agentRunLaunchResponse
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.RunID == "" {
+		t.Fatal("expected non-empty run_id")
+	}
+	if body.StartedAt.IsZero() {
+		t.Fatal("expected non-zero started_at")
+	}
+
+	// run_started is written synchronously before the response — the
+	// ledger contains it immediately.
+	events, err := store.Read(body.RunID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(events) == 0 || events[0].Type != persist.EventRunStarted {
+		t.Fatalf("expected first event run_started, got %+v", events)
+	}
+	var started persist.RunStartedPayload
+	if err := json.Unmarshal(events[0].Payload, &started); err != nil {
+		t.Fatalf("decode run_started: %v", err)
+	}
+	if started.Skill != "demo-ts" {
+		t.Fatalf("expected skill=demo-ts, got %q", started.Skill)
+	}
+	if started.Flavor != "ts" {
+		t.Fatalf("expected flavor=ts, got %q", started.Flavor)
+	}
+	if string(started.Input) != `{"q":"hi"}` {
+		t.Fatalf("expected raw input preserved, got %s", started.Input)
+	}
+}
+
+func TestAgentRunsLaunch_DefaultsInputToEmptyObject(t *testing.T) {
+	srv, store, regServer := newAgentRunLaunchTestServer(t)
+	seedTypedSkill(t, regServer, "demo-ts", "ts")
+
+	rr := postLaunch(t, srv, `{"skill_name":"demo-ts"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	var body agentRunLaunchResponse
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	events, err := store.Read(body.RunID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	var started persist.RunStartedPayload
+	if err := json.Unmarshal(events[0].Payload, &started); err != nil {
+		t.Fatalf("decode run_started: %v", err)
+	}
+	if string(started.Input) != `{}` {
+		t.Fatalf("expected default input {}, got %s", started.Input)
+	}
+}
+
+func TestAgentRunsLaunch_404ForUnknownSkill(t *testing.T) {
+	srv, _, _ := newAgentRunLaunchTestServer(t)
+	rr := postLaunch(t, srv, `{"skill_name":"missing","input":{}}`)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAgentRunsLaunch_422ForGoSkill(t *testing.T) {
+	srv, _, regServer := newAgentRunLaunchTestServer(t)
+	seedTypedSkill(t, regServer, "demo-go", "go")
+
+	rr := postLaunch(t, srv, `{"skill_name":"demo-go","input":{}}`)
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Go handler") {
+		t.Fatalf("expected error to mention Go handler, got %s", rr.Body.String())
+	}
+}
+
+func TestAgentRunsLaunch_422ForPromptOnlySkill(t *testing.T) {
+	srv, _, regServer := newAgentRunLaunchTestServer(t)
+	seedTypedSkill(t, regServer, "demo-prompt", "")
+
+	rr := postLaunch(t, srv, `{"skill_name":"demo-prompt","input":{}}`)
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "prompt-only") {
+		t.Fatalf("expected error to mention prompt-only, got %s", rr.Body.String())
+	}
+}
+
+func TestAgentRunsLaunch_400ForMissingSkillName(t *testing.T) {
+	srv, _, _ := newAgentRunLaunchTestServer(t)
+	rr := postLaunch(t, srv, `{"input":{}}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAgentRunsLaunch_400ForNonObjectInput(t *testing.T) {
+	srv, _, regServer := newAgentRunLaunchTestServer(t)
+	seedTypedSkill(t, regServer, "demo-ts", "ts")
+
+	cases := []string{
+		`{"skill_name":"demo-ts","input":[1,2,3]}`,
+		`{"skill_name":"demo-ts","input":"string"}`,
+		`{"skill_name":"demo-ts","input":42}`,
+		`{"skill_name":"demo-ts","input":null}`,
+	}
+	for _, body := range cases {
+		rr := postLaunch(t, srv, body)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for body %q, got %d body=%s", body, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+func TestAgentRunsLaunch_400ForMalformedBody(t *testing.T) {
+	srv, _, _ := newAgentRunLaunchTestServer(t)
+	rr := postLaunch(t, srv, `not json`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestAgentRunsLaunch_503WithoutStore(t *testing.T) {
+	srv := newTestServer(t)
+	rr := postLaunch(t, srv, `{"skill_name":"demo","input":{}}`)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rr.Code)
+	}
+}
+
+func TestAgentRunsLaunch_503WithoutRegistryServer(t *testing.T) {
+	srv, _, _ := newAgentRunsTestServer(t) // sets store + approval registry, but not registryServer
+	rr := postLaunch(t, srv, `{"skill_name":"demo","input":{}}`)
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rr.Code)
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -322,6 +322,7 @@ func (s *Server) Handler() http.Handler {
 	// always available when a store is wired; resume/approve route
 	// through the in-process approval registry.
 	mux.HandleFunc("GET /api/agent/runs", s.handleAgentRunsList)
+	mux.HandleFunc("POST /api/agent/runs", s.handleAgentRunsLaunch)
 	mux.HandleFunc("GET /api/agent/runs/{run_id}", s.handleAgentRunGet)
 	mux.HandleFunc("GET /api/agent/runs/{run_id}/events", s.handleAgentRunEvents)
 	mux.HandleFunc("POST /api/agent/runs/{run_id}/resume", s.handleAgentRunResume)

--- a/pkg/agent/runner/runner.go
+++ b/pkg/agent/runner/runner.go
@@ -1,0 +1,180 @@
+// Package runner orchestrates skill-run execution against the daemon's
+// wired runtime, persisting the typed event ledger as it goes.
+//
+// The runner sits between the API layer (POST /api/agent/runs) and the
+// registry-server dispatch path. It opens a JSONL ledger via
+// persist.Store, writes EventRunStarted synchronously, dispatches the
+// skill asynchronously, and records EventRunCompleted (and an
+// EventError on failure) when the dispatcher returns. The synchronous
+// start lets the API return {run_id, started_at} before the run
+// completes; SSE subscribers see the head of the ledger without racing
+// the first event.
+//
+// The runner is intentionally decoupled from pkg/registry: it accepts
+// an Executor interface that any caller can satisfy. *registry.Server
+// satisfies it via its existing CallTool method.
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/agent/persist"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// Executor invokes a registered skill with the daemon's fully-wired
+// bindings (tool/llm/approval). *registry.Server satisfies this via
+// its CallTool method.
+type Executor interface {
+	CallTool(ctx context.Context, name string, arguments map[string]any) (*mcp.ToolCallResult, error)
+}
+
+// StartOptions configures a single Start call.
+type StartOptions struct {
+	// Skill is the registered skill name to invoke.
+	Skill string
+
+	// Flavor is the skill's handler-language flavor ("ts" today).
+	// Recorded in the ledger so the inspector can render it.
+	Flavor string
+
+	// Input is the parsed JSON input handed to the executor.
+	Input map[string]any
+
+	// RawInput is the original JSON bytes for the input, preserved
+	// verbatim in EventRunStarted so resume can re-issue the run
+	// without re-encoding through Go's map iteration order.
+	RawInput json.RawMessage
+}
+
+// Start opens a new run ledger, writes EventRunStarted synchronously,
+// and dispatches the skill asynchronously via exec. Returns the run ID
+// and the started_at timestamp from the recorded event. The async
+// goroutine writes EventRunCompleted (and an EventError on failure)
+// before closing the recorder.
+//
+// The goroutine inherits ctx's values (trace span context, request
+// IDs) but not its cancellation — the dispatch outlives the HTTP
+// request that started it.
+func Start(ctx context.Context, store *persist.Store, exec Executor, opts StartOptions) (string, time.Time, error) {
+	if store == nil {
+		return "", time.Time{}, errors.New("runner: store is required")
+	}
+	if exec == nil {
+		return "", time.Time{}, errors.New("runner: executor is required")
+	}
+	if opts.Skill == "" {
+		return "", time.Time{}, errors.New("runner: skill is required")
+	}
+
+	runID := persist.NewRunID()
+	rec, err := store.OpenWriter(runID)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("runner: opening run ledger: %w", err)
+	}
+
+	ev, err := rec.Record(persist.EventRunStarted, persist.RunStartedPayload{
+		Skill:  opts.Skill,
+		Flavor: opts.Flavor,
+		Input:  opts.RawInput,
+	})
+	if err != nil {
+		_ = rec.Close()
+		return "", time.Time{}, fmt.Errorf("runner: recording run_started: %w", err)
+	}
+
+	args := opts.Input
+	if args == nil {
+		args = map[string]any{}
+	}
+
+	// Detach from the request context so the dispatch outlives the
+	// HTTP request. Values (trace context, request IDs) propagate;
+	// cancellation does not.
+	go runAsync(context.WithoutCancel(ctx), rec, exec, opts.Skill, args)
+
+	return runID, ev.Time, nil
+}
+
+func runAsync(ctx context.Context, rec *persist.Recorder, exec Executor, skillName string, args map[string]any) {
+	defer func() {
+		if err := rec.Close(); err != nil {
+			slog.Warn("runner: closing recorder", "run_id", rec.RunID(), "err", err)
+		}
+	}()
+
+	result, callErr := exec.CallTool(ctx, skillName, args)
+	if callErr != nil {
+		recordFailure(rec, callErr.Error())
+		return
+	}
+
+	if result != nil && result.IsError {
+		msg := extractText(result)
+		if msg == "" {
+			msg = "skill returned error result"
+		}
+		recordFailure(rec, msg)
+		return
+	}
+
+	if _, err := rec.Record(persist.EventRunCompleted, persist.RunCompletedPayload{
+		Status: "ok",
+		Output: outputFromResult(result),
+	}); err != nil {
+		slog.Warn("runner: recording run_completed", "run_id", rec.RunID(), "err", err)
+	}
+}
+
+// recordFailure writes the EventError + EventRunCompleted{status:error}
+// pair the async path emits on dispatch failure. Ledger writes are
+// logged at warn level on error so a corrupted ledger is not silent.
+func recordFailure(rec *persist.Recorder, msg string) {
+	if _, err := rec.Record(persist.EventError, persist.ErrorPayload{Message: msg}); err != nil {
+		slog.Warn("runner: recording error event", "run_id", rec.RunID(), "err", err)
+	}
+	if _, err := rec.Record(persist.EventRunCompleted, persist.RunCompletedPayload{
+		Status: "error",
+		Error:  msg,
+	}); err != nil {
+		slog.Warn("runner: recording run_completed", "run_id", rec.RunID(), "err", err)
+	}
+}
+
+// outputFromResult extracts the skill's output payload from a tool-call
+// result. The dispatcher wraps the typed return value as a single text
+// content block; probe-parse as JSON and store the raw bytes when
+// valid. Non-JSON text is JSON-string-wrapped so the ledger row
+// remains a syntactically valid value. This diverges from the CLI
+// (cmd/gridctl/run.go), which records `null` and emits a stderr
+// warning — we preserve the literal text because the API surface
+// returns the run_id immediately and has no stderr to write to;
+// inspectors then see the actual return value rather than a silent
+// data loss.
+func outputFromResult(result *mcp.ToolCallResult) json.RawMessage {
+	if result == nil || len(result.Content) == 0 {
+		return json.RawMessage("null")
+	}
+	text := result.Content[0].Text
+	if text == "" {
+		return json.RawMessage("null")
+	}
+	var probe any
+	if err := json.Unmarshal([]byte(text), &probe); err == nil {
+		return json.RawMessage(text)
+	}
+	encoded, _ := json.Marshal(text)
+	return json.RawMessage(encoded)
+}
+
+func extractText(result *mcp.ToolCallResult) string {
+	if result == nil || len(result.Content) == 0 {
+		return ""
+	}
+	return result.Content[0].Text
+}

--- a/pkg/agent/runner/runner_test.go
+++ b/pkg/agent/runner/runner_test.go
@@ -1,0 +1,232 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/agent/persist"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+type stubExecutor struct {
+	result *mcp.ToolCallResult
+	err    error
+	done   chan struct{}
+}
+
+func newStubExecutor(result *mcp.ToolCallResult, err error) *stubExecutor {
+	return &stubExecutor{result: result, err: err, done: make(chan struct{})}
+}
+
+func (e *stubExecutor) CallTool(_ context.Context, _ string, _ map[string]any) (*mcp.ToolCallResult, error) {
+	defer close(e.done)
+	return e.result, e.err
+}
+
+// waitForStatus polls the ledger until a run reaches a terminal status
+// or the deadline elapses. The async goroutine in Start writes
+// EventRunCompleted before closing the recorder, so the summary's
+// status flips off "running" within milliseconds of dispatch return.
+func waitForStatus(t *testing.T, store *persist.Store, runID string) persist.RunSummary {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		summary, err := store.Summary(runID)
+		if err == nil && summary.Status != "running" {
+			return summary
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("run %s did not reach terminal status within deadline", runID)
+	return persist.RunSummary{}
+}
+
+func TestStart_HappyPathWritesStartedAndCompleted(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	result := &mcp.ToolCallResult{
+		Content: []mcp.Content{mcp.NewTextContent(`{"ok":true}`)},
+	}
+	exec := newStubExecutor(result, nil)
+
+	runID, startedAt, err := Start(context.Background(), store, exec, StartOptions{
+		Skill:    "demo",
+		Flavor:   "ts",
+		Input:    map[string]any{"name": "world"},
+		RawInput: json.RawMessage(`{"name":"world"}`),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if runID == "" {
+		t.Fatal("expected non-empty run id")
+	}
+	if startedAt.IsZero() {
+		t.Fatal("expected non-zero started_at")
+	}
+
+	summary := waitForStatus(t, store, runID)
+	if summary.Status != "ok" {
+		t.Fatalf("expected status=ok, got %q (error=%q)", summary.Status, summary.Error)
+	}
+	events, err := store.Read(runID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (run_started, run_completed), got %d", len(events))
+	}
+	if events[0].Type != persist.EventRunStarted {
+		t.Fatalf("event 0: expected run_started, got %s", events[0].Type)
+	}
+	if events[1].Type != persist.EventRunCompleted {
+		t.Fatalf("event 1: expected run_completed, got %s", events[1].Type)
+	}
+
+	var completed persist.RunCompletedPayload
+	if err := json.Unmarshal(events[1].Payload, &completed); err != nil {
+		t.Fatalf("decode run_completed: %v", err)
+	}
+	if completed.Status != "ok" {
+		t.Fatalf("expected status=ok, got %q", completed.Status)
+	}
+	if string(completed.Output) != `{"ok":true}` {
+		t.Fatalf("unexpected output: %s", completed.Output)
+	}
+}
+
+func TestStart_ExecutorErrorRecordsErrorAndCompleted(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	exec := newStubExecutor(nil, errors.New("boom"))
+
+	runID, _, err := Start(context.Background(), store, exec, StartOptions{Skill: "demo", Flavor: "ts"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	summary := waitForStatus(t, store, runID)
+	if summary.Status != "error" {
+		t.Fatalf("expected status=error, got %q", summary.Status)
+	}
+	if summary.Error != "boom" {
+		t.Fatalf("expected error=%q, got %q", "boom", summary.Error)
+	}
+	events, err := store.Read(runID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	// run_started + error + run_completed
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+	if events[1].Type != persist.EventError {
+		t.Fatalf("event 1: expected error, got %s", events[1].Type)
+	}
+}
+
+func TestStart_IsErrorResultRecordsAsErrorStatus(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	result := &mcp.ToolCallResult{
+		Content: []mcp.Content{mcp.NewTextContent("auth failed")},
+		IsError: true,
+	}
+	exec := newStubExecutor(result, nil)
+
+	runID, _, err := Start(context.Background(), store, exec, StartOptions{Skill: "demo", Flavor: "ts"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	summary := waitForStatus(t, store, runID)
+	if summary.Status != "error" {
+		t.Fatalf("expected status=error, got %q", summary.Status)
+	}
+	if !strings.Contains(summary.Error, "auth failed") {
+		t.Fatalf("expected error to include %q, got %q", "auth failed", summary.Error)
+	}
+}
+
+func TestStart_RejectsMissingDependencies(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	exec := newStubExecutor(nil, nil)
+
+	if _, _, err := Start(context.Background(), nil, exec, StartOptions{Skill: "demo"}); err == nil {
+		t.Fatal("expected error for nil store")
+	}
+	if _, _, err := Start(context.Background(), store, nil, StartOptions{Skill: "demo"}); err == nil {
+		t.Fatal("expected error for nil executor")
+	}
+	if _, _, err := Start(context.Background(), store, exec, StartOptions{Skill: ""}); err == nil {
+		t.Fatal("expected error for empty skill")
+	}
+}
+
+func TestStart_RunStartedPayloadCarriesInput(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	exec := newStubExecutor(&mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent("null")}}, nil)
+
+	raw := json.RawMessage(`{"q":"hi"}`)
+	runID, _, err := Start(context.Background(), store, exec, StartOptions{
+		Skill:    "demo",
+		Flavor:   "ts",
+		Input:    map[string]any{"q": "hi"},
+		RawInput: raw,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// run_started is written synchronously; readable immediately.
+	events, err := store.Read(runID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(events) == 0 || events[0].Type != persist.EventRunStarted {
+		t.Fatalf("expected first event run_started, got %+v", events)
+	}
+	var started persist.RunStartedPayload
+	if err := json.Unmarshal(events[0].Payload, &started); err != nil {
+		t.Fatalf("decode run_started: %v", err)
+	}
+	if started.Skill != "demo" {
+		t.Fatalf("expected skill=demo, got %q", started.Skill)
+	}
+	if started.Flavor != "ts" {
+		t.Fatalf("expected flavor=ts, got %q", started.Flavor)
+	}
+	if string(started.Input) != string(raw) {
+		t.Fatalf("expected raw input preserved, got %s", started.Input)
+	}
+
+	// Drain async work so the test doesn't race the goroutine.
+	waitForStatus(t, store, runID)
+}
+
+func TestStart_NonJSONOutputIsWrappedAsString(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	result := &mcp.ToolCallResult{
+		Content: []mcp.Content{mcp.NewTextContent("hello world")},
+	}
+	exec := newStubExecutor(result, nil)
+
+	runID, _, err := Start(context.Background(), store, exec, StartOptions{Skill: "demo", Flavor: "ts"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	waitForStatus(t, store, runID)
+	events, err := store.Read(runID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	var completed persist.RunCompletedPayload
+	if err := json.Unmarshal(events[len(events)-1].Payload, &completed); err != nil {
+		t.Fatalf("decode run_completed: %v", err)
+	}
+	if string(completed.Output) != `"hello world"` {
+		t.Fatalf("expected wrapped string output, got %s", completed.Output)
+	}
+}


### PR DESCRIPTION
## Description

Adds `POST /api/agent/runs` to launch agent skill runs from the daemon's wired runtime (vault, gateway routing, approval registry). Backs the agent skill runner UI (Phase 1 of 2 — backend only; frontend lands separately).

## Type of Change

- [x] New feature

## Changes Made

- New `pkg/agent/runner` package with `Start(ctx, store, exec, opts)` — opens JSONL ledger, writes `EventRunStarted` synchronously, dispatches async via an `Executor` interface (satisfied by `*registry.Server.CallTool`), writes `EventRunCompleted` on completion. Uses `context.WithoutCancel` so dispatch outlives the HTTP request.
- New `handleAgentRunsLaunch` in `internal/api/agent_runs.go`. Validates `skill_name` + JSON-object input; rejects unknown skill (404), Go-handler skill (422), prompt-only skill (422), missing/invalid input (400), and missing runtime (503).
- Route `POST /api/agent/runs` registered alongside the existing run-lifecycle routes.

## Testing

- `go test -race ./...` passes
- `golangci-lint run ./...` reports 0 issues
- `make build` succeeds
- Runner unit tests cover happy path, executor error, `IsError` result, missing deps, raw input preservation, non-JSON output wrapping
- Handler tests cover 200 (TS skill), default-input, 404, 422 (Go + prompt-only), 400 (missing/non-object/malformed), 503 (missing store + missing registry server)

## Notes for reviewers

- **Scope**: TS-handler skills only. Go skills require plugin load — same constraint as `gridctl run` — and are rejected with an actionable 422 message. Prompt-only skills surface as MCP prompts, not invocable tools, and are also rejected with 422.
- **EventRunStarted is written synchronously** before the response returns so SSE subscribers do not race the first event.
- **Output handling diverges from `cmd/gridctl/run.go`**: the runner JSON-string-wraps non-JSON output instead of recording `null`. Rationale (preserve information for the API surface that has no stderr) is documented inline. The CLI path is unchanged.
- **Architectural note**: the daemon's MCP `tools/call` path does not write the run ledger today — that was a CLI-only concept. The new runner combines daemon-wired bindings (via `registry.Server.CallTool`) with ledger emission. A future cleanup could share this runner with the CLI's `gridctl run`.
- **Trace overlay v1**: only `run_started` and `run_completed` are recorded today (the sandbox does not emit intermediate `node_enter`/`tool_call` events from this path). Richer trace events are a separate workstream.
- **Auth**: uses the same chain as `POST /api/agent/runs/{id}/resume` and `.../approve` — no new auth surface.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #624