### PR TITLE
feat: emit per-node telemetry from typed-skill runs

### DIFF
--- a/pkg/agent/persist/events.go
+++ b/pkg/agent/persist/events.go
@@ -161,8 +161,12 @@ type RunCompletedPayload struct {
 
 	// Output is the run's final output payload, when Status is
 	// "ok". JSON-encoded; readers decode against the skill's output
-	// schema.
+	// schema. Truncated to MaxPayloadBytes (and wrapped as a JSON
+	// string) when Truncated is set.
 	Output json.RawMessage `json:"output,omitempty"`
+
+	// Truncated is true when Output was capped at MaxPayloadBytes.
+	Truncated bool `json:"truncated,omitempty"`
 
 	// Error is the terminal error message when Status is "error" or
 	// "cancelled". Empty otherwise.
@@ -205,6 +209,11 @@ type ToolCallPayload struct {
 	// agent.ToolCall.ID. Used to pair tool_call with tool_result.
 	CallID string `json:"call_id"`
 
+	// NodeID, when set, links the tool call to the wrapping
+	// node_enter/node_exit pair so the inspector can collapse
+	// per-tool detail under its node row.
+	NodeID string `json:"node_id,omitempty"`
+
 	// Name is the prefixed tool name (server__tool) the gateway
 	// dispatches against. Recording the prefixed form keeps the
 	// ledger unambiguous when the same tool name is exposed by
@@ -213,8 +222,16 @@ type ToolCallPayload struct {
 
 	// Arguments is the JSON-encoded argument object as the model
 	// emitted it. Verbatim — provider key ordering and escaping is
-	// preserved.
+	// preserved, unless the encoded form exceeded MaxPayloadBytes,
+	// in which case it is replaced with the first MaxPayloadBytes
+	// as a JSON-quoted string and Truncated is set. Consumers
+	// treating a truncated payload as opaque get a syntactically
+	// valid value either way.
 	Arguments json.RawMessage `json:"arguments,omitempty"`
+
+	// Truncated is true when Arguments was capped at MaxPayloadBytes.
+	// Inspectors render the prefix and a "truncated" marker.
+	Truncated bool `json:"truncated,omitempty"`
 }
 
 // ToolResultPayload is the body of an EventToolResult event.
@@ -222,11 +239,18 @@ type ToolResultPayload struct {
 	// CallID matches the EventToolCall it answers.
 	CallID string `json:"call_id"`
 
+	// NodeID, when set, mirrors the matching EventToolCall.NodeID so
+	// the inspector can pair the two without an arguments lookup.
+	NodeID string `json:"node_id,omitempty"`
+
 	// Output is the textual content the runtime surfaced to the
 	// model. Multi-block content collapses to a single string here;
 	// structured-content support follows when the gateway exposes it
-	// uniformly.
+	// uniformly. Truncated to MaxPayloadBytes when Truncated is set.
 	Output string `json:"output,omitempty"`
+
+	// Truncated is true when Output was capped at MaxPayloadBytes.
+	Truncated bool `json:"truncated,omitempty"`
 
 	// IsError mirrors the gateway's error flag.
 	IsError bool `json:"is_error,omitempty"`
@@ -336,6 +360,46 @@ type ErrorPayload struct {
 	// Empty for runtime-level errors that don't belong to a single
 	// node.
 	NodeID string `json:"node_id,omitempty"`
+}
+
+// MaxPayloadBytes caps the verbatim slice of `Arguments` / `Output` an
+// event carries. The cap protects the ledger from authors feeding a
+// multi-megabyte file read or LLM response straight into a tool call —
+// the JSONL file would balloon, the SSE stream would stall, and the
+// IDE would gag on a single 50 MB line. 64 KB is large enough to keep
+// the common path lossless (typical tool args and prose outputs) and
+// small enough that a truncated payload still renders quickly.
+const MaxPayloadBytes = 64 * 1024
+
+// CapRawJSON returns a value safe to store as a payload field of type
+// json.RawMessage, along with a flag indicating whether the original
+// exceeded the cap. Over-cap values are replaced with a JSON-encoded
+// string of the first MaxPayloadBytes — that keeps the field
+// syntactically valid JSON (so readers don't choke) while flagging
+// loss. Callers should also set their payload's Truncated field when
+// the returned flag is true.
+func CapRawJSON(raw []byte) (json.RawMessage, bool) {
+	if len(raw) <= MaxPayloadBytes {
+		return raw, false
+	}
+	quoted, err := json.Marshal(string(raw[:MaxPayloadBytes]))
+	if err != nil {
+		// json.Marshal of a string never fails in practice; fall back
+		// to a minimal valid placeholder rather than poison the ledger.
+		return json.RawMessage(`""`), true
+	}
+	return quoted, true
+}
+
+// CapString returns the first MaxPayloadBytes of s and a flag noting
+// whether the original was longer. Used for plain-text payload fields
+// (e.g. ToolResultPayload.Output) where the cap is purely a length
+// trim — no JSON-quoting is needed.
+func CapString(s string) (string, bool) {
+	if len(s) <= MaxPayloadBytes {
+		return s, false
+	}
+	return s[:MaxPayloadBytes], true
 }
 
 // MarshalEvent renders a typed payload into an Event ready for write.

--- a/pkg/agent/persist/store_test.go
+++ b/pkg/agent/persist/store_test.go
@@ -324,3 +324,273 @@ func TestMarshalEventEmbedsPayload(t *testing.T) {
 		t.Fatalf("payload mismatch: %+v", p)
 	}
 }
+
+// TestEventVocabularyRoundTrip drives every event type the closed
+// contract in events.go exposes (except EventLLMChunk, intentionally
+// deferred — streaming chunk emission lands in a follow-on) through
+// the same Record → Read → typed-decode cycle. Adding a new event
+// type to the vocabulary should fail this test until the new payload
+// shape is exercised here too; the table is the single place to
+// extend.
+func TestEventVocabularyRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		evType  EventType
+		payload any
+		verify  func(t *testing.T, ev Event)
+	}{
+		{
+			name:    "run_started",
+			evType:  EventRunStarted,
+			payload: RunStartedPayload{Skill: "demo", Flavor: "ts", ParentRunID: "run_parent", TraceID: "trace_x"},
+			verify: func(t *testing.T, ev Event) {
+				var p RunStartedPayload
+				if err := json.Unmarshal(ev.Payload, &p); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if p.ParentRunID != "run_parent" || p.Flavor != "ts" {
+					t.Fatalf("payload mismatch: %+v", p)
+				}
+			},
+		},
+		{
+			name:    "run_completed",
+			evType:  EventRunCompleted,
+			payload: RunCompletedPayload{Status: "ok", Output: json.RawMessage(`{"answer":42}`)},
+			verify: func(t *testing.T, ev Event) {
+				var p RunCompletedPayload
+				if err := json.Unmarshal(ev.Payload, &p); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if p.Status != "ok" || string(p.Output) != `{"answer":42}` {
+					t.Fatalf("payload mismatch: %+v", p)
+				}
+			},
+		},
+		{
+			name:    "node_enter",
+			evType:  EventNodeEnter,
+			payload: NodeEnterPayload{NodeID: "tool:srv__t#1", NodeName: "tool", SpanID: "span_a"},
+			verify: func(t *testing.T, ev Event) {
+				var p NodeEnterPayload
+				if err := json.Unmarshal(ev.Payload, &p); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if p.NodeID != "tool:srv__t#1" || p.NodeName != "tool" {
+					t.Fatalf("payload mismatch: %+v", p)
+				}
+			},
+		},
+		{
+			name:    "node_exit",
+			evType:  EventNodeExit,
+			payload: NodeExitPayload{NodeID: "tool:srv__t#1", DurationMicros: 4321, Success: true},
+			verify: func(t *testing.T, ev Event) {
+				var p NodeExitPayload
+				if err := json.Unmarshal(ev.Payload, &p); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if p.DurationMicros != 4321 || !p.Success {
+					t.Fatalf("payload mismatch: %+v", p)
+				}
+			},
+		},
+		{
+			name:   "tool_call",
+			evType: EventToolCall,
+			payload: ToolCallPayload{
+				CallID:    "call_1",
+				NodeID:    "tool:srv__t#1",
+				Name:      "srv__t",
+				Arguments: json.RawMessage(`{"k":"v"}`),
+			},
+			verify: func(t *testing.T, ev Event) {
+				var p ToolCallPayload
+				if err := json.Unmarshal(ev.Payload, &p); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if p.NodeID != "tool:srv__t#1" || string(p.Arguments) != `{"k":"v"}` {
+					t.Fatalf("payload mismatch: %+v", p)
+				}
+			},
+		},
+		{
+			name:   "tool_result",
+			evType: EventToolResult,
+			payload: ToolResultPayload{
+				CallID: "call_1",
+				NodeID: "tool:srv__t#1",
+				Output: "ok",
+			},
+			verify: func(t *testing.T, ev Event) {
+				var p ToolResultPayload
+				if err := json.Unmarshal(ev.Payload, &p); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if p.Output != "ok" || p.IsError {
+					t.Fatalf("payload mismatch: %+v", p)
+				}
+			},
+		},
+		{
+			name:   "llm_call",
+			evType: EventLLMCall,
+			payload: LLMCallPayload{
+				Model:        "claude-opus-4-7",
+				Provider:     "anthropic",
+				PromptTokens: 12,
+				OutputTokens: 34,
+				CostUSD:      0.0125,
+			},
+			verify: func(t *testing.T, ev Event) {
+				var p LLMCallPayload
+				if err := json.Unmarshal(ev.Payload, &p); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if p.PromptTokens != 12 || p.OutputTokens != 34 || p.CostUSD != 0.0125 {
+					t.Fatalf("payload mismatch: %+v", p)
+				}
+			},
+		},
+		{
+			name:    "structured_output",
+			evType:  EventStructuredOutput,
+			payload: StructuredOutputPayload{SchemaDigest: "sha256:abc", Output: json.RawMessage(`{"ok":true}`)},
+			verify: func(t *testing.T, ev Event) {
+				var p StructuredOutputPayload
+				if err := json.Unmarshal(ev.Payload, &p); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if p.SchemaDigest != "sha256:abc" || string(p.Output) != `{"ok":true}` {
+					t.Fatalf("payload mismatch: %+v", p)
+				}
+			},
+		},
+		{
+			name:    "approval_request",
+			evType:  EventApprovalRequest,
+			payload: ApprovalRequestPayload{ApprovalID: "ap_1", Prompt: "ok?", TimeoutSeconds: 60},
+			verify: func(t *testing.T, ev Event) {
+				var p ApprovalRequestPayload
+				if err := json.Unmarshal(ev.Payload, &p); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if p.ApprovalID != "ap_1" || p.TimeoutSeconds != 60 {
+					t.Fatalf("payload mismatch: %+v", p)
+				}
+			},
+		},
+		{
+			name:    "approval_response",
+			evType:  EventApprovalResponse,
+			payload: ApprovalResponsePayload{ApprovalID: "ap_1", Approved: true, Reason: "ship it", Source: "web"},
+			verify: func(t *testing.T, ev Event) {
+				var p ApprovalResponsePayload
+				if err := json.Unmarshal(ev.Payload, &p); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if !p.Approved || p.Source != "web" {
+					t.Fatalf("payload mismatch: %+v", p)
+				}
+			},
+		},
+		{
+			name:    "error",
+			evType:  EventError,
+			payload: ErrorPayload{Message: "boom", NodeID: "tool:srv__t#1"},
+			verify: func(t *testing.T, ev Event) {
+				var p ErrorPayload
+				if err := json.Unmarshal(ev.Payload, &p); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if p.Message != "boom" || p.NodeID != "tool:srv__t#1" {
+					t.Fatalf("payload mismatch: %+v", p)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			store := NewStore(dir)
+			runID := NewRunID()
+			rec, err := store.OpenWriter(runID)
+			if err != nil {
+				t.Fatalf("OpenWriter: %v", err)
+			}
+			if _, err := rec.Record(tc.evType, tc.payload); err != nil {
+				t.Fatalf("Record: %v", err)
+			}
+			if err := rec.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			events, err := store.Read(runID)
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if len(events) != 1 {
+				t.Fatalf("expected 1 event, got %d", len(events))
+			}
+			if events[0].Type != tc.evType {
+				t.Fatalf("event type = %s, want %s", events[0].Type, tc.evType)
+			}
+			tc.verify(t, events[0])
+		})
+	}
+}
+
+// TestCapRawJSONRespectsBudget locks in the size-cap contract for
+// verbatim payload fields. The cap protects the ledger from authors
+// feeding multi-megabyte blobs into a tool call; under-budget values
+// pass through unchanged so the common path is lossless.
+func TestCapRawJSONRespectsBudget(t *testing.T) {
+	t.Parallel()
+	small := []byte(`{"a":1}`)
+	got, truncated := CapRawJSON(small)
+	if truncated {
+		t.Fatalf("under-budget value flagged as truncated")
+	}
+	if string(got) != string(small) {
+		t.Fatalf("under-budget value mutated: got %s, want %s", got, small)
+	}
+
+	big := make([]byte, MaxPayloadBytes+1024)
+	for i := range big {
+		big[i] = 'a'
+	}
+	got, truncated = CapRawJSON(big)
+	if !truncated {
+		t.Fatalf("over-budget value not flagged as truncated")
+	}
+	// The returned value must still be valid JSON so readers don't
+	// choke; the cap helper wraps the prefix as a JSON string.
+	var probe any
+	if err := json.Unmarshal(got, &probe); err != nil {
+		t.Fatalf("capped value is not valid JSON: %v", err)
+	}
+	if s, ok := probe.(string); !ok || len(s) != MaxPayloadBytes {
+		t.Fatalf("capped string length = %d, want %d (probe=%T)", len(s), MaxPayloadBytes, probe)
+	}
+}
+
+// TestCapStringRespectsBudget mirrors TestCapRawJSONRespectsBudget for
+// plain-text fields (e.g. ToolResultPayload.Output).
+func TestCapStringRespectsBudget(t *testing.T) {
+	t.Parallel()
+	got, truncated := CapString("hello")
+	if truncated || got != "hello" {
+		t.Fatalf("under-budget string mutated: got %q, truncated=%v", got, truncated)
+	}
+	big := strings.Repeat("x", MaxPayloadBytes+512)
+	got, truncated = CapString(big)
+	if !truncated {
+		t.Fatalf("over-budget string not flagged as truncated")
+	}
+	if len(got) != MaxPayloadBytes {
+		t.Fatalf("capped length = %d, want %d", len(got), MaxPayloadBytes)
+	}
+}

--- a/pkg/agent/runner/runner.go
+++ b/pkg/agent/runner/runner.go
@@ -34,6 +34,59 @@ type Executor interface {
 	CallTool(ctx context.Context, name string, arguments map[string]any) (*mcp.ToolCallResult, error)
 }
 
+// runIDKey is the context-value handle for the active run's ID. A
+// caller that sees a non-empty value knows it is running inside a run
+// — the parent of any nested skill call dispatched off this context.
+// The key is a private struct (not a string) so unrelated packages
+// can't collide with it and so leak-detection tools surface the type
+// in trace dumps.
+type runIDKey struct{}
+
+// recorderKey is the context-value handle for the active run's
+// recorder. Carrying it lets sandbox bindings emit per-call events
+// (tool_call, llm_call, approval_*) into the same ledger the runner
+// opened — no second OpenWriter, no risk of two writers racing on the
+// same JSONL file.
+type recorderKey struct{}
+
+// RunIDFromContext returns the run ID stashed on ctx by a parent
+// runner.Run / runner.Start, plus a flag noting whether the value was
+// present. The flag distinguishes "no parent run" from "parent run
+// with empty id" (which should never happen but is structurally
+// possible).
+func RunIDFromContext(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	v, ok := ctx.Value(runIDKey{}).(string)
+	return v, ok && v != ""
+}
+
+// RecorderFromContext returns the active run's recorder, when one is
+// in scope. Bindings that emit per-call events read it through this
+// accessor rather than caching the recorder at install time, because
+// the install* helpers run before the recorder is wired in.
+func RecorderFromContext(ctx context.Context) (*persist.Recorder, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	rec, ok := ctx.Value(recorderKey{}).(*persist.Recorder)
+	return rec, ok && rec != nil
+}
+
+// contextWithRun returns a child context carrying the run ID and
+// recorder under the package's private keys. Used by Run and Start to
+// hand the dispatcher a context that downstream bindings can read.
+func contextWithRun(ctx context.Context, runID string, rec *persist.Recorder) context.Context {
+	if runID != "" {
+		ctx = context.WithValue(ctx, runIDKey{}, runID)
+	}
+	if rec != nil {
+		ctx = context.WithValue(ctx, recorderKey{}, rec)
+	}
+	return ctx
+}
+
 // StartOptions configures a single Start call.
 type StartOptions struct {
 	// Skill is the registered skill name to invoke.
@@ -84,10 +137,16 @@ func Run(ctx context.Context, store *persist.Store, exec Executor, opts StartOpt
 		}
 	}()
 
+	// If ctx already carries a run ID we are dispatching a nested
+	// skill call (e.g. handoff() from inside a parent run); preserve
+	// the linkage on the child's RunStarted payload so the IDE can
+	// reconstruct the tree.
+	parentRunID, _ := RunIDFromContext(ctx)
 	if _, err := rec.Record(persist.EventRunStarted, persist.RunStartedPayload{
-		Skill:  opts.Skill,
-		Flavor: opts.Flavor,
-		Input:  opts.RawInput,
+		Skill:       opts.Skill,
+		Flavor:      opts.Flavor,
+		Input:       opts.RawInput,
+		ParentRunID: parentRunID,
 	}); err != nil {
 		return "", nil, fmt.Errorf("runner: recording run_started: %w", err)
 	}
@@ -97,6 +156,10 @@ func Run(ctx context.Context, store *persist.Store, exec Executor, opts StartOpt
 		args = map[string]any{}
 	}
 
+	// Hand the dispatcher a ctx tagged with this run's ID and
+	// recorder so sandbox bindings can attach per-call telemetry and
+	// nested skill calls can inherit the parent run id.
+	ctx = contextWithRun(ctx, runID, rec)
 	result, callErr := exec.CallTool(ctx, opts.Skill, args)
 	if callErr != nil {
 		recordFailure(rec, callErr.Error())
@@ -110,9 +173,11 @@ func Run(ctx context.Context, store *persist.Store, exec Executor, opts StartOpt
 		recordFailure(rec, msg)
 		return runID, result, nil
 	}
+	output, truncated := outputFromResult(result)
 	if _, err := rec.Record(persist.EventRunCompleted, persist.RunCompletedPayload{
-		Status: "ok",
-		Output: outputFromResult(result),
+		Status:    "ok",
+		Output:    output,
+		Truncated: truncated,
 	}); err != nil {
 		slog.Warn("runner: recording run_completed", "run_id", runID, "err", err)
 	}
@@ -145,10 +210,12 @@ func Start(ctx context.Context, store *persist.Store, exec Executor, opts StartO
 		return "", time.Time{}, fmt.Errorf("runner: opening run ledger: %w", err)
 	}
 
+	parentRunID, _ := RunIDFromContext(ctx)
 	ev, err := rec.Record(persist.EventRunStarted, persist.RunStartedPayload{
-		Skill:  opts.Skill,
-		Flavor: opts.Flavor,
-		Input:  opts.RawInput,
+		Skill:       opts.Skill,
+		Flavor:      opts.Flavor,
+		Input:       opts.RawInput,
+		ParentRunID: parentRunID,
 	})
 	if err != nil {
 		_ = rec.Close()
@@ -162,8 +229,11 @@ func Start(ctx context.Context, store *persist.Store, exec Executor, opts StartO
 
 	// Detach from the request context so the dispatch outlives the
 	// HTTP request. Values (trace context, request IDs) propagate;
-	// cancellation does not.
-	go runAsync(context.WithoutCancel(ctx), rec, exec, opts.Skill, args)
+	// cancellation does not. Tag the detached ctx with this run's ID
+	// and recorder so the dispatcher and downstream bindings can
+	// attach per-call telemetry and inherit the parent run id.
+	dispatchCtx := contextWithRun(context.WithoutCancel(ctx), runID, rec)
+	go runAsync(dispatchCtx, rec, exec, opts.Skill, args)
 
 	return runID, ev.Time, nil
 }
@@ -190,9 +260,11 @@ func runAsync(ctx context.Context, rec *persist.Recorder, exec Executor, skillNa
 		return
 	}
 
+	output, truncated := outputFromResult(result)
 	if _, err := rec.Record(persist.EventRunCompleted, persist.RunCompletedPayload{
-		Status: "ok",
-		Output: outputFromResult(result),
+		Status:    "ok",
+		Output:    output,
+		Truncated: truncated,
 	}); err != nil {
 		slog.Warn("runner: recording run_completed", "run_id", rec.RunID(), "err", err)
 	}
@@ -214,29 +286,36 @@ func recordFailure(rec *persist.Recorder, msg string) {
 }
 
 // outputFromResult extracts the skill's output payload from a tool-call
-// result. The dispatcher wraps the typed return value as a single text
-// content block; probe-parse as JSON and store the raw bytes when
-// valid. Non-JSON text is JSON-string-wrapped so the ledger row
-// remains a syntactically valid value. This diverges from the CLI
+// result, capped at persist.MaxPayloadBytes. The dispatcher wraps the
+// typed return value as a single text content block; probe-parse as
+// JSON and store the raw bytes when valid. Non-JSON text is
+// JSON-string-wrapped so the ledger row remains a syntactically valid
+// value. Returns the (possibly truncated) JSON value and a flag noting
+// whether truncation occurred so the caller can populate the
+// RunCompletedPayload.Truncated field. This diverges from the CLI
 // (cmd/gridctl/run.go), which records `null` and emits a stderr
 // warning — we preserve the literal text because the API surface
 // returns the run_id immediately and has no stderr to write to;
 // inspectors then see the actual return value rather than a silent
 // data loss.
-func outputFromResult(result *mcp.ToolCallResult) json.RawMessage {
+func outputFromResult(result *mcp.ToolCallResult) (json.RawMessage, bool) {
 	if result == nil || len(result.Content) == 0 {
-		return json.RawMessage("null")
+		return json.RawMessage("null"), false
 	}
 	text := result.Content[0].Text
 	if text == "" {
-		return json.RawMessage("null")
+		return json.RawMessage("null"), false
 	}
+	var raw json.RawMessage
 	var probe any
 	if err := json.Unmarshal([]byte(text), &probe); err == nil {
-		return json.RawMessage(text)
+		raw = json.RawMessage(text)
+	} else {
+		encoded, _ := json.Marshal(text)
+		raw = json.RawMessage(encoded)
 	}
-	encoded, _ := json.Marshal(text)
-	return json.RawMessage(encoded)
+	capped, truncated := persist.CapRawJSON(raw)
+	return capped, truncated
 }
 
 func extractText(result *mcp.ToolCallResult) string {

--- a/pkg/agent/runner/runner_test.go
+++ b/pkg/agent/runner/runner_test.go
@@ -322,6 +322,123 @@ func TestRun_RejectsMissingDependencies(t *testing.T) {
 	}
 }
 
+// TestRun_NestedRunCarriesParentRunID confirms that a runner.Run
+// invocation whose ctx already carries a run ID (i.e. a child run
+// fired from inside a parent run's dispatch — handoff() reaches
+// runner.Run via the childRunSkillCaller adapter) writes ParentRunID
+// onto the child's EventRunStarted payload. The parent → child link
+// is what gives the IDE's runs browser its nested-tree shape.
+func TestRun_NestedRunCarriesParentRunID(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	result := &mcp.ToolCallResult{
+		Content: []mcp.Content{mcp.NewTextContent(`null`)},
+	}
+	exec := newStubExecutor(result, nil)
+
+	// Pre-tag ctx with a parent run ID exactly the way runner.Run
+	// itself does when wrapping the dispatcher ctx for downstream
+	// bindings. The exported RunIDFromContext / contextWithRun pair
+	// is intentionally minimal — the test calls the helper indirectly
+	// by stashing a fake parent ID via the typed key.
+	parentRunID := persist.NewRunID()
+	parentCtx := context.WithValue(context.Background(), runIDKey{}, parentRunID)
+
+	childRunID, _, err := Run(parentCtx, store, exec, StartOptions{Skill: "leaf", Flavor: "ts"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if childRunID == parentRunID {
+		t.Fatal("expected distinct child run ID")
+	}
+	events, err := store.Read(childRunID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(events) == 0 || events[0].Type != persist.EventRunStarted {
+		t.Fatalf("expected first event run_started, got %+v", events)
+	}
+	var started persist.RunStartedPayload
+	if err := json.Unmarshal(events[0].Payload, &started); err != nil {
+		t.Fatalf("decode run_started: %v", err)
+	}
+	if started.ParentRunID != parentRunID {
+		t.Fatalf("expected parent_run_id=%q, got %q", parentRunID, started.ParentRunID)
+	}
+}
+
+// TestRun_TopLevelHasEmptyParentRunID confirms the inverse: a run
+// fired outside of a parent dispatch (top-level MCP tools/call or
+// in-IDE launcher) has no parent linkage on its RunStarted payload.
+func TestRun_TopLevelHasEmptyParentRunID(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	result := &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent(`null`)}}
+	exec := newStubExecutor(result, nil)
+
+	runID, _, err := Run(context.Background(), store, exec, StartOptions{Skill: "demo", Flavor: "ts"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	events, err := store.Read(runID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	var started persist.RunStartedPayload
+	if err := json.Unmarshal(events[0].Payload, &started); err != nil {
+		t.Fatalf("decode run_started: %v", err)
+	}
+	if started.ParentRunID != "" {
+		t.Fatalf("expected empty parent_run_id on top-level run, got %q", started.ParentRunID)
+	}
+}
+
+// TestRun_StashesRunIDAndRecorderOnDispatchContext confirms the
+// runner hands the downstream executor a ctx tagged with the run's ID
+// and recorder. Sandbox bindings read these via RunIDFromContext /
+// RecorderFromContext to emit per-call telemetry into the same
+// JSONL the runner opened.
+func TestRun_StashesRunIDAndRecorderOnDispatchContext(t *testing.T) {
+	store := persist.NewStore(t.TempDir())
+	captured := struct {
+		runID    string
+		recorder *persist.Recorder
+		hasRunID bool
+		hasRec   bool
+	}{}
+	exec := &capturingExecutor{
+		result: &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent(`null`)}},
+		onCall: func(ctx context.Context) {
+			captured.runID, captured.hasRunID = RunIDFromContext(ctx)
+			captured.recorder, captured.hasRec = RecorderFromContext(ctx)
+		},
+	}
+
+	runID, _, err := Run(context.Background(), store, exec, StartOptions{Skill: "demo", Flavor: "ts"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !captured.hasRunID || captured.runID != runID {
+		t.Fatalf("dispatcher ctx missing runID: got hasRunID=%v runID=%q want runID=%q", captured.hasRunID, captured.runID, runID)
+	}
+	if !captured.hasRec || captured.recorder == nil {
+		t.Fatalf("dispatcher ctx missing recorder: hasRec=%v rec=%v", captured.hasRec, captured.recorder)
+	}
+	if captured.recorder.RunID() != runID {
+		t.Fatalf("dispatcher recorder run_id = %q, want %q", captured.recorder.RunID(), runID)
+	}
+}
+
+type capturingExecutor struct {
+	result *mcp.ToolCallResult
+	onCall func(ctx context.Context)
+}
+
+func (e *capturingExecutor) CallTool(ctx context.Context, _ string, _ map[string]any) (*mcp.ToolCallResult, error) {
+	if e.onCall != nil {
+		e.onCall(ctx)
+	}
+	return e.result, nil
+}
+
 func TestStart_NonJSONOutputIsWrappedAsString(t *testing.T) {
 	store := persist.NewStore(t.TempDir())
 	result := &mcp.ToolCallResult{

--- a/pkg/agent/sandbox/bindings.go
+++ b/pkg/agent/sandbox/bindings.go
@@ -2,6 +2,8 @@ package sandbox
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -12,6 +14,20 @@ import (
 	"github.com/gridctl/gridctl/pkg/agent"
 	"github.com/gridctl/gridctl/pkg/mcp"
 )
+
+// newCallID produces a per-binding call identifier used to pair
+// EventToolCall with EventToolResult (and EventApprovalRequest with
+// EventApprovalResponse). 8 random bytes is overkill for one run's
+// scope but keeps the wire format aligned with persist.NewRunID's
+// random-suffix shape. Failure to read entropy falls back to a static
+// placeholder — callers downstream tolerate any non-empty string.
+func newCallID() string {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return "call_static"
+	}
+	return "call_" + hex.EncodeToString(buf)
+}
 
 // keepAliveSlack is the headroom over the sandbox execution timeout
 // that the asyncDeliver watchdog uses. The runCtx watchdog in
@@ -123,16 +139,38 @@ func installToolBinding(vm *goja.Runtime, loop *eventloop.EventLoop, ctx context
 			panic(vm.NewGoError(err))
 		}
 
+		// Emit node_enter + tool_call synchronously on the goja
+		// thread so the wire-order of "tool dispatched at T" matches
+		// the JSONL order; the matching tool_result + node_exit are
+		// written from the goroutine before asyncDeliver settles the
+		// Promise, preserving causal ordering across the boundary.
+		nodeID := b.Session.NextNodeID("tool", resolved)
+		b.Session.RecordNodeEnter(nodeID, "tool")
+		callID := newCallID()
+		b.Session.RecordToolCall(nodeID, callID, resolved, args)
+		started := time.Now()
+
 		promise, resolve, reject := vm.NewPromise()
 		deliver := asyncDeliver(vm, loop, timeout, reject, fmt.Sprintf("tool %q", resolved))
 		go func() {
 			res, err := b.ToolCaller.CallTool(ctx, resolved, args)
-			deliver(func(vm *goja.Runtime) {
-				if err != nil {
+			// Record terminal events on the goroutine BEFORE the
+			// deliver hop so the ledger reflects causal completion
+			// even if loop.RunOnLoop is delayed by a long-running
+			// JS tick.
+			if err != nil {
+				b.Session.RecordToolResult(nodeID, callID, err.Error(), true)
+				b.Session.RecordNodeExit(nodeID, time.Since(started).Microseconds(), false)
+				deliver(func(vm *goja.Runtime) {
 					_ = reject(vm.NewGoError(fmt.Errorf("tool %q: %w", resolved, err)))
-					return
-				}
-				if res != nil && res.IsError {
+				})
+				return
+			}
+			isErr := res != nil && res.IsError
+			b.Session.RecordToolResult(nodeID, callID, contentText(res), isErr)
+			b.Session.RecordNodeExit(nodeID, time.Since(started).Microseconds(), !isErr)
+			deliver(func(vm *goja.Runtime) {
+				if isErr {
 					_ = reject(vm.NewGoError(fmt.Errorf("tool %q error: %s", resolved, contentText(res))))
 					return
 				}
@@ -192,15 +230,27 @@ func installLLMBinding(vm *goja.Runtime, loop *eventloop.EventLoop, ctx context.
 			panic(vm.NewGoError(err))
 		}
 
+		nodeID := b.Session.NextNodeID("llm", req.Model)
+		b.Session.RecordNodeEnter(nodeID, "llm")
+		started := time.Now()
+
 		promise, resolve, reject := vm.NewPromise()
 		deliver := asyncDeliver(vm, loop, timeout, reject, "llm")
 		go func() {
 			resp, err := b.ChatModel.Generate(ctx, req)
-			deliver(func(vm *goja.Runtime) {
-				if err != nil {
+			if err != nil {
+				b.Session.RecordError(nodeID, err.Error())
+				b.Session.RecordNodeExit(nodeID, time.Since(started).Microseconds(), false)
+				deliver(func(vm *goja.Runtime) {
 					_ = reject(vm.NewGoError(fmt.Errorf("llm: %w", err)))
-					return
-				}
+				})
+				return
+			}
+			// Token counts and cost arrive only after the provider
+			// replies; emit llm_call once on completion.
+			b.Session.RecordLLMCall(req.Model, "", resp.Usage.InputTokens, resp.Usage.OutputTokens, resp.Usage.CacheReadTokens, resp.Usage.CacheWriteTokens, 0)
+			b.Session.RecordNodeExit(nodeID, time.Since(started).Microseconds(), true)
+			deliver(func(vm *goja.Runtime) {
 				_ = resolve(vm.ToValue(chatResponseToMap(resp)))
 			})
 		}()
@@ -386,16 +436,35 @@ func installHandoffBinding(vm *goja.Runtime, loop *eventloop.EventLoop, ctx cont
 			input = normalizeArgs(call.Arguments[1].Export())
 		}
 
+		// handoff() routes through the SkillCaller adapter that opens
+		// a child recorder via runner.Run when the parent ctx carries
+		// a run id; from the parent's perspective the call surfaces
+		// as a single "skill:<name>#N" node, and the child run's own
+		// JSONL ledger carries the per-node detail with
+		// ParentRunID pointing back at the parent.
+		nodeID := b.Session.NextNodeID("skill", name)
+		b.Session.RecordNodeEnter(nodeID, "skill")
+		callID := newCallID()
+		b.Session.RecordToolCall(nodeID, callID, name, input)
+		started := time.Now()
+
 		promise, resolve, reject := vm.NewPromise()
 		deliver := asyncDeliver(vm, loop, timeout, reject, fmt.Sprintf("handoff %q", name))
 		go func() {
 			res, err := b.SkillCaller.CallTool(ctx, name, input)
-			deliver(func(vm *goja.Runtime) {
-				if err != nil {
+			if err != nil {
+				b.Session.RecordToolResult(nodeID, callID, err.Error(), true)
+				b.Session.RecordNodeExit(nodeID, time.Since(started).Microseconds(), false)
+				deliver(func(vm *goja.Runtime) {
 					_ = reject(vm.NewGoError(fmt.Errorf("handoff %q: %w", name, err)))
-					return
-				}
-				if res != nil && res.IsError {
+				})
+				return
+			}
+			isErr := res != nil && res.IsError
+			b.Session.RecordToolResult(nodeID, callID, contentText(res), isErr)
+			b.Session.RecordNodeExit(nodeID, time.Since(started).Microseconds(), !isErr)
+			deliver(func(vm *goja.Runtime) {
+				if isErr {
 					_ = reject(vm.NewGoError(fmt.Errorf("handoff %q error: %s", name, contentText(res))))
 					return
 				}
@@ -418,9 +487,21 @@ func installApprovalBinding(vm *goja.Runtime, loop *eventloop.EventLoop, ctx con
 		if len(call.Arguments) >= 1 {
 			prompt = call.Arguments[0].String()
 		}
+
+		nodeID := b.Session.NextNodeID("approval", "")
+		b.Session.RecordNodeEnter(nodeID, "approval")
+		approvalID := newCallID()
+		b.Session.RecordApprovalRequest(approvalID, prompt)
+		started := time.Now()
+
 		promise, resolve, reject := vm.NewPromise()
 		deliver := asyncDeliver(vm, loop, timeout, reject, "approval")
 		if approver == nil {
+			// Stub auto-approver — record the synthetic response so
+			// the ledger still has a paired request/response shape
+			// and the inspector can render the gate cleanly.
+			b.Session.RecordApprovalResponse(approvalID, true, prompt, "auto")
+			b.Session.RecordNodeExit(nodeID, time.Since(started).Microseconds(), true)
 			deliver(func(vm *goja.Runtime) {
 				_ = resolve(vm.ToValue(map[string]any{
 					"approved":  true,
@@ -432,11 +513,23 @@ func installApprovalBinding(vm *goja.Runtime, loop *eventloop.EventLoop, ctx con
 		}
 		go func() {
 			decision, err := approver.Approve(ctx, prompt)
-			deliver(func(vm *goja.Runtime) {
-				if err != nil {
+			if err != nil {
+				// Emit a synthetic approval_response carrying the
+				// error so the request/response pair the inspector
+				// joins by ApprovalID stays intact — an orphan
+				// EventApprovalRequest would otherwise render as a
+				// permanently-suspended gate.
+				b.Session.RecordApprovalResponse(approvalID, false, err.Error(), "error")
+				b.Session.RecordError(nodeID, err.Error())
+				b.Session.RecordNodeExit(nodeID, time.Since(started).Microseconds(), false)
+				deliver(func(vm *goja.Runtime) {
 					_ = reject(vm.NewGoError(fmt.Errorf("approval: %w", err)))
-					return
-				}
+				})
+				return
+			}
+			b.Session.RecordApprovalResponse(approvalID, decision.Approved, decision.Reason, "")
+			b.Session.RecordNodeExit(nodeID, time.Since(started).Microseconds(), decision.Approved)
+			deliver(func(vm *goja.Runtime) {
 				_ = resolve(vm.ToValue(map[string]any{
 					"approved":  decision.Approved,
 					"reason":    decision.Reason,

--- a/pkg/agent/sandbox/dispatcher_test.go
+++ b/pkg/agent/sandbox/dispatcher_test.go
@@ -2,12 +2,15 @@ package sandbox
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/gridctl/gridctl/pkg/agent"
+	"github.com/gridctl/gridctl/pkg/agent/persist"
 	"github.com/gridctl/gridctl/pkg/mcp"
 )
 
@@ -117,6 +120,342 @@ func TestDispatcher_NewDispatcherRejectsNilSandbox(t *testing.T) {
 	if !strings.Contains(err.Error(), "non-nil sandbox") {
 		t.Errorf("err = %v, want explanation that sandbox is required", err)
 	}
+}
+
+// TestDispatcher_EmitsTelemetryAroundBindings drives a TS skill that
+// calls tool(), llm(), and handoff() through the dispatcher with a
+// RunSession wired in, and asserts the JSONL ledger captures the
+// expected per-binding event sequence: node_enter / tool_call /
+// tool_result / node_exit pairs around tool(), node_enter / llm_call
+// / node_exit around llm(), and node_enter / tool_call / tool_result
+// / node_exit around handoff() (the dispatcher path doesn't open a
+// child recorder — that wrapping lives in pkg/controller — so handoff
+// surfaces as a single skill node here). Closes the test gap PR #628
+// deferred.
+func TestDispatcher_EmitsTelemetryAroundBindings(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "exercise.ts")
+	src := `
+		export default async function (input: any) {
+			const toolRes = await tool('srv__echo', { from: 'tool' });
+			const llmRes = await llm({ model: 'claude-opus-4-7', messages: [{ role: 'user', content: 'hi' }] });
+			const handoffRes = await handoff('leaf-skill', { from: 'handoff' });
+			return { toolRes, llmRes, handoffRes };
+		}
+	`
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatalf("writing skill source: %v", err)
+	}
+
+	store := persist.NewStore(t.TempDir())
+	runID := persist.NewRunID()
+	rec, err := store.OpenWriter(runID)
+	if err != nil {
+		t.Fatalf("OpenWriter: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+	session := NewRunSession(rec)
+
+	bindings := Bindings{
+		ToolCaller: stubToolCaller{
+			result: &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent(`{"ok":"tool"}`)}},
+		},
+		AllowedTools: []mcp.Tool{{Name: "srv__echo"}},
+		ChatModel: stubChatModel{resp: agent.ChatResponse{
+			Model:   "claude-opus-4-7",
+			Content: "hello",
+			Usage: agent.Usage{
+				InputTokens:  17,
+				OutputTokens: 42,
+			},
+		}},
+		SkillCaller: stubSkillCaller{
+			result: &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent(`{"ok":"handoff"}`)}},
+		},
+		Session: session,
+	}
+
+	sb := New(5 * time.Second)
+	disp, err := NewDispatcher(sb, func(_ context.Context, _ string) Bindings { return bindings })
+	if err != nil {
+		t.Fatalf("NewDispatcher: %v", err)
+	}
+	if _, err := disp.Dispatch(context.Background(), "exercise", path, map[string]any{}); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	events, err := store.Read(runID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	// Group events by type; the wall-clock order of LLM / tool /
+	// handoff is governed by the skill's await sequence, but each
+	// pair (enter/exit, call/result) must appear and pair correctly.
+	byType := map[persist.EventType]int{}
+	for _, ev := range events {
+		byType[ev.Type]++
+	}
+	if byType[persist.EventNodeEnter] != 3 {
+		t.Errorf("node_enter count = %d, want 3 (tool, llm, handoff)", byType[persist.EventNodeEnter])
+	}
+	if byType[persist.EventNodeExit] != 3 {
+		t.Errorf("node_exit count = %d, want 3", byType[persist.EventNodeExit])
+	}
+	if byType[persist.EventToolCall] != 2 {
+		t.Errorf("tool_call count = %d, want 2 (tool + handoff)", byType[persist.EventToolCall])
+	}
+	if byType[persist.EventToolResult] != 2 {
+		t.Errorf("tool_result count = %d, want 2", byType[persist.EventToolResult])
+	}
+	if byType[persist.EventLLMCall] != 1 {
+		t.Errorf("llm_call count = %d, want 1", byType[persist.EventLLMCall])
+	}
+
+	// Locate the llm_call event and confirm tokens propagated.
+	for _, ev := range events {
+		if ev.Type != persist.EventLLMCall {
+			continue
+		}
+		var p persist.LLMCallPayload
+		if err := json.Unmarshal(ev.Payload, &p); err != nil {
+			t.Fatalf("decode llm_call: %v", err)
+		}
+		if p.Model != "claude-opus-4-7" {
+			t.Errorf("llm_call model = %q, want claude-opus-4-7", p.Model)
+		}
+		if p.PromptTokens != 17 || p.OutputTokens != 42 {
+			t.Errorf("llm_call tokens = (%d, %d), want (17, 42)", p.PromptTokens, p.OutputTokens)
+		}
+	}
+
+	// tool_call NodeID must pair with a matching tool_result NodeID.
+	callsByID := map[string]string{}
+	for _, ev := range events {
+		if ev.Type == persist.EventToolCall {
+			var p persist.ToolCallPayload
+			if err := json.Unmarshal(ev.Payload, &p); err != nil {
+				t.Fatalf("decode tool_call: %v", err)
+			}
+			callsByID[p.CallID] = p.NodeID
+		}
+	}
+	for _, ev := range events {
+		if ev.Type != persist.EventToolResult {
+			continue
+		}
+		var p persist.ToolResultPayload
+		if err := json.Unmarshal(ev.Payload, &p); err != nil {
+			t.Fatalf("decode tool_result: %v", err)
+		}
+		if want, ok := callsByID[p.CallID]; !ok {
+			t.Errorf("tool_result references unknown call_id %q", p.CallID)
+		} else if p.NodeID != want {
+			t.Errorf("tool_result node_id = %q, want %q (matching tool_call)", p.NodeID, want)
+		}
+	}
+}
+
+// TestDispatcher_EmitsApprovalEventsWhenStubAutoApproves confirms the
+// auto-approve stub (no Approver wired) still emits the paired
+// approval_request / approval_response events the inspector pairs
+// when rendering a suspended-then-resumed gate.
+func TestDispatcher_EmitsApprovalEventsWhenStubAutoApproves(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "approve.ts")
+	src := `
+		export default async function () {
+			return await approval('ship it?');
+		}
+	`
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatalf("writing skill source: %v", err)
+	}
+
+	store := persist.NewStore(t.TempDir())
+	runID := persist.NewRunID()
+	rec, err := store.OpenWriter(runID)
+	if err != nil {
+		t.Fatalf("OpenWriter: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+	session := NewRunSession(rec)
+
+	sb := New(2 * time.Second)
+	disp, err := NewDispatcher(sb, func(_ context.Context, _ string) Bindings {
+		return Bindings{Session: session}
+	})
+	if err != nil {
+		t.Fatalf("NewDispatcher: %v", err)
+	}
+	if _, err := disp.Dispatch(context.Background(), "approve", path, nil); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	events, err := store.Read(runID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	var sawRequest, sawResponse bool
+	var requestID, responseID string
+	for _, ev := range events {
+		switch ev.Type {
+		case persist.EventApprovalRequest:
+			sawRequest = true
+			var p persist.ApprovalRequestPayload
+			if err := json.Unmarshal(ev.Payload, &p); err != nil {
+				t.Fatalf("decode approval_request: %v", err)
+			}
+			requestID = p.ApprovalID
+			if p.Prompt != "ship it?" {
+				t.Errorf("prompt = %q, want %q", p.Prompt, "ship it?")
+			}
+		case persist.EventApprovalResponse:
+			sawResponse = true
+			var p persist.ApprovalResponsePayload
+			if err := json.Unmarshal(ev.Payload, &p); err != nil {
+				t.Fatalf("decode approval_response: %v", err)
+			}
+			responseID = p.ApprovalID
+			if !p.Approved || p.Source != "auto" {
+				t.Errorf("response = %+v, want approved=true source=auto", p)
+			}
+		}
+	}
+	if !sawRequest || !sawResponse {
+		t.Fatalf("missing approval pair: req=%v resp=%v", sawRequest, sawResponse)
+	}
+	if requestID != responseID {
+		t.Errorf("approval IDs do not pair: request=%q response=%q", requestID, responseID)
+	}
+}
+
+// TestDispatcher_ApprovalErrorStillEmitsResponsePair guards the
+// pairing invariant the inspector relies on: every EventApprovalRequest
+// must be answered by exactly one EventApprovalResponse with the
+// matching ApprovalID, even when the Approver itself errored out.
+// Without this pair, an inspector renders the gate as
+// permanently-suspended — a worse UX failure than the underlying
+// error message.
+func TestDispatcher_ApprovalErrorStillEmitsResponsePair(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "approve_err.ts")
+	src := `
+		export default async function () {
+			try { await approval('ship?'); return { ok: true }; }
+			catch (e) { return { ok: false, error: String(e) }; }
+		}
+	`
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatalf("writing skill source: %v", err)
+	}
+
+	store := persist.NewStore(t.TempDir())
+	runID := persist.NewRunID()
+	rec, err := store.OpenWriter(runID)
+	if err != nil {
+		t.Fatalf("OpenWriter: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+
+	bindings := Bindings{
+		Session:  NewRunSession(rec),
+		Approver: stubFailingApprover{},
+	}
+	sb := New(2 * time.Second)
+	disp, err := NewDispatcher(sb, func(_ context.Context, _ string) Bindings { return bindings })
+	if err != nil {
+		t.Fatalf("NewDispatcher: %v", err)
+	}
+	if _, err := disp.Dispatch(context.Background(), "approve_err", path, nil); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	events, err := store.Read(runID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	var requestID, responseID string
+	var sawResponse bool
+	for _, ev := range events {
+		switch ev.Type {
+		case persist.EventApprovalRequest:
+			var p persist.ApprovalRequestPayload
+			if err := json.Unmarshal(ev.Payload, &p); err != nil {
+				t.Fatalf("decode approval_request: %v", err)
+			}
+			requestID = p.ApprovalID
+		case persist.EventApprovalResponse:
+			sawResponse = true
+			var p persist.ApprovalResponsePayload
+			if err := json.Unmarshal(ev.Payload, &p); err != nil {
+				t.Fatalf("decode approval_response: %v", err)
+			}
+			responseID = p.ApprovalID
+			if p.Approved {
+				t.Errorf("expected approved=false on error path, got true")
+			}
+			if p.Source != "error" {
+				t.Errorf("expected source=error, got %q", p.Source)
+			}
+		}
+	}
+	if !sawResponse {
+		t.Fatal("approver-error path emitted no EventApprovalResponse — pair would be orphaned")
+	}
+	if requestID == "" || requestID != responseID {
+		t.Errorf("approval IDs do not pair: request=%q response=%q", requestID, responseID)
+	}
+}
+
+type stubFailingApprover struct{}
+
+func (stubFailingApprover) Approve(_ context.Context, _ string) (ApprovalDecision, error) {
+	return ApprovalDecision{}, errAuthorityUnavailable
+}
+
+var errAuthorityUnavailable = stubError("authority unavailable")
+
+type stubError string
+
+func (e stubError) Error() string { return string(e) }
+
+// stubToolCaller satisfies agent.ToolCaller for tests; returns the
+// pre-baked result regardless of name/args.
+type stubToolCaller struct {
+	result *mcp.ToolCallResult
+}
+
+func (s stubToolCaller) CallTool(_ context.Context, _ string, _ map[string]any) (*mcp.ToolCallResult, error) {
+	return s.result, nil
+}
+
+// stubChatModel satisfies agent.ChatModel; the Stream path is unused
+// here so it returns a not-implemented error.
+type stubChatModel struct {
+	resp agent.ChatResponse
+}
+
+func (s stubChatModel) Generate(_ context.Context, _ agent.ChatRequest) (agent.ChatResponse, error) {
+	return s.resp, nil
+}
+func (s stubChatModel) Stream(_ context.Context, _ agent.ChatRequest) (*agent.StreamReader[agent.ChatChunk], error) {
+	return nil, nil
+}
+
+// stubSkillCaller satisfies sandbox.SkillCaller.
+type stubSkillCaller struct {
+	result *mcp.ToolCallResult
+}
+
+func (s stubSkillCaller) CallTool(_ context.Context, _ string, _ map[string]any) (*mcp.ToolCallResult, error) {
+	return s.result, nil
 }
 
 // TestDispatcher_SatisfiesRegistryTSDispatcherShape is a structural

--- a/pkg/agent/sandbox/sandbox.go
+++ b/pkg/agent/sandbox/sandbox.go
@@ -99,6 +99,15 @@ type Bindings struct {
 	// SkillName is the registered skill name. Exposed as `skill.name`
 	// in the JS sandbox for parity with Go's ctx.SkillName().
 	SkillName string
+
+	// Session, when non-nil, is the per-invocation telemetry handle
+	// the bindings emit through. The runtime wires this to the
+	// parent run's recorder so external MCP clients firing tools/call
+	// against a typed skill see the same per-node trace the in-IDE
+	// Run Launcher produces. A nil Session disables emission — the
+	// bindings still function, the ledger just records the run's
+	// terminal boundaries only.
+	Session *RunSession
 }
 
 // SkillCaller is the dispatch surface handoff() uses. The signature

--- a/pkg/agent/sandbox/session.go
+++ b/pkg/agent/sandbox/session.go
@@ -1,0 +1,217 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/gridctl/gridctl/pkg/agent/persist"
+)
+
+// RunSession is the per-invocation telemetry handle the sandbox
+// bindings emit through. It carries the parent run's recorder (opened
+// by runner.Run) plus a monotonic node counter so each top-level
+// binding call (tool, llm, handoff, approval) can be addressed as a
+// stable "node" in the run's event timeline.
+//
+// A nil *RunSession is the no-recording mode every accessor recognises
+// — the in-process compose tests and the registry's NewInvoker harness
+// run without a recorder wired, and the bindings stay quiet rather
+// than panicking. Production dispatches (gateway → runner → sandbox)
+// always carry a session.
+type RunSession struct {
+	// Recorder is the parent run's ledger writer. Bindings call
+	// Record* helpers below; those helpers route every write through
+	// this recorder's existing mutex so events from concurrent
+	// goroutines don't interleave bytes mid-line.
+	Recorder *persist.Recorder
+
+	// nodeSeq is the monotonic counter behind NextNodeID. Atomic so
+	// concurrent goroutine deliveries (parallel(), background tool
+	// calls) get distinct ids without a mutex.
+	nodeSeq atomic.Uint64
+}
+
+// NewRunSession constructs a session bound to the given recorder. A
+// nil recorder yields a session whose Record* methods are no-ops —
+// callers don't need to special-case test or no-persistence paths.
+func NewRunSession(rec *persist.Recorder) *RunSession {
+	return &RunSession{Recorder: rec}
+}
+
+// NextNodeID returns a "<kind>:<name>#<n>" id for the next top-level
+// binding call. The id pairs the NodeEnter and NodeExit events the
+// caller emits around its work and gives the inspector a stable key
+// for per-call decoration even when the same tool is called twice.
+func (s *RunSession) NextNodeID(kind, name string) string {
+	if s == nil {
+		return ""
+	}
+	n := s.nodeSeq.Add(1)
+	if name == "" {
+		return fmt.Sprintf("%s#%d", kind, n)
+	}
+	return fmt.Sprintf("%s:%s#%d", kind, name, n)
+}
+
+// RecordNodeEnter writes an EventNodeEnter for the given binding
+// invocation. NodeName carries a human-friendly label ("tool", "llm",
+// etc.); the id is whatever NextNodeID produced. A nil session is a
+// silent no-op so test wiring without a recorder still passes.
+func (s *RunSession) RecordNodeEnter(nodeID, nodeName string) {
+	if s == nil || s.Recorder == nil || nodeID == "" {
+		return
+	}
+	if _, err := s.Recorder.Record(persist.EventNodeEnter, persist.NodeEnterPayload{
+		NodeID:   nodeID,
+		NodeName: nodeName,
+	}); err != nil {
+		slog.Warn("sandbox: recording node_enter", "run_id", s.runID(), "err", err)
+	}
+}
+
+// RecordNodeExit writes the matching EventNodeExit. DurationMicros is
+// the wall-clock time the binding held — typically computed as
+// time.Since(start).Microseconds() at the boundary. Success=false
+// signals a failure; callers typically also emit EventError for the
+// propagated message.
+func (s *RunSession) RecordNodeExit(nodeID string, durationMicros int64, success bool) {
+	if s == nil || s.Recorder == nil || nodeID == "" {
+		return
+	}
+	if _, err := s.Recorder.Record(persist.EventNodeExit, persist.NodeExitPayload{
+		NodeID:         nodeID,
+		DurationMicros: durationMicros,
+		Success:        success,
+	}); err != nil {
+		slog.Warn("sandbox: recording node_exit", "run_id", s.runID(), "err", err)
+	}
+}
+
+// RecordToolCall captures the tool() binding's pre-dispatch event.
+// Arguments are size-capped via persist.CapRawJSON so a tool fed a
+// multi-megabyte blob can't bloat the ledger; the cap flag is mirrored
+// into the payload so consumers know the value is a prefix, not the
+// full picture.
+func (s *RunSession) RecordToolCall(nodeID, callID, name string, args map[string]any) {
+	if s == nil || s.Recorder == nil {
+		return
+	}
+	var raw json.RawMessage
+	if args != nil {
+		if encoded, err := json.Marshal(args); err == nil {
+			raw = encoded
+		}
+	}
+	capped, truncated := persist.CapRawJSON(raw)
+	if _, err := s.Recorder.Record(persist.EventToolCall, persist.ToolCallPayload{
+		CallID:    callID,
+		NodeID:    nodeID,
+		Name:      name,
+		Arguments: capped,
+		Truncated: truncated,
+	}); err != nil {
+		slog.Warn("sandbox: recording tool_call", "run_id", s.runID(), "err", err)
+	}
+}
+
+// RecordToolResult captures the tool() binding's post-dispatch event.
+// Output is the raw text the gateway returned (the dispatcher already
+// collapses multi-block content to a single string at the boundary);
+// strings over persist.MaxPayloadBytes are trimmed.
+func (s *RunSession) RecordToolResult(nodeID, callID, output string, isError bool) {
+	if s == nil || s.Recorder == nil {
+		return
+	}
+	capped, truncated := persist.CapString(output)
+	if _, err := s.Recorder.Record(persist.EventToolResult, persist.ToolResultPayload{
+		CallID:    callID,
+		NodeID:    nodeID,
+		Output:    capped,
+		Truncated: truncated,
+		IsError:   isError,
+	}); err != nil {
+		slog.Warn("sandbox: recording tool_result", "run_id", s.runID(), "err", err)
+	}
+}
+
+// RecordLLMCall captures the llm() binding's post-dispatch event.
+// Token counts and cost arrive only after the provider replies, so
+// the event is emitted once on completion — not split across a
+// request/response pair like tool calls. EventLLMChunk for streaming
+// fragments is deliberately out of scope for this slice (the ledger
+// would balloon on long generations) and lands in a follow-on.
+func (s *RunSession) RecordLLMCall(model, provider string, promptTokens, outputTokens, cacheReadTokens, cacheWriteTokens int, costUSD float64) {
+	if s == nil || s.Recorder == nil {
+		return
+	}
+	if _, err := s.Recorder.Record(persist.EventLLMCall, persist.LLMCallPayload{
+		Model:            model,
+		Provider:         provider,
+		PromptTokens:     promptTokens,
+		OutputTokens:     outputTokens,
+		CacheReadTokens:  cacheReadTokens,
+		CacheWriteTokens: cacheWriteTokens,
+		CostUSD:          costUSD,
+	}); err != nil {
+		slog.Warn("sandbox: recording llm_call", "run_id", s.runID(), "err", err)
+	}
+}
+
+// RecordApprovalRequest captures the approval() binding's gate-open
+// event. The matching EventApprovalResponse is written from the same
+// binding once the Approver replies; the pair lets the inspector show
+// the suspension and the resume cleanly.
+func (s *RunSession) RecordApprovalRequest(approvalID, prompt string) {
+	if s == nil || s.Recorder == nil {
+		return
+	}
+	if _, err := s.Recorder.Record(persist.EventApprovalRequest, persist.ApprovalRequestPayload{
+		ApprovalID: approvalID,
+		Prompt:     prompt,
+	}); err != nil {
+		slog.Warn("sandbox: recording approval_request", "run_id", s.runID(), "err", err)
+	}
+}
+
+// RecordApprovalResponse captures the Approver's reply. Source is
+// "auto" for the stub auto-approver, otherwise whatever the gate
+// surface reports ("cli", "web", "mcp").
+func (s *RunSession) RecordApprovalResponse(approvalID string, approved bool, reason, source string) {
+	if s == nil || s.Recorder == nil {
+		return
+	}
+	if _, err := s.Recorder.Record(persist.EventApprovalResponse, persist.ApprovalResponsePayload{
+		ApprovalID: approvalID,
+		Approved:   approved,
+		Reason:     reason,
+		Source:     source,
+	}); err != nil {
+		slog.Warn("sandbox: recording approval_response", "run_id", s.runID(), "err", err)
+	}
+}
+
+// RecordError writes a mid-run error (a binding goroutine surfacing a
+// failure that does not abort the run). The terminal error path is
+// the runner's recordFailure helper — bindings only write here.
+func (s *RunSession) RecordError(nodeID, message string) {
+	if s == nil || s.Recorder == nil {
+		return
+	}
+	if _, err := s.Recorder.Record(persist.EventError, persist.ErrorPayload{
+		Message: message,
+		NodeID:  nodeID,
+	}); err != nil {
+		slog.Warn("sandbox: recording error", "run_id", s.runID(), "err", err)
+	}
+}
+
+// runID is a logging helper — returns "" when the session has no
+// recorder so the log line still emits without an extra guard.
+func (s *RunSession) runID() string {
+	if s == nil || s.Recorder == nil {
+		return ""
+	}
+	return s.Recorder.RunID()
+}

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
@@ -21,6 +23,7 @@ import (
 	"github.com/gridctl/gridctl/pkg/agent/dev/watcher"
 	agentgateway "github.com/gridctl/gridctl/pkg/agent/gateway"
 	"github.com/gridctl/gridctl/pkg/agent/persist"
+	"github.com/gridctl/gridctl/pkg/agent/runner"
 	agentruntime "github.com/gridctl/gridctl/pkg/agent/runtime"
 	"github.com/gridctl/gridctl/pkg/agent/sandbox"
 	"github.com/gridctl/gridctl/pkg/agent/skill"
@@ -886,12 +889,32 @@ func (b *GatewayBuilder) tokenizerName() string {
 // effect for the dispatcher path. Orchestrator-driven runs construct a
 // real compose.Gate (which needs a per-run recorder) and supply it via
 // their own bindings.
+//
+// Session is built per dispatch from the recorder ctx-stashed by
+// runner.Run upstream. When the parent dispatcher is firing for an
+// in-runner call, the recorder is non-nil and the sandbox bindings
+// emit per-node telemetry (node_enter / tool_call / llm_call / …) into
+// the same JSONL ledger the runner opened. Test wiring that calls
+// Dispatch without a runner gets a nil session — the bindings still
+// function, just without recording.
+//
+// The SkillCaller is wrapped with childRunSkillCaller so handoff() (and
+// any tool() call that resolves to a registered skill) opens its own
+// child recorder via runner.Run, automatically populating ParentRunID
+// on the child's run_started payload.
 func makeDispatcherBindings(gw *mcp.Gateway, store *registry.Store, skillCaller sandbox.SkillCaller, toolCaller agent.ToolCaller) sandbox.BindingsProvider {
-	return func(_ context.Context, skillName string) sandbox.Bindings {
+	rt, _ := gw.AgentRuntime().(*agentruntime.Runtime)
+	var runStore *persist.Store
+	if rt != nil {
+		runStore = rt.RunStore()
+	}
+	nestedSkillCaller := newChildRunSkillCaller(skillCaller, runStore, store)
+	nestedToolCaller := newChildRunToolCaller(toolCaller, skillCaller, runStore, store)
+	return func(ctx context.Context, skillName string) sandbox.Bindings {
 		b := sandbox.Bindings{
 			AllowedTools: gw.Router().AggregatedTools(),
-			SkillCaller:  skillCaller,
-			ToolCaller:   toolCaller,
+			SkillCaller:  nestedSkillCaller,
+			ToolCaller:   nestedToolCaller,
 			SkillName:    skillName,
 		}
 		if store != nil && skillName != "" {
@@ -899,11 +922,153 @@ func makeDispatcherBindings(gw *mcp.Gateway, store *registry.Store, skillCaller 
 				b.SkillBody = sk.Body
 			}
 		}
-		if rt, ok := gw.AgentRuntime().(*agentruntime.Runtime); ok && rt != nil {
+		if rt != nil {
 			b.ChatModel = rt.ChatModel()
+		}
+		if rec, ok := runner.RecorderFromContext(ctx); ok {
+			b.Session = sandbox.NewRunSession(rec)
 		}
 		return b
 	}
+}
+
+// registryServerName mirrors registry.Server.Name() — the agent prefix
+// used when a registered skill is surfaced as an MCP tool. The wrappers
+// below test against this string to decide whether a tool() call is
+// hitting a registered skill (and therefore deserves a child recorder
+// with ParentRunID populated) or a real MCP-server tool (which stays
+// stateless). Hardcoded here so pkg/controller does not have to import
+// pkg/registry for a single literal.
+const registryServerName = "registry"
+
+// childRunSkillCaller wraps the registry server so that handoff() from
+// inside a parent run opens a fresh child recorder via runner.Run. The
+// runner reads the parent run ID off ctx (set by the parent run's
+// runner.Run) and writes it as ParentRunID on the child's
+// EventRunStarted, which is what gives the IDE the orchestrator → leaf
+// tree shape. When ctx has no parent run id (top-level handoff outside
+// of a tracked run, e.g. an internal harness path), the wrapper falls
+// through to the underlying SkillCaller without opening a recorder.
+type childRunSkillCaller struct {
+	inner    sandbox.SkillCaller
+	store    *persist.Store
+	regStore *registry.Store
+}
+
+func newChildRunSkillCaller(inner sandbox.SkillCaller, store *persist.Store, regStore *registry.Store) sandbox.SkillCaller {
+	if inner == nil || store == nil {
+		return inner
+	}
+	return &childRunSkillCaller{inner: inner, store: store, regStore: regStore}
+}
+
+func (c *childRunSkillCaller) CallTool(ctx context.Context, name string, arguments map[string]any) (*mcp.ToolCallResult, error) {
+	if _, parented := runner.RunIDFromContext(ctx); !parented {
+		return c.inner.CallTool(ctx, name, arguments)
+	}
+	_, res, err := runner.Run(ctx, c.store, c.inner, runner.StartOptions{
+		Skill:    name,
+		Flavor:   flavorForSkill(c.regStore, name),
+		Input:    arguments,
+		RawInput: marshalArgsForLedger(arguments),
+	})
+	return res, err
+}
+
+// childRunToolCaller wraps the gateway-backed ToolCaller so a tool()
+// invocation that resolves to a registered typed skill opens a child
+// recorder (just like handoff). Bare MCP-tool calls fall through to
+// the underlying ToolCaller unchanged. The wrapper strips the registry
+// agent prefix from the resolved name before consulting the registry
+// store — bindings.go's resolveToolName returns the prefixed form
+// (`registry__<skill>`) because that is what the gateway router
+// dispatches against, but the registry store indexes skills by their
+// unprefixed name. Without the strip, the lookup would miss every
+// real call and the parent-link path would silently never engage.
+type childRunToolCaller struct {
+	inner     agent.ToolCaller
+	skillCall sandbox.SkillCaller
+	store     *persist.Store
+	regStore  *registry.Store
+}
+
+func newChildRunToolCaller(inner agent.ToolCaller, skillCall sandbox.SkillCaller, store *persist.Store, regStore *registry.Store) agent.ToolCaller {
+	if inner == nil {
+		return inner
+	}
+	return &childRunToolCaller{inner: inner, skillCall: skillCall, store: store, regStore: regStore}
+}
+
+func (c *childRunToolCaller) CallTool(ctx context.Context, name string, arguments map[string]any) (*mcp.ToolCallResult, error) {
+	if c.store == nil || c.regStore == nil {
+		return c.inner.CallTool(ctx, name, arguments)
+	}
+	if _, parented := runner.RunIDFromContext(ctx); !parented {
+		return c.inner.CallTool(ctx, name, arguments)
+	}
+	skillName, isRegistrySkill := unprefixRegistrySkillName(name)
+	if !isRegistrySkill {
+		return c.inner.CallTool(ctx, name, arguments)
+	}
+	sk, err := c.regStore.GetSkill(skillName)
+	if err != nil || sk == nil || sk.HandlerLanguage != "ts" {
+		return c.inner.CallTool(ctx, name, arguments)
+	}
+	// Dispatch via runner.Run so the child run gets its own recorder
+	// and ParentRunID linkage. Pass the unprefixed name through —
+	// SkillCaller (registry.Server.CallTool) expects unprefixed.
+	_, res, err := runner.Run(ctx, c.store, c.skillCall, runner.StartOptions{
+		Skill:    skillName,
+		Flavor:   sk.HandlerLanguage,
+		Input:    arguments,
+		RawInput: marshalArgsForLedger(arguments),
+	})
+	return res, err
+}
+
+// unprefixRegistrySkillName splits a tool name of the form
+// "registry__<skill>" into its bare skill component and reports
+// whether the prefix matched. Tool names that are not prefixed with
+// the registry agent name (i.e. real MCP-server tools) are returned
+// verbatim with a false flag so the caller can fall through to the
+// gateway dispatch path. The shape of "<agent>__<tool>" is the
+// gridctl-wide convention codified in mcp.PrefixTool.
+func unprefixRegistrySkillName(prefixed string) (string, bool) {
+	prefix := registryServerName + mcp.ToolNameDelimiter
+	if !strings.HasPrefix(prefixed, prefix) {
+		return prefixed, false
+	}
+	return prefixed[len(prefix):], true
+}
+
+// flavorForSkill resolves the handler language for a skill name from
+// the registry store, returning the empty string when the skill is
+// not on disk (e.g. a programmatically registered Go skill that
+// bypassed the walker). The child run's flavor field is purely
+// informational, so an empty value is acceptable.
+func flavorForSkill(store *registry.Store, name string) string {
+	if store == nil || name == "" {
+		return ""
+	}
+	if sk, err := store.GetSkill(name); err == nil && sk != nil {
+		return sk.HandlerLanguage
+	}
+	return ""
+}
+
+// marshalArgsForLedger encodes a child run's input map for verbatim
+// storage on the run's EventRunStarted payload. An encoding failure is
+// non-fatal — the runner accepts a nil RawInput and inspects the
+// parsed map separately.
+func marshalArgsForLedger(args map[string]any) []byte {
+	if args == nil {
+		return nil
+	}
+	raw, err := json.Marshal(args)
+	if err != nil {
+		return nil
+	}
+	return raw
 }
 
 // buildTokenCounter creates the token counter based on the stack gateway config.

--- a/pkg/controller/gateway_builder_telemetry_test.go
+++ b/pkg/controller/gateway_builder_telemetry_test.go
@@ -1,0 +1,65 @@
+package controller
+
+import (
+	"testing"
+)
+
+// TestUnprefixRegistrySkillName locks in the prefix-strip the
+// childRunToolCaller wrapper relies on. The wrapper is the path
+// tool()-from-inside-a-run takes when its target is a registered
+// typed skill (vs. a real MCP-server tool); skipping this strip
+// caused the child-recorder branch to silently miss every realistic
+// call, because bindings.go's resolveToolName returns the prefixed
+// form (`registry__<skill>`) but the registry store indexes skills
+// by their unprefixed name.
+func TestUnprefixRegistrySkillName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		in           string
+		wantSkill    string
+		wantIsSkill  bool
+	}{
+		{
+			name:        "registry-prefixed skill name strips and reports true",
+			in:          "registry__audit-repo",
+			wantSkill:   "audit-repo",
+			wantIsSkill: true,
+		},
+		{
+			name:        "real mcp server tool passes through unchanged",
+			in:          "github__get-issue",
+			wantSkill:   "github__get-issue",
+			wantIsSkill: false,
+		},
+		{
+			name:        "skill name with embedded delimiter keeps the suffix",
+			in:          "registry__sub__skill",
+			wantSkill:   "sub__skill",
+			wantIsSkill: true,
+		},
+		{
+			name:        "bare name without delimiter passes through",
+			in:          "naked",
+			wantSkill:   "naked",
+			wantIsSkill: false,
+		},
+		{
+			name:        "registry prefix without a skill body is not a registry skill",
+			in:          "registry__",
+			wantSkill:   "",
+			wantIsSkill: true,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotSkill, gotIsSkill := unprefixRegistrySkillName(tc.in)
+			if gotSkill != tc.wantSkill || gotIsSkill != tc.wantIsSkill {
+				t.Fatalf("unprefixRegistrySkillName(%q) = (%q, %v), want (%q, %v)",
+					tc.in, gotSkill, gotIsSkill, tc.wantSkill, tc.wantIsSkill)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Slice A of the run-observability work (Part of #629): the TypeScript-handler skill dispatch path now emits the rich event vocabulary defined in `pkg/agent/persist/events.go`, and nested skill calls populate `ParentRunID` so the IDE can reconstruct orchestrator → leaf trees. Before this change, MCP `tools/call` runs persisted only `run_started` + `run_completed`, leaving the Agent IDE with nothing to render against.

## Type of Change

- [x] New feature (backend, no UI surface — that lands in the follow-on Slice B/C PR)

## Changes Made

- Thread the active run ID and `*persist.Recorder` through `context.Context` from `runner.Run` / `runner.Start` to the sandbox bindings (private `runIDKey` / `recorderKey`; exported `RunIDFromContext` / `RecorderFromContext` accessors).
- Populate `RunStartedPayload.ParentRunID` when ctx already carries a parent run ID — gives the IDE the nested-tree shape for handoff and tool()-to-registered-skill calls.
- Add `RunSession` (`pkg/agent/sandbox/session.go`) — per-invocation telemetry handle with emit helpers that route every write through the parent recorder's mutex. Nil session is the no-recording mode test wiring uses.
- Emit `node_enter` / `node_exit` / `tool_call` / `tool_result` / `llm_call` / `approval_request` / `approval_response` from `bindings.go`. Pre-events fire on the goja thread before goroutine dispatch; post-events fire on the goroutine before `asyncDeliver` so wire-order matches causal-order.
- `BindingsProvider` in `pkg/controller/gateway_builder.go` extracts the recorder from ctx and wraps `SkillCaller` / `ToolCaller` with `childRunSkillCaller` / `childRunToolCaller` so `handoff()` and `tool()`-to-registered-skill open their own child recorders via `runner.Run` (which then writes `ParentRunID`).
- 64 KB cap on verbatim `Arguments` / `Output` payloads via `persist.CapRawJSON` / `persist.CapString`; over-cap values store a JSON-valid prefix with `Truncated: true`.

## Out of Scope (deferred to follow-ons)

- `EventLLMChunk` streaming emission (ledger-bloat risk).
- OpenTelemetry GenAI export.
- Frontend Run Output pane + Runs browser sidebar (Slice B + Slice C — separate PR).
- Go-skill (eino) per-node telemetry.

## Testing

- `pkg/agent/persist/store_test.go` — table-driven roundtrip across the closed event vocabulary (except `llm_chunk`) plus boundary tests for `CapRawJSON` / `CapString`.
- `pkg/agent/runner/runner_test.go` — parent-run linkage, top-level empty `ParentRunID`, ctx stash for downstream bindings.
- `pkg/agent/sandbox/dispatcher_test.go` — drives a TS skill calling `tool() + llm() + handoff()` and asserts the expected event sequence + `tool_call` / `tool_result` `NodeID` pairing; orphan-pair guard for `approval()` on Approver error.
- `pkg/controller/gateway_builder_telemetry_test.go` — locks in the `registry__<skill>` prefix strip so the `tool()`-to-registered-skill child-recorder path actually fires.
- `make build` + `go test -race ./...` + `golangci-lint run` all green.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #629