### PR TITLE
feat: add agent skill run launcher UI

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
+        "@rjsf/core": "^5.24.13",
+        "@rjsf/utils": "^5.24.13",
+        "@rjsf/validator-ajv8": "^5.24.13",
         "@xyflow/react": "^12.10.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -1330,6 +1333,90 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
+    },
+    "node_modules/@rjsf/core": {
+      "version": "5.24.13",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.24.13.tgz",
+      "integrity": "sha512-ONTr14s7LFIjx2VRFLuOpagL76sM/HPy6/OhdBfq6UukINmTIs6+aFN0GgcR0aXQHFDXQ7f/fel0o/SO05Htdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "markdown-to-jsx": "^7.4.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@rjsf/utils": "^5.24.x",
+        "react": "^16.14.0 || >=17"
+      }
+    },
+    "node_modules/@rjsf/utils": {
+      "version": "5.24.13",
+      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.24.13.tgz",
+      "integrity": "sha512-rNF8tDxIwTtXzz5O/U23QU73nlhgQNYJ+Sv5BAwQOIyhIE2Z3S5tUiSVMwZHt0julkv/Ryfwi+qsD4FiE5rOuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema-merge-allof": "^0.8.1",
+        "jsonpointer": "^5.0.1",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || >=17"
+      }
+    },
+    "node_modules/@rjsf/utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/@rjsf/validator-ajv8": {
+      "version": "5.24.13",
+      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-5.24.13.tgz",
+      "integrity": "sha512-oWHP7YK581M8I5cF1t+UXFavnv+bhcqjtL1a7MG/Kaffi0EwhgcYjODrD8SsnrhncsEYMqSECr4ZOEoirnEUWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@rjsf/utils": "^5.24.x"
+      }
+    },
+    "node_modules/@rjsf/validator-ajv8/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@rjsf/validator-ajv8/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.12",
@@ -2720,6 +2807,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2958,6 +3084,27 @@
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/compute-gcd": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "node_modules/compute-lcm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+      "dependencies": {
+        "compute-gcd": "^1.2.1",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
       }
     },
     "node_modules/convert-source-map": {
@@ -3581,7 +3728,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3597,6 +3743,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3947,7 +4109,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -4021,6 +4182,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/json-schema-merge-allof": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
+      "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-lcm": "^1.1.2",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.20"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4046,6 +4230,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/keyv": {
@@ -4349,6 +4542,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4427,6 +4644,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "7.7.17",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.7.17.tgz",
+      "integrity": "sha512-7mG/1feQ0TX5I7YyMZVDgCC/y2I3CiEhIRQIhyov9nGBP5eoVrOXXHuL5ZP8GRfxVZKRiXWJgwXkb9It+nQZfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/marked": {
@@ -4513,6 +4747,15 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -4708,6 +4951,23 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4949,7 +5209,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5430,6 +5689,39 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==",
+      "license": "MIT"
+    },
+    "node_modules/validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
+    },
+    "node_modules/validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
+      "dependencies": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "node_modules/validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "node_modules/validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,9 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
+    "@rjsf/core": "^5.24.13",
+    "@rjsf/utils": "^5.24.13",
+    "@rjsf/validator-ajv8": "^5.24.13",
     "@xyflow/react": "^12.10.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/web/src/__tests__/RunLauncherModal.test.tsx
+++ b/web/src/__tests__/RunLauncherModal.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+vi.mock('../lib/agent-runs', async () => {
+  const actual = await vi.importActual<typeof import('../lib/agent-runs')>(
+    '../lib/agent-runs',
+  );
+  return {
+    ...actual,
+    fetchAgentRuns: vi.fn().mockResolvedValue([]),
+    fetchAgentRun: vi.fn().mockResolvedValue(null),
+    launchRun: vi.fn(),
+  };
+});
+
+import { RunLauncherModal } from '../components/agent/ide/RunLauncherModal';
+import {
+  fetchAgentRuns,
+  fetchAgentRun,
+  launchRun,
+  LaunchRunError,
+} from '../lib/agent-runs';
+
+const mockedLaunchRun = vi.mocked(launchRun);
+const mockedFetchAgentRuns = vi.mocked(fetchAgentRuns);
+const mockedFetchAgentRun = vi.mocked(fetchAgentRun);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedFetchAgentRuns.mockResolvedValue([]);
+  mockedFetchAgentRun.mockResolvedValue(null);
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderModal(overrides: {
+  skill?: { name: string; description?: string; inputSchema?: Record<string, unknown> };
+  onClose?: () => void;
+  onLaunched?: (r: { run_id: string; started_at: string }) => void;
+} = {}) {
+  const onClose = overrides.onClose ?? vi.fn();
+  const onLaunched = overrides.onLaunched ?? vi.fn();
+  const skill = overrides.skill ?? { name: 'repo-audit' };
+  render(
+    <RunLauncherModal skill={skill} onClose={onClose} onLaunched={onLaunched} />,
+  );
+  return { onClose, onLaunched };
+}
+
+describe('RunLauncherModal', () => {
+  it('renders the skill name in the header', () => {
+    renderModal({ skill: { name: 'repo-audit' } });
+    expect(screen.getByRole('heading', { name: 'repo-audit' })).toBeInTheDocument();
+  });
+
+  it('renders the description when provided', () => {
+    renderModal({ skill: { name: 'repo-audit', description: 'audits repos for risk' } });
+    expect(screen.getByText('audits repos for risk')).toBeInTheDocument();
+  });
+
+  it('pre-fills the JSON editor with {} on first open', () => {
+    renderModal();
+    const editor = screen.getByLabelText(/input json/i) as HTMLTextAreaElement;
+    expect(editor.value).toBe('{}');
+  });
+
+  it('restores last input from localStorage', () => {
+    window.localStorage.setItem(
+      'gridctl.agent.lastInput.repo-audit',
+      '{\n  "url": "https://example.com"\n}',
+    );
+    renderModal({ skill: { name: 'repo-audit' } });
+    const editor = screen.getByLabelText(/input json/i) as HTMLTextAreaElement;
+    expect(editor.value).toContain('"url": "https://example.com"');
+  });
+
+  it('shows an inline parse error and disables Run for invalid JSON', async () => {
+    renderModal();
+    const editor = screen.getByLabelText(/input json/i) as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: '{ "bad": ' } });
+    await waitFor(() => {
+      expect(document.getElementById('run-launcher-json-error')).not.toBeNull();
+    });
+    const run = screen.getByRole('button', { name: /^run$/i });
+    expect(run).toBeDisabled();
+  });
+
+  it('rejects non-object JSON (arrays, scalars)', async () => {
+    renderModal();
+    const editor = screen.getByLabelText(/input json/i) as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: '[1, 2, 3]' } });
+    await waitFor(() => {
+      expect(screen.getByText(/must be a JSON object/i)).toBeInTheDocument();
+    });
+  });
+
+  it('POSTs the parsed input and calls onLaunched on success', async () => {
+    mockedLaunchRun.mockResolvedValueOnce({
+      run_id: 'run-abc-123',
+      started_at: '2026-05-13T17:30:00Z',
+    });
+    const { onLaunched } = renderModal();
+    const editor = screen.getByLabelText(/input json/i) as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: '{"url":"https://example.com"}' } });
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+    await waitFor(() => {
+      expect(mockedLaunchRun).toHaveBeenCalledWith({
+        skill_name: 'repo-audit',
+        input: { url: 'https://example.com' },
+      });
+    });
+    await waitFor(() => {
+      expect(onLaunched).toHaveBeenCalledWith({
+        run_id: 'run-abc-123',
+        started_at: '2026-05-13T17:30:00Z',
+      });
+    });
+    expect(window.localStorage.getItem('gridctl.agent.lastInput.repo-audit')).toContain(
+      'example.com',
+    );
+  });
+
+  it('renders the server error in an alert banner on 4xx', async () => {
+    mockedLaunchRun.mockRejectedValueOnce(
+      new LaunchRunError(422, 'skill "x" has a Go handler; the launcher does not yet support Go plugins'),
+    );
+    renderModal({ skill: { name: 'x' } });
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Go handler');
+  });
+
+  it('closes when the user presses ESC', () => {
+    const { onClose } = renderModal();
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes when Cancel is clicked', () => {
+    const { onClose } = renderModal();
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the Form tab when the schema has properties', () => {
+    renderModal({
+      skill: {
+        name: 'x',
+        inputSchema: {
+          type: 'object',
+          properties: { url: { type: 'string' } },
+        },
+      },
+    });
+    expect(screen.getByRole('tab', { name: /form/i })).toBeInTheDocument();
+  });
+
+  it('hides the Form tab when the schema is the permissive default', () => {
+    renderModal({
+      skill: { name: 'x', inputSchema: { type: 'object' } },
+    });
+    expect(screen.queryByRole('tab', { name: /form/i })).not.toBeInTheDocument();
+  });
+
+  it('populates the Run-like picker with prior runs of this skill', async () => {
+    mockedFetchAgentRuns.mockResolvedValueOnce([
+      {
+        run_id: 'a-prev-1',
+        skill: 'repo-audit',
+        status: 'completed',
+        started_at: '2026-05-13T16:00:00Z',
+        event_count: 4,
+      },
+      {
+        run_id: 'b-other',
+        skill: 'something-else',
+        status: 'completed',
+        started_at: '2026-05-13T16:30:00Z',
+        event_count: 2,
+      },
+    ]);
+    renderModal();
+    await waitFor(() => {
+      // The picker option label includes the short run id "a-prev-1"
+      // (first 8 chars). The other-skill run is filtered out.
+      const options = screen.getAllByRole('option');
+      const found = options.some((o) => /a-prev-1/.test(o.textContent ?? ''));
+      expect(found).toBe(true);
+      const cross = options.some((o) => /b-other/.test(o.textContent ?? ''));
+      expect(cross).toBe(false);
+    });
+  });
+});

--- a/web/src/__tests__/agent-runs-launch.test.ts
+++ b/web/src/__tests__/agent-runs-launch.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchAgentRun,
+  inputFromRunDetail,
+  launchRun,
+  LaunchRunError,
+} from '../lib/agent-runs';
+
+function mockResponse(body: unknown, init: { status?: number; statusText?: string } = {}) {
+  const status = init.status ?? 200;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: init.statusText ?? (status === 200 ? 'OK' : 'ERR'),
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('launchRun', () => {
+  it('POSTs skill_name and input and returns the run id', async () => {
+    const fetchStub = vi.fn().mockResolvedValue(
+      mockResponse({ run_id: 'run-123', started_at: '2026-05-13T17:00:00Z' }),
+    );
+    vi.stubGlobal('fetch', fetchStub);
+
+    const res = await launchRun({ skill_name: 'repo-audit', input: { url: 'x' } });
+
+    expect(res.run_id).toBe('run-123');
+    expect(res.started_at).toBe('2026-05-13T17:00:00Z');
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchStub.mock.calls[0];
+    expect(url).toBe('/api/agent/runs');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({ skill_name: 'repo-audit', input: { url: 'x' } });
+  });
+
+  it('throws LaunchRunError with the server message on 4xx', async () => {
+    const fetchStub = vi.fn().mockResolvedValue(
+      mockResponse({ error: 'skill "ghost" not found' }, { status: 404, statusText: 'Not Found' }),
+    );
+    vi.stubGlobal('fetch', fetchStub);
+
+    await expect(launchRun({ skill_name: 'ghost', input: {} })).rejects.toMatchObject({
+      name: 'LaunchRunError',
+      status: 404,
+      message: 'skill "ghost" not found',
+    });
+  });
+
+  it('throws LaunchRunError with the status text on 5xx with no error body', async () => {
+    const fetchStub = vi.fn().mockResolvedValue(
+      // simulate a body where json parse fails — body.error is missing
+      {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: async () => {
+          throw new Error('no body');
+        },
+        text: async () => '',
+      } as unknown as Response,
+    );
+    vi.stubGlobal('fetch', fetchStub);
+
+    const err = await launchRun({ skill_name: 'x', input: {} }).catch((e) => e);
+    expect(err).toBeInstanceOf(LaunchRunError);
+    expect(err.status).toBe(500);
+    expect(err.message).toBe('500 Internal Server Error');
+  });
+});
+
+describe('fetchAgentRun', () => {
+  it('returns the run detail on 200', async () => {
+    const detail = {
+      run: { run_id: 'r1', status: 'completed', event_count: 1 },
+      events: [
+        {
+          run_id: 'r1',
+          seq: 1,
+          time: '2026-05-13T17:00:00Z',
+          type: 'run_started',
+          payload: { skill: 'x', input: { url: 'https://example.com' } },
+        },
+      ],
+    };
+    const fetchStub = vi.fn().mockResolvedValue(mockResponse(detail));
+    vi.stubGlobal('fetch', fetchStub);
+
+    const got = await fetchAgentRun('r1');
+    expect(got?.events[0].type).toBe('run_started');
+  });
+
+  it('returns null on 404', async () => {
+    const fetchStub = vi.fn().mockResolvedValue(mockResponse({}, { status: 404 }));
+    vi.stubGlobal('fetch', fetchStub);
+    expect(await fetchAgentRun('missing')).toBeNull();
+  });
+});
+
+describe('inputFromRunDetail', () => {
+  it('extracts the input object from the run_started event', () => {
+    expect(
+      inputFromRunDetail({
+        run: { run_id: 'r', status: 'ok', event_count: 1 },
+        events: [
+          {
+            run_id: 'r',
+            seq: 1,
+            time: 't',
+            type: 'run_started',
+            payload: { input: { url: 'https://example.com' } },
+          },
+        ],
+      }),
+    ).toEqual({ url: 'https://example.com' });
+  });
+
+  it('returns {} when there is no run_started event', () => {
+    expect(
+      inputFromRunDetail({
+        run: { run_id: 'r', status: 'ok', event_count: 0 },
+        events: [],
+      }),
+    ).toEqual({});
+  });
+
+  it('returns {} for a null detail', () => {
+    expect(inputFromRunDetail(null)).toEqual({});
+  });
+
+  it('returns {} when the input is a non-object', () => {
+    expect(
+      inputFromRunDetail({
+        run: { run_id: 'r', status: 'ok', event_count: 1 },
+        events: [
+          {
+            run_id: 'r',
+            seq: 1,
+            time: 't',
+            type: 'run_started',
+            payload: { input: ['bad'] },
+          },
+        ],
+      }),
+    ).toEqual({});
+  });
+});

--- a/web/src/components/agent/ide/AgentIDE.tsx
+++ b/web/src/components/agent/ide/AgentIDE.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type RefObject } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   fetchSkill,
@@ -10,6 +10,7 @@ import { SkillSidebar } from './SkillSidebar';
 import { NodeList } from './NodeList';
 import { Canvas } from './Canvas';
 import { NodeDetail } from './NodeDetail';
+import { RunLauncherModal, type SkillForLaunch } from './RunLauncherModal';
 import { useDevSocket } from '../../../hooks/useDevSocket';
 import { useRunTrace } from './useRunTrace';
 import { cn } from '../../../lib/cn';
@@ -43,6 +44,14 @@ export function AgentIDE() {
   const [graphError, setGraphError] = useState<string | null>(null);
 
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
+
+  // RunLauncher state — null when no modal is open. The originRef
+  // points at the SkillSidebar Run button that opened the modal so
+  // focus can return to it on close.
+  const [launcher, setLauncher] = useState<{
+    skill: SkillForLaunch;
+    originRef: RefObject<HTMLButtonElement | null>;
+  } | null>(null);
 
   const { lastEvent, connectionState } = useDevSocket(true);
   const runTrace = useRunTrace(runID);
@@ -130,6 +139,30 @@ export function AgentIDE() {
     [params, setParams],
   );
 
+  const handleRunSkill = useCallback(
+    (name: string, originRef: RefObject<HTMLButtonElement | null>) => {
+      // Note: SkillSummary doesn't carry description today — the dev
+      // server only surfaces name/lang/dir/node_count. The modal
+      // omits the description paragraph when undefined. Surfacing
+      // SKILL.md descriptions through the dev API is a follow-up.
+      setLauncher({ skill: { name }, originRef });
+    },
+    [],
+  );
+
+  const handleLaunched = useCallback(
+    (response: { run_id: string; started_at: string }) => {
+      // Update URL to activate useRunTrace on the new run. Use replace
+      // so back-button navigation doesn't accumulate intermediate runs.
+      const next = new URLSearchParams(params);
+      if (launcher?.skill.name) next.set('skill', launcher.skill.name);
+      next.set('run', response.run_id);
+      setParams(next, { replace: true });
+      setLauncher(null);
+    },
+    [params, setParams, launcher],
+  );
+
   const selectedNodeObj = useMemo(() => {
     if (!graph || !selectedNode) return null;
     return graph.nodes.find((n) => n.id === selectedNode) ?? null;
@@ -147,6 +180,7 @@ export function AgentIDE() {
           skills={skills}
           active={activeSkill}
           onSelect={handleSelectSkill}
+          onRunSkill={handleRunSkill}
           loading={skillsLoading}
           error={skillsError}
         />
@@ -205,6 +239,15 @@ export function AgentIDE() {
           onClose={() => setSelectedNode(null)}
         />
       </div>
+
+      {launcher && (
+        <RunLauncherModal
+          skill={launcher.skill}
+          returnFocusRef={launcher.originRef}
+          onClose={() => setLauncher(null)}
+          onLaunched={handleLaunched}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/agent/ide/RunLauncherModal.tsx
+++ b/web/src/components/agent/ide/RunLauncherModal.tsx
@@ -1,0 +1,536 @@
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type RefObject,
+} from 'react';
+import { X, Play, AlertCircle } from 'lucide-react';
+import { cn } from '../../../lib/cn';
+import { formatRelativeTime } from '../../../lib/time';
+import {
+  fetchAgentRun,
+  fetchAgentRuns,
+  inputFromRunDetail,
+  launchRun,
+  LaunchRunError,
+  type AgentRunSummary,
+  type LaunchRunResponse,
+} from '../../../lib/agent-runs';
+
+// RJSF is heavy (~90KB gzipped with AJV) and only renders when a skill
+// exposes an inputSchema with properties. Lazy-load it so the main
+// bundle is unaffected; the chunk only ships when the user clicks the
+// Form tab.
+const SchemaForm = lazy(() => import('./SchemaForm'));
+
+const LS_PREFIX = 'gridctl.agent.lastInput.';
+const RUN_HISTORY_LIMIT = 10;
+
+type Tab = 'json' | 'form';
+
+export interface SkillForLaunch {
+  name: string;
+  description?: string;
+  // inputSchema defaults to {type:"object"} when omitted. Today every
+  // TS skill the registry exposes lands here as the default; richer
+  // schemas will arrive when TS-schema extraction lands and will
+  // automatically activate the Form tab.
+  inputSchema?: Record<string, unknown>;
+}
+
+interface RunLauncherModalProps {
+  skill: SkillForLaunch;
+  onClose: () => void;
+  onLaunched: (response: LaunchRunResponse) => void;
+  returnFocusRef?: RefObject<HTMLElement | null>;
+}
+
+/**
+ * RunLauncherModal is the per-skill run-start surface. It opens on a
+ * Run-button click, lets the operator supply input as JSON (raw
+ * textarea — primary) or via a schema-generated Form (progressive
+ * enhancement when the skill exposes properties), and POSTs to
+ * /api/agent/runs.
+ *
+ * The modal is focus-trapped — Tab cycles through the focusable
+ * controls, ESC closes, focus returns to the originating Run button.
+ * The launcher mutates runtime state only; SKILL source files are
+ * never touched.
+ */
+export function RunLauncherModal({
+  skill,
+  onClose,
+  onLaunched,
+  returnFocusRef,
+}: RunLauncherModalProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('json');
+  const [jsonText, setJsonText] = useState<string>(() => readInitialInput(skill.name));
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [recentRuns, setRecentRuns] = useState<AgentRunSummary[]>([]);
+  const [recentLoading, setRecentLoading] = useState(true);
+  const [selectedRunID, setSelectedRunID] = useState<string>('');
+
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const hasRichSchema = useMemo(() => schemaHasProperties(skill.inputSchema), [skill.inputSchema]);
+
+  // Debounced parse — keep the textarea snappy while still flagging
+  // bad JSON before the operator hits Run.
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      setParseError(validateJSON(jsonText));
+    }, 200);
+    return () => window.clearTimeout(handle);
+  }, [jsonText]);
+
+  // Fetch recent runs of THIS skill for the "Run like…" picker. The
+  // backend list endpoint returns ~50 runs; we filter client-side by
+  // skill name and trim to the most recent N. Failure is silent — the
+  // dropdown simply won't populate.
+  useEffect(() => {
+    let cancelled = false;
+    fetchAgentRuns(50)
+      .then((runs) => {
+        if (cancelled) return;
+        const filtered = runs
+          .filter((r) => r.skill === skill.name)
+          .slice(0, RUN_HISTORY_LIMIT);
+        setRecentRuns(filtered);
+      })
+      .catch(() => {
+        // Quietly degrade — Run like… is optional.
+      })
+      .finally(() => {
+        if (!cancelled) setRecentLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [skill.name]);
+
+  // Move focus into the dialog when it mounts; remember the previously
+  // focused element so we can return it on close. Capture the return
+  // target on mount so the cleanup uses a stable reference even if the
+  // ref's current value changes during the modal's lifetime.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const returnTarget = returnFocusRef?.current ?? previouslyFocused;
+    // Defer one frame so the textarea has rendered.
+    const handle = window.requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+      textareaRef.current?.select();
+    });
+    return () => {
+      window.cancelAnimationFrame(handle);
+      returnTarget?.focus?.();
+    };
+  }, [returnFocusRef]);
+
+  // ESC closes; Tab is trapped within the dialog so focus cannot
+  // escape to the underlying IDE chrome.
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key === 'Tab' && dialogRef.current) {
+        trapTab(e, dialogRef.current);
+      }
+    },
+    [onClose],
+  );
+
+  const handleSelectRecent = useCallback(
+    async (runID: string) => {
+      setSelectedRunID(runID);
+      if (!runID) return;
+      try {
+        const detail = await fetchAgentRun(runID);
+        const input = inputFromRunDetail(detail);
+        setJsonText(JSON.stringify(input, null, 2));
+      } catch (err) {
+        setSubmitError(
+          err instanceof Error
+            ? `couldn't load run ${runID.slice(0, 8)}: ${err.message}`
+            : `couldn't load run ${runID.slice(0, 8)}`,
+        );
+      }
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    setSubmitError(null);
+    const parsed = tryParse(jsonText);
+    if (parsed.kind === 'error') {
+      setParseError(parsed.message);
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const response = await launchRun({ skill_name: skill.name, input: parsed.value });
+      // Persist the last-used input so the next open of this skill's
+      // modal pre-fills it. Stored as the raw text the operator typed,
+      // not the parsed-and-restringified form, so formatting survives.
+      try {
+        window.localStorage.setItem(LS_PREFIX + skill.name, jsonText);
+      } catch {
+        // localStorage may be unavailable / over quota; non-fatal.
+      }
+      onLaunched(response);
+    } catch (err) {
+      const message =
+        err instanceof LaunchRunError
+          ? err.message
+          : err instanceof Error
+          ? err.message
+          : String(err);
+      setSubmitError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [jsonText, skill.name, onLaunched]);
+
+  const submitDisabled = submitting || parseError !== null;
+
+  return (
+    <div
+      ref={overlayRef}
+      role="presentation"
+      className="fixed inset-0 z-40 flex items-center justify-center px-4 py-8 bg-black/60 backdrop-blur-sm animate-fade-in-scale"
+      onMouseDown={(e) => {
+        // Click on the backdrop (not bubbled from inside the dialog)
+        // dismisses, mirroring native <dialog> semantics.
+        if (e.target === overlayRef.current) onClose();
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="run-launcher-title"
+        className={cn(
+          'relative w-full max-w-2xl max-h-full flex flex-col',
+          'rounded-lg border border-border-subtle bg-background shadow-2xl',
+          'overflow-hidden',
+        )}
+      >
+        <header className="px-5 py-4 border-b border-border-subtle">
+          <div className="flex items-start gap-3">
+            <div className="flex-1 min-w-0">
+              <div className="font-sans text-text-muted/70 text-[10px] uppercase tracking-[0.3em] mb-1">
+                launch run
+              </div>
+              <h2
+                id="run-launcher-title"
+                className="font-mono text-base text-text-primary truncate"
+              >
+                {skill.name}
+              </h2>
+              {skill.description && (
+                <p className="font-sans text-text-muted text-xs mt-1 leading-snug line-clamp-2">
+                  {skill.description}
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={onClose}
+              className="text-text-muted hover:text-text-primary p-1 rounded focus:outline-none focus:ring-1 focus:ring-primary/60"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        </header>
+
+        <div className="px-5 py-3 border-b border-border-subtle bg-surface/20">
+          <label className="block font-sans text-text-muted text-[10px] uppercase tracking-[0.3em] mb-1.5">
+            run like…
+          </label>
+          <select
+            value={selectedRunID}
+            disabled={recentLoading || recentRuns.length === 0}
+            onChange={(e) => void handleSelectRecent(e.target.value)}
+            className={cn(
+              'w-full px-2.5 py-1.5 rounded-md',
+              'bg-surface border border-border-subtle text-text-primary',
+              'font-mono text-xs',
+              'focus:outline-none focus:ring-1 focus:ring-primary/60 focus:border-primary/60',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            <option value="">
+              {recentLoading
+                ? 'loading…'
+                : recentRuns.length === 0
+                ? 'no previous runs'
+                : 'start fresh'}
+            </option>
+            {recentRuns.map((r) => (
+              <option key={r.run_id} value={r.run_id}>
+                {r.run_id.slice(0, 8)} — {r.status} — {relativeOrDash(r.started_at)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="px-5 pt-3 flex items-center gap-1 border-b border-border-subtle/50">
+          <TabButton
+            active={activeTab === 'json'}
+            onClick={() => setActiveTab('json')}
+            label="JSON"
+          />
+          {hasRichSchema && (
+            <TabButton
+              active={activeTab === 'form'}
+              onClick={() => setActiveTab('form')}
+              label="Form"
+            />
+          )}
+        </div>
+
+        <div className="flex-1 px-5 py-4 overflow-y-auto min-h-0">
+          {activeTab === 'json' && (
+            <JSONTab
+              ref={textareaRef}
+              value={jsonText}
+              onChange={setJsonText}
+              parseError={parseError}
+            />
+          )}
+          {activeTab === 'form' && hasRichSchema && (
+            <Suspense
+              fallback={
+                <div className="font-mono text-xs text-text-muted animate-pulse">
+                  loading form…
+                </div>
+              }
+            >
+              <SchemaForm
+                schema={skill.inputSchema as Record<string, unknown>}
+                value={tryParseLoose(jsonText)}
+                onChange={(next) => setJsonText(JSON.stringify(next, null, 2))}
+              />
+            </Suspense>
+          )}
+        </div>
+
+        {submitError && (
+          <div
+            role="alert"
+            aria-live="polite"
+            className="mx-5 mb-3 flex items-start gap-2 px-3 py-2 rounded-md border border-status-error/30 bg-status-error/10 text-status-error text-xs"
+          >
+            <AlertCircle size={14} className="shrink-0 mt-0.5" />
+            <span className="font-mono leading-snug break-words">{submitError}</span>
+          </div>
+        )}
+
+        <footer className="px-5 py-3 border-t border-border-subtle flex items-center justify-end gap-2 bg-surface/20">
+          <button
+            type="button"
+            onClick={onClose}
+            className={cn(
+              'px-3 py-1.5 rounded-md font-mono text-xs uppercase tracking-[0.16em]',
+              'text-text-muted hover:text-text-primary',
+              'border border-transparent hover:border-border-subtle',
+              'focus:outline-none focus:ring-1 focus:ring-primary/60',
+            )}
+          >
+            cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSubmit()}
+            disabled={submitDisabled}
+            className={cn(
+              'inline-flex items-center gap-2 px-3 py-1.5 rounded-md',
+              'font-mono text-xs uppercase tracking-[0.16em]',
+              'border border-primary/40 text-primary-light bg-primary/10',
+              'hover:bg-primary/20 hover:border-primary/60 transition-colors',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+              'focus:outline-none focus:ring-1 focus:ring-primary/60',
+            )}
+          >
+            <Play size={12} className="translate-x-px" aria-hidden />
+            {submitting ? 'starting…' : 'run'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+interface JSONTabProps {
+  value: string;
+  onChange: (next: string) => void;
+  parseError: string | null;
+}
+
+const JSONTab = function JSONTabImpl({
+  value,
+  onChange,
+  parseError,
+  ref,
+}: JSONTabProps & { ref?: RefObject<HTMLTextAreaElement | null> }) {
+  return (
+    <div>
+      <label
+        htmlFor="run-launcher-json-editor"
+        className="block font-sans text-text-muted text-[10px] uppercase tracking-[0.3em] mb-1.5"
+      >
+        input json
+      </label>
+      <textarea
+        ref={ref ?? null}
+        id="run-launcher-json-editor"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        spellCheck={false}
+        rows={12}
+        aria-invalid={parseError ? 'true' : 'false'}
+        aria-describedby={parseError ? 'run-launcher-json-error' : undefined}
+        className={cn(
+          'w-full px-3 py-2 rounded-md resize-y',
+          'bg-surface border font-mono text-xs leading-relaxed text-text-primary',
+          parseError ? 'border-status-error/40' : 'border-border-subtle',
+          'focus:outline-none focus:ring-1 focus:ring-primary/60 focus:border-primary/60',
+        )}
+      />
+      <div className="min-h-[18px] mt-1.5" aria-live="polite">
+        {parseError && (
+          <p
+            id="run-launcher-json-error"
+            className="font-mono text-[11px] text-status-error"
+          >
+            {parseError}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+function TabButton({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        'px-3 py-1.5 -mb-px',
+        'font-mono text-[10px] uppercase tracking-[0.2em]',
+        'border-b-2 transition-colors',
+        active
+          ? 'border-primary text-text-primary'
+          : 'border-transparent text-text-muted hover:text-text-primary',
+        'focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/60',
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function readInitialInput(skillName: string): string {
+  try {
+    const saved = window.localStorage.getItem(LS_PREFIX + skillName);
+    if (saved !== null) return saved;
+  } catch {
+    // localStorage unavailable
+  }
+  return '{}';
+}
+
+function schemaHasProperties(schema: Record<string, unknown> | undefined): boolean {
+  if (!schema) return false;
+  const props = schema.properties;
+  return (
+    typeof props === 'object' &&
+    props !== null &&
+    Object.keys(props as Record<string, unknown>).length > 0
+  );
+}
+
+type ParseResult =
+  | { kind: 'ok'; value: Record<string, unknown> }
+  | { kind: 'error'; message: string };
+
+function tryParse(text: string): ParseResult {
+  const trimmed = text.trim();
+  if (trimmed === '') {
+    return { kind: 'ok', value: {} };
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { kind: 'error', message: 'input must be a JSON object' };
+    }
+    return { kind: 'ok', value: parsed as Record<string, unknown> };
+  } catch (err) {
+    return {
+      kind: 'error',
+      message: err instanceof Error ? err.message : 'invalid JSON',
+    };
+  }
+}
+
+function tryParseLoose(text: string): Record<string, unknown> {
+  const result = tryParse(text);
+  return result.kind === 'ok' ? result.value : {};
+}
+
+function validateJSON(text: string): string | null {
+  const result = tryParse(text);
+  return result.kind === 'error' ? result.message : null;
+}
+
+function trapTab(e: KeyboardEvent<HTMLDivElement>, container: HTMLElement) {
+  const focusable = container.querySelectorAll<HTMLElement>(
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+  );
+  if (focusable.length === 0) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+  if (e.shiftKey) {
+    if (active === first || !container.contains(active)) {
+      e.preventDefault();
+      last.focus();
+    }
+  } else {
+    if (active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+}
+
+function relativeOrDash(when: string | undefined): string {
+  if (!when) return '—';
+  const parsed = new Date(when);
+  if (isNaN(parsed.getTime())) return '—';
+  return formatRelativeTime(parsed);
+}

--- a/web/src/components/agent/ide/SchemaForm.tsx
+++ b/web/src/components/agent/ide/SchemaForm.tsx
@@ -1,0 +1,41 @@
+import Form from '@rjsf/core';
+import validator from '@rjsf/validator-ajv8';
+import type { RJSFSchema } from '@rjsf/utils';
+
+interface SchemaFormProps {
+  schema: Record<string, unknown>;
+  value: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+}
+
+/**
+ * SchemaForm wraps RJSF with our minimal styling. Lazy-loaded by
+ * RunLauncherModal so the ~90KB RJSF + AJV chunk only ships when the
+ * Form tab is actually opened — which today only happens for skills
+ * whose `inputSchema` exposes properties beyond `{type:"object"}`
+ * (none in v1; future TS-schema extraction will unlock it).
+ *
+ * The Submit button is suppressed — the parent modal owns the Run
+ * action and reads form values back through onChange.
+ */
+export default function SchemaForm({ schema, value, onChange }: SchemaFormProps) {
+  return (
+    <div className="rjsf-launcher font-sans text-sm">
+      <Form
+        schema={schema as RJSFSchema}
+        formData={value}
+        validator={validator}
+        onChange={(e) => {
+          const next = (e.formData ?? {}) as Record<string, unknown>;
+          onChange(next);
+        }}
+        liveValidate={false}
+        showErrorList={false}
+      >
+        {/* Empty children suppresses RJSF's default submit button;
+            the parent modal owns the Run action. */}
+        <span />
+      </Form>
+    </div>
+  );
+}

--- a/web/src/components/agent/ide/SkillRunButton.tsx
+++ b/web/src/components/agent/ide/SkillRunButton.tsx
@@ -1,0 +1,55 @@
+import { forwardRef } from 'react';
+import { Play } from 'lucide-react';
+import { cn } from '../../../lib/cn';
+
+interface SkillRunButtonProps {
+  skillName: string;
+  onClick: () => void;
+  className?: string;
+}
+
+/**
+ * SkillRunButton is the small ▶ affordance rendered on each row of
+ * the SkillSidebar. The button is keyboard-focusable and always-rendered
+ * (display, not visibility, is governed by the parent row's :hover /
+ * :focus-within state via the `group` Tailwind pattern). Clicks
+ * stopPropagation so the row's own onClick (select-skill) does not
+ * fire in tandem.
+ *
+ * We forward the ref so the modal can return focus to this button
+ * when it closes — the focus-return requirement from the a11y spec.
+ */
+export const SkillRunButton = forwardRef<HTMLButtonElement, SkillRunButtonProps>(
+  function SkillRunButton({ skillName, onClick, className }, ref) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-label={`Run ${skillName}`}
+        title={`Run ${skillName}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick();
+        }}
+        onKeyDown={(e) => {
+          // Prevent the parent row's onClick from also firing when the
+          // user presses Space/Enter on the button.
+          if (e.key === ' ' || e.key === 'Enter') {
+            e.stopPropagation();
+          }
+        }}
+        className={cn(
+          'inline-flex items-center justify-center w-6 h-6 rounded-md',
+          'text-text-muted/60 hover:text-text-primary',
+          'border border-transparent hover:border-border-subtle hover:bg-surface-elevated',
+          'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100',
+          'transition-opacity transition-colors',
+          'focus:outline-none focus:ring-1 focus:ring-primary/60',
+          className,
+        )}
+      >
+        <Play size={12} className="translate-x-px" aria-hidden />
+      </button>
+    );
+  },
+);

--- a/web/src/components/agent/ide/SkillSidebar.tsx
+++ b/web/src/components/agent/ide/SkillSidebar.tsx
@@ -1,11 +1,13 @@
+import { useRef } from 'react';
 import { type SkillSummary } from '../../../lib/agent-api';
 import { cn } from '../../../lib/cn';
+import { SkillRunButton } from './SkillRunButton';
 
 interface SkillSidebarProps {
   skills: SkillSummary[];
   active: string | null;
   onSelect: (name: string) => void;
-  onNewRun?: () => void;
+  onRunSkill?: (name: string, originRef: React.RefObject<HTMLButtonElement | null>) => void;
   loading?: boolean;
   error?: string | null;
 }
@@ -20,6 +22,7 @@ export function SkillSidebar({
   skills,
   active,
   onSelect,
+  onRunSkill,
   loading,
   error,
 }: SkillSidebarProps) {
@@ -74,44 +77,78 @@ export function SkillSidebar({
         )}
         <ul className="space-y-px px-2">
           {skills.map((s) => (
-            <li key={s.name}>
-              <button
-                type="button"
-                onClick={() => onSelect(s.name)}
-                className={cn(
-                  'w-full text-left px-3 py-2 rounded-md transition-colors',
-                  'border border-transparent',
-                  active === s.name
-                    ? 'bg-surface-elevated/80 border-border-subtle'
-                    : 'hover:bg-surface/50 hover:border-border-subtle/60',
-                )}
-              >
-                <div className="flex items-center gap-2 mb-0.5">
-                  <span
-                    className={cn(
-                      'font-mono text-[10px] px-1.5 py-px rounded uppercase tracking-[0.16em]',
-                      s.lang === 'go'
-                        ? 'bg-secondary/15 text-secondary-light border border-secondary/30'
-                        : s.lang === 'ts'
-                        ? 'bg-tertiary/15 text-tertiary-light border border-tertiary/30'
-                        : 'bg-surface text-text-muted border border-border',
-                    )}
-                  >
-                    {s.lang || '—'}
-                  </span>
-                  <span className="font-mono text-sm text-text-primary truncate">{s.name}</span>
-                </div>
-                <div className="flex items-center justify-between font-mono text-[10px] text-text-muted">
-                  <span className="truncate">{s.dir === '.' ? '·' : s.dir}</span>
-                  <span className="tabular-nums">
-                    {s.has_error ? '⚠' : ''} {s.node_count} {s.node_count === 1 ? 'node' : 'nodes'}
-                  </span>
-                </div>
-              </button>
-            </li>
+            <SkillRow
+              key={s.name}
+              skill={s}
+              active={active === s.name}
+              onSelect={onSelect}
+              onRunSkill={onRunSkill}
+            />
           ))}
         </ul>
       </div>
     </aside>
+  );
+}
+
+interface SkillRowProps {
+  skill: SkillSummary;
+  active: boolean;
+  onSelect: (name: string) => void;
+  onRunSkill?: (name: string, originRef: React.RefObject<HTMLButtonElement | null>) => void;
+}
+
+function SkillRow({ skill: s, active, onSelect, onRunSkill }: SkillRowProps) {
+  const runButtonRef = useRef<HTMLButtonElement>(null);
+  const canRun = s.lang === 'ts' && Boolean(onRunSkill);
+  return (
+    <li>
+      <div
+        className={cn(
+          'group relative flex items-stretch rounded-md transition-colors',
+          'border border-transparent',
+          active
+            ? 'bg-surface-elevated/80 border-border-subtle'
+            : 'hover:bg-surface/50 hover:border-border-subtle/60',
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => onSelect(s.name)}
+          className="flex-1 min-w-0 text-left px-3 py-2"
+        >
+          <div className="flex items-center gap-2 mb-0.5">
+            <span
+              className={cn(
+                'font-mono text-[10px] px-1.5 py-px rounded uppercase tracking-[0.16em]',
+                s.lang === 'go'
+                  ? 'bg-secondary/15 text-secondary-light border border-secondary/30'
+                  : s.lang === 'ts'
+                  ? 'bg-tertiary/15 text-tertiary-light border border-tertiary/30'
+                  : 'bg-surface text-text-muted border border-border',
+              )}
+            >
+              {s.lang || '—'}
+            </span>
+            <span className="font-mono text-sm text-text-primary truncate">{s.name}</span>
+          </div>
+          <div className="flex items-center justify-between font-mono text-[10px] text-text-muted">
+            <span className="truncate">{s.dir === '.' ? '·' : s.dir}</span>
+            <span className="tabular-nums">
+              {s.has_error ? '⚠' : ''} {s.node_count} {s.node_count === 1 ? 'node' : 'nodes'}
+            </span>
+          </div>
+        </button>
+        {canRun && (
+          <div className="flex items-center pr-2">
+            <SkillRunButton
+              ref={runButtonRef}
+              skillName={s.name}
+              onClick={() => onRunSkill?.(s.name, runButtonRef)}
+            />
+          </div>
+        )}
+      </div>
+    </li>
   );
 }

--- a/web/src/lib/agent-runs.ts
+++ b/web/src/lib/agent-runs.ts
@@ -76,3 +76,94 @@ export async function approveAgentRun(req: ApprovalRequest): Promise<void> {
     throw new Error(`approve failed: ${response.status} ${text}`);
   }
 }
+
+export interface LaunchRunRequest {
+  skill_name: string;
+  input: Record<string, unknown>;
+}
+
+export interface LaunchRunResponse {
+  run_id: string;
+  started_at: string;
+}
+
+// LaunchRunError carries the structured server-side rejection so the
+// modal can render the operator-facing message verbatim (skill not
+// found, wrong handler language, invalid input, runtime not configured).
+export class LaunchRunError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'LaunchRunError';
+    this.status = status;
+  }
+}
+
+export interface AgentRunEvent {
+  run_id: string;
+  seq: number;
+  time: string;
+  type: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface AgentRunDetail {
+  run: AgentRunSummary;
+  events: AgentRunEvent[];
+}
+
+/**
+ * Fetch a single run's typed event timeline. The first event is
+ * guaranteed to be `run_started` with the input payload — the Run
+ * Launcher uses this to pre-fill the editor when the operator selects
+ * a previous run from the "Run like…" picker.
+ */
+export async function fetchAgentRun(runID: string): Promise<AgentRunDetail | null> {
+  const response = await fetch(
+    `${API_BASE}/api/agent/runs/${encodeURIComponent(runID)}`,
+    { headers: buildHeaders() },
+  );
+  if (response.status === 404 || response.status === 503) return null;
+  if (!response.ok) {
+    throw new Error(`fetchAgentRun(${runID}): ${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as AgentRunDetail;
+}
+
+/**
+ * Extract the input object from a run's run_started event. Returns
+ * {} when the event is missing or the input is empty.
+ */
+export function inputFromRunDetail(detail: AgentRunDetail | null): Record<string, unknown> {
+  if (!detail) return {};
+  const started = detail.events.find((e) => e.type === 'run_started');
+  const raw = started?.payload?.input;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  return raw as Record<string, unknown>;
+}
+
+/**
+ * Start a new agent run for the given skill via POST /api/agent/runs.
+ * Returns the run id and start timestamp; the run continues async and
+ * its events stream through the existing /api/agent/runs/{id}/events
+ * SSE endpoint.
+ */
+export async function launchRun(req: LaunchRunRequest): Promise<LaunchRunResponse> {
+  const response = await fetch(`${API_BASE}/api/agent/runs`, {
+    method: 'POST',
+    headers: buildHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ skill_name: req.skill_name, input: req.input }),
+  });
+  if (!response.ok) {
+    let message = `${response.status} ${response.statusText}`;
+    try {
+      const body = (await response.json()) as { error?: string };
+      if (body.error) message = body.error;
+    } catch {
+      const text = await response.text().catch(() => '');
+      if (text) message = text;
+    }
+    throw new LaunchRunError(response.status, message);
+  }
+  return (await response.json()) as LaunchRunResponse;
+}


### PR DESCRIPTION
## Summary

Adds a per-skill Run launcher to the `/agent` IDE so operators can start a TS-handler skill from the browser. Hovering a skill row in `SkillSidebar` reveals a ▶ button; clicking it opens a focus-trapped modal that POSTs `{skill_name, input}` to `POST /api/agent/runs` (shipped in #625) and then updates the URL to `/agent?skill=<name>&run=<new_id>` so the existing `useRunTrace` SSE subscription activates the trace overlay. The launcher is read-only with respect to source — only runtime state is mutated.

## What's in the modal

- **JSON tab** (primary): styled textarea, debounced `JSON.parse`, inline parse errors. Pre-fills with `{}`, the last input used for this skill (from `localStorage["gridctl.agent.lastInput.<skill_name>"]`), or the input of a "Run like…" selection.
- **"Run like…" picker**: the 10 most recent runs of the active skill, filtered client-side from `fetchAgentRuns(50)`; selecting one replaces the JSON editor contents.
- **Form tab** (progressive enhancement): RJSF + AJV, lazy-loaded via dynamic import. Only renders when the skill's `inputSchema` exposes properties beyond `{type:"object"}` — today that's never the case (all TS skills default to the permissive schema), so the tab simply does not appear. It activates automatically once TS schema-extraction work lands.
- **Error banner** for 4xx/5xx server rejections (skill not found, Go-handler skill, prompt-only skill, invalid input, runtime not configured) with \`role=\"alert\"\` + \`aria-live=\"polite\"\` announcements.

## A11y

- Focus moves into the JSON editor on open; Tab is trapped within the dialog; ESC closes; focus returns to the originating Run button.
- The Run button on each row is keyboard-focusable (Tab) and \`aria-label\`ed per skill.
- Parse errors are announced via \`aria-live=\"polite\"\`; the textarea carries \`aria-invalid\` and \`aria-describedby\` when the error is active.

## Bundle delta (gzipped, from `npm run build`)

| Chunk | Before | After | Delta |
|---|---|---|---|
| \`index.js\` (main) | 225.93 kB | 226.21 kB | +0.28 kB |
| \`AgentIDEPage\` (route-split chunk) | 7.47 kB | 10.11 kB | +2.64 kB |
| \`index.css\` | 19.10 kB | 19.25 kB | +0.15 kB |
| \`SchemaForm\` (NEW lazy chunk) | — | 120.40 kB | on-demand only |

Ship-always delta for the Agent IDE route: ~2.9 kB gzipped, well under the 100 kB budget. The 120.40 kB \`SchemaForm\` chunk only loads when a user opens the Form tab, which won't occur until TS schemas carry properties.

## What this does NOT do

- Go-handler skills, prompt-only skills (server rejects 422 with actionable messages — surfaced in the modal banner)
- New /runs route, new BottomPanel tab, multi-step wizard
- Run cancellation, file-upload inputs
- Schema-quality improvements for TS skills (separate follow-up)
- Surfacing SKILL.md \`description\` through the dev server — \`SkillForLaunch\` accepts an optional \`description\` prop and the modal renders it when present; wiring up the source for it is a small follow-up

## Test plan

- [x] \`golangci-lint run\` — 0 issues
- [x] \`go test -race ./...\` — all packages pass
- [x] \`npm test\` — 39 files / 513 tests pass (includes 22 new launcher tests)
- [x] \`npm run build\` — succeeds; SchemaForm split into its own chunk
- [ ] Manual: from \`/agent\`, hover a TS skill row, click Run, paste \`{}\`, click Run — URL updates to \`?skill=…&run=<id>\`, trace overlay activates
- [ ] Manual: invalid JSON disables Run and shows inline error
- [ ] Manual: ESC closes the modal and focus returns to the Run button
- [ ] Manual: 4xx (e.g., POST against a Go-handler skill) renders the server error in the modal banner

Closes #624
