### PR TITLE
fix: detect foreground daemons via port ownership in stop --force

### DIFF
--- a/pkg/state/orphan_unix.go
+++ b/pkg/state/orphan_unix.go
@@ -4,8 +4,8 @@ package state
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -15,24 +15,55 @@ import (
 // FindOrphan looks for an orphan gridctl daemon listening on port — a
 // process that owns the port but has no managed state file (because
 // e.g. an earlier shutdown deleted state mid-way, or the daemon was
-// started by a pre-fix binary).
+// started in a mode that doesn't write state, like 'serve --foreground').
 //
-// Returns (pid, true, nil) only when both signals agree: the /health
-// endpoint responds 200 AND pgrep -f finds exactly one matching
-// gridctl --daemon-child process for that port. Any ambiguity
-// (multiple matches, no /health response, no matching process)
-// returns ok=false so the caller can fall through to the legacy
-// behavior rather than acting on guesswork.
+// Returns (pid, true, nil) only when all three signals agree:
+//  1. The /health endpoint on port responds 200.
+//  2. Exactly one process (after excluding our own PID) holds the TCP
+//     listen socket for that port.
+//  3. That process's executable basename is "gridctl".
 //
-// The pgrep pattern requires --daemon-child, which the parent
-// gridctl stop process never sets, so this can never match the
-// caller itself.
+// Any ambiguity — health probe fails, no listener, multiple listeners
+// after self-exclusion, or executable name mismatch — returns ok=false
+// so the caller falls through to the legacy behavior rather than acting
+// on guesswork.
 func FindOrphan(port int) (int, bool, error) {
-	if !probeHealth(port) {
+	if !probeHealthFn(port) {
 		return 0, false, nil
 	}
-	return runPgrep(port)
+
+	pids, err := listenerForPort(port)
+	if err != nil {
+		return 0, false, err
+	}
+
+	self := os.Getpid()
+	var candidates []int
+	for _, pid := range pids {
+		if pid == self {
+			continue
+		}
+		candidates = append(candidates, pid)
+	}
+	if len(candidates) != 1 {
+		return 0, false, nil
+	}
+
+	exe, err := executableForPID(candidates[0])
+	if err != nil || exe != "gridctl" {
+		return 0, false, nil
+	}
+	return candidates[0], true, nil
 }
+
+// Seams: package-level vars so tests can substitute fakes without
+// shelling out. The cmd/gridctl/stop_test.go file uses the same pattern
+// for findOrphan.
+var (
+	probeHealthFn    = probeHealth
+	listenerForPort  = lookupListenerPort
+	executableForPID = lookupExecutable
+)
 
 func probeHealth(port int) bool {
 	client := &http.Client{Timeout: 500 * time.Millisecond}
@@ -45,16 +76,19 @@ func probeHealth(port int) bool {
 	return resp.StatusCode == http.StatusOK
 }
 
-func runPgrep(port int) (int, bool, error) {
-	pattern := fmt.Sprintf("gridctl.*--daemon-child.*--port %d", port)
-	out, err := exec.Command("pgrep", "-f", pattern).Output()
+// lookupListenerPort returns the PIDs currently holding a TCP listen
+// socket on port. Uses `lsof -nP -iTCP:<port> -sTCP:LISTEN -t`, whose
+// -t flag emits one numeric PID per line and nothing else. Exit code 1
+// from lsof means "no matches" and is reported as an empty slice rather
+// than an error.
+func lookupListenerPort(port int) ([]int, error) {
+	out, err := exec.Command("lsof", "-nP", "-iTCP:"+strconv.Itoa(port), "-sTCP:LISTEN", "-t").Output()
 	if err != nil {
-		// pgrep exit code 1 means "no matches" — not an error.
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-			return 0, false, nil
+			return nil, nil
 		}
-		return 0, false, fmt.Errorf("pgrep: %w", err)
+		return nil, err
 	}
 
 	var pids []int
@@ -65,8 +99,23 @@ func runPgrep(port int) (int, bool, error) {
 		}
 		pids = append(pids, pid)
 	}
-	if len(pids) != 1 {
-		return 0, false, nil
+	return pids, nil
+}
+
+// lookupExecutable returns the bare executable basename for pid via
+// `ps -o comm= -p <pid>`. Linux ps may decorate renamed threads with
+// parens; trim them so the returned name compares cleanly to "gridctl".
+func lookupExecutable(pid int) (string, error) {
+	out, err := exec.Command("ps", "-o", "comm=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return "", err
 	}
-	return pids[0], true, nil
+	name := strings.TrimSpace(string(out))
+	name = strings.Trim(name, "()")
+	// Some ps implementations return the full executable path; the
+	// daemon-vs-caller decision only cares about the basename.
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name, nil
 }

--- a/pkg/state/orphan_unix_test.go
+++ b/pkg/state/orphan_unix_test.go
@@ -1,0 +1,148 @@
+//go:build !windows
+
+package state
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+// stubProbeHealth installs a fake probeHealthFn and restores the real
+// implementation on test cleanup. Mirrors stubFindOrphan in
+// cmd/gridctl/stop_test.go.
+func stubProbeHealth(t *testing.T, fn func(int) bool) {
+	t.Helper()
+	orig := probeHealthFn
+	probeHealthFn = fn
+	t.Cleanup(func() { probeHealthFn = orig })
+}
+
+func stubListenerForPort(t *testing.T, fn func(int) ([]int, error)) {
+	t.Helper()
+	orig := listenerForPort
+	listenerForPort = fn
+	t.Cleanup(func() { listenerForPort = orig })
+}
+
+func stubExecutableForPID(t *testing.T, fn func(int) (string, error)) {
+	t.Helper()
+	orig := executableForPID
+	executableForPID = fn
+	t.Cleanup(func() { executableForPID = orig })
+}
+
+func TestFindOrphan_ForegroundProcess(t *testing.T) {
+	stubProbeHealth(t, func(int) bool { return true })
+	stubListenerForPort(t, func(int) ([]int, error) { return []int{4242}, nil })
+	stubExecutableForPID(t, func(int) (string, error) { return "gridctl", nil })
+
+	pid, ok, err := FindOrphan(8180)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok || pid != 4242 {
+		t.Errorf("expected (4242, true, nil); got (%d, %v, %v)", pid, ok, err)
+	}
+}
+
+func TestFindOrphan_NonGridctlListener(t *testing.T) {
+	stubProbeHealth(t, func(int) bool { return true })
+	stubListenerForPort(t, func(int) ([]int, error) { return []int{4242}, nil })
+	stubExecutableForPID(t, func(int) (string, error) { return "nginx", nil })
+
+	pid, ok, err := FindOrphan(8180)
+	if err != nil || ok || pid != 0 {
+		t.Errorf("expected (0, false, nil); got (%d, %v, %v)", pid, ok, err)
+	}
+}
+
+func TestFindOrphan_ExcludesSelf(t *testing.T) {
+	stubProbeHealth(t, func(int) bool { return true })
+	self := os.Getpid()
+	stubListenerForPort(t, func(int) ([]int, error) { return []int{self}, nil })
+	exeCalled := false
+	stubExecutableForPID(t, func(int) (string, error) {
+		exeCalled = true
+		return "gridctl", nil
+	})
+
+	pid, ok, err := FindOrphan(8180)
+	if err != nil || ok || pid != 0 {
+		t.Errorf("expected (0, false, nil); got (%d, %v, %v)", pid, ok, err)
+	}
+	if exeCalled {
+		t.Error("expected executable lookup to be skipped when only candidate is self")
+	}
+}
+
+func TestFindOrphan_NoListener(t *testing.T) {
+	stubProbeHealth(t, func(int) bool { return true })
+	stubListenerForPort(t, func(int) ([]int, error) { return nil, nil })
+	stubExecutableForPID(t, func(int) (string, error) {
+		t.Fatal("executable lookup should not run when no listeners")
+		return "", nil
+	})
+
+	pid, ok, err := FindOrphan(8180)
+	if err != nil || ok || pid != 0 {
+		t.Errorf("expected (0, false, nil); got (%d, %v, %v)", pid, ok, err)
+	}
+}
+
+func TestFindOrphan_MultipleListeners(t *testing.T) {
+	stubProbeHealth(t, func(int) bool { return true })
+	stubListenerForPort(t, func(int) ([]int, error) { return []int{4242, 5151}, nil })
+	stubExecutableForPID(t, func(int) (string, error) {
+		t.Fatal("executable lookup should not run when listeners are ambiguous")
+		return "", nil
+	})
+
+	pid, ok, err := FindOrphan(8180)
+	if err != nil || ok || pid != 0 {
+		t.Errorf("expected (0, false, nil); got (%d, %v, %v)", pid, ok, err)
+	}
+}
+
+func TestFindOrphan_HealthDown(t *testing.T) {
+	stubProbeHealth(t, func(int) bool { return false })
+	stubListenerForPort(t, func(int) ([]int, error) {
+		t.Fatal("listener lookup should not run when health probe fails")
+		return nil, nil
+	})
+	stubExecutableForPID(t, func(int) (string, error) {
+		t.Fatal("executable lookup should not run when health probe fails")
+		return "", nil
+	})
+
+	pid, ok, err := FindOrphan(8180)
+	if err != nil || ok || pid != 0 {
+		t.Errorf("expected (0, false, nil); got (%d, %v, %v)", pid, ok, err)
+	}
+}
+
+func TestFindOrphan_ListenerLookupError(t *testing.T) {
+	wantErr := errors.New("boom")
+	stubProbeHealth(t, func(int) bool { return true })
+	stubListenerForPort(t, func(int) ([]int, error) { return nil, wantErr })
+	stubExecutableForPID(t, func(int) (string, error) {
+		t.Fatal("executable lookup should not run on listener lookup error")
+		return "", nil
+	})
+
+	pid, ok, err := FindOrphan(8180)
+	if !errors.Is(err, wantErr) || ok || pid != 0 {
+		t.Errorf("expected (0, false, %v); got (%d, %v, %v)", wantErr, pid, ok, err)
+	}
+}
+
+func TestFindOrphan_ExecutableLookupError(t *testing.T) {
+	stubProbeHealth(t, func(int) bool { return true })
+	stubListenerForPort(t, func(int) ([]int, error) { return []int{4242}, nil })
+	stubExecutableForPID(t, func(int) (string, error) { return "", errors.New("nope") })
+
+	pid, ok, err := FindOrphan(8180)
+	if err != nil || ok || pid != 0 {
+		t.Errorf("expected (0, false, nil); got (%d, %v, %v)", pid, ok, err)
+	}
+}


### PR DESCRIPTION
## Description

`gridctl stop --force` could not find a daemon started with `gridctl serve --foreground` (or `gridctl apply <stack> --foreground`) because the orphan-detection `pgrep` pattern at `pkg/state/orphan_unix.go:48` required `--daemon-child` in argv. Foreground processes never have that token, so the fallback always returned `no stackless daemon is running` even with the gateway alive and serving traffic.

This PR rewrites `FindOrphan` to identify the orphan by **port ownership** (`lsof -nP -iTCP:<port> -sTCP:LISTEN -t`), verify the executable basename equals `gridctl` (`ps -o comm= -p <pid>`), and exclude `os.Getpid()`. Port ownership is the deterministic signal — one process per LISTEN socket — so it works across every launch mode (foreground, daemon-fork, future entry points) without coupling to argv shape.

## Type of Change

- [x] Bug fix

## Changes Made

- `pkg/state/orphan_unix.go` — replace argv-pattern `pgrep` with port-ownership lookup; add `lookupListenerPort` and `lookupExecutable` helpers; add `probeHealthFn` / `listenerForPort` / `executableForPID` package-level seams for tests; preserve the existing "fall through cleanly on ambiguity" safety contract (anything unexpected returns `ok=false`).
- `pkg/state/orphan_unix_test.go` — new file. Eight tests covering: foreground-mode discovery, non-gridctl listener rejection, self-PID exclusion, no listener, multiple listeners (ambiguous), health probe down, listener-lookup error propagation, executable-lookup error fall-through.

Out of scope (per investigation): foreground mode still does not write a state file, `cmd/gridctl/stop.go` is unchanged, `orphan_windows.go` is unchanged, no new `go.mod` dependencies.

## Testing

Automated:
- `go test ./...` — full suite passes, including the 8 new `TestFindOrphan_*` cases.
- `golangci-lint run ./...` — 0 issues.

Manual repro (macOS, gridctl built from this branch):

1. Terminal A: `./gridctl serve --foreground --port 8180`
2. Terminal B: `./gridctl stop` — now reports `pid <N> is listening on :8180 ... run 'gridctl stop --force' to terminate it` (was: `no stackless daemon is running`).
3. Terminal B: `./gridctl stop --force` — terminates the foreground daemon and exits 0.

Default daemon-fork path (`./gridctl serve` then `./gridctl stop`) continues to work via the state-file path; covered by `TestRunStop_RunningDaemon`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #632