### PR TITLE
feat: surface run output and runs browser in agent IDE

### DIFF
--- a/web/src/components/agent/ide/AgentIDE.tsx
+++ b/web/src/components/agent/ide/AgentIDE.tsx
@@ -53,6 +53,10 @@ export function AgentIDE() {
     originRef: RefObject<HTMLButtonElement | null>;
   } | null>(null);
 
+  // Bumped on every launch so the sidebar Runs tab re-fetches the
+  // list — the new run shows up at the top without a manual refresh.
+  const [runsRefreshKey, setRunsRefreshKey] = useState(0);
+
   const { lastEvent, connectionState } = useDevSocket(true);
   const runTrace = useRunTrace(runID);
 
@@ -159,6 +163,9 @@ export function AgentIDE() {
       next.set('run', response.run_id);
       setParams(next, { replace: true });
       setLauncher(null);
+      // Nudge the sidebar's Runs tab to re-fetch so the new run row
+      // appears at the top immediately.
+      setRunsRefreshKey((k) => k + 1);
     },
     [params, setParams, launcher],
   );
@@ -183,6 +190,8 @@ export function AgentIDE() {
           onRunSkill={handleRunSkill}
           loading={skillsLoading}
           error={skillsError}
+          runsRefreshKey={runsRefreshKey}
+          activeRunID={runID}
         />
 
         <main className="flex flex-col h-full overflow-hidden bg-background">

--- a/web/src/components/agent/ide/NodeDetail.tsx
+++ b/web/src/components/agent/ide/NodeDetail.tsx
@@ -3,6 +3,7 @@ import { editorURL, type AgentNode } from '../../../lib/agent-api';
 import { styleFor } from './kind-style';
 import { TracePill } from './TracePill';
 import { ResumeButton } from './ResumeButton';
+import { RunOutputView } from './RunOutputView';
 import type { RunTrace, NodeTrace } from './useRunTrace';
 import { cn } from '../../../lib/cn';
 
@@ -43,19 +44,27 @@ export function NodeDetail({
 
   if (!node) {
     return (
-      <aside className="h-full bg-surface/40 border-l border-border-subtle p-6 flex flex-col">
-        <h3 className="font-sans text-text-muted text-xs uppercase tracking-[0.3em] mb-3">
-          Inspector
-        </h3>
-        <div className="flex-1 flex items-center justify-center text-center text-text-muted text-sm">
-          <div>
-            <div className="font-sans text-text-muted/40 text-[10px] uppercase tracking-[0.4em] mb-2">
-              awaiting selection
+      <aside className="h-full bg-surface/40 border-l border-border-subtle flex flex-col overflow-hidden">
+        <header className="px-6 pt-5 pb-4 border-b border-border-subtle">
+          <h3 className="font-sans text-text-muted text-xs uppercase tracking-[0.3em]">
+            Inspector
+          </h3>
+        </header>
+        <div className="flex-1 overflow-y-auto px-6 py-5">
+          {runID ? (
+            <RunOutputView runID={runID} runTrace={runTrace} />
+          ) : (
+            <div className="h-full flex items-center justify-center text-center text-text-muted text-sm">
+              <div>
+                <div className="font-sans text-text-muted/40 text-[10px] uppercase tracking-[0.4em] mb-2">
+                  awaiting selection
+                </div>
+                <p className="text-text-muted">
+                  Select a node to see its source location, trace data, and resume control.
+                </p>
+              </div>
             </div>
-            <p className="text-text-muted">
-              Select a node to see its source location, trace data, and resume control.
-            </p>
-          </div>
+          )}
         </div>
       </aside>
     );

--- a/web/src/components/agent/ide/RunLauncherModal.tsx
+++ b/web/src/components/agent/ide/RunLauncherModal.tsx
@@ -14,13 +14,12 @@ import { cn } from '../../../lib/cn';
 import { formatRelativeTime } from '../../../lib/time';
 import {
   fetchAgentRun,
-  fetchAgentRuns,
   inputFromRunDetail,
   launchRun,
   LaunchRunError,
-  type AgentRunSummary,
   type LaunchRunResponse,
 } from '../../../lib/agent-runs';
+import { useRunsForSkill } from './useRunsForSkill';
 
 // RJSF is heavy (~90KB gzipped with AJV) and only renders when a skill
 // exposes an inputSchema with properties. Lazy-load it so the main
@@ -73,9 +72,16 @@ export function RunLauncherModal({
   const [parseError, setParseError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [recentRuns, setRecentRuns] = useState<AgentRunSummary[]>([]);
-  const [recentLoading, setRecentLoading] = useState(true);
   const [selectedRunID, setSelectedRunID] = useState<string>('');
+
+  // Recent runs of THIS skill for the "Run like…" picker. The shared
+  // hook handles the filter; the modal stays silent on failure (the
+  // dropdown simply won't populate — Run like… is optional).
+  const { runs: recentRuns, loading: recentLoading } = useRunsForSkill({
+    skillName: skill.name,
+    limit: RUN_HISTORY_LIMIT,
+    fetchLimit: 50,
+  });
 
   const overlayRef = useRef<HTMLDivElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -91,31 +97,6 @@ export function RunLauncherModal({
     }, 200);
     return () => window.clearTimeout(handle);
   }, [jsonText]);
-
-  // Fetch recent runs of THIS skill for the "Run like…" picker. The
-  // backend list endpoint returns ~50 runs; we filter client-side by
-  // skill name and trim to the most recent N. Failure is silent — the
-  // dropdown simply won't populate.
-  useEffect(() => {
-    let cancelled = false;
-    fetchAgentRuns(50)
-      .then((runs) => {
-        if (cancelled) return;
-        const filtered = runs
-          .filter((r) => r.skill === skill.name)
-          .slice(0, RUN_HISTORY_LIMIT);
-        setRecentRuns(filtered);
-      })
-      .catch(() => {
-        // Quietly degrade — Run like… is optional.
-      })
-      .finally(() => {
-        if (!cancelled) setRecentLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [skill.name]);
 
   // Move focus into the dialog when it mounts; remember the previously
   // focused element so we can return it on close. Capture the return

--- a/web/src/components/agent/ide/RunOutputView.tsx
+++ b/web/src/components/agent/ide/RunOutputView.tsx
@@ -1,0 +1,365 @@
+import { useMemo, useState } from 'react';
+import { cn } from '../../../lib/cn';
+import { formatRelativeTime } from '../../../lib/time';
+import type { RunEvent } from '../../../lib/agent-api';
+import type { RunTrace } from './useRunTrace';
+
+interface RunOutputViewProps {
+  runID: string;
+  runTrace: RunTrace;
+}
+
+// Soft cap on what we render verbatim inside the inspector. Anything
+// beyond this is collapsed behind an expand affordance — the JSON
+// stays in memory but is not painted to DOM until the user asks.
+const COLLAPSE_THRESHOLD = 10_000;
+
+// Verbatim cap matches the backend recorder's size cap (64 KB) so the
+// "truncated" pill in the UI maps 1:1 to the recorder's "truncated:
+// true" marker on Output/Arguments payloads.
+const TRUNCATION_HINT_BYTES = 64 * 1024;
+
+interface CompletionShape {
+  output?: unknown;
+  error?: string;
+  duration_micros?: number;
+  truncated?: boolean;
+  status?: string;
+}
+
+interface StartedShape {
+  parent_run_id?: string;
+  skill?: string;
+}
+
+/**
+ * RunOutputView is the right-pane terminal-output viewer that lights
+ * up the moment no node is selected but a run is active. It folds
+ * the run's `run_started` + `run_completed` events into a single
+ * scannable view: a status header, a JSON viewer for the terminal
+ * Output (or a red `<pre>` for Error), and a live event counter
+ * while the run is still in-flight.
+ *
+ * Long outputs stay collapsed behind an expand affordance — never
+ * paint > ~10KB of JSON eagerly, the panel is 360px wide and the
+ * canvas/inspector layout can't survive a runaway DOM tree.
+ */
+export function RunOutputView({ runID, runTrace }: RunOutputViewProps) {
+  const completed = useMemo(
+    () => findEvent(runTrace.events, 'run_completed'),
+    [runTrace.events],
+  );
+  const started = useMemo(
+    () => findEvent(runTrace.events, 'run_started'),
+    [runTrace.events],
+  );
+
+  const startedPayload = (started?.payload ?? {}) as StartedShape;
+  const completedPayload = (completed?.payload ?? {}) as CompletionShape;
+
+  const completedAt = completed?.time ? new Date(completed.time) : null;
+  const completedAtValid = completedAt && !isNaN(completedAt.getTime()) ? completedAt : null;
+
+  const errored = isErrorOutcome(completedPayload);
+  const durationLabel = formatDuration(completedPayload.duration_micros);
+
+  if (!completed) {
+    return (
+      <div className="space-y-4" aria-live="polite">
+        <Header
+          runID={runID}
+          parentRunID={startedPayload.parent_run_id}
+          eyebrow="awaiting output"
+        />
+        <InFlightCard
+          eventCount={runTrace.events.length}
+          status={runTrace.status}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Header
+        runID={runID}
+        parentRunID={startedPayload.parent_run_id}
+        eyebrow={errored ? 'run errored' : 'run completed'}
+        accent={errored ? 'error' : 'ok'}
+      />
+      <div className="flex items-center gap-3 font-mono text-[10px] text-text-muted/80 -mt-1">
+        {completedAtValid && (
+          <span className="tabular-nums">{formatRelativeTime(completedAtValid)}</span>
+        )}
+        {durationLabel && (
+          <>
+            <span className="text-text-muted/30">·</span>
+            <span className="tabular-nums">{durationLabel}</span>
+          </>
+        )}
+        <span className="text-text-muted/30">·</span>
+        <span className="tabular-nums">{runTrace.events.length} events</span>
+      </div>
+      {errored ? (
+        <ErrorPayload message={completedPayload.error ?? 'unknown error'} />
+      ) : (
+        <OutputPayload
+          output={completedPayload.output}
+          truncated={completedPayload.truncated}
+        />
+      )}
+    </div>
+  );
+}
+
+function findEvent(events: RunEvent[], type: string): RunEvent | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].type === type) return events[i];
+  }
+  return undefined;
+}
+
+function isErrorOutcome(payload: CompletionShape): boolean {
+  if (typeof payload.error === 'string' && payload.error.length > 0) return true;
+  if (typeof payload.status === 'string') {
+    const s = payload.status.toLowerCase();
+    if (s === 'error' || s === 'errored' || s === 'failed') return true;
+  }
+  return false;
+}
+
+function formatDuration(micros: number | undefined): string | null {
+  if (micros == null) return null;
+  if (micros < 1000) return `${micros}µs`;
+  if (micros < 1_000_000) return `${(micros / 1000).toFixed(1)}ms`;
+  return `${(micros / 1_000_000).toFixed(2)}s`;
+}
+
+interface HeaderProps {
+  runID: string;
+  parentRunID: string | undefined;
+  eyebrow: string;
+  accent?: 'ok' | 'error';
+}
+
+function Header({ runID, parentRunID, eyebrow, accent }: HeaderProps) {
+  const accentClass =
+    accent === 'error'
+      ? 'text-status-error'
+      : accent === 'ok'
+        ? 'text-status-running/80'
+        : 'text-text-muted/60';
+  return (
+    <div>
+      <div
+        className={cn(
+          'font-sans text-[10px] uppercase tracking-[0.3em] mb-1',
+          accentClass,
+        )}
+      >
+        {eyebrow}
+      </div>
+      <div className="font-mono text-xs text-text-primary tabular-nums truncate">
+        run {runID.slice(0, 8)}
+      </div>
+      {parentRunID && (
+        <div className="font-mono text-[10px] text-text-muted mt-0.5 truncate">
+          parent {parentRunID.slice(0, 8)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface InFlightCardProps {
+  eventCount: number;
+  status: 'connecting' | 'open' | 'error' | 'idle';
+}
+
+function InFlightCard({ eventCount, status }: InFlightCardProps) {
+  const statusLabel =
+    status === 'open'
+      ? 'streaming'
+      : status === 'connecting'
+        ? 'connecting'
+        : status === 'error'
+          ? 'disconnected'
+          : 'idle';
+  return (
+    <div
+      className={cn(
+        'rounded-md border border-border-subtle bg-surface/40 px-4 py-5',
+        'flex flex-col items-center text-center gap-3',
+      )}
+    >
+      <div className="relative">
+        <span
+          aria-hidden
+          className={cn(
+            'block w-2 h-2 rounded-full',
+            status === 'error' ? 'bg-status-error' : 'bg-status-running',
+          )}
+          style={
+            status === 'open'
+              ? {
+                  boxShadow: '0 0 12px var(--color-status-running)',
+                  animation: 'pulse 2s ease-in-out infinite',
+                }
+              : undefined
+          }
+        />
+      </div>
+      <div className="font-sans text-text-primary text-sm leading-snug">
+        waiting for completion…
+      </div>
+      <div className="flex items-center gap-2 font-mono text-[10px] text-text-muted/80">
+        <span className="tabular-nums">{eventCount} {eventCount === 1 ? 'event' : 'events'}</span>
+        <span className="text-text-muted/30">·</span>
+        <span className="uppercase tracking-[0.16em]">{statusLabel}</span>
+      </div>
+    </div>
+  );
+}
+
+interface OutputPayloadProps {
+  output: unknown;
+  truncated: boolean | undefined;
+}
+
+function OutputPayload({ output, truncated }: OutputPayloadProps) {
+  // Use a stable string form so the collapse decision and the
+  // rendered text agree. Object outputs stringify pretty; primitives
+  // print verbatim (still wrapped in a <pre>).
+  const text = useMemo(() => stringify(output), [output]);
+  const [expanded, setExpanded] = useState<boolean>(() => text.length <= COLLAPSE_THRESHOLD);
+  const empty = output == null || (typeof text === 'string' && text.trim().length === 0);
+
+  if (empty) {
+    return (
+      <div className="rounded-md border border-border-subtle bg-surface/40 px-3 py-3">
+        <Caption>output</Caption>
+        <p className="font-sans text-text-muted text-xs leading-snug">
+          run produced no output payload.
+        </p>
+        {truncated && <TruncationPill />}
+      </div>
+    );
+  }
+
+  const tooLong = text.length > COLLAPSE_THRESHOLD;
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-1.5">
+        <Caption>output</Caption>
+        <div className="flex items-center gap-2">
+          {truncated && <TruncationPill />}
+          <ByteCount bytes={text.length} />
+        </div>
+      </div>
+      <pre
+        className={cn(
+          'p-3 rounded-md border border-border-subtle bg-surface',
+          'font-mono text-[11px] leading-relaxed text-text-primary',
+          'whitespace-pre-wrap break-words',
+          'max-h-[60vh] overflow-y-auto',
+          !expanded && 'max-h-32 overflow-hidden relative',
+        )}
+      >
+        {expanded ? text : preview(text)}
+        {!expanded && (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-surface to-transparent"
+          />
+        )}
+      </pre>
+      {tooLong && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className={cn(
+            'mt-1.5 inline-flex items-center gap-1.5 px-2 py-1 rounded',
+            'font-mono text-[10px] uppercase tracking-[0.18em]',
+            'text-text-muted hover:text-text-primary',
+            'border border-border-subtle hover:border-border',
+            'focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/60',
+          )}
+        >
+          {expanded ? '⌃ collapse' : `⌄ expand · ${text.length.toLocaleString()} chars`}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ErrorPayload({ message }: { message: string }) {
+  return (
+    <div>
+      <Caption className="text-status-error/80">error</Caption>
+      <pre
+        className={cn(
+          'mt-1.5 p-3 rounded-md',
+          'bg-status-error/5 border border-status-error/20 text-status-error',
+          'font-mono text-[11px] leading-relaxed whitespace-pre-wrap break-words',
+        )}
+      >
+        {message}
+      </pre>
+    </div>
+  );
+}
+
+function Caption({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <span
+      className={cn(
+        'font-sans text-text-muted text-[10px] uppercase tracking-[0.3em]',
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ByteCount({ bytes }: { bytes: number }) {
+  return (
+    <span className="font-mono text-[10px] text-text-muted/70 tabular-nums">
+      {bytes.toLocaleString()} chars
+    </span>
+  );
+}
+
+function TruncationPill() {
+  return (
+    <span
+      title={`truncated to ${TRUNCATION_HINT_BYTES.toLocaleString()} bytes`}
+      className={cn(
+        'inline-flex items-center px-1.5 py-px rounded',
+        'font-mono text-[9px] uppercase tracking-[0.18em]',
+        'bg-status-pending/15 text-status-pending border border-status-pending/30',
+      )}
+    >
+      truncated
+    </span>
+  );
+}
+
+function stringify(value: unknown): string {
+  if (value === undefined) return '';
+  if (value === null) return 'null';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function preview(text: string): string {
+  // Cap the rendered preview so an expand-required output doesn't
+  // shovel half a megabyte of JSON into the DOM behind the gradient.
+  if (text.length <= 2_000) return text;
+  return text.slice(0, 2_000);
+}

--- a/web/src/components/agent/ide/RunsList.tsx
+++ b/web/src/components/agent/ide/RunsList.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { cn } from '../../../lib/cn';
+import { formatRelativeTime } from '../../../lib/time';
+import type { AgentRunSummary } from '../../../lib/agent-runs';
+import { useRunsForSkill } from './useRunsForSkill';
+
+interface RunsListProps {
+  /**
+   * Bump to force a re-fetch — AgentIDE increments this when a new
+   * run is launched so the sidebar reflects the new row immediately.
+   */
+  refreshKey: number;
+  /**
+   * Currently selected run id (from URL). The row gets a highlight
+   * so the operator can scan back to where they are.
+   */
+  activeRunID: string | null;
+}
+
+interface RunRowNode {
+  run: AgentRunSummary;
+  depth: number;
+  children: RunRowNode[];
+}
+
+/**
+ * RunsList is the Slice C surface — the SkillSidebar's `Runs` tab
+ * body. Renders the ~100 most recent runs across all skills, sorted
+ * by `started_at` desc, with child runs (non-empty `parent_run_id`)
+ * indented under their parent and a disclosure caret on parent rows.
+ *
+ * Clicking a row sets `?skill=<r.skill>&run=<r.run_id>` so the IDE's
+ * existing trace overlay path activates. The list is a primary
+ * surface for MCP-client users (who arrive at the IDE with no prior
+ * skill context), so failure is loud — we surface the error with a
+ * retry button rather than silently degrading.
+ */
+export function RunsList({ refreshKey, activeRunID }: RunsListProps) {
+  const [, setParams] = useSearchParams();
+  const { runs, loading, error, refresh } = useRunsForSkill({
+    fetchLimit: 100,
+    refreshKey,
+  });
+
+  const tree = useMemo(() => buildTree(runs), [runs]);
+
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+
+  const toggleCollapsed = useCallback((id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleSelectRun = useCallback(
+    (run: AgentRunSummary) => {
+      setParams(
+        (curr) => {
+          const next = new URLSearchParams(curr);
+          if (run.skill) next.set('skill', run.skill);
+          else next.delete('skill');
+          next.set('run', run.run_id);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setParams],
+  );
+
+  if (loading && runs.length === 0) {
+    return (
+      <div className="px-5 py-8 text-center" aria-live="polite">
+        <span className="font-mono text-[10px] text-text-muted/70 animate-pulse uppercase tracking-[0.3em]">
+          loading runs…
+        </span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mx-5 my-4 px-3 py-3 rounded-md border border-status-error/30 bg-status-error/5">
+        <div className="font-sans text-status-error/80 text-[10px] uppercase tracking-[0.3em] mb-1">
+          couldn't load runs
+        </div>
+        <p className="font-mono text-[11px] text-status-error/90 mb-2 break-words">{error}</p>
+        <button
+          type="button"
+          onClick={refresh}
+          className={cn(
+            'inline-flex items-center px-2 py-1 rounded',
+            'font-mono text-[10px] uppercase tracking-[0.16em]',
+            'border border-status-error/30 text-status-error',
+            'hover:bg-status-error/10 transition-colors',
+            'focus:outline-none focus-visible:ring-1 focus-visible:ring-status-error/50',
+          )}
+        >
+          retry
+        </button>
+      </div>
+    );
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div className="mx-5 my-8 text-center text-text-muted text-xs leading-relaxed">
+        <div className="font-sans text-text-muted/40 text-[10px] uppercase tracking-[0.4em] mb-2">
+          no runs yet
+        </div>
+        <p>
+          Launch a skill from the <code className="font-mono text-text-secondary">Skills</code>{' '}
+          tab — its run lands here the moment it starts.
+        </p>
+      </div>
+    );
+  }
+
+  // Flatten the tree honouring collapsed state.
+  const rows = flattenTree(tree, collapsed);
+
+  return (
+    <ul
+      role="list"
+      className="px-2 space-y-px"
+      aria-label="Recent agent runs"
+    >
+      {rows.map((row) => (
+        <RunRow
+          key={row.run.run_id}
+          row={row}
+          isActive={activeRunID === row.run.run_id}
+          isCollapsed={collapsed.has(row.run.run_id)}
+          hasChildren={row.children.length > 0}
+          onSelect={handleSelectRun}
+          onToggle={toggleCollapsed}
+        />
+      ))}
+    </ul>
+  );
+}
+
+interface RunRowProps {
+  row: RunRowNode;
+  isActive: boolean;
+  isCollapsed: boolean;
+  hasChildren: boolean;
+  onSelect: (run: AgentRunSummary) => void;
+  onToggle: (id: string) => void;
+}
+
+function RunRow({ row, isActive, isCollapsed, hasChildren, onSelect, onToggle }: RunRowProps) {
+  const { run, depth } = row;
+  const tone = statusTone(run.status);
+  const startedDate = run.started_at ? new Date(run.started_at) : null;
+  const startedValid = startedDate && !isNaN(startedDate.getTime()) ? startedDate : null;
+
+  return (
+    <li
+      style={{ paddingLeft: `${depth * 14}px` }}
+      className="relative"
+    >
+      {depth > 0 && (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute left-2 top-0 bottom-0 border-l border-border-subtle/60"
+          style={{ left: `${depth * 14 - 8}px` }}
+        />
+      )}
+      <button
+        type="button"
+        onClick={() => onSelect(run)}
+        aria-current={isActive ? 'true' : undefined}
+        className={cn(
+          'group w-full text-left px-2 py-1.5 rounded-md',
+          'border border-transparent transition-colors',
+          'focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/60',
+          isActive
+            ? 'bg-surface-elevated/80 border-border-subtle'
+            : 'hover:bg-surface/50 hover:border-border-subtle/60',
+        )}
+      >
+        <div className="flex items-center gap-2">
+          {hasChildren ? (
+            <span
+              role="button"
+              tabIndex={-1}
+              aria-label={isCollapsed ? 'expand children' : 'collapse children'}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggle(run.run_id);
+              }}
+              className={cn(
+                'inline-flex w-3.5 h-3.5 items-center justify-center',
+                'text-text-muted hover:text-text-primary transition-transform',
+                isCollapsed ? '' : 'rotate-90',
+              )}
+            >
+              <span aria-hidden className="text-[9px] leading-none">▶</span>
+            </span>
+          ) : (
+            <span aria-hidden className="inline-block w-3.5" />
+          )}
+          <StatusDot tone={tone} />
+          <span className="font-mono text-[11px] text-text-primary tabular-nums">
+            {run.run_id.slice(0, 8)}
+          </span>
+          <span className="flex-1 min-w-0 font-mono text-[11px] text-text-muted truncate">
+            {run.skill ?? '—'}
+          </span>
+        </div>
+        <div className="mt-0.5 flex items-center justify-between gap-2 pl-[22px] font-mono text-[10px] text-text-muted">
+          <span className={cn('uppercase tracking-[0.16em]', tone.text)}>
+            {run.status || 'unknown'}
+          </span>
+          <div className="flex items-center gap-2">
+            {startedValid && (
+              <span className="tabular-nums">{formatRelativeTime(startedValid)}</span>
+            )}
+            <span className="text-text-muted/30">·</span>
+            <span className="tabular-nums">{run.event_count} ev</span>
+          </div>
+        </div>
+      </button>
+    </li>
+  );
+}
+
+interface StatusTone {
+  dot: string;
+  glow: string | undefined;
+  text: string;
+}
+
+function statusTone(status: string | undefined): StatusTone {
+  const s = (status ?? '').toLowerCase();
+  if (s === 'running' || s === 'started' || s === 'in_progress') {
+    return {
+      dot: 'bg-status-running',
+      glow: '0 0 8px var(--color-status-running)',
+      text: 'text-status-running',
+    };
+  }
+  if (s === 'error' || s === 'errored' || s === 'failed') {
+    return {
+      dot: 'bg-status-error',
+      glow: '0 0 6px var(--color-status-error)',
+      text: 'text-status-error',
+    };
+  }
+  if (s === 'awaiting_approval' || s === 'suspended' || s === 'pending') {
+    return {
+      dot: 'bg-status-pending',
+      glow: '0 0 6px var(--color-status-pending)',
+      text: 'text-status-pending',
+    };
+  }
+  if (s === 'completed' || s === 'ok' || s === 'success') {
+    return {
+      dot: 'bg-status-running/60',
+      glow: undefined,
+      text: 'text-status-running/80',
+    };
+  }
+  return {
+    dot: 'bg-text-muted/40',
+    glow: undefined,
+    text: 'text-text-muted',
+  };
+}
+
+function StatusDot({ tone }: { tone: StatusTone }) {
+  return (
+    <span
+      aria-hidden
+      className={cn('inline-block w-1.5 h-1.5 rounded-full', tone.dot)}
+      style={tone.glow ? { boxShadow: tone.glow } : undefined}
+    />
+  );
+}
+
+/**
+ * buildTree groups runs by parent_run_id and returns a depth-tagged
+ * forest. Runs whose parent is not in the current window are
+ * surfaced as roots so they don't vanish.
+ */
+function buildTree(runs: AgentRunSummary[]): RunRowNode[] {
+  const byID = new Map<string, RunRowNode>();
+  for (const r of runs) {
+    byID.set(r.run_id, { run: r, depth: 0, children: [] });
+  }
+  const roots: RunRowNode[] = [];
+  for (const r of runs) {
+    const node = byID.get(r.run_id)!;
+    const parentID = r.parent_run_id;
+    if (parentID && byID.has(parentID)) {
+      const parent = byID.get(parentID)!;
+      node.depth = parent.depth + 1;
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  // After parent-attached pass, recompute depth via BFS so deeply
+  // nested children get the right indent even when the source order
+  // surfaces a grandparent after its grandchild.
+  const queue: RunRowNode[] = [...roots];
+  while (queue.length > 0) {
+    const n = queue.shift()!;
+    for (const c of n.children) {
+      c.depth = n.depth + 1;
+      queue.push(c);
+    }
+  }
+  return roots;
+}
+
+function flattenTree(roots: RunRowNode[], collapsed: Set<string>): RunRowNode[] {
+  const out: RunRowNode[] = [];
+  const walk = (node: RunRowNode) => {
+    out.push(node);
+    if (collapsed.has(node.run.run_id)) return;
+    for (const c of node.children) walk(c);
+  };
+  for (const r of roots) walk(r);
+  return out;
+}

--- a/web/src/components/agent/ide/SkillSidebar.tsx
+++ b/web/src/components/agent/ide/SkillSidebar.tsx
@@ -1,7 +1,10 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { type SkillSummary } from '../../../lib/agent-api';
 import { cn } from '../../../lib/cn';
 import { SkillRunButton } from './SkillRunButton';
+import { RunsList } from './RunsList';
+
+type SidebarTab = 'skills' | 'runs';
 
 interface SkillSidebarProps {
   skills: SkillSummary[];
@@ -10,13 +13,26 @@ interface SkillSidebarProps {
   onRunSkill?: (name: string, originRef: React.RefObject<HTMLButtonElement | null>) => void;
   loading?: boolean;
   error?: string | null;
+  /**
+   * AgentIDE bumps this each time a run is launched — the Runs tab
+   * uses it to re-fetch the list so the newly-started run appears
+   * at the top without waiting for the next mount.
+   */
+  runsRefreshKey: number;
+  /**
+   * Currently-active run id from the URL. Highlighted in the Runs
+   * list so the operator can scan back to where they are.
+   */
+  activeRunID: string | null;
 }
 
 /**
- * SkillSidebar is the IDE's left rail — every typed skill the
- * project exposes, with a node-count badge and a flavor pill. The
- * rail is dense and monospace by design; this is a developer tool,
- * not a marketing surface.
+ * SkillSidebar is the IDE's left rail. The Skills tab lists every
+ * typed skill the project exposes; the Runs tab lists recent agent
+ * runs (across all skills) with parent-child indent so nested
+ * `handoff` calls render their hierarchy. The rail is dense and
+ * monospace by design; this is a developer tool, not a marketing
+ * surface.
  */
 export function SkillSidebar({
   skills,
@@ -25,11 +41,14 @@ export function SkillSidebar({
   onRunSkill,
   loading,
   error,
+  runsRefreshKey,
+  activeRunID,
 }: SkillSidebarProps) {
+  const [tab, setTab] = useState<SidebarTab>('skills');
   return (
     <aside
       className="h-full bg-surface/30 border-r border-border-subtle flex flex-col overflow-hidden"
-      aria-label="Skills"
+      aria-label="Skills and runs"
     >
       <header className="px-5 pt-6 pb-4 border-b border-border-subtle">
         <div className="font-sans text-text-muted/70 text-[10px] uppercase tracking-[0.4em] mb-1">
@@ -48,46 +67,111 @@ export function SkillSidebar({
         </p>
       </header>
 
+      <div
+        role="tablist"
+        aria-label="Sidebar sections"
+        className="px-5 pt-3 flex items-center gap-1 border-b border-border-subtle/50"
+      >
+        <TabButton
+          active={tab === 'skills'}
+          onClick={() => setTab('skills')}
+          label="Skills"
+          controls="sidebar-tab-skills"
+        />
+        <TabButton
+          active={tab === 'runs'}
+          onClick={() => setTab('runs')}
+          label="Runs"
+          controls="sidebar-tab-runs"
+        />
+      </div>
+
       <div className="flex-1 overflow-y-auto py-3">
-        <div className="px-5 mb-3 flex items-center justify-between">
-          <span className="font-sans text-text-muted text-[10px] uppercase tracking-[0.3em]">
-            skills
-          </span>
-          {loading && (
-            <span className="font-mono text-[10px] text-text-muted/70 animate-pulse">
-              loading…
-            </span>
-          )}
-        </div>
-        {error && (
-          <div className="mx-5 mb-3 px-3 py-2 rounded text-xs text-status-error bg-status-error/5 border border-status-error/20">
-            {error}
-          </div>
-        )}
-        {!loading && skills.length === 0 && !error && (
-          <div className="mx-5 my-8 text-center text-text-muted text-xs leading-relaxed">
-            <div className="font-sans text-text-muted/40 text-[10px] uppercase tracking-[0.4em] mb-2">
-              empty project
+        {tab === 'skills' && (
+          <div role="tabpanel" id="sidebar-tab-skills" aria-label="Skills">
+            <div className="px-5 mb-3 flex items-center justify-between">
+              <span className="font-sans text-text-muted text-[10px] uppercase tracking-[0.3em]">
+                skills
+              </span>
+              {loading && (
+                <span className="font-mono text-[10px] text-text-muted/70 animate-pulse">
+                  loading…
+                </span>
+              )}
             </div>
-            <p>
-              No SKILL.md found. Run <code className="font-mono text-text-secondary">gridctl agent init</code>
-              {' '}to scaffold a starter.
-            </p>
+            {error && (
+              <div className="mx-5 mb-3 px-3 py-2 rounded text-xs text-status-error bg-status-error/5 border border-status-error/20">
+                {error}
+              </div>
+            )}
+            {!loading && skills.length === 0 && !error && (
+              <div className="mx-5 my-8 text-center text-text-muted text-xs leading-relaxed">
+                <div className="font-sans text-text-muted/40 text-[10px] uppercase tracking-[0.4em] mb-2">
+                  empty project
+                </div>
+                <p>
+                  No SKILL.md found. Run{' '}
+                  <code className="font-mono text-text-secondary">gridctl agent init</code> to
+                  scaffold a starter.
+                </p>
+              </div>
+            )}
+            <ul className="space-y-px px-2">
+              {skills.map((s) => (
+                <SkillRow
+                  key={s.name}
+                  skill={s}
+                  active={active === s.name}
+                  onSelect={onSelect}
+                  onRunSkill={onRunSkill}
+                />
+              ))}
+            </ul>
           </div>
         )}
-        <ul className="space-y-px px-2">
-          {skills.map((s) => (
-            <SkillRow
-              key={s.name}
-              skill={s}
-              active={active === s.name}
-              onSelect={onSelect}
-              onRunSkill={onRunSkill}
-            />
-          ))}
-        </ul>
+
+        {tab === 'runs' && (
+          <div role="tabpanel" id="sidebar-tab-runs" aria-label="Runs">
+            <div className="px-5 mb-3 flex items-center justify-between">
+              <span className="font-sans text-text-muted text-[10px] uppercase tracking-[0.3em]">
+                recent runs
+              </span>
+            </div>
+            <RunsList refreshKey={runsRefreshKey} activeRunID={activeRunID} />
+          </div>
+        )}
       </div>
     </aside>
+  );
+}
+
+interface TabButtonProps {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  controls: string;
+}
+
+function TabButton({ active, onClick, label, controls }: TabButtonProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      aria-controls={controls}
+      onClick={onClick}
+      className={cn(
+        'px-3 py-1.5 -mb-px',
+        'font-mono text-[10px] uppercase tracking-[0.2em]',
+        'border-b-2 transition-colors',
+        active
+          ? 'border-primary text-text-primary'
+          : 'border-transparent text-text-muted hover:text-text-primary',
+        'focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/60',
+      )}
+    >
+      {label}
+    </button>
   );
 }
 
@@ -124,8 +208,8 @@ function SkillRow({ skill: s, active, onSelect, onRunSkill }: SkillRowProps) {
                 s.lang === 'go'
                   ? 'bg-secondary/15 text-secondary-light border border-secondary/30'
                   : s.lang === 'ts'
-                  ? 'bg-tertiary/15 text-tertiary-light border border-tertiary/30'
-                  : 'bg-surface text-text-muted border border-border',
+                    ? 'bg-tertiary/15 text-tertiary-light border border-tertiary/30'
+                    : 'bg-surface text-text-muted border border-border',
               )}
             >
               {s.lang || '—'}

--- a/web/src/components/agent/ide/useRunsForSkill.ts
+++ b/web/src/components/agent/ide/useRunsForSkill.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchAgentRuns, type AgentRunSummary } from '../../../lib/agent-runs';
+
+export interface UseRunsForSkillOptions {
+  /**
+   * When set, the returned `runs` are filtered to only include runs
+   * for this skill. When omitted, every run within the fetch window
+   * is returned — used by the sidebar Runs tab.
+   */
+  skillName?: string;
+  /**
+   * Maximum number of rows to keep after filtering. The fetch always
+   * pulls `fetchLimit` rows from the API; this trims post-filter so
+   * the modal's "Run like…" picker can render the most recent N.
+   */
+  limit?: number;
+  /**
+   * Number of rows requested from the API. Bigger windows give the
+   * skill filter room to find matches when many other skills have
+   * recently run.
+   */
+  fetchLimit?: number;
+  /**
+   * Bumping this value re-runs the fetch. Used by AgentIDE to
+   * refresh the sidebar list when a new run is launched.
+   */
+  refreshKey?: number | string;
+}
+
+export interface UseRunsForSkillResult {
+  runs: AgentRunSummary[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * useRunsForSkill is the shared fetch+filter hook behind both the
+ * RunLauncherModal's "Run like…" picker and the SkillSidebar's Runs
+ * tab. The single hook keeps the two surfaces honest about what a
+ * "run" looks like and lets either surface refresh the other (via
+ * the AgentIDE-managed refreshKey) when a new run is launched.
+ *
+ * The hook returns the unsorted server order — the API already
+ * returns `started_at` desc. Consumers that need other orderings can
+ * sort the returned slice.
+ */
+export function useRunsForSkill(options: UseRunsForSkillOptions = {}): UseRunsForSkillResult {
+  const { skillName, limit, fetchLimit = 100, refreshKey } = options;
+  const [runs, setRuns] = useState<AgentRunSummary[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [localKey, setLocalKey] = useState(0);
+
+  // Track the in-flight request id so a stale fetch can't clobber a
+  // newer one. The ref pattern keeps the cancellation check out of
+  // the effect body (which would trip set-state-in-effect lint).
+  const requestRef = useRef(0);
+
+  const refresh = useCallback(() => setLocalKey((k) => k + 1), []);
+
+  useEffect(() => {
+    requestRef.current += 1;
+    const myRequest = requestRef.current;
+    fetchAgentRuns(fetchLimit)
+      .then((all) => {
+        if (requestRef.current !== myRequest) return;
+        const filtered = skillName ? all.filter((r) => r.skill === skillName) : all;
+        const trimmed = limit != null ? filtered.slice(0, limit) : filtered;
+        setRuns(trimmed);
+        setError(null);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (requestRef.current !== myRequest) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setRuns([]);
+        setLoading(false);
+      });
+    return () => {
+      // Bump so the in-flight promise's settle handler bails out.
+      requestRef.current += 1;
+    };
+  }, [skillName, limit, fetchLimit, refreshKey, localKey]);
+
+  return { runs, loading, error, refresh };
+}


### PR DESCRIPTION
## Description

Closes the observability loop for typed-skill runs in the Agent IDE. After this PR, a run fired from any launch surface — CLI, in-IDE launcher, or external MCP client — inspects identically: per-node canvas decoration, final JSON output in the inspector, and a recent-runs list with parent/child hierarchy.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Add `useRunsForSkill` shared hook, consumed by both the launcher modal's "Run like…" picker and the new sidebar Runs tab
- Add `RunOutputView` — JSON viewer with truncate/expand, error variant, and live in-flight status with event count; rendered in the inspector when no node is selected and a run is active
- Add `RunsList` — recent runs across all skills, sorted by start time, with child runs indented under their parent and a fold/unfold caret
- Add `Skills | Runs` tab toggle to `SkillSidebar` (`role=tablist`, `aria-selected`)
- Wire `AgentIDE` to bump a refresh key on launch so the sidebar list reflects the new run immediately

## Testing

- `npm run build` and `npm run lint` clean for changed files
- SchemaForm lazy chunk preserved
- Manual: launch a skill via the modal → sidebar refreshes; open `?run=<id>` directly → output renders; toggle Skills/Runs tabs; verify nested-run indent for parent_run_id rows

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #629