### PR TITLE
fix: persist mcp tools/call runs to ledger

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -103,12 +103,19 @@ type Server struct {
 
 // NewServer creates a new API server.
 func NewServer(gateway *mcp.Gateway, staticFS fs.FS) *Server {
-	return &Server{
-		gateway:            gateway,
-		streamableServer:   mcp.NewStreamableHTTPServer(gateway, nil),
-		sseServer:          mcp.NewSSEServer(gateway),
-		staticFS:           staticFS,
+	s := &Server{
+		gateway:          gateway,
+		streamableServer: mcp.NewStreamableHTTPServer(gateway, nil),
+		sseServer:        mcp.NewSSEServer(gateway),
+		staticFS:         staticFS,
 	}
+	// Wire the run-persister adapter so MCP tools/call against typed
+	// skills lands in ~/.gridctl/runs/<run_id>.jsonl alongside Run
+	// Launcher invocations. The adapter resolves the store and
+	// registry lazily, so SetRegistryServer / SetAgentRunStore /
+	// SetAgentRuntime can land in any order without losing wiring.
+	gateway.SetRunPersister(newRunPersisterAdapter(s))
+	return s
 }
 
 // SetDockerClient sets the Docker client for container operations.

--- a/internal/api/run_persister.go
+++ b/internal/api/run_persister.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gridctl/gridctl/pkg/agent/persist"
+	"github.com/gridctl/gridctl/pkg/agent/runner"
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/registry"
+)
+
+// runPersisterAdapter bridges the MCP gateway's RunPersister hook to
+// the runner + persist.Store. It is the single chokepoint that decides
+// whether a routed tool call should land in ~/.gridctl/runs/<run_id>.jsonl:
+// typed-skill calls routed to the registry server are persisted via
+// runner.Run; everything else (Go-plugin lookups bypassing tools/list,
+// upstream MCP servers proxied through the router) falls through to
+// direct dispatch with no ledger side effect.
+//
+// Persistence wiring is dynamic — the adapter consults the API server's
+// runStore() and registryServer at PersistAndCall time so partial
+// fixtures (test wiring that sets only one component) and the
+// production SetAgentRuntime sequence both work without ordering
+// constraints.
+type runPersisterAdapter struct {
+	server *Server
+}
+
+func newRunPersisterAdapter(s *Server) *runPersisterAdapter {
+	return &runPersisterAdapter{server: s}
+}
+
+// PersistAndCall implements mcp.RunPersister.
+func (a *runPersisterAdapter) PersistAndCall(ctx context.Context, client mcp.AgentClient, toolName string, arguments map[string]any) (string, *mcp.ToolCallResult, error) {
+	if a == nil || a.server == nil || client == nil {
+		return passthrough(ctx, client, toolName, arguments)
+	}
+
+	store, regServer := a.resolve()
+	if store == nil || regServer == nil {
+		return passthrough(ctx, client, toolName, arguments)
+	}
+
+	// Only persist calls that route through the typed-skill registry
+	// server. Upstream MCP proxies surface under their own client name
+	// and stay stateless.
+	if client.Name() != regServer.Name() {
+		return passthrough(ctx, client, toolName, arguments)
+	}
+
+	sk, err := regServer.Store().GetSkill(toolName)
+	if err != nil || sk.HandlerLanguage != "ts" {
+		return passthrough(ctx, client, toolName, arguments)
+	}
+
+	args := arguments
+	if args == nil {
+		args = map[string]any{}
+	}
+	rawInput, err := json.Marshal(args)
+	if err != nil {
+		// Argument shapes routed through the gateway have already been
+		// JSON-decoded once, so re-marshalling should never fail in
+		// practice; record an empty object rather than dropping the
+		// run on the floor.
+		rawInput = []byte(`{}`)
+	}
+
+	return runner.Run(ctx, store, client, runner.StartOptions{
+		Skill:    toolName,
+		Flavor:   sk.HandlerLanguage,
+		Input:    args,
+		RawInput: rawInput,
+	})
+}
+
+func (a *runPersisterAdapter) resolve() (*persist.Store, *registry.Server) {
+	store := a.server.runStore()
+	regServer := a.server.registryServer
+	return store, regServer
+}
+
+func passthrough(ctx context.Context, client mcp.AgentClient, toolName string, arguments map[string]any) (string, *mcp.ToolCallResult, error) {
+	result, err := client.CallTool(ctx, toolName, arguments)
+	return "", result, err
+}

--- a/internal/api/run_persister_test.go
+++ b/internal/api/run_persister_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/agent/persist"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// stubSkillRegistry satisfies registry.SkillRegistry for the adapter
+// tests without bringing the agent sandbox into the unit-test surface.
+// It always returns the configured result, so registry.Server.CallTool
+// short-circuits before reaching the TS dispatcher branch.
+type stubSkillRegistry struct {
+	result *mcp.ToolCallResult
+	err    error
+}
+
+func (s *stubSkillRegistry) Tools() []mcp.Tool { return nil }
+
+func (s *stubSkillRegistry) CallTool(_ context.Context, _ string, _ map[string]any) (*mcp.ToolCallResult, error) {
+	return s.result, s.err
+}
+
+// fakeAgentClient stands in for a proxied upstream MCP server.
+type fakeAgentClient struct {
+	name       string
+	callResult *mcp.ToolCallResult
+	callErr    error
+}
+
+func (f *fakeAgentClient) Name() string                                { return f.name }
+func (f *fakeAgentClient) Initialize(_ context.Context) error          { return nil }
+func (f *fakeAgentClient) RefreshTools(_ context.Context) error        { return nil }
+func (f *fakeAgentClient) Tools() []mcp.Tool                           { return nil }
+func (f *fakeAgentClient) IsInitialized() bool                         { return true }
+func (f *fakeAgentClient) ServerInfo() mcp.ServerInfo                  { return mcp.ServerInfo{Name: f.name, Version: "1.0"} }
+func (f *fakeAgentClient) CallTool(_ context.Context, _ string, _ map[string]any) (*mcp.ToolCallResult, error) {
+	return f.callResult, f.callErr
+}
+
+func TestRunPersisterAdapter_PersistsTypedSkill(t *testing.T) {
+	srv, store, regServer := newAgentRunLaunchTestServer(t)
+	regServer.SetSkillRegistry(&stubSkillRegistry{
+		result: &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent(`{"ok":true}`)}},
+	})
+	seedTypedSkill(t, regServer, "demo-ts", "ts")
+
+	adapter := newRunPersisterAdapter(srv)
+	runID, result, err := adapter.PersistAndCall(context.Background(), regServer, "demo-ts", map[string]any{"q": "hi"})
+	if err != nil {
+		t.Fatalf("PersistAndCall: %v", err)
+	}
+	if runID == "" {
+		t.Fatal("expected non-empty run id for typed-skill dispatch")
+	}
+	if result == nil || len(result.Content) == 0 || result.Content[0].Text != `{"ok":true}` {
+		t.Fatalf("expected result forwarded unchanged, got %+v", result)
+	}
+
+	events, err := store.Read(runID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (run_started, run_completed), got %d", len(events))
+	}
+	if events[0].Type != persist.EventRunStarted {
+		t.Fatalf("event 0: expected run_started, got %s", events[0].Type)
+	}
+	if events[1].Type != persist.EventRunCompleted {
+		t.Fatalf("event 1: expected run_completed, got %s", events[1].Type)
+	}
+
+	summary, err := store.Summary(runID)
+	if err != nil {
+		t.Fatalf("Summary: %v", err)
+	}
+	if summary.Status != "ok" {
+		t.Fatalf("expected status=ok, got %q", summary.Status)
+	}
+	if summary.Skill != "demo-ts" {
+		t.Fatalf("expected skill=demo-ts, got %q", summary.Skill)
+	}
+	if summary.Flavor != "ts" {
+		t.Fatalf("expected flavor=ts, got %q", summary.Flavor)
+	}
+}
+
+func TestRunPersisterAdapter_FallsThrough_NonRegistryClient(t *testing.T) {
+	srv, store, _ := newAgentRunLaunchTestServer(t)
+
+	upstream := &fakeAgentClient{
+		name:       "upstream",
+		callResult: &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent("ok")}},
+	}
+	adapter := newRunPersisterAdapter(srv)
+	runID, result, err := adapter.PersistAndCall(context.Background(), upstream, "echo", map[string]any{})
+	if err != nil {
+		t.Fatalf("PersistAndCall: %v", err)
+	}
+	if runID != "" {
+		t.Fatalf("expected empty run id for proxied upstream call, got %q", runID)
+	}
+	if result == nil || len(result.Content) == 0 || result.Content[0].Text != "ok" {
+		t.Fatalf("expected upstream result forwarded unchanged, got %+v", result)
+	}
+	assertLedgerEmpty(t, store)
+}
+
+func TestRunPersisterAdapter_FallsThrough_NonTypedSkill(t *testing.T) {
+	srv, store, regServer := newAgentRunLaunchTestServer(t)
+	regServer.SetSkillRegistry(&stubSkillRegistry{
+		result: &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent("ok")}},
+	})
+	// Seed a Go-plugin (non-TS) skill — must not land in the ledger.
+	seedTypedSkill(t, regServer, "demo-go", "go")
+
+	adapter := newRunPersisterAdapter(srv)
+	runID, result, err := adapter.PersistAndCall(context.Background(), regServer, "demo-go", map[string]any{})
+	if err != nil {
+		t.Fatalf("PersistAndCall: %v", err)
+	}
+	if runID != "" {
+		t.Fatalf("expected empty run id for Go-plugin skill, got %q", runID)
+	}
+	if result == nil {
+		t.Fatal("expected result forwarded for Go-plugin skill")
+	}
+	assertLedgerEmpty(t, store)
+}
+
+func TestRunPersisterAdapter_FallsThrough_StoreUnset(t *testing.T) {
+	// A bare Server with neither run store nor registry server wired
+	// must still pass tool calls through — the adapter's guard rails
+	// preserve pre-fix behaviour for partial daemon configurations.
+	srv := &Server{}
+	upstream := &fakeAgentClient{
+		name:       "upstream",
+		callResult: &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent("ok")}},
+	}
+	adapter := newRunPersisterAdapter(srv)
+	runID, result, err := adapter.PersistAndCall(context.Background(), upstream, "echo", map[string]any{})
+	if err != nil {
+		t.Fatalf("PersistAndCall: %v", err)
+	}
+	if runID != "" {
+		t.Fatalf("expected empty run id when store is unset, got %q", runID)
+	}
+	if result == nil {
+		t.Fatal("expected result forwarded when store is unset")
+	}
+}
+
+// assertLedgerEmpty fails the test when the store's directory contains
+// any JSONL files. The directory itself may not exist yet — that is
+// equivalent to empty for this assertion's purpose.
+func assertLedgerEmpty(t *testing.T, store *persist.Store) {
+	t.Helper()
+	entries, err := os.ReadDir(store.Dir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) > 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected empty ledger, got %d entries: %v", len(entries), names)
+	}
+}

--- a/pkg/agent/runner/runner.go
+++ b/pkg/agent/runner/runner.go
@@ -52,6 +52,73 @@ type StartOptions struct {
 	RawInput json.RawMessage
 }
 
+// Run opens a new run ledger, writes EventRunStarted synchronously,
+// dispatches the skill synchronously via exec, records the terminal
+// event, and closes the recorder before returning. Unlike Start it
+// blocks until dispatch completes and returns both the run ID and the
+// tool-call result so callers (e.g. the MCP transport, which must put
+// the result on the wire) can surface them together.
+//
+// ctx is propagated as-is to the dispatcher — cancellation does flow
+// through, so an interrupted MCP request records an error event and
+// returns ctx.Err() to the caller.
+func Run(ctx context.Context, store *persist.Store, exec Executor, opts StartOptions) (string, *mcp.ToolCallResult, error) {
+	if store == nil {
+		return "", nil, errors.New("runner: store is required")
+	}
+	if exec == nil {
+		return "", nil, errors.New("runner: executor is required")
+	}
+	if opts.Skill == "" {
+		return "", nil, errors.New("runner: skill is required")
+	}
+
+	runID := persist.NewRunID()
+	rec, err := store.OpenWriter(runID)
+	if err != nil {
+		return "", nil, fmt.Errorf("runner: opening run ledger: %w", err)
+	}
+	defer func() {
+		if cerr := rec.Close(); cerr != nil {
+			slog.Warn("runner: closing recorder", "run_id", runID, "err", cerr)
+		}
+	}()
+
+	if _, err := rec.Record(persist.EventRunStarted, persist.RunStartedPayload{
+		Skill:  opts.Skill,
+		Flavor: opts.Flavor,
+		Input:  opts.RawInput,
+	}); err != nil {
+		return "", nil, fmt.Errorf("runner: recording run_started: %w", err)
+	}
+
+	args := opts.Input
+	if args == nil {
+		args = map[string]any{}
+	}
+
+	result, callErr := exec.CallTool(ctx, opts.Skill, args)
+	if callErr != nil {
+		recordFailure(rec, callErr.Error())
+		return runID, nil, callErr
+	}
+	if result != nil && result.IsError {
+		msg := extractText(result)
+		if msg == "" {
+			msg = "skill returned error result"
+		}
+		recordFailure(rec, msg)
+		return runID, result, nil
+	}
+	if _, err := rec.Record(persist.EventRunCompleted, persist.RunCompletedPayload{
+		Status: "ok",
+		Output: outputFromResult(result),
+	}); err != nil {
+		slog.Warn("runner: recording run_completed", "run_id", runID, "err", err)
+	}
+	return runID, result, nil
+}
+
 // Start opens a new run ledger, writes EventRunStarted synchronously,
 // and dispatches the skill asynchronously via exec. Returns the run ID
 // and the started_at timestamp from the recorded event. The async

--- a/pkg/agent/runner/runner_test.go
+++ b/pkg/agent/runner/runner_test.go
@@ -205,6 +205,123 @@ func TestStart_RunStartedPayloadCarriesInput(t *testing.T) {
 	waitForStatus(t, store, runID)
 }
 
+func TestRun_HappyPathWritesStartedAndCompleted(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	result := &mcp.ToolCallResult{
+		Content: []mcp.Content{mcp.NewTextContent(`{"ok":true}`)},
+	}
+	exec := newStubExecutor(result, nil)
+
+	runID, got, err := Run(context.Background(), store, exec, StartOptions{
+		Skill:    "demo",
+		Flavor:   "ts",
+		Input:    map[string]any{"name": "world"},
+		RawInput: json.RawMessage(`{"name":"world"}`),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if runID == "" {
+		t.Fatal("expected non-empty run id")
+	}
+	if got != result {
+		t.Fatal("expected the exec result returned unchanged")
+	}
+
+	summary, err := store.Summary(runID)
+	if err != nil {
+		t.Fatalf("Summary: %v", err)
+	}
+	if summary.Status != "ok" {
+		t.Fatalf("expected status=ok, got %q", summary.Status)
+	}
+	events, err := store.Read(runID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (run_started, run_completed), got %d", len(events))
+	}
+	if events[0].Type != persist.EventRunStarted {
+		t.Fatalf("event 0: expected run_started, got %s", events[0].Type)
+	}
+	if events[1].Type != persist.EventRunCompleted {
+		t.Fatalf("event 1: expected run_completed, got %s", events[1].Type)
+	}
+	var completed persist.RunCompletedPayload
+	if err := json.Unmarshal(events[1].Payload, &completed); err != nil {
+		t.Fatalf("decode run_completed: %v", err)
+	}
+	if string(completed.Output) != `{"ok":true}` {
+		t.Fatalf("unexpected output: %s", completed.Output)
+	}
+}
+
+func TestRun_ExecutorErrorRecordsErrorAndReturnsError(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	exec := newStubExecutor(nil, errors.New("boom"))
+
+	runID, got, err := Run(context.Background(), store, exec, StartOptions{Skill: "demo", Flavor: "ts"})
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("expected boom error, got %v", err)
+	}
+	if got != nil {
+		t.Fatal("expected nil result on dispatch error")
+	}
+	summary, err := store.Summary(runID)
+	if err != nil {
+		t.Fatalf("Summary: %v", err)
+	}
+	if summary.Status != "error" {
+		t.Fatalf("expected status=error, got %q", summary.Status)
+	}
+	if summary.Error != "boom" {
+		t.Fatalf("expected error=%q, got %q", "boom", summary.Error)
+	}
+}
+
+func TestRun_IsErrorResultRecordsAsErrorAndForwardsResult(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	result := &mcp.ToolCallResult{
+		Content: []mcp.Content{mcp.NewTextContent("auth failed")},
+		IsError: true,
+	}
+	exec := newStubExecutor(result, nil)
+
+	runID, got, err := Run(context.Background(), store, exec, StartOptions{Skill: "demo", Flavor: "ts"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got != result {
+		t.Fatal("expected IsError result forwarded so the caller can put it on the wire")
+	}
+	summary, err := store.Summary(runID)
+	if err != nil {
+		t.Fatalf("Summary: %v", err)
+	}
+	if summary.Status != "error" {
+		t.Fatalf("expected status=error, got %q", summary.Status)
+	}
+	if !strings.Contains(summary.Error, "auth failed") {
+		t.Fatalf("expected error to include %q, got %q", "auth failed", summary.Error)
+	}
+}
+
+func TestRun_RejectsMissingDependencies(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	exec := newStubExecutor(nil, nil)
+
+	if _, _, err := Run(context.Background(), nil, exec, StartOptions{Skill: "demo"}); err == nil {
+		t.Fatal("expected error for nil store")
+	}
+	if _, _, err := Run(context.Background(), store, nil, StartOptions{Skill: "demo"}); err == nil {
+		t.Fatal("expected error for nil executor")
+	}
+	if _, _, err := Run(context.Background(), store, exec, StartOptions{Skill: ""}); err == nil {
+		t.Fatal("expected error for empty skill")
+	}
+}
+
 func TestStart_NonJSONOutputIsWrappedAsString(t *testing.T) {
 	store := persist.NewStore(t.TempDir())
 	result := &mcp.ToolCallResult{

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -145,6 +145,7 @@ type Gateway struct {
 	replicaHealth map[string]map[int]*HealthStatus // name -> replica_id -> health
 
 	toolCallObserver ToolCallObserver // optional observer for tool call metrics
+	runPersister     RunPersister     // optional adapter that wraps typed-skill calls in an on-disk run ledger
 
 	defaultOutputFormat    string                // gateway-level default output format
 	tokenCounter          token.Counter          // token counter for format savings calculation
@@ -200,6 +201,19 @@ func (g *Gateway) SetToolCallObserver(obs ToolCallObserver) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.toolCallObserver = obs
+}
+
+// SetRunPersister installs the adapter the gateway delegates to when
+// dispatching tool calls. The adapter decides whether to wrap a given
+// call in the on-disk run ledger (e.g. typed-skill targets) or pass
+// through to direct dispatch (e.g. proxied upstream MCP servers).
+// Passing nil disables persistence — the gateway then dispatches tool
+// calls directly via the routed AgentClient, matching the pre-adapter
+// behaviour.
+func (g *Gateway) SetRunPersister(p RunPersister) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.runPersister = p
 }
 
 // SetVersion sets the gateway version string.
@@ -1359,8 +1373,20 @@ func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*
 	logger.Info("tool call started", "server", client.Name(), "tool", toolName)
 	start := time.Now()
 
+	g.mu.RLock()
+	persister := g.runPersister
+	g.mu.RUnlock()
+
 	replica.IncInFlight()
-	result, err := client.CallTool(ctx, toolName, params.Arguments)
+	var (
+		result *ToolCallResult
+		runID  string
+	)
+	if persister != nil {
+		runID, result, err = persister.PersistAndCall(ctx, client, toolName, params.Arguments)
+	} else {
+		result, err = client.CallTool(ctx, toolName, params.Arguments)
+	}
 	replica.DecInFlight()
 	duration := time.Since(start)
 
@@ -1376,6 +1402,12 @@ func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*
 
 	if result.IsError {
 		span.SetStatus(codes.Error, "tool returned error result")
+	}
+	if runID != "" {
+		if result.Meta == nil {
+			result.Meta = map[string]any{}
+		}
+		result.Meta["run_id"] = runID
 	}
 	logger.Info("tool call finished", "server", client.Name(), "tool", toolName, "duration", duration, "is_error", result.IsError)
 

--- a/pkg/mcp/streamable_test.go
+++ b/pkg/mcp/streamable_test.go
@@ -257,6 +257,129 @@ func TestStreamableHTTPServer_ToolsCall(t *testing.T) {
 	}
 }
 
+// stubRunPersister captures calls so the gateway-level wiring of
+// SetRunPersister can be asserted without pulling pkg/agent/runner
+// into the mcp test surface.
+type stubRunPersister struct {
+	runID  string
+	result *ToolCallResult
+	err    error
+	calls  []stubRunPersisterCall
+}
+
+type stubRunPersisterCall struct {
+	clientName string
+	toolName   string
+	arguments  map[string]any
+}
+
+func (s *stubRunPersister) PersistAndCall(_ context.Context, client AgentClient, toolName string, arguments map[string]any) (string, *ToolCallResult, error) {
+	name := ""
+	if client != nil {
+		name = client.Name()
+	}
+	s.calls = append(s.calls, stubRunPersisterCall{clientName: name, toolName: toolName, arguments: arguments})
+	return s.runID, s.result, s.err
+}
+
+func TestStreamableHTTPServer_ToolsCall_RunIDFromPersisterAppearsInMeta(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+	// AgentClient.CallTool is not consulted because the persister
+	// intercepts dispatch — only the surrounding routing/observer
+	// glue runs.
+	client := setupMockAgentClient(ctrl, "registry", []Tool{
+		{Name: "demo", Description: "Demo skill"},
+	})
+	g.Router().AddClient(client)
+	g.Router().RefreshTools()
+
+	persister := &stubRunPersister{
+		runID:  "run_test_123",
+		result: &ToolCallResult{Content: []Content{NewTextContent(`{"ok":true}`)}},
+	}
+	g.SetRunPersister(persister)
+
+	srv := NewStreamableHTTPServer(g, nil)
+	sessionID := initializeStreamable(t, srv, "")
+
+	params, _ := json.Marshal(ToolCallParams{Name: "registry__demo", Arguments: map[string]any{"q": "hi"}})
+	body, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": json.RawMessage(params)})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	var resp jsonrpc.Response
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+	var result ToolCallResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatal("expected successful tool call")
+	}
+	if result.Meta == nil {
+		t.Fatal("expected result._meta to be populated when persister returns a non-empty run id")
+	}
+	got, _ := result.Meta["run_id"].(string)
+	if got != "run_test_123" {
+		t.Fatalf("expected _meta.run_id=run_test_123, got %q", got)
+	}
+	if len(persister.calls) != 1 {
+		t.Fatalf("expected 1 persister call, got %d", len(persister.calls))
+	}
+	if persister.calls[0].clientName != "registry" {
+		t.Fatalf("expected persister client.Name()=registry, got %q", persister.calls[0].clientName)
+	}
+	if persister.calls[0].toolName != "demo" {
+		t.Fatalf("expected persister toolName=demo (unprefixed), got %q", persister.calls[0].toolName)
+	}
+}
+
+func TestStreamableHTTPServer_ToolsCall_PersisterEmptyRunIDLeavesMetaOff(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+	client := setupMockAgentClient(ctrl, "upstream", []Tool{
+		{Name: "echo", Description: "Echo tool"},
+	})
+	g.Router().AddClient(client)
+	g.Router().RefreshTools()
+
+	persister := &stubRunPersister{
+		// runID="" signals "did not persist" — gateway must NOT add _meta.
+		result: &ToolCallResult{Content: []Content{NewTextContent("ok")}},
+	}
+	g.SetRunPersister(persister)
+
+	srv := NewStreamableHTTPServer(g, nil)
+	sessionID := initializeStreamable(t, srv, "")
+
+	params, _ := json.Marshal(ToolCallParams{Name: "upstream__echo", Arguments: map[string]any{}})
+	body, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": json.RawMessage(params)})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	var resp jsonrpc.Response
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	var result ToolCallResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Meta != nil {
+		t.Fatalf("expected no _meta when persister returns empty run id, got %v", result.Meta)
+	}
+}
+
 func TestStreamableHTTPServer_Delete(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
 	sessionID := initializeStreamable(t, srv, "")

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -116,6 +116,22 @@ type ClientObserver interface {
 	ObserveToolCallWithClient(ctx context.Context, obs ToolCallObservation) ToolCallSummary
 }
 
+// RunPersister wraps a tool-call dispatch with an on-disk run ledger
+// when the routed target is a persisted-skill surface (typed skills).
+// The gateway invokes PersistAndCall in place of client.CallTool when
+// a RunPersister is installed via Gateway.SetRunPersister. The adapter
+// is the single source of truth for the "should this call persist?"
+// decision — proxied upstream MCP server calls fall through to direct
+// dispatch by returning an empty runID and the upstream result.
+//
+// A non-empty runID is embedded in the response's _meta.run_id so MCP
+// clients have a handle for trace inspection, approval responses, and
+// resume — the same operations the Run Launcher surfaces via
+// /api/agent/runs/{run_id}/*.
+type RunPersister interface {
+	PersistAndCall(ctx context.Context, client AgentClient, toolName string, arguments map[string]any) (runID string, result *ToolCallResult, err error)
+}
+
 // FormatSavingsRecorder receives format savings observations.
 // Used by the gateway to report token savings from format conversion
 // without coupling to the metrics package directly.
@@ -286,11 +302,19 @@ type ToolCallResult struct {
 	// result — model ID, cache-read/cache-write tokens. The field is
 	// nil for tool calls that do not report usage. Skipped during
 	// JSON marshalling: the MCP wire shape for usage metadata is
-	// finalized in a follow-up PR (the spec's `_meta` field is used by
-	// tracing and pipelock for keyed extensions, so we cannot claim
-	// the entire object here). Internal observers populate Usage in
-	// memory only.
+	// finalized in a follow-up PR (the spec's `_meta` field is used
+	// by tracing and pipelock for keyed extensions, so we cannot
+	// claim the entire object here). Internal observers populate
+	// Usage in memory only.
 	Usage *CallUsage `json:"-"`
+
+	// Meta is the MCP-spec extension point on result objects. The
+	// gateway populates Meta["run_id"] when a typed-skill call is
+	// persisted to the on-disk ledger so external MCP clients have a
+	// handle for resume / approval / trace inspection. Other keyed
+	// extensions (usage, drift signals) can land here as the wire
+	// shape stabilises.
+	Meta map[string]any `json:"_meta,omitempty"`
 }
 
 // CallUsage is the optional per-call usage metadata that an MCP server may


### PR DESCRIPTION
## Description

MCP `tools/call` against a typed (TS-handler) skill now lands in the on-disk run ledger at `~/.gridctl/runs/<run_id>.jsonl`, matching the Run Launcher's contract. Every downstream consumer that was blind to MCP-triggered invocations — `gridctl runs list`/`runs trace`, `/api/agent/runs`, the web UI Runs tab, `optimize.go` heuristics, the `approval()` binding — now sees them.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- New `runner.Run` synchronous variant alongside the existing async `runner.Start` (Run Launcher contract untouched)
- `RunPersister` interface + `Gateway.SetRunPersister` hook; `HandleToolsCall` routes through it for all current and future MCP transports
- Runner-backed adapter in `internal/api/` that persists only when the routed target is the registry server AND the skill is TS-handler (proxied upstream MCP servers stay stateless)
- `result._meta.run_id` surfaces the new run id on the MCP wire via the spec's standard extension point — external clients (Claude Desktop, Cursor, et al.) can pass it to `gridctl runs trace`, `/api/agent/runs/{id}/approve`, etc.
- Approval gates work automatically — once a recorder exists, `compose.NewGate`'s nil-recorder guard is satisfied
- Regression coverage: 4 tests for `runner.Run`, 2 gateway-level tests for the persister hook, 4 adapter tests covering typed-skill / Go-plugin / non-registry / store-unset branches

## Testing

- `go test -race ./...` clean
- `make build` clean
- `golangci-lint run ./...` clean

## Out of Scope

- Populating `ParentRunID` for nested skill chains (separate latent issue — the field is never written today)
- Removing the legacy unmounted `pkg/mcp/handler.go`

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #627