### PR TITLE
feat: add real runs workspace with global SSE bus

### DIFF
--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -6,12 +6,24 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gridctl/gridctl/pkg/agent/compose"
 	"github.com/gridctl/gridctl/pkg/agent/persist"
 	"github.com/gridctl/gridctl/pkg/agent/runner"
 )
+
+// agentRunsListDefaultLimit caps the default page size for
+// GET /api/agent/runs when no `limit` query param is supplied.
+const agentRunsListDefaultLimit = 50
+
+// agentRunsListMaxLimit caps the page size operators can request.
+// Large requests still page through the directory scan; a hard ceiling
+// keeps a malicious or buggy client from forcing the daemon to read
+// thousands of summary files in one request.
+const agentRunsListMaxLimit = 500
 
 // SetAgentRunStore wires the persist.Store the /api/agent/runs/*
 // handlers fall back to when no runtime aggregate is installed.
@@ -48,29 +60,107 @@ type agentRunListItem struct {
 }
 
 // handleAgentRunsList returns a paginated list of recent runs.
+//
+// Query params (all optional):
+//   - status  — exact match against summary status (running / ok / error /
+//     cancelled / awaiting_approval / suspended).
+//   - skill   — exact match against the skill name the run was launched
+//     against.
+//   - parent  — exact match against parent_run_id; surfaces child runs of
+//     a given root.
+//   - since   — RFC 3339 timestamp or relative duration (`5m`, `1h`,
+//     `24h`, `7d`); excludes runs older than the cutoff.
+//   - limit   — page size, clamped to [1, agentRunsListMaxLimit].
+//   - cursor  — last run_id from the previous page; resumes the scan
+//     from the next-older run.
+//
+// Filtering scans the ledger directory in run-ID order (newest first)
+// and applies the predicates in-memory. For installs with more than
+// ~10k persisted runs the store should grow a sidecar index; until
+// then the scan cost is bounded by the page size + filter window.
 func (s *Server) handleAgentRunsList(w http.ResponseWriter, r *http.Request) {
 	store := s.runStore()
 	if store == nil {
 		writeJSONError(w, "agent runtime not configured", http.StatusServiceUnavailable)
 		return
 	}
-	limit := 50
-	if v := r.URL.Query().Get("limit"); v != "" {
-		var parsed int
-		if _, err := fmt.Sscanf(v, "%d", &parsed); err == nil && parsed > 0 {
+
+	q := r.URL.Query()
+	limit := agentRunsListDefaultLimit
+	if v := q.Get("limit"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
 			limit = parsed
 		}
 	}
-	summaries, err := store.List(limit)
+	if limit > agentRunsListMaxLimit {
+		limit = agentRunsListMaxLimit
+	}
+
+	filter := persist.ListFilter{
+		Status:   strings.TrimSpace(q.Get("status")),
+		Skill:    strings.TrimSpace(q.Get("skill")),
+		Parent:   strings.TrimSpace(q.Get("parent")),
+		BeforeID: strings.TrimSpace(q.Get("cursor")),
+	}
+	if since := strings.TrimSpace(q.Get("since")); since != "" {
+		t, err := parseSinceParam(since)
+		if err != nil {
+			writeJSONError(w, fmt.Sprintf("invalid since: %v", err), http.StatusBadRequest)
+			return
+		}
+		filter.Since = t
+	}
+
+	// Over-fetch by one so we can emit a forward cursor only when
+	// there is something to page to.
+	summaries, err := store.ListFiltered(filter, limit+1)
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	var nextCursor string
+	if len(summaries) > limit {
+		summaries = summaries[:limit]
+	}
+	if len(summaries) == limit && limit > 0 {
+		nextCursor = summaries[limit-1].RunID
+	}
+
 	out := make([]agentRunListItem, 0, len(summaries))
 	for _, sum := range summaries {
 		out = append(out, summaryToListItem(sum))
 	}
-	writeJSON(w, map[string]any{"runs": out})
+	body := map[string]any{"runs": out}
+	if nextCursor != "" {
+		body["next_cursor"] = nextCursor
+	}
+	writeJSON(w, body)
+}
+
+// parseSinceParam accepts an RFC 3339 timestamp ("2026-05-14T10:00:00Z")
+// or a relative duration ("5m", "1h", "24h", "7d"). Relative values are
+// resolved against time.Now() so the lower bound moves with the
+// request. Custom shapes (e.g. "1d2h") are rejected — the UI only ever
+// sends the canonical forms.
+func parseSinceParam(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), nil
+	}
+	// Go's ParseDuration accepts the unit suffixes we care about; "d"
+	// is not native, so expand it before delegating.
+	if strings.HasSuffix(s, "d") {
+		days, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
+		if err != nil || days <= 0 {
+			return time.Time{}, fmt.Errorf("invalid duration %q", s)
+		}
+		return time.Now().UTC().Add(-time.Duration(days) * 24 * time.Hour), nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return time.Time{}, fmt.Errorf("invalid duration %q", s)
+	}
+	return time.Now().UTC().Add(-d), nil
 }
 
 // handleAgentRunGet returns a run's typed event timeline. The full
@@ -151,6 +241,77 @@ func (s *Server) handleAgentRunEvents(w http.ResponseWriter, r *http.Request) {
 		safe, _ := json.Marshal(err.Error())
 		fmt.Fprintf(w, "event: error\ndata: %s\n\n", safe)
 		flusher.Flush()
+	}
+}
+
+// handleAgentRunsEventsStream is the global live tail across every
+// run. It subscribes to the persist.Store bus and forwards each event
+// as an SSE `data:` line for the lifetime of the connection.
+//
+// Reconnect contract: clients dedupe by `(run_id, seq)` against a
+// per-run watermark, because the per-run event endpoint replays the
+// full ledger on subscribe and the same event will appear on both
+// streams. When the per-subscriber buffer overflows the handler emits
+// an `event: stream_restarted` frame ahead of the next event so the
+// client can resync its watermark — at-least-once with a one-shot
+// gap signal, not at-most-once.
+func (s *Server) handleAgentRunsEventsStream(w http.ResponseWriter, r *http.Request) {
+	store := s.runStore()
+	if store == nil {
+		writeJSONError(w, "agent runtime not configured", http.StatusServiceUnavailable)
+		return
+	}
+	bus := store.Bus()
+	if bus == nil {
+		writeJSONError(w, "global event bus not available", http.StatusServiceUnavailable)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeJSONError(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	sub, unsub := bus.Subscribe()
+	defer unsub()
+
+	// Emit a no-op ready frame so the client can confirm the stream is
+	// open before any actual events arrive. EventSource readers ignore
+	// unknown event types, so this is safe to ship without a matching
+	// listener.
+	fmt.Fprint(w, "event: ready\ndata: {}\n\n")
+	flusher.Flush()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-sub.C:
+			if !ok {
+				return
+			}
+			if sub.TakeDropped() {
+				fmt.Fprint(w, "event: stream_restarted\ndata: {}\n\n")
+			}
+			raw, err := json.Marshal(ev)
+			if err != nil {
+				// Best-effort: keep the stream alive but surface the
+				// problem so the client can decide to refetch.
+				safe, _ := json.Marshal(err.Error())
+				fmt.Fprintf(w, "event: error\ndata: %s\n\n", safe)
+				flusher.Flush()
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", raw); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
 	}
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -330,6 +330,11 @@ func (s *Server) Handler() http.Handler {
 	// through the in-process approval registry.
 	mux.HandleFunc("GET /api/agent/runs", s.handleAgentRunsList)
 	mux.HandleFunc("POST /api/agent/runs", s.handleAgentRunsLaunch)
+	// Global live tail across every run — wired before the {run_id}
+	// surface so the more-specific event subscription doesn't shadow
+	// the path. The per-run SSE remains the source of truth for any
+	// single run; this stream is the cross-run observability surface.
+	mux.HandleFunc("GET /api/agent/runs/events/stream", s.handleAgentRunsEventsStream)
 	mux.HandleFunc("GET /api/agent/runs/{run_id}", s.handleAgentRunGet)
 	mux.HandleFunc("GET /api/agent/runs/{run_id}/events", s.handleAgentRunEvents)
 	mux.HandleFunc("POST /api/agent/runs/{run_id}/resume", s.handleAgentRunResume)

--- a/pkg/agent/persist/bus.go
+++ b/pkg/agent/persist/bus.go
@@ -1,0 +1,84 @@
+package persist
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// busSubscriberBuffer is the default per-subscriber channel depth.
+// Slow consumers cap out here; once the channel is full the publisher
+// drops the event for that subscriber and flags `dropped`, which the
+// SSE handler surfaces as a `stream_restarted` sentinel on the next
+// successful send. Sized to absorb a reasonable burst of node events
+// from a handful of concurrent runs without forcing every consumer to
+// stay on the hot path.
+const busSubscriberBuffer = 256
+
+// Bus is a process-wide pub/sub fan-out for run lifecycle events. The
+// per-run JSONL ledger remains the durable source of truth; the bus is
+// a best-effort live-tail surface for cross-run observers (the /runs
+// workspace, the bottom-panel waterfall, anything else that needs to
+// see events as they happen without subscribing per-run).
+//
+// Sends are non-blocking — a slow subscriber loses events rather than
+// stalling the recorder. Dropped subscribers see a one-shot
+// `stream_restarted` notification on the next successful delivery so
+// clients can decide whether to refetch the affected run.
+type Bus struct {
+	mu   sync.RWMutex
+	subs map[*Subscriber]struct{}
+}
+
+// Subscriber is one live tail of the global event stream. The SSE
+// handler reads from C, checks Dropped before each send, and emits a
+// sentinel when the flag flips from true → false.
+type Subscriber struct {
+	C       chan Event
+	dropped atomic.Bool
+}
+
+// NewBus constructs an empty bus.
+func NewBus() *Bus {
+	return &Bus{subs: make(map[*Subscriber]struct{})}
+}
+
+// Subscribe registers a new subscriber and returns its channel along
+// with an unsubscribe function. Callers must Unsubscribe on shutdown
+// or the bus will hold the channel alive past its owning goroutine.
+func (b *Bus) Subscribe() (*Subscriber, func()) {
+	sub := &Subscriber{C: make(chan Event, busSubscriberBuffer)}
+	b.mu.Lock()
+	b.subs[sub] = struct{}{}
+	b.mu.Unlock()
+	return sub, func() {
+		b.mu.Lock()
+		if _, ok := b.subs[sub]; ok {
+			delete(b.subs, sub)
+			close(sub.C)
+		}
+		b.mu.Unlock()
+	}
+}
+
+// Publish fans out an event to every subscriber. Subscribers whose
+// channel is full have their dropped flag set instead of receiving the
+// event; the SSE handler converts that into a `stream_restarted`
+// frame on the next successful send.
+func (b *Bus) Publish(ev Event) {
+	b.mu.RLock()
+	for sub := range b.subs {
+		select {
+		case sub.C <- ev:
+		default:
+			sub.dropped.Store(true)
+		}
+	}
+	b.mu.RUnlock()
+}
+
+// TakeDropped clears the dropped flag and returns whether the
+// subscriber had missed events since the last call. SSE handlers call
+// this before each send so the sentinel rides ahead of the next event.
+func (s *Subscriber) TakeDropped() bool {
+	return s.dropped.Swap(false)
+}

--- a/pkg/agent/persist/bus_test.go
+++ b/pkg/agent/persist/bus_test.go
@@ -1,0 +1,96 @@
+package persist
+
+import (
+	"testing"
+	"time"
+)
+
+// busFanOutEvent is the fixture every bus test reuses — a benign
+// `run_started` payload with a known run ID so assertions can match on
+// the envelope without dragging in the marshalling code paths.
+func busFanOutEvent(runID string, seq uint64) Event {
+	return Event{
+		RunID: runID,
+		Seq:   seq,
+		Time:  time.Unix(0, 0).UTC(),
+		Type:  EventRunStarted,
+	}
+}
+
+func TestBus_PublishFansOutToSubscribers(t *testing.T) {
+	bus := NewBus()
+	subA, unsubA := bus.Subscribe()
+	t.Cleanup(unsubA)
+	subB, unsubB := bus.Subscribe()
+	t.Cleanup(unsubB)
+
+	want := busFanOutEvent("run_a", 1)
+	bus.Publish(want)
+
+	select {
+	case got := <-subA.C:
+		if got.RunID != want.RunID || got.Seq != want.Seq {
+			t.Fatalf("subA: got %+v, want %+v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("subA: did not receive event within 1s")
+	}
+
+	select {
+	case got := <-subB.C:
+		if got.RunID != want.RunID || got.Seq != want.Seq {
+			t.Fatalf("subB: got %+v, want %+v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("subB: did not receive event within 1s")
+	}
+}
+
+func TestBus_UnsubscribeStopsDelivery(t *testing.T) {
+	bus := NewBus()
+	sub, unsub := bus.Subscribe()
+
+	unsub()
+	bus.Publish(busFanOutEvent("run_a", 1))
+
+	// After unsubscribe the channel is closed and drained — no
+	// pending event should remain.
+	select {
+	case ev, ok := <-sub.C:
+		if ok {
+			t.Fatalf("expected closed channel, got event %+v", ev)
+		}
+	default:
+		// Closed channels receive zero-value immediately; the default
+		// branch here would only fire if Unsubscribe hadn't closed
+		// the channel, which is the failure mode we're guarding.
+		t.Fatalf("expected channel to be closed after unsubscribe")
+	}
+}
+
+func TestBus_DropOnFullSetsDroppedFlag(t *testing.T) {
+	bus := NewBus()
+	sub, unsub := bus.Subscribe()
+	t.Cleanup(unsub)
+
+	// Fill the buffer plus one to force a drop. The buffer depth is
+	// an implementation detail, so loop until TakeDropped() returns
+	// true rather than hard-coding it.
+	for i := 0; i < busSubscriberBuffer*2; i++ {
+		bus.Publish(busFanOutEvent("run_a", uint64(i+1)))
+	}
+	if !sub.TakeDropped() {
+		t.Fatalf("expected dropped flag to be set after overflow")
+	}
+	// Second read clears the flag — it's a one-shot signal so the SSE
+	// handler only emits a single `stream_restarted` frame per gap.
+	if sub.TakeDropped() {
+		t.Fatalf("expected dropped flag to clear after TakeDropped")
+	}
+}
+
+func TestBus_NoSubscribersPublishIsNoOp(t *testing.T) {
+	bus := NewBus()
+	// Should not panic or block.
+	bus.Publish(busFanOutEvent("run_a", 1))
+}

--- a/pkg/agent/persist/store.go
+++ b/pkg/agent/persist/store.go
@@ -44,6 +44,8 @@ type Store struct {
 
 	mu      sync.Mutex
 	writers map[string]*Recorder
+
+	bus *Bus
 }
 
 // NewStore constructs a Store rooted at the given directory. The
@@ -56,7 +58,18 @@ func NewStore(dir string) *Store {
 	return &Store{
 		dir:     dir,
 		writers: make(map[string]*Recorder),
+		bus:     NewBus(),
 	}
+}
+
+// Bus exposes the global event bus so cross-run observers (the /runs
+// workspace SSE stream, future cross-run metrics) can subscribe to
+// every event without polling the disk. The bus is best-effort: events
+// arrive after the durable JSONL write and slow consumers see drops
+// surfaced as `stream_restarted` sentinels rather than backpressure
+// against the recorder.
+func (s *Store) Bus() *Bus {
+	return s.bus
 }
 
 // Dir returns the configured runs directory.
@@ -172,6 +185,101 @@ func (s *Store) Stream(ctx context.Context, runID string, fn func(Event) error) 
 		}
 	}
 	return scanner.Err()
+}
+
+// ListFilter constrains a List call without forcing every caller
+// through an in-memory post-filter. Empty fields match everything.
+//
+// Note: scanning the runs directory and reading each summary stays
+// linear in total runs on disk. TODO(runs-index): once installs grow
+// past ~10k runs the API handler should consult a sidecar index
+// (sqlite or an mtime-bucketed manifest) instead of re-scanning.
+type ListFilter struct {
+	Status   string    // exact match against RunSummary.Status; empty = any
+	Skill    string    // exact match against RunSummary.Skill; empty = any
+	Parent   string    // exact match against ParentRunID; empty = any
+	Since    time.Time // include runs with StartedAt >= Since; zero = no lower bound
+	BeforeID string    // cursor: skip runs newer-or-equal to this ID (run ID is time-ordered)
+}
+
+// ListFiltered is List with optional filters and an ID-based cursor.
+// Runs are returned newest first; pass the last RunID from the prior
+// page in `BeforeID` to fetch the next page.
+func (s *Store) ListFiltered(filter ListFilter, limit int) ([]RunSummary, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("persist: reading runs dir: %w", err)
+	}
+	type tagged struct {
+		runID   string
+		modTime time.Time
+	}
+	files := make([]tagged, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, fileExt) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, tagged{
+			runID:   strings.TrimSuffix(name, fileExt),
+			modTime: info.ModTime(),
+		})
+	}
+	// Sort by run ID descending — IDs embed a UTC timestamp prefix so
+	// lexicographic order matches start order more faithfully than
+	// mtime (which moves whenever a long-running run records its next
+	// event).
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].runID == files[j].runID {
+			return files[i].modTime.After(files[j].modTime)
+		}
+		return files[i].runID > files[j].runID
+	})
+
+	out := make([]RunSummary, 0, limit)
+	skipping := filter.BeforeID != ""
+	for _, t := range files {
+		if skipping {
+			if t.runID == filter.BeforeID {
+				skipping = false
+			}
+			continue
+		}
+		summary, err := s.Summary(t.runID)
+		if err != nil {
+			continue
+		}
+		if filter.Status != "" && summary.Status != filter.Status {
+			continue
+		}
+		if filter.Skill != "" && summary.Skill != filter.Skill {
+			continue
+		}
+		if filter.Parent != "" && summary.ParentRunID != filter.Parent {
+			continue
+		}
+		if !filter.Since.IsZero() && summary.StartedAt.Before(filter.Since) {
+			// Files are sorted newest-first; once we see a run older
+			// than the lower bound the rest will be too. Bail early to
+			// keep the scan O(window) instead of O(all runs).
+			break
+		}
+		out = append(out, summary)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
 }
 
 // List enumerates every run on disk, newest first by mtime. Each
@@ -323,7 +431,10 @@ func (r *Recorder) NextSeq() uint64 {
 
 // Record appends a typed payload as an Event. The sequence number is
 // allocated from the recorder's monotonic counter; Time is set to
-// time.Now().UTC().
+// time.Now().UTC(). After the durable write succeeds the event fans
+// out to the store's global bus so cross-run subscribers (the /runs
+// live tail) see it immediately. Bus publish is non-blocking — a slow
+// subscriber drops the event rather than stalling the recorder.
 func (r *Recorder) Record(eventType EventType, payload any) (Event, error) {
 	seq := r.seq.Add(1)
 	ev, err := MarshalEvent(r.runID, seq, eventType, payload)
@@ -332,6 +443,9 @@ func (r *Recorder) Record(eventType EventType, payload any) (Event, error) {
 	}
 	if err := r.write(ev); err != nil {
 		return Event{}, err
+	}
+	if r.store != nil && r.store.bus != nil {
+		r.store.bus.Publish(ev)
 	}
 	return ev, nil
 }

--- a/pkg/agent/persist/store_test.go
+++ b/pkg/agent/persist/store_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestNewRunIDIsUnique(t *testing.T) {
@@ -574,6 +575,114 @@ func TestCapRawJSONRespectsBudget(t *testing.T) {
 	}
 	if s, ok := probe.(string); !ok || len(s) != MaxPayloadBytes {
 		t.Fatalf("capped string length = %d, want %d (probe=%T)", len(s), MaxPayloadBytes, probe)
+	}
+}
+
+// writeMinimalRun emits a run_started + run_completed pair so the
+// summary tests below have something to filter against without having
+// to know the recorder internals.
+func writeMinimalRun(t *testing.T, store *Store, skill, status string) string {
+	t.Helper()
+	runID := NewRunID()
+	rec, err := store.OpenWriter(runID)
+	if err != nil {
+		t.Fatalf("OpenWriter: %v", err)
+	}
+	if _, err := rec.Record(EventRunStarted, RunStartedPayload{Skill: skill, Flavor: "ts"}); err != nil {
+		t.Fatalf("Record start: %v", err)
+	}
+	if status != "" {
+		if _, err := rec.Record(EventRunCompleted, RunCompletedPayload{Status: status}); err != nil {
+			t.Fatalf("Record completed: %v", err)
+		}
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// NewRunID() embeds millisecond-precision timestamps; insert a
+	// gap so subsequent runs sort distinctly.
+	time.Sleep(2 * time.Millisecond)
+	return runID
+}
+
+func TestListFilteredByStatus(t *testing.T) {
+	t.Parallel()
+	store := NewStore(t.TempDir())
+	defer store.CloseAll() //nolint:errcheck
+
+	writeMinimalRun(t, store, "alpha", "ok")
+	errored := writeMinimalRun(t, store, "alpha", "error")
+	writeMinimalRun(t, store, "beta", "ok")
+
+	got, err := store.ListFiltered(ListFilter{Status: "error"}, 10)
+	if err != nil {
+		t.Fatalf("ListFiltered: %v", err)
+	}
+	if len(got) != 1 || got[0].RunID != errored {
+		t.Fatalf("expected one errored run %q, got %+v", errored, got)
+	}
+}
+
+func TestListFilteredBySkill(t *testing.T) {
+	t.Parallel()
+	store := NewStore(t.TempDir())
+	defer store.CloseAll() //nolint:errcheck
+
+	writeMinimalRun(t, store, "alpha", "ok")
+	writeMinimalRun(t, store, "alpha", "ok")
+	beta := writeMinimalRun(t, store, "beta", "ok")
+
+	got, err := store.ListFiltered(ListFilter{Skill: "beta"}, 10)
+	if err != nil {
+		t.Fatalf("ListFiltered: %v", err)
+	}
+	if len(got) != 1 || got[0].RunID != beta {
+		t.Fatalf("expected one beta run %q, got %+v", beta, got)
+	}
+}
+
+func TestListFilteredCursorPaginates(t *testing.T) {
+	t.Parallel()
+	store := NewStore(t.TempDir())
+	defer store.CloseAll() //nolint:errcheck
+
+	runs := make([]string, 0, 5)
+	for i := 0; i < 5; i++ {
+		runs = append(runs, writeMinimalRun(t, store, "alpha", "ok"))
+	}
+
+	page1, err := store.ListFiltered(ListFilter{}, 2)
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	if len(page1) != 2 {
+		t.Fatalf("page1 size = %d, want 2", len(page1))
+	}
+
+	cursor := page1[len(page1)-1].RunID
+	page2, err := store.ListFiltered(ListFilter{BeforeID: cursor}, 2)
+	if err != nil {
+		t.Fatalf("page2: %v", err)
+	}
+	if len(page2) != 2 {
+		t.Fatalf("page2 size = %d, want 2", len(page2))
+	}
+	// Pages must not overlap — the cursor is exclusive.
+	for _, a := range page1 {
+		for _, b := range page2 {
+			if a.RunID == b.RunID {
+				t.Fatalf("page1 and page2 overlap on %q", a.RunID)
+			}
+		}
+	}
+	// Run IDs sort lexicographically by their embedded timestamps, so
+	// the newest run lands first across both pages.
+	all := append(page1, page2...)
+	for i := range all {
+		want := runs[len(runs)-1-i]
+		if all[i].RunID != want {
+			t.Fatalf("pos %d: got %q, want %q (full=%v)", i, all[i].RunID, want, runs)
+		}
 	}
 }
 

--- a/web/src/__tests__/RunLauncherModal.test.tsx
+++ b/web/src/__tests__/RunLauncherModal.test.tsx
@@ -8,7 +8,7 @@ vi.mock('../lib/agent-runs', async () => {
   );
   return {
     ...actual,
-    fetchAgentRuns: vi.fn().mockResolvedValue([]),
+    fetchAgentRuns: vi.fn().mockResolvedValue({ runs: [] }),
     fetchAgentRun: vi.fn().mockResolvedValue(null),
     launchRun: vi.fn(),
   };
@@ -28,7 +28,7 @@ const mockedFetchAgentRun = vi.mocked(fetchAgentRun);
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockedFetchAgentRuns.mockResolvedValue([]);
+  mockedFetchAgentRuns.mockResolvedValue({ runs: [] });
   mockedFetchAgentRun.mockResolvedValue(null);
   window.localStorage.clear();
 });
@@ -167,22 +167,24 @@ describe('RunLauncherModal', () => {
   });
 
   it('populates the Run-like picker with prior runs of this skill', async () => {
-    mockedFetchAgentRuns.mockResolvedValueOnce([
-      {
-        run_id: 'a-prev-1',
-        skill: 'repo-audit',
-        status: 'completed',
-        started_at: '2026-05-13T16:00:00Z',
-        event_count: 4,
-      },
-      {
-        run_id: 'b-other',
-        skill: 'something-else',
-        status: 'completed',
-        started_at: '2026-05-13T16:30:00Z',
-        event_count: 2,
-      },
-    ]);
+    mockedFetchAgentRuns.mockResolvedValueOnce({
+      runs: [
+        {
+          run_id: 'a-prev-1',
+          skill: 'repo-audit',
+          status: 'completed',
+          started_at: '2026-05-13T16:00:00Z',
+          event_count: 4,
+        },
+        {
+          run_id: 'b-other',
+          skill: 'something-else',
+          status: 'completed',
+          started_at: '2026-05-13T16:30:00Z',
+          event_count: 2,
+        },
+      ],
+    });
     renderModal();
     await waitFor(() => {
       // The picker option label includes the short run id "a-prev-1"

--- a/web/src/__tests__/runsTree.test.ts
+++ b/web/src/__tests__/runsTree.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { buildRunTree, flattenRunTree } from '../components/runs/tree';
+import type { AgentRunSummary } from '../lib/agent-runs';
+
+function r(id: string, parent?: string): AgentRunSummary {
+  return {
+    run_id: id,
+    status: 'ok',
+    event_count: 0,
+    parent_run_id: parent,
+  };
+}
+
+describe('buildRunTree / flattenRunTree', () => {
+  it('roots orphans whose parent is not in the window', () => {
+    const runs = [r('child', 'missing'), r('standalone')];
+    const tree = buildRunTree(runs);
+    expect(tree.map((n) => n.run.run_id).sort()).toEqual(['child', 'standalone']);
+    for (const n of tree) expect(n.depth).toBe(0);
+  });
+
+  it('assigns BFS depth even when grandchildren appear before grandparents', () => {
+    // Source order surfaces a grandchild ahead of its grandparent.
+    // A naive parent-attach-and-set-depth pass would mis-indent.
+    const runs = [
+      r('grandchild', 'child'),
+      r('child', 'root'),
+      r('root'),
+    ];
+    const tree = buildRunTree(runs);
+    expect(tree).toHaveLength(1);
+    const root = tree[0];
+    expect(root.run.run_id).toBe('root');
+    expect(root.depth).toBe(0);
+    expect(root.children).toHaveLength(1);
+    const child = root.children[0];
+    expect(child.run.run_id).toBe('child');
+    expect(child.depth).toBe(1);
+    expect(child.children).toHaveLength(1);
+    expect(child.children[0].run.run_id).toBe('grandchild');
+    expect(child.children[0].depth).toBe(2);
+  });
+
+  it('flattenRunTree honours the collapsed set', () => {
+    const tree = buildRunTree([r('root'), r('child', 'root'), r('grandchild', 'child')]);
+    const all = flattenRunTree(tree, new Set());
+    expect(all.map((n) => n.run.run_id)).toEqual(['root', 'child', 'grandchild']);
+
+    const collapsedRoot = flattenRunTree(tree, new Set(['root']));
+    expect(collapsedRoot.map((n) => n.run.run_id)).toEqual(['root']);
+
+    const collapsedChild = flattenRunTree(tree, new Set(['child']));
+    expect(collapsedChild.map((n) => n.run.run_id)).toEqual(['root', 'child']);
+  });
+});

--- a/web/src/__tests__/useRunsStore.test.ts
+++ b/web/src/__tests__/useRunsStore.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useRunsStore, RUNS_DEFAULT_FILTERS } from '../stores/useRunsStore';
+import type { RunEvent } from '../lib/agent-api';
+
+// fresh resets every store field between tests — useRunsStore is a
+// process-wide singleton so without this the "Set" instances leak.
+function resetStore() {
+  useRunsStore.setState({
+    runs: [],
+    nextCursor: '',
+    loading: false,
+    loadingMore: false,
+    error: null,
+    filters: { ...RUNS_DEFAULT_FILTERS },
+    selectedRunID: null,
+    lastSeenSeq: {},
+    inFlightRuns: new Set<string>(),
+    streamStatus: 'idle',
+  });
+}
+
+function ev(runID: string, seq: number, type: string, payload: Record<string, unknown> = {}, time = '2026-05-14T10:00:00Z'): RunEvent {
+  return { run_id: runID, seq, type, time, payload };
+}
+
+describe('useRunsStore.applyRunEvent', () => {
+  beforeEach(resetStore);
+
+  it('inserts a new run on run_started and tracks it as in-flight', () => {
+    useRunsStore.getState().applyRunEvent(
+      ev('run_a', 1, 'run_started', { skill: 'audit', flavor: 'ts' }),
+    );
+
+    const state = useRunsStore.getState();
+    expect(state.runs).toHaveLength(1);
+    expect(state.runs[0].run_id).toBe('run_a');
+    expect(state.runs[0].skill).toBe('audit');
+    expect(state.runs[0].status).toBe('running');
+    expect(state.inFlightRuns.has('run_a')).toBe(true);
+    expect(state.lastSeenSeq['run_a']).toBe(1);
+  });
+
+  it('marks the run completed on run_completed and clears in-flight', () => {
+    const s = useRunsStore.getState();
+    s.applyRunEvent(ev('run_a', 1, 'run_started', { skill: 'audit' }));
+    s.applyRunEvent(ev('run_a', 2, 'run_completed', { status: 'ok' }));
+
+    const state = useRunsStore.getState();
+    expect(state.runs[0].status).toBe('ok');
+    expect(state.inFlightRuns.has('run_a')).toBe(false);
+  });
+
+  it('dedupes events by (run_id, seq) so replays do not double-count', () => {
+    const s = useRunsStore.getState();
+    s.applyRunEvent(ev('run_a', 1, 'run_started', { skill: 'audit' }));
+    s.applyRunEvent(ev('run_a', 2, 'run_completed', { status: 'ok' }));
+
+    // Replay the same seq=2 event — should be a no-op.
+    s.applyRunEvent(ev('run_a', 2, 'run_completed', { status: 'error' }));
+
+    // Status stays at "ok" because the duplicate was ignored.
+    expect(useRunsStore.getState().runs[0].status).toBe('ok');
+  });
+
+  it('ignores out-of-order events whose seq is below the watermark', () => {
+    const s = useRunsStore.getState();
+    s.applyRunEvent(ev('run_a', 1, 'run_started', { skill: 'audit' }));
+    s.applyRunEvent(ev('run_a', 3, 'run_completed', { status: 'ok' }));
+
+    // A stale node_enter for seq=2 — should be dropped.
+    s.applyRunEvent(ev('run_a', 2, 'node_enter', { node_id: 'n1' }));
+
+    expect(useRunsStore.getState().lastSeenSeq['run_a']).toBe(3);
+  });
+
+  it('promotes status to awaiting_approval on approval_request', () => {
+    const s = useRunsStore.getState();
+    s.applyRunEvent(ev('run_a', 1, 'run_started', { skill: 'audit' }));
+    s.applyRunEvent(ev('run_a', 2, 'approval_request', { approval_id: 'ap_1' }));
+
+    const run = useRunsStore.getState().runs[0];
+    expect(run.status).toBe('awaiting_approval');
+    expect(run.pending_approval).toBe('ap_1');
+  });
+
+  it('clears watermarks on stream restart and surfaces the new status', () => {
+    const s = useRunsStore.getState();
+    s.applyRunEvent(ev('run_a', 1, 'run_started', { skill: 'audit' }));
+    s.handleStreamRestart();
+
+    const state = useRunsStore.getState();
+    expect(state.lastSeenSeq).toEqual({});
+    expect(state.streamStatus).toBe('restarted');
+  });
+});
+
+describe('useRunsStore.setFilters', () => {
+  beforeEach(resetStore);
+
+  it('merges partial updates over the current filter state', () => {
+    const s = useRunsStore.getState();
+    s.setFilters({ status: 'error' });
+    expect(useRunsStore.getState().filters).toEqual({
+      ...RUNS_DEFAULT_FILTERS,
+      status: 'error',
+    });
+
+    s.setFilters({ skill: 'audit' });
+    expect(useRunsStore.getState().filters).toEqual({
+      ...RUNS_DEFAULT_FILTERS,
+      status: 'error',
+      skill: 'audit',
+    });
+  });
+
+  it('resetFilters restores the defaults', () => {
+    const s = useRunsStore.getState();
+    s.setFilters({ status: 'error', skill: 'audit', parent: 'run_x' });
+    s.resetFilters();
+    expect(useRunsStore.getState().filters).toEqual(RUNS_DEFAULT_FILTERS);
+  });
+});

--- a/web/src/components/agent/ApprovalBanner.tsx
+++ b/web/src/components/agent/ApprovalBanner.tsx
@@ -24,7 +24,7 @@ export function ApprovalBanner() {
     let cancelled = false;
     async function poll() {
       try {
-        const runs = await fetchAgentRuns(100);
+        const { runs } = await fetchAgentRuns(100);
         if (cancelled) return;
         setPending(runs.filter((r) => r.status === 'awaiting_approval' && r.pending_approval));
         setError(null);

--- a/web/src/components/agent/ide/RunsList.tsx
+++ b/web/src/components/agent/ide/RunsList.tsx
@@ -4,6 +4,15 @@ import { cn } from '../../../lib/cn';
 import { formatRelativeTime } from '../../../lib/time';
 import type { AgentRunSummary } from '../../../lib/agent-runs';
 import { useRunsForSkill } from './useRunsForSkill';
+import {
+  statusTone,
+  type RunStatusTone,
+} from '../../runs/status';
+import {
+  buildRunTree,
+  flattenRunTree,
+  type RunRowNode,
+} from '../../runs/tree';
 
 interface RunsListProps {
   /**
@@ -16,12 +25,6 @@ interface RunsListProps {
    * so the operator can scan back to where they are.
    */
   activeRunID: string | null;
-}
-
-interface RunRowNode {
-  run: AgentRunSummary;
-  depth: number;
-  children: RunRowNode[];
 }
 
 /**
@@ -43,7 +46,7 @@ export function RunsList({ refreshKey, activeRunID }: RunsListProps) {
     refreshKey,
   });
 
-  const tree = useMemo(() => buildTree(runs), [runs]);
+  const tree = useMemo(() => buildRunTree(runs), [runs]);
 
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
 
@@ -121,7 +124,7 @@ export function RunsList({ refreshKey, activeRunID }: RunsListProps) {
   }
 
   // Flatten the tree honouring collapsed state.
-  const rows = flattenTree(tree, collapsed);
+  const rows = flattenRunTree(tree, collapsed);
 
   return (
     <ul
@@ -230,50 +233,10 @@ function RunRow({ row, isActive, isCollapsed, hasChildren, onSelect, onToggle }:
   );
 }
 
-interface StatusTone {
-  dot: string;
-  glow: string | undefined;
-  text: string;
-}
-
-function statusTone(status: string | undefined): StatusTone {
-  const s = (status ?? '').toLowerCase();
-  if (s === 'running' || s === 'started' || s === 'in_progress') {
-    return {
-      dot: 'bg-status-running',
-      glow: '0 0 8px var(--color-status-running)',
-      text: 'text-status-running',
-    };
-  }
-  if (s === 'error' || s === 'errored' || s === 'failed') {
-    return {
-      dot: 'bg-status-error',
-      glow: '0 0 6px var(--color-status-error)',
-      text: 'text-status-error',
-    };
-  }
-  if (s === 'awaiting_approval' || s === 'suspended' || s === 'pending') {
-    return {
-      dot: 'bg-status-pending',
-      glow: '0 0 6px var(--color-status-pending)',
-      text: 'text-status-pending',
-    };
-  }
-  if (s === 'completed' || s === 'ok' || s === 'success') {
-    return {
-      dot: 'bg-status-running/60',
-      glow: undefined,
-      text: 'text-status-running/80',
-    };
-  }
-  return {
-    dot: 'bg-text-muted/40',
-    glow: undefined,
-    text: 'text-text-muted',
-  };
-}
-
-function StatusDot({ tone }: { tone: StatusTone }) {
+// The IDE sidebar prefers a dot-only status row (no icon, no label —
+// the depth indent + skill name is already the row's main signal).
+// StatusDot renders the shared tone with the IDE's glow halo.
+function StatusDot({ tone }: { tone: RunStatusTone }) {
   return (
     <span
       aria-hidden
@@ -281,51 +244,4 @@ function StatusDot({ tone }: { tone: StatusTone }) {
       style={tone.glow ? { boxShadow: tone.glow } : undefined}
     />
   );
-}
-
-/**
- * buildTree groups runs by parent_run_id and returns a depth-tagged
- * forest. Runs whose parent is not in the current window are
- * surfaced as roots so they don't vanish.
- */
-function buildTree(runs: AgentRunSummary[]): RunRowNode[] {
-  const byID = new Map<string, RunRowNode>();
-  for (const r of runs) {
-    byID.set(r.run_id, { run: r, depth: 0, children: [] });
-  }
-  const roots: RunRowNode[] = [];
-  for (const r of runs) {
-    const node = byID.get(r.run_id)!;
-    const parentID = r.parent_run_id;
-    if (parentID && byID.has(parentID)) {
-      const parent = byID.get(parentID)!;
-      node.depth = parent.depth + 1;
-      parent.children.push(node);
-    } else {
-      roots.push(node);
-    }
-  }
-  // After parent-attached pass, recompute depth via BFS so deeply
-  // nested children get the right indent even when the source order
-  // surfaces a grandparent after its grandchild.
-  const queue: RunRowNode[] = [...roots];
-  while (queue.length > 0) {
-    const n = queue.shift()!;
-    for (const c of n.children) {
-      c.depth = n.depth + 1;
-      queue.push(c);
-    }
-  }
-  return roots;
-}
-
-function flattenTree(roots: RunRowNode[], collapsed: Set<string>): RunRowNode[] {
-  const out: RunRowNode[] = [];
-  const walk = (node: RunRowNode) => {
-    out.push(node);
-    if (collapsed.has(node.run.run_id)) return;
-    for (const c of node.children) walk(c);
-  };
-  for (const r of roots) walk(r);
-  return out;
 }

--- a/web/src/components/agent/ide/useRunsForSkill.ts
+++ b/web/src/components/agent/ide/useRunsForSkill.ts
@@ -63,7 +63,7 @@ export function useRunsForSkill(options: UseRunsForSkillOptions = {}): UseRunsFo
     requestRef.current += 1;
     const myRequest = requestRef.current;
     fetchAgentRuns(fetchLimit)
-      .then((all) => {
+      .then(({ runs: all }) => {
         if (requestRef.current !== myRequest) return;
         const filtered = skillName ? all.filter((r) => r.skill === skillName) : all;
         const trimmed = limit != null ? filtered.slice(0, limit) : filtered;

--- a/web/src/components/layout/BottomPanel.tsx
+++ b/web/src/components/layout/BottomPanel.tsx
@@ -5,14 +5,17 @@ import {
   BarChart3,
   FileCode2,
   Activity,
+  PlayCircle,
   LockOpen,
 } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { useUIStore } from '../../stores/useUIStore';
+import { useRunsStore } from '../../stores/useRunsStore';
 import { LogsTab } from '../log/LogsTab';
 import { MetricsTab } from '../metrics/MetricsTab';
 import { SpecTab } from '../spec/SpecTab';
 import { TracesTab } from '../traces/TracesTab';
+import { RunsBottomTab } from '../runs/RunsBottomTab';
 import { PinsPanel } from '../pins/PinsPanel';
 
 const TABS = [
@@ -20,6 +23,7 @@ const TABS = [
   { id: 'metrics' as const, label: 'Metrics', icon: BarChart3 },
   { id: 'spec' as const, label: 'Spec', icon: FileCode2 },
   { id: 'traces' as const, label: 'Traces', icon: Activity },
+  { id: 'runs' as const, label: 'Runs', icon: PlayCircle },
   { id: 'pins' as const, label: 'Pins', icon: LockOpen },
 ];
 
@@ -31,6 +35,7 @@ export function BottomPanel() {
   const logsDetached = useUIStore((s) => s.logsDetached);
   const metricsDetached = useUIStore((s) => s.metricsDetached);
   const tracesDetached = useUIStore((s) => s.tracesDetached);
+  const inFlightCount = useRunsStore((s) => s.inFlightRuns.size);
 
   return (
     <div
@@ -65,6 +70,7 @@ export function BottomPanel() {
           <div role="tablist" aria-label="Bottom panel tabs" className="flex items-center gap-1">
           {TABS.map((tab) => {
             const isActive = bottomPanelTab === tab.id;
+            const badge = tab.id === 'runs' && inFlightCount > 0 ? inFlightCount : null;
             return (
               <button
                 key={tab.id}
@@ -84,6 +90,18 @@ export function BottomPanel() {
               >
                 <tab.icon size={12} className={isActive ? 'text-primary' : ''} />
                 {tab.label}
+                {badge != null && (
+                  <span
+                    aria-label={`${badge} in flight`}
+                    className={cn(
+                      'inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full',
+                      'text-[9px] font-mono leading-none',
+                      'bg-status-running/15 text-status-running border border-status-running/30',
+                    )}
+                  >
+                    {badge}
+                  </span>
+                )}
                 {/* Active indicator */}
                 {isActive && (
                   <span className="absolute bottom-0 left-2 right-2 h-0.5 bg-primary rounded-full" />
@@ -109,6 +127,9 @@ export function BottomPanel() {
           </div>
           <div id="panel-traces" role="tabpanel" aria-labelledby="tab-traces" className={cn('absolute inset-0', bottomPanelTab !== 'traces' && 'invisible')}>
             <TracesTab />
+          </div>
+          <div id="panel-runs" role="tabpanel" aria-labelledby="tab-runs" className={cn('absolute inset-0', bottomPanelTab !== 'runs' && 'invisible')}>
+            <RunsBottomTab />
           </div>
           <div id="panel-pins" role="tabpanel" aria-labelledby="tab-pins" className={cn('absolute inset-0', bottomPanelTab !== 'pins' && 'invisible')}>
             <PinsPanel />

--- a/web/src/components/runs/RunInspector.tsx
+++ b/web/src/components/runs/RunInspector.tsx
@@ -1,0 +1,145 @@
+import { useMemo } from 'react';
+import { X, ExternalLink, GitBranch, Layers } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { cn } from '../../lib/cn';
+import { useRunsStore } from '../../stores/useRunsStore';
+import { useRunTrace } from '../agent/ide/useRunTrace';
+import { RunOutputView } from '../agent/ide/RunOutputView';
+import { statusTone } from './status';
+import { StatusPill } from './StatusPill';
+import { shortRunID, formatDurationBetween, formatAbsoluteTime } from './format';
+
+interface RunInspectorProps {
+  runID: string;
+  onClose: () => void;
+  onOpenDetail: () => void;
+}
+
+/**
+ * RunInspector is the right-rail companion to the runs grid. It opens
+ * a per-run SSE stream via useRunTrace, surfaces run metadata
+ * (ancestry, timing, status) and composes the existing
+ * RunOutputView so the inspector stays in lockstep with what
+ * developers already know from the Agent IDE.
+ *
+ * The detail view at /runs/:id is the larger Honeycomb-style
+ * waterfall — the inspector intentionally stays scannable.
+ */
+export function RunInspector({ runID, onClose, onOpenDetail }: RunInspectorProps) {
+  const navigate = useNavigate();
+  const runTrace = useRunTrace(runID);
+  const run = useRunsStore((s) =>
+    s.runs.find((r) => r.run_id === runID),
+  );
+
+  const tone = useMemo(() => statusTone(run?.status), [run?.status]);
+  const children = useRunsStore((s) =>
+    s.runs.filter((r) => r.parent_run_id === runID),
+  );
+
+  return (
+    <aside
+      aria-label="Run inspector"
+      className="h-full flex flex-col bg-surface/40 backdrop-blur-sm"
+    >
+      <header className="flex items-center justify-between px-4 py-3 border-b border-border/30">
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-[0.3em] text-text-muted/70">Run</div>
+          <button
+            type="button"
+            onClick={onOpenDetail}
+            className="block font-mono text-sm text-text-primary hover:underline truncate"
+            title={runID}
+          >
+            {shortRunID(runID)}
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close inspector"
+          className="p-1 rounded-md text-text-muted hover:text-text-primary hover:bg-surface-highlight/40"
+        >
+          <X size={14} />
+        </button>
+      </header>
+
+      <div className="px-4 py-3 border-b border-border/20 space-y-2">
+        <StatusPill tone={tone} />
+        <dl className="grid grid-cols-[80px_1fr] gap-y-1.5 text-[11px]">
+          <Term label="Skill" />
+          <Definition>{run?.skill ?? '—'}</Definition>
+          <Term label="Started" />
+          <Definition className="font-mono tabular-nums">
+            {formatAbsoluteTime(run?.started_at)}
+          </Definition>
+          <Term label="Duration" />
+          <Definition className="font-mono tabular-nums">
+            {formatDurationBetween(run?.started_at, run?.completed_at)}
+          </Definition>
+          {run?.parent_run_id && (
+            <>
+              <Term label="Parent" />
+              <Definition>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/runs/${run.parent_run_id}`)}
+                  className="inline-flex items-center gap-1 font-mono text-primary hover:underline"
+                >
+                  <GitBranch size={10} />
+                  {shortRunID(run.parent_run_id)}
+                </button>
+              </Definition>
+            </>
+          )}
+          {children.length > 0 && (
+            <>
+              <Term label="Children" />
+              <Definition>
+                <span className="inline-flex items-center gap-1 text-text-secondary">
+                  <Layers size={10} aria-hidden />
+                  {children.length}
+                </span>
+              </Definition>
+            </>
+          )}
+        </dl>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-auto scrollbar-dark px-4 py-4">
+        <RunOutputView runID={runID} runTrace={runTrace} />
+      </div>
+
+      <footer className="flex items-center gap-2 px-4 py-2 border-t border-border/30 bg-surface/60">
+        <button
+          type="button"
+          onClick={onOpenDetail}
+          className="inline-flex items-center gap-1.5 px-2.5 py-1 text-[11px] rounded-md border border-primary/30 text-primary hover:bg-primary/10"
+        >
+          <ExternalLink size={11} />
+          Open detail
+        </button>
+        {/* TODO(runs-external-telemetry): once we ship the OTel handoff
+            for Phoenix / Langfuse / LangSmith, add a launcher here. */}
+      </footer>
+    </aside>
+  );
+}
+
+function Term({ label }: { label: string }) {
+  return (
+    <dt className="text-[10px] uppercase tracking-[0.16em] text-text-muted/70">
+      {label}
+    </dt>
+  );
+}
+
+function Definition({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return <dd className={cn('text-text-secondary truncate', className)}>{children}</dd>;
+}

--- a/web/src/components/runs/RunWaterfall.tsx
+++ b/web/src/components/runs/RunWaterfall.tsx
@@ -1,0 +1,184 @@
+import { useMemo, useState } from 'react';
+import { cn } from '../../lib/cn';
+import type { AgentRunEvent } from '../../lib/agent-runs';
+import { formatDurationMicros } from './format';
+
+interface RunWaterfallProps {
+  events: AgentRunEvent[];
+  /** Optional filter — only spans matching this substring (against
+   *  node_id / node_name / type) are rendered. */
+  filter?: string;
+}
+
+interface Span {
+  key: string;
+  nodeID: string;
+  nodeName: string;
+  startMs: number;
+  durationMs: number;
+  status: 'running' | 'ok' | 'error';
+  depth: number;
+}
+
+interface NodeEnterPayload {
+  node_id?: string;
+  node_name?: string;
+}
+interface NodeExitPayload {
+  node_id?: string;
+  duration_micros?: number;
+  success?: boolean;
+}
+
+/**
+ * RunWaterfall renders a Honeycomb-style timeline of node spans. The
+ * input is the raw event timeline; we reconstruct spans by pairing
+ * `node_enter` with the matching `node_exit` (when present) or
+ * leaving the span open-ended (currently in flight).
+ *
+ * The visual is intentionally lo-fi — single-color bars sized by
+ * duration, with the depth axis carried through indentation. It is
+ * meant to be readable on a 1200px screen at a glance; richer drill
+ * downs route through the per-span row tooltip and the output panel.
+ */
+export function RunWaterfall({ events, filter }: RunWaterfallProps) {
+  const { spans, totalMs } = useMemo(() => buildSpans(events), [events]);
+  const [hoverKey, setHoverKey] = useState<string | null>(null);
+
+  const filtered = useMemo(() => {
+    if (!filter) return spans;
+    const q = filter.toLowerCase();
+    return spans.filter(
+      (s) =>
+        s.nodeID.toLowerCase().includes(q) ||
+        s.nodeName.toLowerCase().includes(q),
+    );
+  }, [spans, filter]);
+
+  if (filtered.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-[12px] text-text-muted">
+        No spans recorded for this run yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-[11px] font-mono">
+      <ol className="space-y-0.5">
+        {filtered.map((span) => {
+          const leftPct = totalMs > 0 ? (span.startMs / totalMs) * 100 : 0;
+          const widthPct =
+            totalMs > 0 ? Math.max((span.durationMs / totalMs) * 100, 0.5) : 100;
+          const isHover = hoverKey === span.key;
+          return (
+            <li
+              key={span.key}
+              onMouseEnter={() => setHoverKey(span.key)}
+              onMouseLeave={() => setHoverKey(null)}
+              className={cn(
+                'group grid grid-cols-[220px_1fr_80px] items-center gap-3 px-3 py-1 rounded-sm',
+                isHover && 'bg-surface-highlight/30',
+              )}
+              style={{ paddingLeft: `${12 + span.depth * 12}px` }}
+            >
+              <div className="truncate text-text-secondary" title={span.nodeID}>
+                <span className="text-text-muted mr-1.5">{span.nodeName}</span>
+                <span className="text-text-muted/60">{span.nodeID}</span>
+              </div>
+              <div className="relative h-3.5 bg-background/40 rounded-sm">
+                <div
+                  className={cn(
+                    'absolute top-0 bottom-0 rounded-sm',
+                    span.status === 'error' && 'bg-status-error/80',
+                    span.status === 'running' && 'bg-status-running/60 animate-pulse',
+                    span.status === 'ok' && 'bg-primary/60',
+                  )}
+                  style={{ left: `${leftPct}%`, width: `${widthPct}%` }}
+                  aria-label={`${span.nodeName} ${formatDurationMicros(span.durationMs * 1000)}`}
+                />
+              </div>
+              <div className="text-right text-text-muted tabular-nums">
+                {span.status === 'running'
+                  ? 'live'
+                  : formatDurationMicros(span.durationMs * 1000)}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
+function buildSpans(events: AgentRunEvent[]): { spans: Span[]; totalMs: number } {
+  if (events.length === 0) return { spans: [], totalMs: 0 };
+  const runStart = Date.parse(events[0]?.time ?? '');
+  const baseMs = Number.isNaN(runStart) ? 0 : runStart;
+
+  const open: Map<string, { enterMs: number; depth: number; nodeName: string; key: string }> = new Map();
+  const depthStack: string[] = [];
+  const spans: Span[] = [];
+  let counter = 0;
+
+  for (const ev of events) {
+    const tMs = Date.parse(ev.time);
+    if (Number.isNaN(tMs)) continue;
+    const offsetMs = tMs - baseMs;
+
+    if (ev.type === 'node_enter') {
+      const p = (ev.payload ?? {}) as NodeEnterPayload;
+      const nodeID = p.node_id ?? `node-${counter++}`;
+      const nodeName = p.node_name ?? '';
+      const depth = depthStack.length;
+      const key = `${nodeID}@${ev.seq}`;
+      open.set(nodeID, { enterMs: offsetMs, depth, nodeName, key });
+      depthStack.push(nodeID);
+    } else if (ev.type === 'node_exit') {
+      const p = (ev.payload ?? {}) as NodeExitPayload;
+      const nodeID = p.node_id ?? depthStack[depthStack.length - 1];
+      const opened = nodeID ? open.get(nodeID) : undefined;
+      if (opened && nodeID) {
+        spans.push({
+          key: opened.key,
+          nodeID,
+          nodeName: opened.nodeName,
+          startMs: opened.enterMs,
+          durationMs:
+            p.duration_micros != null
+              ? p.duration_micros / 1000
+              : offsetMs - opened.enterMs,
+          status: p.success ? 'ok' : 'error',
+          depth: opened.depth,
+        });
+        open.delete(nodeID);
+        // Pop matching frame off the depth stack.
+        const idx = depthStack.lastIndexOf(nodeID);
+        if (idx !== -1) depthStack.splice(idx, 1);
+      }
+    }
+  }
+
+  // Append any still-open spans as in-flight markers anchored to the
+  // last event we've seen.
+  const lastTimeMs =
+    Date.parse(events[events.length - 1]?.time ?? '') - baseMs || 0;
+  for (const [nodeID, opened] of open.entries()) {
+    spans.push({
+      key: opened.key,
+      nodeID,
+      nodeName: opened.nodeName,
+      startMs: opened.enterMs,
+      durationMs: Math.max(lastTimeMs - opened.enterMs, 1),
+      status: 'running',
+      depth: opened.depth,
+    });
+  }
+
+  spans.sort((a, b) => a.startMs - b.startMs);
+  const totalMs = spans.reduce(
+    (max, s) => Math.max(max, s.startMs + s.durationMs),
+    1,
+  );
+  return { spans, totalMs };
+}

--- a/web/src/components/runs/RunsBottomTab.tsx
+++ b/web/src/components/runs/RunsBottomTab.tsx
@@ -1,0 +1,160 @@
+import { useMemo } from 'react';
+import { Activity, ExternalLink, AlertCircle } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { cn } from '../../lib/cn';
+import { useRunsStore } from '../../stores/useRunsStore';
+import { RunWaterfall } from './RunWaterfall';
+import { useRunTrace } from '../agent/ide/useRunTrace';
+import { shortRunID } from './format';
+import { statusTone } from './status';
+
+/**
+ * RunsBottomTab is the BottomPanel "Runs" surface — a live span
+ * waterfall across the most recent in-flight runs. The tab badge
+ * (count of in-flight runs) is rendered by BottomPanel; this body
+ * focuses on the waterfall + a row of run chips for quick pivoting.
+ *
+ * The OTel-style "Traces" tab next to this one still serves the
+ * MCP-server HTTP traces — they're a different domain so the two
+ * tabs stay separate.
+ */
+export function RunsBottomTab() {
+  const inFlight = useRunsStore((s) => s.inFlightRuns);
+  const runs = useRunsStore((s) => s.runs);
+  const streamStatus = useRunsStore((s) => s.streamStatus);
+
+  const liveRuns = useMemo(() => {
+    return runs.filter((r) => inFlight.has(r.run_id)).slice(0, 8);
+  }, [runs, inFlight]);
+
+  // Pick a focal run for the waterfall: the most recent in-flight, or
+  // the most recent run overall if nothing is live. Useful even when
+  // the daemon is idle so the panel isn't a blank rectangle.
+  const focal = liveRuns[0] ?? runs[0];
+  const focalTrace = useRunTrace(focal?.run_id ?? null);
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="flex items-center justify-between px-3 h-9 flex-shrink-0 border-b border-border/30 bg-surface-elevated/20">
+        <div className="flex items-center gap-2 text-[11px] text-text-muted">
+          <Activity size={11} aria-hidden />
+          <span className="uppercase tracking-[0.14em]">Live runs</span>
+          <span className="text-text-muted/60">
+            ({inFlight.size} in flight)
+          </span>
+        </div>
+        <StreamStatusChip status={streamStatus} />
+      </header>
+
+      {liveRuns.length === 0 && !focal && (
+        <div className="flex flex-col items-center justify-center flex-1 gap-2 text-text-muted">
+          <Activity size={24} className="text-text-muted/30" />
+          <span className="text-xs">No runs yet</span>
+          <span className="text-[10px] text-text-muted/60">
+            Launch a skill from the Skills workspace.
+          </span>
+        </div>
+      )}
+
+      {focal && (
+        <div className="flex flex-1 min-h-0">
+          {liveRuns.length > 0 && (
+            <div className="w-44 flex-shrink-0 border-r border-border/30 overflow-y-auto scrollbar-dark py-1">
+              {liveRuns.map((r) => (
+                <LiveRunChip key={r.run_id} runID={r.run_id} skill={r.skill} status={r.status} active={r.run_id === focal.run_id} />
+              ))}
+            </div>
+          )}
+          <div className="flex-1 min-h-0 overflow-auto scrollbar-dark py-2">
+            <RunWaterfall events={focalTrace.events} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LiveRunChip({
+  runID,
+  skill,
+  status,
+  active,
+}: {
+  runID: string;
+  skill?: string;
+  status: string;
+  active: boolean;
+}) {
+  const navigate = useNavigate();
+  const tone = statusTone(status);
+  return (
+    <button
+      type="button"
+      onClick={() => navigate(`/runs/${runID}`)}
+      className={cn(
+        'w-full text-left px-3 py-1.5 flex items-center gap-2',
+        'border-l-2 transition-colors',
+        active
+          ? 'bg-primary/5 border-primary'
+          : 'border-transparent hover:bg-surface-highlight/30',
+      )}
+      title={runID}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'inline-block w-1.5 h-1.5 rounded-full flex-shrink-0',
+          tone.dot,
+          tone.pulse && 'animate-pulse',
+        )}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="font-mono text-[11px] text-text-primary truncate">
+          {shortRunID(runID)}
+        </div>
+        <div className="font-mono text-[10px] text-text-muted truncate">
+          {skill ?? '—'}
+        </div>
+      </div>
+      <ExternalLink size={9} className="text-text-muted/60" aria-hidden />
+    </button>
+  );
+}
+
+// Note: LiveRunChip intentionally uses a custom layout (no StatusPill)
+// because the chip is dot-only — the small list cell can't fit the
+// status label. The full StatusPill is used everywhere status text is
+// visible.
+
+function StreamStatusChip({ status }: { status: ReturnType<typeof useRunsStore.getState>['streamStatus'] }) {
+  if (status === 'open') {
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] text-status-running font-medium">
+        <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
+        Live
+      </span>
+    );
+  }
+  if (status === 'restarted') {
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] text-status-pending">
+        <AlertCircle size={10} />
+        Resynced
+      </span>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] text-status-error">
+        <AlertCircle size={10} />
+        Offline
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] text-text-muted">
+      <span className="w-1.5 h-1.5 rounded-full bg-text-muted/40" />
+      {status === 'connecting' ? 'Connecting' : 'Idle'}
+    </span>
+  );
+}

--- a/web/src/components/runs/RunsFilterBar.tsx
+++ b/web/src/components/runs/RunsFilterBar.tsx
@@ -1,0 +1,127 @@
+import { useMemo } from 'react';
+import { Filter, X } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useRunsStore, RUNS_DEFAULT_FILTERS } from '../../stores/useRunsStore';
+import { FILTERABLE_STATUSES } from './status';
+
+const SINCE_OPTIONS: { value: string; label: string }[] = [
+  { value: '5m', label: 'Last 5 min' },
+  { value: '1h', label: 'Last hour' },
+  { value: '24h', label: 'Last 24 h' },
+  { value: '7d', label: 'Last 7 days' },
+  { value: '', label: 'All time' },
+];
+
+interface RunsFilterBarProps {
+  /** Skills the operator can choose from — populated from the
+   *  currently loaded page so the dropdown stays anchored in what's
+   *  actually present. */
+  skillOptions: string[];
+}
+
+export function RunsFilterBar({ skillOptions }: RunsFilterBarProps) {
+  const filters = useRunsStore((s) => s.filters);
+  const setFilters = useRunsStore((s) => s.setFilters);
+  const resetFilters = useRunsStore((s) => s.resetFilters);
+
+  const hasNonDefault = useMemo(
+    () =>
+      filters.status !== RUNS_DEFAULT_FILTERS.status ||
+      filters.skill !== RUNS_DEFAULT_FILTERS.skill ||
+      filters.since !== RUNS_DEFAULT_FILTERS.since ||
+      filters.parent !== RUNS_DEFAULT_FILTERS.parent,
+    [filters],
+  );
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 px-4 py-3 border-b border-border/30 bg-surface/40">
+      <Filter size={12} className="text-text-muted/70" aria-hidden />
+
+      <FilterChip label="Status">
+        <select
+          aria-label="Filter runs by status"
+          value={filters.status}
+          onChange={(e) => setFilters({ status: e.target.value })}
+          className={chipInputClass}
+        >
+          <option value="">Any</option>
+          {FILTERABLE_STATUSES.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+      </FilterChip>
+
+      <FilterChip label="Skill">
+        <select
+          aria-label="Filter runs by skill"
+          value={filters.skill}
+          onChange={(e) => setFilters({ skill: e.target.value })}
+          className={chipInputClass}
+        >
+          <option value="">Any</option>
+          {skillOptions.map((skill) => (
+            <option key={skill} value={skill}>
+              {skill}
+            </option>
+          ))}
+        </select>
+      </FilterChip>
+
+      <FilterChip label="Since">
+        <select
+          aria-label="Filter runs by start window"
+          value={filters.since}
+          onChange={(e) => setFilters({ since: e.target.value })}
+          className={chipInputClass}
+        >
+          {SINCE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </FilterChip>
+
+      <FilterChip label="Parent">
+        <input
+          type="text"
+          placeholder="run_id"
+          aria-label="Filter runs by parent run ID"
+          value={filters.parent}
+          onChange={(e) => setFilters({ parent: e.target.value })}
+          className={cn(chipInputClass, 'font-mono w-44 placeholder:text-text-muted/40')}
+        />
+      </FilterChip>
+
+      {hasNonDefault && (
+        <button
+          type="button"
+          onClick={resetFilters}
+          className="ml-1 inline-flex items-center gap-1 px-2 py-1 text-[11px] text-text-muted hover:text-text-primary transition-colors"
+        >
+          <X size={11} />
+          Reset
+        </button>
+      )}
+    </div>
+  );
+}
+
+const chipInputClass = cn(
+  'h-7 px-2 text-[11px] rounded-md',
+  'bg-background/60 border border-border/40 text-text-secondary',
+  'focus:outline-none focus:border-primary/50 focus:bg-background',
+);
+
+function FilterChip({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="inline-flex items-center gap-1.5">
+      <span className="text-[10px] font-medium uppercase tracking-[0.16em] text-text-muted/70">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}

--- a/web/src/components/runs/RunsGrid.tsx
+++ b/web/src/components/runs/RunsGrid.tsx
@@ -1,0 +1,232 @@
+import { useCallback, useMemo, useState } from 'react';
+import { ChevronRight, ChevronDown, AlertCircle, RefreshCw, Loader2 } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { formatRelativeTime } from '../../lib/time';
+import { useRunsStore } from '../../stores/useRunsStore';
+import { statusTone } from './status';
+import { StatusPill } from './StatusPill';
+import { formatDurationBetween, shortRunID } from './format';
+import { buildRunTree, flattenRunTree, type RunRowNode } from './tree';
+
+interface RunsGridProps {
+  /** Triggered when a row is double-clicked or the run-id link is
+   *  clicked — navigates to /runs/:id. */
+  onOpenDetail: (runID: string) => void;
+}
+
+export function RunsGrid({ onOpenDetail }: RunsGridProps) {
+  const runs = useRunsStore((s) => s.runs);
+  const loading = useRunsStore((s) => s.loading);
+  const loadingMore = useRunsStore((s) => s.loadingMore);
+  const error = useRunsStore((s) => s.error);
+  const nextCursor = useRunsStore((s) => s.nextCursor);
+  const selectedRunID = useRunsStore((s) => s.selectedRunID);
+  const setSelectedRun = useRunsStore((s) => s.setSelectedRun);
+  const loadRuns = useRunsStore((s) => s.loadRuns);
+  const loadMore = useRunsStore((s) => s.loadMore);
+
+  const tree = useMemo(() => buildRunTree(runs), [runs]);
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+  const rows = useMemo(() => flattenRunTree(tree, collapsed), [tree, collapsed]);
+
+  const handleToggle = useCallback(
+    (id: string) => {
+      setCollapsed((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      });
+    },
+    [setCollapsed],
+  );
+
+  if (error && runs.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-3 px-6">
+        <AlertCircle size={24} className="text-status-error" />
+        <p className="text-sm text-status-error/90 text-center max-w-md">{error}</p>
+        <button
+          type="button"
+          onClick={() => void loadRuns()}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border/50 text-xs hover:bg-surface-highlight/40"
+        >
+          <RefreshCw size={12} /> Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!loading && runs.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-2 text-text-muted">
+        <p className="text-sm">No runs match your filters.</p>
+        <p className="text-[11px] text-text-muted/60">
+          Launch a skill from the Skills workspace and it'll appear here live.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex-1 min-h-0 overflow-auto scrollbar-dark">
+        <table className="w-full text-[12px]">
+          <thead className="sticky top-0 z-10 bg-surface/95 backdrop-blur">
+            <tr className="border-b border-border/40 text-[10px] uppercase tracking-[0.16em] text-text-muted">
+              <Th className="w-[24%]">Run</Th>
+              <Th className="w-[18%]">Skill</Th>
+              <Th className="w-[14%]">Status</Th>
+              <Th className="w-[12%]">Started</Th>
+              <Th className="w-[10%]">Duration</Th>
+              <Th className="w-[8%] text-right">Events</Th>
+              <Th className="w-[14%]">Error</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <RunRow
+                key={row.run.run_id}
+                node={row}
+                isActive={row.run.run_id === selectedRunID}
+                isCollapsed={collapsed.has(row.run.run_id)}
+                onSelect={() => setSelectedRun(row.run.run_id)}
+                onOpen={() => onOpenDetail(row.run.run_id)}
+                onToggle={() => handleToggle(row.run.run_id)}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between px-4 py-2 border-t border-border/30 bg-surface/40 text-[11px] text-text-muted">
+        <span>
+          {runs.length} run{runs.length === 1 ? '' : 's'}
+          {nextCursor ? ' (more available)' : ''}
+        </span>
+        <div className="flex items-center gap-2">
+          {loading && <Loader2 size={12} className="animate-spin" aria-hidden />}
+          {nextCursor && (
+            <button
+              type="button"
+              onClick={() => void loadMore()}
+              disabled={loadingMore}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded border border-border/40 text-text-secondary hover:bg-surface-highlight/30 disabled:opacity-60"
+            >
+              {loadingMore ? (
+                <>
+                  <Loader2 size={11} className="animate-spin" /> Loading…
+                </>
+              ) : (
+                'Load more'
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface RunRowProps {
+  node: RunRowNode;
+  isActive: boolean;
+  isCollapsed: boolean;
+  onSelect: () => void;
+  onOpen: () => void;
+  onToggle: () => void;
+}
+
+function RunRow({
+  node,
+  isActive,
+  isCollapsed,
+  onSelect,
+  onOpen,
+  onToggle,
+}: RunRowProps) {
+  const { run, depth, children } = node;
+  const tone = statusTone(run.status);
+  const hasChildren = children.length > 0;
+  const startedDate = run.started_at ? new Date(run.started_at) : null;
+  const startedValid =
+    startedDate && !Number.isNaN(startedDate.getTime()) ? startedDate : null;
+
+  return (
+    <tr
+      onClick={onSelect}
+      onDoubleClick={onOpen}
+      aria-selected={isActive}
+      className={cn(
+        'cursor-pointer border-b border-border/15 transition-colors group',
+        'border-l-2 border-l-transparent',
+        isActive
+          ? 'bg-primary/5 border-l-primary'
+          : ['hover:bg-surface-highlight/30', tone.rowAccent.replace('border-l-', 'hover:border-l-')],
+      )}
+    >
+      <Td>
+        <div className="flex items-center gap-1.5" style={{ paddingLeft: `${depth * 14}px` }}>
+          {hasChildren ? (
+            <button
+              type="button"
+              aria-label={isCollapsed ? 'Expand children' : 'Collapse children'}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggle();
+              }}
+              className="inline-flex w-4 h-4 items-center justify-center text-text-muted hover:text-text-primary"
+            >
+              {isCollapsed ? <ChevronRight size={11} /> : <ChevronDown size={11} />}
+            </button>
+          ) : (
+            <span aria-hidden className="inline-block w-4" />
+          )}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpen();
+            }}
+            className="font-mono text-[11.5px] text-text-primary hover:underline focus:outline-none focus:underline tabular-nums"
+            title={run.run_id}
+          >
+            {shortRunID(run.run_id)}
+          </button>
+        </div>
+      </Td>
+      <Td className="font-mono text-text-secondary truncate">{run.skill ?? '—'}</Td>
+      <Td>
+        <StatusPill tone={tone} />
+      </Td>
+      <Td className="text-text-muted tabular-nums">
+        {startedValid ? formatRelativeTime(startedValid) : '—'}
+      </Td>
+      <Td className="text-text-muted font-mono tabular-nums">
+        {formatDurationBetween(run.started_at, run.completed_at)}
+      </Td>
+      <Td className="text-right text-text-muted tabular-nums">{run.event_count}</Td>
+      <Td className="text-status-error/80 truncate">
+        <span title={run.error}>{run.error ?? ''}</span>
+      </Td>
+    </tr>
+  );
+}
+
+function Th({ className, children }: { className?: string; children: React.ReactNode }) {
+  return (
+    <th
+      className={cn('px-3 py-2 text-left font-medium align-middle', className)}
+      scope="col"
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({ className, children }: { className?: string; children: React.ReactNode }) {
+  return (
+    <td className={cn('px-3 py-2 align-middle max-w-0', className)}>{children}</td>
+  );
+}
+

--- a/web/src/components/runs/StatusPill.tsx
+++ b/web/src/components/runs/StatusPill.tsx
@@ -1,0 +1,36 @@
+import { cn } from '../../lib/cn';
+import type { RunStatusTone } from './status';
+
+interface StatusPillProps {
+  tone: RunStatusTone;
+  /** "row" shrinks the icon for a list cell; "inspector" sizes it
+   *  for headers. Defaults to "row". */
+  size?: 'row' | 'inspector';
+}
+
+/**
+ * StatusPill is the dot + icon + label trio rendered in every place
+ * the UI surfaces a run's status (the grid, the inspector, the detail
+ * page header). Centralised so a styling tweak lands once.
+ *
+ * The LiveRunChip in BottomPanel keeps its own dot-only layout — the
+ * label doesn't fit a compact chip.
+ */
+export function StatusPill({ tone, size = 'row' }: StatusPillProps) {
+  const Icon = tone.icon;
+  const iconSize = size === 'inspector' ? 12 : 11;
+  return (
+    <span className={cn('inline-flex items-center gap-1.5', tone.text)}>
+      <span
+        aria-hidden
+        className={cn(
+          'inline-block w-1.5 h-1.5 rounded-full',
+          tone.dot,
+          tone.pulse && 'animate-pulse',
+        )}
+      />
+      <Icon size={iconSize} aria-hidden />
+      <span className="text-[11px] uppercase tracking-[0.14em]">{tone.label}</span>
+    </span>
+  );
+}

--- a/web/src/components/runs/format.ts
+++ b/web/src/components/runs/format.ts
@@ -1,0 +1,46 @@
+/**
+ * Formatters shared by the runs grid, inspector, and detail page.
+ * Keeping them in one module means a future "human readable" tweak
+ * (e.g. shorter run-id slug, different duration unit) lands once.
+ */
+
+export function shortRunID(runID: string): string {
+  return runID.length > 12 ? runID.slice(0, 12) : runID;
+}
+
+export function formatDurationMicros(micros: number | undefined): string {
+  if (micros == null || !Number.isFinite(micros)) return '—';
+  if (micros < 1000) return `${micros}µs`;
+  const ms = micros / 1000;
+  if (ms < 1000) return `${ms.toFixed(ms < 10 ? 1 : 0)}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(s < 10 ? 2 : 1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s - m * 60);
+  return `${m}m${rem}s`;
+}
+
+export function formatDurationBetween(
+  start: string | undefined,
+  end: string | undefined,
+): string {
+  if (!start) return '—';
+  const startMs = Date.parse(start);
+  if (Number.isNaN(startMs)) return '—';
+  const endMs = end ? Date.parse(end) : Date.now();
+  if (Number.isNaN(endMs)) return '—';
+  return formatDurationMicros((endMs - startMs) * 1000);
+}
+
+export function formatAbsoluteTime(iso: string | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}

--- a/web/src/components/runs/status.ts
+++ b/web/src/components/runs/status.ts
@@ -1,0 +1,138 @@
+import {
+  CheckCircle2,
+  CircleDashed,
+  CircleSlash,
+  AlertCircle,
+  PauseCircle,
+  Activity,
+  type LucideIcon,
+} from 'lucide-react';
+
+/**
+ * RunStatus is the closed vocabulary the grid renders against. The
+ * server emits any of the listed values plus the legacy `started` /
+ * `in_progress` / `failed` synonyms; `normalizeStatus` maps them onto
+ * the canonical set so callers branch on a small enum.
+ */
+export type RunStatus =
+  | 'running'
+  | 'ok'
+  | 'error'
+  | 'cancelled'
+  | 'awaiting_approval'
+  | 'suspended'
+  | 'unknown';
+
+export interface RunStatusTone {
+  status: RunStatus;
+  label: string;
+  /** Tailwind class for the status dot fill. */
+  dot: string;
+  /** Tailwind class for the status text + icon tint. */
+  text: string;
+  /** Tailwind class for a subtle background highlight on the row. */
+  rowAccent: string;
+  /** Lucide icon to render alongside the dot — color is conveyed via
+   *  shape too, satisfying the a11y rule that color isn't the only
+   *  signal. */
+  icon: LucideIcon;
+  /** Whether the dot should pulse (running / awaiting). */
+  pulse: boolean;
+  /** Optional CSS box-shadow string for the IDE sidebar's glow halo.
+   *  Undefined for terminal states (no glow on completed/cancelled). */
+  glow?: string;
+}
+
+const TONES: Record<RunStatus, RunStatusTone> = {
+  running: {
+    status: 'running',
+    label: 'Running',
+    dot: 'bg-status-running',
+    text: 'text-status-running',
+    rowAccent: 'border-l-status-running/60',
+    icon: Activity,
+    pulse: true,
+    glow: '0 0 8px var(--color-status-running)',
+  },
+  ok: {
+    status: 'ok',
+    label: 'Completed',
+    dot: 'bg-status-running/60',
+    text: 'text-status-running/80',
+    rowAccent: 'border-l-transparent',
+    icon: CheckCircle2,
+    pulse: false,
+  },
+  error: {
+    status: 'error',
+    label: 'Errored',
+    dot: 'bg-status-error',
+    text: 'text-status-error',
+    rowAccent: 'border-l-status-error/70',
+    icon: AlertCircle,
+    pulse: false,
+    glow: '0 0 6px var(--color-status-error)',
+  },
+  cancelled: {
+    status: 'cancelled',
+    label: 'Cancelled',
+    dot: 'bg-text-muted/40',
+    text: 'text-text-muted',
+    rowAccent: 'border-l-transparent',
+    icon: CircleSlash,
+    pulse: false,
+  },
+  awaiting_approval: {
+    status: 'awaiting_approval',
+    label: 'Awaiting approval',
+    dot: 'bg-status-pending',
+    text: 'text-status-pending',
+    rowAccent: 'border-l-status-pending/70',
+    icon: PauseCircle,
+    pulse: true,
+    glow: '0 0 6px var(--color-status-pending)',
+  },
+  suspended: {
+    status: 'suspended',
+    label: 'Suspended',
+    dot: 'bg-status-pending/70',
+    text: 'text-status-pending/80',
+    rowAccent: 'border-l-status-pending/40',
+    icon: PauseCircle,
+    pulse: false,
+  },
+  unknown: {
+    status: 'unknown',
+    label: 'Unknown',
+    dot: 'bg-text-muted/40',
+    text: 'text-text-muted',
+    rowAccent: 'border-l-transparent',
+    icon: CircleDashed,
+    pulse: false,
+  },
+};
+
+export function normalizeStatus(raw: string | undefined | null): RunStatus {
+  const s = (raw ?? '').toLowerCase();
+  if (s === 'running' || s === 'started' || s === 'in_progress') return 'running';
+  if (s === 'ok' || s === 'completed' || s === 'success') return 'ok';
+  if (s === 'error' || s === 'errored' || s === 'failed') return 'error';
+  if (s === 'cancelled' || s === 'canceled') return 'cancelled';
+  if (s === 'awaiting_approval' || s === 'pending_approval' || s === 'pending')
+    return 'awaiting_approval';
+  if (s === 'suspended') return 'suspended';
+  return 'unknown';
+}
+
+export function statusTone(raw: string | undefined | null): RunStatusTone {
+  return TONES[normalizeStatus(raw)];
+}
+
+/** The status list rendered in the filter bar (in display order). */
+export const FILTERABLE_STATUSES: { value: string; label: string }[] = [
+  { value: 'running', label: 'Running' },
+  { value: 'ok', label: 'Completed' },
+  { value: 'error', label: 'Errored' },
+  { value: 'awaiting_approval', label: 'Awaiting approval' },
+  { value: 'cancelled', label: 'Cancelled' },
+];

--- a/web/src/components/runs/tree.ts
+++ b/web/src/components/runs/tree.ts
@@ -1,0 +1,67 @@
+import type { AgentRunSummary } from '../../lib/agent-runs';
+
+/**
+ * RunRowNode is the depth-tagged tree node both the global Runs grid
+ * and the Agent IDE sidebar render against. Lifted to a shared module
+ * so changing the shape (e.g. adding a "muted" parent flag) only
+ * touches one place.
+ */
+export interface RunRowNode {
+  run: AgentRunSummary;
+  depth: number;
+  children: RunRowNode[];
+}
+
+/**
+ * buildRunTree groups runs by `parent_run_id` and returns a
+ * depth-tagged forest sorted in the input order (which the server
+ * already returns newest-first). Runs whose parent is not in the
+ * current window become roots so they don't vanish.
+ *
+ * The depth assignment runs as a BFS pass after the tree is fully
+ * linked — otherwise a child surfaced before its grandparent would
+ * mis-indent under the source-order traversal.
+ */
+export function buildRunTree(runs: AgentRunSummary[]): RunRowNode[] {
+  const byID = new Map<string, RunRowNode>();
+  for (const r of runs) {
+    byID.set(r.run_id, { run: r, depth: 0, children: [] });
+  }
+  const roots: RunRowNode[] = [];
+  for (const r of runs) {
+    const node = byID.get(r.run_id)!;
+    const parentID = r.parent_run_id;
+    if (parentID && byID.has(parentID)) {
+      byID.get(parentID)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  const queue: RunRowNode[] = [...roots];
+  while (queue.length > 0) {
+    const n = queue.shift()!;
+    for (const c of n.children) {
+      c.depth = n.depth + 1;
+      queue.push(c);
+    }
+  }
+  return roots;
+}
+
+/**
+ * flattenRunTree walks the depth-tagged forest in display order,
+ * skipping children of nodes whose ID is in the `collapsed` set.
+ */
+export function flattenRunTree(
+  roots: RunRowNode[],
+  collapsed: Set<string>,
+): RunRowNode[] {
+  const out: RunRowNode[] = [];
+  const walk = (node: RunRowNode) => {
+    out.push(node);
+    if (collapsed.has(node.run.run_id)) return;
+    for (const c of node.children) walk(c);
+  };
+  for (const r of roots) walk(r);
+  return out;
+}

--- a/web/src/components/runs/useGlobalRunsStream.ts
+++ b/web/src/components/runs/useGlobalRunsStream.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { subscribeToGlobalRunEvents } from '../../lib/agent-api';
+import { useRunsStore } from '../../stores/useRunsStore';
+
+/**
+ * useGlobalRunsStream mounts an EventSource against
+ * GET /api/agent/runs/events/stream and routes every frame through
+ * useRunsStore. The hook is owned by the AppShell-level mount point so
+ * the stream stays connected when the user navigates between
+ * workspaces; tearing it down on /runs unmount would lose in-flight
+ * events while the user is on /topology or /skills.
+ *
+ * SSE replay protection: the store dedupes events by `(run_id, seq)`
+ * via its `lastSeenSeq` watermark — see useRunsStore.applyRunEvent.
+ */
+export function useGlobalRunsStream(): void {
+  const applyRunEvent = useRunsStore((s) => s.applyRunEvent);
+  const handleStreamRestart = useRunsStore((s) => s.handleStreamRestart);
+  const setStreamStatus = useRunsStore((s) => s.setStreamStatus);
+
+  useEffect(() => {
+    setStreamStatus('connecting');
+    const sub = subscribeToGlobalRunEvents({
+      onEvent: applyRunEvent,
+      onReady: () => setStreamStatus('open'),
+      onRestart: handleStreamRestart,
+      onError: () => setStreamStatus('error'),
+    });
+    return () => {
+      sub.close();
+      setStreamStatus('idle');
+    };
+  }, [applyRunEvent, handleStreamRestart, setStreamStatus]);
+}

--- a/web/src/components/runs/useRunsCommands.ts
+++ b/web/src/components/runs/useRunsCommands.ts
@@ -1,0 +1,90 @@
+import { useEffect } from 'react';
+import { PlayCircle, AlertCircle, Filter, ExternalLink } from 'lucide-react';
+import { createElement } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useCommandRegistry } from '../../hooks/useCommandRegistry';
+import { useRunsStore } from '../../stores/useRunsStore';
+import { showToast } from '../ui/Toast';
+import type { PaletteCommand } from '../../types/palette';
+
+/**
+ * useRunsCommands registers the workspace-scoped palette commands for
+ * the /runs surface. Mounted at AppShell level so the commands are
+ * present in every workspace's palette but filtered to `workspaces:
+ * ['runs']` — they only appear when the user is on /runs, matching
+ * the per-workspace scoping contract documented in Phase 1.
+ */
+export function useRunsCommands(): void {
+  const { registerCommands, unregisterCommands } = useCommandRegistry();
+  const navigate = useNavigate();
+  const setFilters = useRunsStore((s) => s.setFilters);
+
+  useEffect(() => {
+    const commands: PaletteCommand[] = [
+      {
+        id: 'runs:filter-errored',
+        label: 'Filter runs: errored only',
+        section: 'canvas',
+        workspaces: ['runs'],
+        icon: createElement(AlertCircle, { size: 14 }),
+        keywords: ['failed', 'errors', 'red'],
+        onSelect: () => {
+          setFilters({ status: 'error' });
+          navigate('/runs');
+        },
+      },
+      {
+        id: 'runs:filter-awaiting-approval',
+        label: 'Filter runs: awaiting approval',
+        section: 'canvas',
+        workspaces: ['runs'],
+        icon: createElement(Filter, { size: 14 }),
+        keywords: ['paused', 'pending'],
+        onSelect: () => {
+          setFilters({ status: 'awaiting_approval' });
+          navigate('/runs');
+        },
+      },
+      {
+        id: 'runs:open-by-id',
+        label: 'Open run by ID…',
+        section: 'canvas',
+        workspaces: ['runs'],
+        icon: createElement(ExternalLink, { size: 14 }),
+        keywords: ['jump', 'goto'],
+        onSelect: () => {
+          const id = window.prompt('Run ID');
+          if (!id) return;
+          const trimmed = id.trim();
+          if (!trimmed) return;
+          navigate(`/runs/${encodeURIComponent(trimmed)}`);
+        },
+      },
+      {
+        id: 'runs:reset-filters',
+        label: 'Reset run filters',
+        section: 'canvas',
+        workspaces: ['runs'],
+        icon: createElement(Filter, { size: 14 }),
+        keywords: ['clear', 'reset'],
+        onSelect: () => {
+          useRunsStore.getState().resetFilters();
+          showToast('success', 'Filters reset');
+        },
+      },
+      {
+        id: 'runs:compare',
+        label: 'Compare runs… (coming soon)',
+        section: 'canvas',
+        workspaces: ['runs'],
+        icon: createElement(PlayCircle, { size: 14 }),
+        unavailable: true,
+        onSelect: () => {
+          showToast('error', 'Compare view ships in a follow-up phase');
+        },
+      },
+    ];
+    registerCommands('runs', commands);
+    return () => unregisterCommands('runs');
+  }, [registerCommands, unregisterCommands, navigate, setFilters]);
+}

--- a/web/src/components/shell/AppShell.tsx
+++ b/web/src/components/shell/AppShell.tsx
@@ -16,6 +16,8 @@ import { usePolling } from '../../hooks/usePolling';
 import { useSSEShutdown } from '../../hooks/useSSEShutdown';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { useGlobalCommands } from '../../hooks/useGlobalCommands';
+import { useGlobalRunsStream } from '../runs/useGlobalRunsStream';
+import { useRunsCommands } from '../runs/useRunsCommands';
 import { isWorkspace, type Workspace, WORKSPACES } from '../../types/workspace';
 import {
   LAST_WORKSPACE_GLOBAL_KEY,
@@ -116,6 +118,12 @@ function AppShellInner() {
   });
 
   useGlobalCommands({ onRefresh: handleRefresh });
+
+  // Keep the global run-events stream open across every workspace so
+  // the BottomPanel "Runs" tab + in-flight badge stay live when the
+  // user is sitting on /topology or /skills.
+  useGlobalRunsStream();
+  useRunsCommands();
 
   const bottomRowHeight = bottomPanelOpen ? bottomPanelHeight : BOTTOM_PANEL_COLLAPSED;
 

--- a/web/src/components/workspaces/RunDetailWorkspace.tsx
+++ b/web/src/components/workspaces/RunDetailWorkspace.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, GitBranch, Activity, AlertCircle } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useRunTrace } from '../agent/ide/useRunTrace';
+import { RunOutputView } from '../agent/ide/RunOutputView';
+import { RunWaterfall } from '../runs/RunWaterfall';
+import { statusTone } from '../runs/status';
+import { StatusPill } from '../runs/StatusPill';
+import {
+  shortRunID,
+  formatAbsoluteTime,
+  formatDurationBetween,
+} from '../runs/format';
+import {
+  fetchRunDetail,
+  useRunsStore,
+} from '../../stores/useRunsStore';
+import type { AgentRunDetail } from '../../lib/agent-runs';
+
+/**
+ * RunDetailWorkspace is the /runs/:id page — full waterfall, span
+ * filter, run metadata, and the same RunOutputView the inspector
+ * uses (composed at a larger size). Designed to read like a Honeycomb
+ * trace view: the timeline runs across the top, the output below.
+ */
+export function RunDetailWorkspace() {
+  const { runID } = useParams<{ runID: string }>();
+  const navigate = useNavigate();
+  const [detail, setDetail] = useState<AgentRunDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [spanFilter, setSpanFilter] = useState('');
+  const runTrace = useRunTrace(runID ?? null);
+
+  // Hydrate via the REST endpoint so we render history even when the
+  // run completed long before this page mounted (no SSE replay).
+  useEffect(() => {
+    if (!runID) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const d = await fetchRunDetail(runID);
+        if (cancelled) return;
+        if (!d) {
+          setError(`Run ${runID} not found`);
+          setDetail(null);
+        } else {
+          setError(null);
+          setDetail(d);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [runID]);
+
+  // Prefer live events from the SSE trace once it has caught up to the
+  // hydrated snapshot; this way new events stream in without us having
+  // to re-fetch.
+  const events =
+    runTrace.events.length > (detail?.events?.length ?? 0)
+      ? runTrace.events
+      : (detail?.events ?? []);
+
+  const summary = detail?.run;
+  const tone = statusTone(summary?.status);
+
+  // Hook the inspector store so closing this page leaves a clean
+  // selection in the grid behind us.
+  const setSelectedRun = useRunsStore((s) => s.setSelectedRun);
+
+  if (!runID) {
+    return <ErrorState message="No run ID in URL" onBack={() => navigate('/runs')} />;
+  }
+  if (error) {
+    return <ErrorState message={error} onBack={() => navigate('/runs')} />;
+  }
+
+  return (
+    <div className="absolute inset-0 flex flex-col bg-background">
+      <header className="flex items-center justify-between px-5 py-3 border-b border-border/40 bg-surface/40">
+        <div className="flex items-center gap-3 min-w-0">
+          <button
+            type="button"
+            onClick={() => {
+              setSelectedRun(runID);
+              navigate('/runs');
+            }}
+            className="inline-flex items-center gap-1 text-[11px] text-text-muted hover:text-text-primary"
+          >
+            <ArrowLeft size={12} />
+            Back to Runs
+          </button>
+          <div className="h-4 w-px bg-border/50" />
+          <div className="min-w-0">
+            <div className="text-[10px] uppercase tracking-[0.3em] text-text-muted/70">
+              Run
+            </div>
+            <div className="font-mono text-sm text-text-primary truncate" title={runID}>
+              {shortRunID(runID)}
+            </div>
+          </div>
+          {summary?.parent_run_id && (
+            <button
+              type="button"
+              onClick={() => navigate(`/runs/${summary.parent_run_id}`)}
+              className="inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
+            >
+              <GitBranch size={11} />
+              parent {shortRunID(summary.parent_run_id)}
+            </button>
+          )}
+        </div>
+        <StatusPill tone={tone} size="inspector" />
+      </header>
+
+      <div className="grid grid-cols-[2fr_1fr] flex-1 min-h-0">
+        <section className="flex flex-col min-h-0 border-r border-border/30">
+          <div className="flex items-center justify-between px-5 py-2.5 border-b border-border/30 bg-surface/40">
+            <div className="inline-flex items-center gap-2 text-[11px] text-text-muted">
+              <Activity size={11} aria-hidden />
+              <span className="uppercase tracking-[0.14em]">Span waterfall</span>
+              <span className="text-text-muted/60">({events.length} events)</span>
+            </div>
+            <input
+              type="text"
+              placeholder="Filter spans…"
+              value={spanFilter}
+              onChange={(e) => setSpanFilter(e.target.value)}
+              className="h-6 px-2 text-[11px] bg-background/60 border border-border/40 rounded text-text-secondary placeholder:text-text-muted/40 focus:outline-none focus:border-primary/50 w-44"
+            />
+          </div>
+          <div className="flex-1 min-h-0 overflow-auto scrollbar-dark py-3">
+            <RunWaterfall events={events} filter={spanFilter.trim() || undefined} />
+          </div>
+          <div className="px-5 py-2 border-t border-border/30 flex items-center gap-3 text-[10px] text-text-muted">
+            <Metadata
+              label="Skill"
+              value={summary?.skill ?? '—'}
+              mono
+            />
+            <Metadata
+              label="Started"
+              value={formatAbsoluteTime(summary?.started_at)}
+            />
+            <Metadata
+              label="Duration"
+              value={formatDurationBetween(summary?.started_at, summary?.completed_at)}
+              mono
+            />
+            <Metadata label="Events" value={String(events.length)} mono />
+          </div>
+        </section>
+
+        <section className="flex flex-col min-h-0 overflow-auto scrollbar-dark px-5 py-4">
+          <RunOutputView runID={runID} runTrace={runTrace} />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function ErrorState({ message, onBack }: { message: string; onBack: () => void }) {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background">
+      <AlertCircle size={28} className="text-status-error" />
+      <p className="text-sm text-status-error/90">{message}</p>
+      <button
+        type="button"
+        onClick={onBack}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border/40 text-xs text-text-secondary hover:bg-surface-highlight/30"
+      >
+        <ArrowLeft size={11} />
+        Back to Runs
+      </button>
+    </div>
+  );
+}
+
+function Metadata({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="uppercase tracking-[0.14em] text-text-muted/70">{label}:</span>
+      <span className={cn('text-text-secondary', mono && 'font-mono tabular-nums')}>
+        {value}
+      </span>
+    </span>
+  );
+}
+
+export default RunDetailWorkspace;

--- a/web/src/components/workspaces/RunsWorkspace.tsx
+++ b/web/src/components/workspaces/RunsWorkspace.tsx
@@ -1,15 +1,112 @@
-// Phase 1 placeholder for /runs. The real Runs workspace — filterable grid,
-// ancestry tree, live waterfall — ships in Phase 2.
-export function RunsWorkspace() {
+import { useEffect, useMemo, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { RunsFilterBar } from '../runs/RunsFilterBar';
+import { RunsGrid } from '../runs/RunsGrid';
+import { RunInspector } from '../runs/RunInspector';
+import { useRunsStore, RUNS_DEFAULT_FILTERS } from '../../stores/useRunsStore';
+import type { RunsFilters } from '../../stores/useRunsStore';
+
+const FILTER_KEYS = ['status', 'skill', 'since', 'parent'] as const;
+
+function filtersFromSearchParams(params: URLSearchParams): RunsFilters {
+  return {
+    status: params.get('status') ?? RUNS_DEFAULT_FILTERS.status,
+    skill: params.get('skill') ?? RUNS_DEFAULT_FILTERS.skill,
+    since: params.get('since') ?? RUNS_DEFAULT_FILTERS.since,
+    parent: params.get('parent') ?? RUNS_DEFAULT_FILTERS.parent,
+  };
+}
+
+function filtersAreEqual(a: RunsFilters, b: RunsFilters): boolean {
   return (
-    <div className="absolute inset-0 flex items-center justify-center bg-background">
-      <div className="max-w-md text-center space-y-4 p-8 rounded-2xl bg-surface/60 backdrop-blur-xl border border-border/40">
-        <div className="text-[10px] uppercase tracking-[0.4em] text-text-muted/60">runs</div>
-        <h2 className="text-xl font-semibold text-text-primary">Runs workspace</h2>
-        <p className="text-sm text-text-muted leading-relaxed">
-          Live execution observability is coming next — a filterable grid of every skill run, an
-          ancestry tree for parent/child chains, and a global trace waterfall in the bottom panel.
-        </p>
+    a.status === b.status &&
+    a.skill === b.skill &&
+    a.since === b.since &&
+    a.parent === b.parent
+  );
+}
+
+/**
+ * RunsWorkspace renders the /runs grid + inspector inside AppShell.
+ * URL binding is the single source of truth for the filter state:
+ * the store mirrors the URL, not the other way around, so back/forward
+ * navigation and reload preserve filters without an extra
+ * persistence layer.
+ */
+export function RunsWorkspace() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const filters = useRunsStore((s) => s.filters);
+  const setFilters = useRunsStore((s) => s.setFilters);
+  const selectedRunID = useRunsStore((s) => s.selectedRunID);
+  const setSelectedRun = useRunsStore((s) => s.setSelectedRun);
+  const loadRuns = useRunsStore((s) => s.loadRuns);
+  const runs = useRunsStore((s) => s.runs);
+
+  // URL → store (incoming).
+  useEffect(() => {
+    const next = filtersFromSearchParams(searchParams);
+    if (!filtersAreEqual(next, filters)) {
+      setFilters(next);
+    }
+  }, [searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Store → URL (outgoing). Strip filter keys so unrelated params
+  // (e.g. ?compact, ?stack) survive the rewrite.
+  useEffect(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        for (const key of FILTER_KEYS) {
+          const val = filters[key];
+          if (val && val !== RUNS_DEFAULT_FILTERS[key]) {
+            next.set(key, val);
+          } else {
+            next.delete(key);
+          }
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  }, [filters, setSearchParams]);
+
+  // Re-fetch whenever the filters change. The store does the deep
+  // compare against its own state — this hook just triggers it.
+  const lastLoadedFilters = useRef<RunsFilters | null>(null);
+  useEffect(() => {
+    if (lastLoadedFilters.current && filtersAreEqual(lastLoadedFilters.current, filters)) {
+      return;
+    }
+    lastLoadedFilters.current = filters;
+    void loadRuns();
+  }, [filters, loadRuns]);
+
+  const skillOptions = useMemo(() => {
+    const seen = new Set<string>();
+    for (const r of runs) {
+      if (r.skill) seen.add(r.skill);
+    }
+    return [...seen].sort();
+  }, [runs]);
+
+  return (
+    <div className="absolute inset-0 flex flex-col bg-background">
+      <RunsFilterBar skillOptions={skillOptions} />
+
+      <div className="flex flex-1 min-h-0">
+        <div className="flex-1 min-w-0">
+          <RunsGrid onOpenDetail={(id) => navigate(`/runs/${id}`)} />
+        </div>
+        {selectedRunID && (
+          <div className="w-[360px] flex-shrink-0 border-l border-border/30 bg-surface/40">
+            <RunInspector
+              runID={selectedRunID}
+              onClose={() => setSelectedRun(null)}
+              onOpenDetail={() => navigate(`/runs/${selectedRunID}`)}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/lib/agent-api.ts
+++ b/web/src/lib/agent-api.ts
@@ -173,6 +173,57 @@ export function subscribeToRunEvents(
   };
 }
 
+export interface GlobalRunsSubscriptionHandlers {
+  /** Fires for every event observed on the global bus. */
+  onEvent: (ev: RunEvent) => void;
+  /**
+   * Fires when the server signals a gap (the per-subscriber buffer
+   * overflowed and at least one event was dropped). The /runs store
+   * uses this to invalidate its watermarks and refetch the affected
+   * runs.
+   */
+  onRestart?: () => void;
+  /** Fires when the underlying EventSource errors. */
+  onError?: (err: Error) => void;
+  /** Fires once the server emits the initial `ready` frame. */
+  onReady?: () => void;
+}
+
+/**
+ * subscribeToGlobalRunEvents opens an EventSource against the global
+ * run-events stream and routes each frame to the matching handler.
+ *
+ * Reconnect contract: events on this stream are best-effort. The
+ * server replays nothing on reconnect and may drop events for a slow
+ * client; callers MUST dedupe by `(run_id, seq)` against the per-run
+ * SSE endpoint, which IS authoritative. On a `stream_restarted` frame
+ * the caller should treat its watermarks as invalid.
+ */
+export function subscribeToGlobalRunEvents(
+  handlers: GlobalRunsSubscriptionHandlers,
+): TraceSubscription {
+  const url = `${API_BASE}/api/agent/runs/events/stream`;
+  const es = new EventSource(url, { withCredentials: false });
+  es.onmessage = (msg) => {
+    try {
+      const ev = JSON.parse(msg.data) as RunEvent;
+      handlers.onEvent(ev);
+    } catch (err) {
+      handlers.onError?.(err as Error);
+    }
+  };
+  es.addEventListener('ready', () => handlers.onReady?.());
+  es.addEventListener('stream_restarted', () => handlers.onRestart?.());
+  es.addEventListener('error', () => {
+    handlers.onError?.(new Error('global run event stream interrupted'));
+  });
+  return {
+    close() {
+      es.close();
+    },
+  };
+}
+
 export interface ResumeRequest {
   from_step?: string;
 }

--- a/web/src/lib/agent-runs.ts
+++ b/web/src/lib/agent-runs.ts
@@ -36,20 +36,64 @@ export interface AgentRunSummary {
 
 export interface AgentRunListResponse {
   runs: AgentRunSummary[];
+  next_cursor?: string;
 }
 
-export async function fetchAgentRuns(limit = 50): Promise<AgentRunSummary[]> {
-  const response = await fetch(`${API_BASE}/api/agent/runs?limit=${limit}`, {
-    headers: buildHeaders(),
-  });
+export interface AgentRunListQuery {
+  /**
+   * Page size. Server clamps to a hard ceiling (~500). Defaults to 50
+   * when omitted.
+   */
+  limit?: number;
+  /**
+   * Forward cursor — last run_id from the previous page. The server
+   * skips runs strictly newer than (or equal to) this ID, so an empty
+   * cursor returns the newest page.
+   */
+  cursor?: string;
+  /**
+   * Exact status match. Empty / omitted = any status.
+   */
+  status?: string;
+  /**
+   * Exact skill name. Empty / omitted = any skill.
+   */
+  skill?: string;
+  /**
+   * Lower bound on started_at. Accepts an RFC 3339 timestamp or a
+   * relative window (`5m`, `1h`, `24h`, `7d`).
+   */
+  since?: string;
+  /**
+   * Parent run ID filter; surfaces only child runs of a given root.
+   */
+  parent?: string;
+}
+
+export async function fetchAgentRuns(
+  query: AgentRunListQuery | number = {},
+): Promise<AgentRunListResponse> {
+  // Backwards-compat: `fetchAgentRuns(50)` predates filters. Keep it
+  // working so the Agent IDE sidebar doesn't need to change here.
+  const q: AgentRunListQuery = typeof query === 'number' ? { limit: query } : query;
+  const params = new URLSearchParams();
+  if (q.limit != null) params.set('limit', String(q.limit));
+  if (q.cursor) params.set('cursor', q.cursor);
+  if (q.status) params.set('status', q.status);
+  if (q.skill) params.set('skill', q.skill);
+  if (q.since) params.set('since', q.since);
+  if (q.parent) params.set('parent', q.parent);
+  const qs = params.toString();
+  const url = `${API_BASE}/api/agent/runs${qs ? `?${qs}` : ''}`;
+  const response = await fetch(url, { headers: buildHeaders() });
   if (response.status === 503) {
-    return [];
+    return { runs: [] };
   }
   if (!response.ok) {
     throw new Error(`agent runs API: ${response.status} ${response.statusText}`);
   }
   const body = (await response.json()) as AgentRunListResponse;
-  return body.runs ?? [];
+  return { runs: body.runs ?? [], next_cursor: body.next_cursor };
 }
 
 export interface ApprovalRequest {

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -17,6 +17,7 @@ import { DetachedTracesPage } from './pages/DetachedTracesPage';
 const TopologyWorkspace = lazy(() => import('./components/workspaces/TopologyWorkspace'));
 const SkillsWorkspace = lazy(() => import('./components/workspaces/SkillsWorkspace'));
 const RunsWorkspace = lazy(() => import('./components/workspaces/RunsWorkspace'));
+const RunDetailWorkspace = lazy(() => import('./components/workspaces/RunDetailWorkspace'));
 
 export function AppRoutes() {
   return (
@@ -45,6 +46,14 @@ export function AppRoutes() {
           element={
             <Suspense fallback={<WorkspaceLoadingShell />}>
               <RunsWorkspace />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/runs/:runID"
+          element={
+            <Suspense fallback={<WorkspaceLoadingShell />}>
+              <RunDetailWorkspace />
             </Suspense>
           }
         />

--- a/web/src/stores/useRunsStore.ts
+++ b/web/src/stores/useRunsStore.ts
@@ -1,0 +1,319 @@
+import { create } from 'zustand';
+import type { AgentRunSummary } from '../lib/agent-runs';
+import { fetchAgentRuns, fetchAgentRun } from '../lib/agent-runs';
+import type { RunEvent } from '../lib/agent-api';
+
+/**
+ * RunsFilters mirrors the server-side query parameters. Each field
+ * binds to a URL search param so the grid is shareable / bookmarkable
+ * — the workspace component reads these from `?status=…&skill=…` on
+ * mount and writes them back as the user changes filters.
+ *
+ * `since` accepts the relative shapes the backend recognises (`5m`,
+ * `1h`, `24h`, `7d`) plus the empty string ("all time"). RFC 3339
+ * timestamps work too but the bar UI only emits the relative forms.
+ */
+export interface RunsFilters {
+  status: string;
+  skill: string;
+  since: string;
+  parent: string;
+}
+
+export const RUNS_DEFAULT_FILTERS: RunsFilters = {
+  status: '',
+  skill: '',
+  since: '24h',
+  parent: '',
+};
+
+const PAGE_SIZE = 100;
+
+interface RunsState {
+  /**
+   * Ordered list of run summaries. The map keyed by `run_id` lives
+   * inside the array — order matters (newest first) so we don't keep
+   * a secondary index.
+   */
+  runs: AgentRunSummary[];
+  /**
+   * Forward cursor for the next page. Empty string = no more pages.
+   */
+  nextCursor: string;
+  /** True while the initial page or a filter change is loading. */
+  loading: boolean;
+  /** True while a "load more" page is loading. */
+  loadingMore: boolean;
+  /** Latest fetch error, surfaced as an inline retry affordance. */
+  error: string | null;
+
+  /** Current filter state. Mirrors URL search params on the workspace. */
+  filters: RunsFilters;
+
+  /** Selected run in the grid (right-rail inspector). */
+  selectedRunID: string | null;
+
+  /**
+   * Per-run `seq` watermark. Used to dedupe events arriving on the
+   * global SSE bus against the per-run replay endpoint — clients see
+   * the same event on both streams and must take the first.
+   */
+  lastSeenSeq: Record<string, number>;
+
+  /**
+   * Set of currently in-flight runs (started but not yet completed).
+   * Powers the BottomPanel runs-tab badge.
+   */
+  inFlightRuns: Set<string>;
+
+  /** Status of the global event stream. */
+  streamStatus: 'idle' | 'connecting' | 'open' | 'restarted' | 'error';
+
+  // Actions ─────────────────────────────────────────────────────────────────
+
+  setFilters: (partial: Partial<RunsFilters>) => void;
+  resetFilters: () => void;
+  setSelectedRun: (runID: string | null) => void;
+
+  /** Fresh fetch — replaces the current page. */
+  loadRuns: () => Promise<void>;
+  /** Append the next page using the stored cursor. */
+  loadMore: () => Promise<void>;
+
+  /** Apply a single event observed on the global SSE stream. */
+  applyRunEvent: (ev: RunEvent) => void;
+  /** The server signalled a gap — drop watermarks and refetch. */
+  handleStreamRestart: () => void;
+  setStreamStatus: (status: RunsState['streamStatus']) => void;
+}
+
+function mergeRuns(
+  existing: AgentRunSummary[],
+  incoming: AgentRunSummary[],
+): AgentRunSummary[] {
+  const seen = new Map<string, AgentRunSummary>();
+  for (const r of existing) seen.set(r.run_id, r);
+  for (const r of incoming) seen.set(r.run_id, r);
+  // Preserve newest-first ordering: sort by started_at desc, falling
+  // back to run_id lexicographic (run IDs embed the start timestamp).
+  return [...seen.values()].sort((a, b) => {
+    const at = a.started_at ?? '';
+    const bt = b.started_at ?? '';
+    if (at && bt && at !== bt) return at > bt ? -1 : 1;
+    return a.run_id > b.run_id ? -1 : 1;
+  });
+}
+
+function upsertRunInOrder(
+  runs: AgentRunSummary[],
+  next: AgentRunSummary,
+): AgentRunSummary[] {
+  const idx = runs.findIndex((r) => r.run_id === next.run_id);
+  if (idx === -1) {
+    return mergeRuns(runs, [next]);
+  }
+  const updated = runs.slice();
+  updated[idx] = { ...updated[idx], ...next };
+  return updated;
+}
+
+interface StartedPayload {
+  skill?: string;
+  parent_run_id?: string;
+  trace_id?: string;
+  flavor?: string;
+}
+interface CompletedPayload {
+  status?: string;
+  error?: string;
+}
+interface ApprovalPayload {
+  approval_id?: string;
+}
+
+function summaryFromEvent(
+  prior: AgentRunSummary | undefined,
+  ev: RunEvent,
+): AgentRunSummary {
+  const base: AgentRunSummary = prior ?? {
+    run_id: ev.run_id,
+    status: 'running',
+    event_count: 0,
+  };
+  const next: AgentRunSummary = {
+    ...base,
+    event_count: Math.max(base.event_count, ev.seq),
+  };
+  const payload = (ev.payload ?? {}) as Record<string, unknown>;
+  switch (ev.type) {
+    case 'run_started': {
+      const p = payload as unknown as StartedPayload;
+      next.skill = p.skill ?? next.skill;
+      next.flavor = p.flavor ?? next.flavor;
+      next.parent_run_id = p.parent_run_id ?? next.parent_run_id;
+      next.trace_id = p.trace_id ?? next.trace_id;
+      next.started_at = ev.time;
+      next.status = 'running';
+      break;
+    }
+    case 'run_completed': {
+      const p = payload as unknown as CompletedPayload;
+      next.status = p.status ?? 'ok';
+      next.completed_at = ev.time;
+      if (p.error) next.error = p.error;
+      next.pending_approval = '';
+      break;
+    }
+    case 'approval_request': {
+      const p = payload as unknown as ApprovalPayload;
+      next.pending_approval = p.approval_id;
+      next.status = 'awaiting_approval';
+      break;
+    }
+    case 'approval_response': {
+      next.pending_approval = '';
+      if (next.status === 'awaiting_approval') {
+        next.status = 'running';
+      }
+      break;
+    }
+    case 'error': {
+      // Mid-run errors don't necessarily terminate — leave status
+      // alone; the matching run_completed (status=error) is the
+      // authoritative terminal signal.
+      break;
+    }
+  }
+  return next;
+}
+
+export const useRunsStore = create<RunsState>((set, get) => ({
+  runs: [],
+  nextCursor: '',
+  loading: false,
+  loadingMore: false,
+  error: null,
+  filters: { ...RUNS_DEFAULT_FILTERS },
+  selectedRunID: null,
+  lastSeenSeq: {},
+  inFlightRuns: new Set<string>(),
+  streamStatus: 'idle',
+
+  setFilters: (partial) =>
+    set((s) => ({ filters: { ...s.filters, ...partial } })),
+  resetFilters: () => set({ filters: { ...RUNS_DEFAULT_FILTERS } }),
+  setSelectedRun: (runID) => set({ selectedRunID: runID }),
+
+  loadRuns: async () => {
+    const { filters } = get();
+    set({ loading: true, error: null });
+    try {
+      const { runs, next_cursor } = await fetchAgentRuns({
+        limit: PAGE_SIZE,
+        status: filters.status,
+        skill: filters.skill,
+        since: filters.since,
+        parent: filters.parent,
+      });
+      // Rebuild the in-flight set from the freshly fetched page; we
+      // don't trust the prior state across a refetch since filters
+      // may have excluded an in-flight run we already had.
+      const inFlight = new Set<string>();
+      for (const r of runs) {
+        if (r.status === 'running' || r.status === 'started') {
+          inFlight.add(r.run_id);
+        }
+      }
+      set({
+        runs,
+        nextCursor: next_cursor ?? '',
+        loading: false,
+        inFlightRuns: inFlight,
+      });
+    } catch (err) {
+      set({
+        loading: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+
+  loadMore: async () => {
+    const { filters, nextCursor, runs } = get();
+    if (!nextCursor || get().loadingMore) return;
+    set({ loadingMore: true, error: null });
+    try {
+      const page = await fetchAgentRuns({
+        limit: PAGE_SIZE,
+        cursor: nextCursor,
+        status: filters.status,
+        skill: filters.skill,
+        since: filters.since,
+        parent: filters.parent,
+      });
+      set({
+        runs: mergeRuns(runs, page.runs),
+        nextCursor: page.next_cursor ?? '',
+        loadingMore: false,
+      });
+    } catch (err) {
+      set({
+        loadingMore: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  },
+
+  applyRunEvent: (ev) => {
+    const state = get();
+    const lastSeen = state.lastSeenSeq[ev.run_id] ?? 0;
+    // Dedup: per-run seq is monotonic so any seq we've already seen
+    // is a replay. The /runs grid sees events twice — once from the
+    // global bus, once when an inspector opens the per-run endpoint.
+    if (ev.seq <= lastSeen) return;
+
+    const prior = state.runs.find((r) => r.run_id === ev.run_id);
+    // run_started for a run we don't have a summary for becomes a
+    // synthetic insertion — important for runs launched while the
+    // user is sitting on /runs with no manual refresh.
+    if (!prior && ev.type !== 'run_started') {
+      // Without the head event we can't render a useful row yet; the
+      // next fetch will pull it in.
+      set((s) => ({ lastSeenSeq: { ...s.lastSeenSeq, [ev.run_id]: ev.seq } }));
+      return;
+    }
+
+    const nextSummary = summaryFromEvent(prior, ev);
+    const inFlight = new Set(state.inFlightRuns);
+    if (nextSummary.status === 'running' || nextSummary.status === 'started') {
+      inFlight.add(nextSummary.run_id);
+    } else {
+      inFlight.delete(nextSummary.run_id);
+    }
+
+    set({
+      runs: upsertRunInOrder(state.runs, nextSummary),
+      lastSeenSeq: { ...state.lastSeenSeq, [ev.run_id]: ev.seq },
+      inFlightRuns: inFlight,
+    });
+  },
+
+  handleStreamRestart: () => {
+    // The bus dropped events for us; the watermarks are unreliable
+    // until we refetch. Clear them and reload the active page —
+    // run_completed for completed runs will land via the refetch
+    // rather than the (potentially missed) bus event.
+    set({ lastSeenSeq: {}, streamStatus: 'restarted' });
+    void get().loadRuns();
+  },
+
+  setStreamStatus: (streamStatus) => set({ streamStatus }),
+}));
+
+/**
+ * fetchRunDetail wraps fetchAgentRun for callers (the inspector and
+ * the detail page) that want a single helper to call. Re-exported here
+ * so workspace code imports from one module rather than reaching into
+ * the API client directly.
+ */
+export { fetchAgentRun as fetchRunDetail };

--- a/web/src/stores/useUIStore.ts
+++ b/web/src/stores/useUIStore.ts
@@ -4,7 +4,7 @@ import { persist } from 'zustand/middleware';
 import type { Workspace } from '../types/workspace';
 
 type SidebarTab = 'details' | 'tools' | 'logs';
-type BottomPanelTab = 'logs' | 'metrics' | 'spec' | 'traces' | 'pins';
+type BottomPanelTab = 'logs' | 'metrics' | 'spec' | 'traces' | 'runs' | 'pins';
 type EdgeStyle = 'default' | 'straight'; // 'default' = Bezier curves
 
 // Cross-workspace shell state. Lives on useUIStore via the Zustand slices


### PR DESCRIPTION
## Summary

Phase 2 of the One Cockpit Unification refactor. Replaces the `/runs` placeholder with a real workspace: a filterable, paginated grid of every run across the active stack with an ancestry tree, a slide-in `RunInspector`, a Honeycomb-style waterfall at `/runs/:runID`, and a live BottomPanel `Runs` tab fed by a new global SSE event bus.

## Backend

- `pkg/agent/persist/Bus` — non-blocking pub/sub fan-out with bounded per-subscriber buffers and a drop-on-full `stream_restarted` sentinel.
- `Recorder.Record` publishes to the bus after every durable write; the per-run JSONL ledger remains the source of truth.
- `Store.ListFiltered` adds server-side filtering (status / skill / parent / since) plus a run-ID cursor for forward pagination.
- `GET /api/agent/runs` accepts `?status=&skill=&since=&parent=&limit=&cursor=` and returns `next_cursor` when a forward page exists.
- New `GET /api/agent/runs/events/stream` streams every run lifecycle event across all runs. Clients dedupe by `(run_id, seq)` against the per-run endpoint, which remains authoritative.

## Frontend

- `useRunsStore` (standalone, slices-compatible) — filters, cursor pagination, per-run `seq` watermark for SSE dedup, in-flight set, stream status.
- `/runs` workspace: `RunsFilterBar` (URL-bound chips), `RunsGrid` (ancestry tree, status icons, pagination), slide-in `RunInspector` composing the existing `RunOutputView`.
- `/runs/:runID` detail page: span waterfall with substring filter, run metadata, output view.
- BottomPanel `Runs` tab with live focal-run waterfall and an in-flight badge. Kept separate from the existing OTel `Traces` tab — those are HTTP-level MCP traces, agent runs are a distinct domain.
- Workspace-scoped palette commands: filter shortcuts, open-by-id, reset filters.
- Global stream mounted at `AppShell` so it stays connected across `/topology` and `/skills` too.
- Shared `runs/{tree,status,format,StatusPill}` lifted out; the Agent IDE `RunsList` now consumes them (no more duplicate `buildTree`, `statusTone`, or pill markup).

## Architectural notes

- No "store of stores" — `useRunsStore` is standalone. `useUIStore.activeWorkspace` and per-workspace stores stay isolated.
- No Polymorphic Inspector — the new `RunInspector` is its own component; it shares formatters and the status pill with the grid and detail page.
- No Unified Canvas — `/runs/:runID` waterfall is a custom timeline component, not a React Flow instance.

## Out of scope (defer)

- Skills workspace migration (Phase 3).
- `CanvasBase` + Inspector primitive extraction (Phase 4).
- Compare-runs view UI (stretch — backend optional too).
- External OTel handoff (Phoenix / Langfuse / LangSmith) — TODO left in `RunInspector`.
- Detached `/sidebar?workspace=runs` window.

## Test plan

- [x] `go test ./pkg/agent/persist/... ./internal/api/...` (Bus fan-out, drop semantics; ListFiltered status / skill / cursor; full API suite)
- [x] `npm test` — 549/549 passing (new: 8 useRunsStore tests covering SSE dedup + filters, 3 tree tests covering BFS depth)
- [x] `npx tsc -b` clean; `npm run build` produces RunsWorkspace chunk at 13KB gzipped (well under 300KB budget)
- [x] `npm run lint` clean on all changed files
- [x] End-to-end: launched a run via `POST /api/agent/runs` while subscribed to the new global stream; observed full lifecycle (`ready` → `run_started` → `node_enter` → `llm_call` → `node_exit` → `run_completed`) with monotonic `seq`
- [x] Cursor pagination returns non-overlapping pages; `since=` accepts both RFC 3339 and relative durations (`5m`, `1h`, `24h`, `7d`); invalid `since=` returns 400
- [x] Browser smoke: filter bar + grid + inspector + detail page render and update live; BottomPanel `Runs` tab badge tracks in-flight count

Part of #634