### PR TITLE
refactor: extract shared inspector and canvas primitives

### DIFF
--- a/web/src/__tests__/CanvasBase.test.tsx
+++ b/web/src/__tests__/CanvasBase.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReactFlowProvider } from '@xyflow/react';
+import { CanvasBase } from '../components/canvas/CanvasBase';
+
+// ResizeObserver isn't implemented in jsdom; React Flow needs it.
+class ResizeObserverPolyfill {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).ResizeObserver ??= ResizeObserverPolyfill;
+
+describe('CanvasBase', () => {
+  it('renders ReactFlow with the supplied nodes', () => {
+    const nodes = [{ id: 'a', position: { x: 0, y: 0 }, data: { label: 'A' } }];
+    const { container } = render(
+      <ReactFlowProvider>
+        <CanvasBase nodes={nodes} edges={[]} />
+      </ReactFlowProvider>,
+    );
+    // ReactFlow renders a wrapper with the .react-flow class.
+    expect(container.querySelector('.react-flow')).toBeInTheDocument();
+  });
+
+  it('renders children inside the React Flow container (e.g. workspace controls)', () => {
+    render(
+      <ReactFlowProvider>
+        <CanvasBase nodes={[]} edges={[]}>
+          <div data-testid="control-slot">Controls</div>
+        </CanvasBase>
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByTestId('control-slot')).toBeInTheDocument();
+  });
+
+  it('forwards onPaneClick to the underlying React Flow', () => {
+    const onPaneClick = vi.fn();
+    const { container } = render(
+      <ReactFlowProvider>
+        <CanvasBase nodes={[]} edges={[]} onPaneClick={onPaneClick} />
+      </ReactFlowProvider>,
+    );
+    const pane = container.querySelector('.react-flow__pane');
+    expect(pane).toBeInTheDocument();
+    if (pane) {
+      fireEvent.click(pane);
+      expect(onPaneClick).toHaveBeenCalled();
+    }
+  });
+});

--- a/web/src/__tests__/EmptyState.test.tsx
+++ b/web/src/__tests__/EmptyState.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { Layers } from 'lucide-react';
+import { EmptyState } from '../components/ui/EmptyState';
+
+describe('EmptyState', () => {
+  it('renders title and description', () => {
+    render(<EmptyState title="No stacks" description="Create one to begin." />);
+    expect(screen.getByText('No stacks')).toBeInTheDocument();
+    expect(screen.getByText('Create one to begin.')).toBeInTheDocument();
+  });
+
+  it('renders the supplied icon when provided', () => {
+    const { container } = render(
+      <EmptyState icon={Layers} title="No stacks" />,
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders the action slot', () => {
+    render(
+      <EmptyState
+        title="No stacks"
+        action={<button>Create</button>}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();
+  });
+
+  it('switches to inline layout when `inline` is set', () => {
+    const { container } = render(<EmptyState title="No stacks" inline />);
+    const root = container.firstElementChild;
+    expect(root?.className).not.toContain('h-full');
+    expect(root?.className).toContain('py-8');
+  });
+});

--- a/web/src/__tests__/InspectorSection.test.tsx
+++ b/web/src/__tests__/InspectorSection.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Activity } from 'lucide-react';
+import { InspectorSection } from '../components/inspector/InspectorSection';
+
+describe('InspectorSection', () => {
+  it('starts collapsed by default and hides its content', () => {
+    render(
+      <InspectorSection title="Status">
+        <div>panel body</div>
+      </InspectorSection>,
+    );
+    // Body is rendered but collapsed via max-h/opacity classes — assert the
+    // animated wrapper carries the "collapsed" classes rather than the open ones.
+    const body = screen.getByText('panel body');
+    const animatedWrapper = body.parentElement?.parentElement;
+    expect(animatedWrapper?.className).toContain('max-h-0');
+    expect(animatedWrapper?.className).toContain('opacity-0');
+  });
+
+  it('respects defaultOpen', () => {
+    render(
+      <InspectorSection title="Status" defaultOpen>
+        <div>panel body</div>
+      </InspectorSection>,
+    );
+    const body = screen.getByText('panel body');
+    const animatedWrapper = body.parentElement?.parentElement;
+    expect(animatedWrapper?.className).toContain('max-h-[1000px]');
+    expect(animatedWrapper?.className).toContain('opacity-100');
+  });
+
+  it('toggles when the header is clicked', () => {
+    render(
+      <InspectorSection title="Status">
+        <div>panel body</div>
+      </InspectorSection>,
+    );
+    const body = screen.getByText('panel body');
+    const animatedWrapper = body.parentElement?.parentElement;
+    expect(animatedWrapper?.className).toContain('max-h-0');
+
+    fireEvent.click(screen.getByRole('button', { name: /status/i }));
+    expect(animatedWrapper?.className).toContain('max-h-[1000px]');
+
+    fireEvent.click(screen.getByRole('button', { name: /status/i }));
+    expect(animatedWrapper?.className).toContain('max-h-0');
+  });
+
+  it('renders an icon and a count badge', () => {
+    render(
+      <InspectorSection title="Tools" icon={Activity} count={3}>
+        body
+      </InspectorSection>,
+    );
+    expect(screen.getByText('Tools')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/InspectorTabList.test.tsx
+++ b/web/src/__tests__/InspectorTabList.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InspectorTabList, InspectorTabButton } from '../components/inspector/InspectorTabList';
+
+function Harness({ initial = 'a' }: { initial?: 'a' | 'b' }) {
+  // Active tab is static for these tests — we only assert aria + click
+  // wiring; selection-state behavior is the caller's contract, not the
+  // primitive's.
+  return (
+    <InspectorTabList ariaLabel="Sample">
+      <InspectorTabButton
+        active={initial === 'a'}
+        onClick={vi.fn()}
+        label="Alpha"
+        controls="panel-a"
+      />
+      <InspectorTabButton
+        active={initial === 'b'}
+        onClick={vi.fn()}
+        label="Beta"
+        controls="panel-b"
+      />
+    </InspectorTabList>
+  );
+}
+
+describe('InspectorTabList', () => {
+  it('renders a tablist with the provided aria-label', () => {
+    render(<Harness />);
+    expect(screen.getByRole('tablist', { name: 'Sample' })).toBeInTheDocument();
+  });
+
+  it('marks the active tab with aria-selected', () => {
+    render(<Harness initial="b" />);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('wires aria-controls to the panel id', () => {
+    render(<Harness />);
+    const [alpha, beta] = screen.getAllByRole('tab');
+    expect(alpha).toHaveAttribute('aria-controls', 'panel-a');
+    expect(beta).toHaveAttribute('aria-controls', 'panel-b');
+  });
+
+  it('calls onClick when a tab is clicked', () => {
+    const handler = vi.fn();
+    render(
+      <InspectorTabList ariaLabel="Sample">
+        <InspectorTabButton
+          active={false}
+          onClick={handler}
+          label="Alpha"
+          controls="panel-a"
+        />
+      </InspectorTabList>,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Alpha' }));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/README.md
+++ b/web/src/components/README.md
@@ -1,0 +1,127 @@
+# Web Components
+
+gridctl's SPA is structured around a single application shell that hosts three
+URL-routable workspaces. This file documents the shell architecture, the
+Zustand store layout, and the do-and-don't conventions every new component
+should follow.
+
+## Shell architecture
+
+```
+<AppShell>             web/src/components/shell/AppShell.tsx
+├── <Header>           web/src/components/layout/Header.tsx
+│   └── <WorkspaceSwitcher>   pills bound to React Router NavLinks
+├── <Outlet />         renders the active workspace body
+│   ├── <TopologyWorkspace>   /topology
+│   ├── <SkillsWorkspace>     /skills
+│   └── <RunsWorkspace>       /runs   (also /runs/:id → RunDetailWorkspace)
+├── <BottomPanel>      Logs / Metrics / Spec / Traces / Runs / Pins
+├── <StatusBar>        connection · servers · sessions · tokens · spec
+├── <CommandPalette>   workspace-scoped via the command registry
+└── <ToastContainer>
+```
+
+The shell is constant across workspaces; only the `<Outlet />` body and the
+right rail change. Workspace switching is done via React Router `NavLink`s
+in the header, the `⌘1` / `⌘2` / `⌘3` shortcuts, or the command palette.
+
+Detached windows (`/sidebar`, `/logs`, `/editor`, `/metrics`, `/vault`,
+`/traces`, `/registry`) render *outside* AppShell — they're popout-friendly
+single-purpose pages that accept a `?workspace=` query param to render the
+appropriate workspace content.
+
+## Store layout (Zustand slices pattern)
+
+Cross-workspace shell state lives on `useUIStore` via composed slices:
+
+```
+useUIStore
+├── WorkspaceSlice       activeWorkspace, setActiveWorkspace
+├── CompactModeSlice     compactMode (per workspace), set/toggle helpers
+└── (UIState extras)     sidebarOpen, bottomPanelOpen, command palette, …
+```
+
+Each workspace owns its own data store and never imports another workspace's
+store:
+
+- Topology  → `useStackStore`
+- Skills    → component-local state + agent-API hooks (`useDevSocket`, `useRunTrace`)
+- Runs      → `useRunsStore`
+
+Several supporting stores (`useSpecStore`, `useAuthStore`, `usePinsStore`,
+`useRegistryStore`, `useTelemetryStore`, `useTracesStore`, `useVaultStore`,
+`useWizardStore`, `usePlaygroundStore`) sit alongside the workspace stores;
+they're feature-scoped and have no cross-store coupling.
+
+## Shared primitives
+
+These primitives live under `web/src/components/` and are consumed by every
+workspace. Reach for them before duplicating UI:
+
+| Primitive | Location | Used by |
+|---|---|---|
+| `CanvasBase` | `components/canvas/` | Topology `graph/Canvas.tsx`, Skills `agent/ide/Canvas.tsx` |
+| `InspectorHeader` | `components/inspector/` | Inspectors that need the standard icon + title + close/popout strip |
+| `InspectorSection` | `components/inspector/` | Topology `Sidebar.tsx`, `DetachedSidebarPage.tsx` (collapsible section pattern) |
+| `InspectorTabList` / `InspectorTabButton` | `components/inspector/` | Skills `SkillSidebar.tsx` (tablist a11y wrapper) |
+| `EmptyState` | `components/ui/` | Skills Canvas, anywhere a "no items / no selection" affordance is needed |
+
+`CanvasBase` is intentionally small (~120 LOC) — it owns the React Flow
+boilerplate (wrapper element, Background layers, proOptions) and exposes
+workspace-specific props. The Topology canvas and Skills canvas remain
+separate components that *compose* CanvasBase; they do **not** share a
+polymorphic super-canvas.
+
+## What to do / what not to do
+
+**Do**
+
+- Use the slices pattern in `useUIStore` for cross-workspace state.
+- Compose new primitives in `components/inspector/`, `components/canvas/`,
+  or `components/ui/` when you find yourself duplicating UI shells across
+  workspaces.
+- Register workspace-specific command-palette entries via
+  `useCommandRegistry().registerCommands(scope, commands)` on mount; clean
+  up on unmount. See `useRunsCommands` and `useSkillsCommands` for the
+  pattern.
+- Use Tailwind **semantic tokens** (`bg-primary`, `text-secondary`,
+  `border-status-error`) — never raw color literals like `bg-amber-500` in
+  new code.
+- Code-split each workspace with `React.lazy()` + `<Suspense>`; the router
+  already wires this up in `routes.tsx`.
+
+**Don't**
+
+- Don't build a `useWorkspaceStore` "store of stores" that imports the
+  other Zustand stores. Use a slice or pass an action through props/context
+  instead.
+- Don't unify the Topology and Skills canvases into a single polymorphic
+  canvas with overlay rendering modes. They share infrastructure, not
+  rendering. Compose `CanvasBase` from two separate components.
+- Don't build a polymorphic Inspector with a provider registry. The two
+  Inspectors (`layout/Sidebar.tsx` for Topology, `agent/ide/NodeDetail.tsx`
+  for Skills) serve different mental models. Share *primitives*, not the
+  shell.
+- Don't mix workspace bundles. A workspace component should not import from
+  another workspace's folder (`components/graph/*` from a Skills file, for
+  example). Shared utilities go in `components/canvas/`, `components/ui/`,
+  or `components/inspector/`.
+- Don't put behavior-changing logic in `CanvasBase`. Background layers,
+  control bars, overlays, and node types all belong in the workspace canvas.
+
+## File map
+
+```
+web/src/components/
+├── shell/            AppShell, WorkspaceSwitcher, RootRedirect, AgentRedirect
+├── workspaces/       TopologyWorkspace, SkillsWorkspace, RunsWorkspace, RunDetailWorkspace
+├── layout/           Header, BottomPanel, StatusBar, Sidebar (Topology inspector)
+├── inspector/        InspectorHeader, InspectorSection, InspectorTabList    ← shared primitives
+├── canvas/           CanvasBase                                              ← shared React Flow scaffolding
+├── graph/            Topology Canvas + custom node types
+├── agent/ide/        Skills Canvas + NodeDetail + SkillSidebar + NodeList
+├── skills/           SkillsWorkspace command registry, DetachedSkillsSidebar
+├── runs/             RunsGrid, RunInspector, RunWaterfall, useGlobalRunsStream
+├── palette/          CommandPalette (workspace-scoped via useCommandRegistry)
+└── ui/               Badge, Toast, IconButton, EmptyState, …
+```

--- a/web/src/components/agent/ide/Canvas.tsx
+++ b/web/src/components/agent/ide/Canvas.tsx
@@ -1,10 +1,8 @@
 import { useMemo, useEffect, useCallback } from 'react';
 import {
-  ReactFlow,
   ReactFlowProvider,
-  Background,
-  BackgroundVariant,
   Controls,
+  BackgroundVariant,
   type Node as RFNode,
   type Edge as RFEdge,
   type NodeProps,
@@ -12,12 +10,14 @@ import {
   Position,
   useReactFlow,
 } from '@xyflow/react';
-import '@xyflow/react/dist/style.css';
 import { editorURL, type SkillGraph } from '../../../lib/agent-api';
 import { styleFor } from './kind-style';
 import type { NodeTrace } from './useRunTrace';
 import { TracePill } from './TracePill';
+import { CanvasBase } from '../../canvas/CanvasBase';
+import { EmptyState } from '../../ui/EmptyState';
 import { cn } from '../../../lib/cn';
+import { Sparkles } from 'lucide-react';
 
 interface CanvasProps {
   graph: SkillGraph;
@@ -41,14 +41,13 @@ const NODE_WIDTH = 240;
 const ROW_HEIGHT = 100;
 
 /**
- * Canvas is the Slice 3 view — a read-only React Flow rendering of
- * the same AST graph the NodeList shows. Per-kind custom nodes
- * inherit the Slice 1 colour map so the two views are recognisably
- * the same data.
+ * Canvas is the Skills workspace's React Flow surface — a read-only,
+ * single-column rendering of the parsed typed-skill AST. The graph mirrors
+ * what NodeList shows; both consume the same trace overlay so the views
+ * stay recognisably the same data.
  *
- * "The fallacy of the graph applies — code is canon." The canvas
- * never writes back to source. Click a node to jump to the source
- * line; canvas mutations are deferred to a future slice.
+ * "The fallacy of the graph applies — code is canon." The canvas never
+ * writes back to source. Double-click a node to jump to its source line.
  */
 export function Canvas(props: CanvasProps) {
   return (
@@ -114,52 +113,42 @@ function CanvasInner({ graph, skillDir, selected, onSelect, trace }: CanvasProps
 
   if (graph.nodes.length === 0) {
     return (
-      <div className="h-full flex flex-col items-center justify-center text-center px-12">
-        <div className="font-sans text-text-muted/60 text-xs uppercase tracking-[0.4em] mb-3">
-          empty canvas
-        </div>
-        <h2 className="font-sans text-2xl text-text-secondary mb-2">No primitives recognised</h2>
-        <p className="text-text-muted text-sm max-w-sm leading-relaxed">
-          Add a tool(), llm(), parallel(), handoff(), or approval() call to the source — the canvas
-          re-renders on save.
-        </p>
-      </div>
+      <EmptyState
+        icon={Sparkles}
+        title="No primitives recognised"
+        description="Add a tool(), llm(), parallel(), handoff(), or approval() call to the source — the canvas re-renders on save."
+      />
     );
   }
 
   return (
-    <div className="h-full w-full agent-canvas">
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={nodeTypes}
-        onNodeClick={handleNodeClick}
-        onPaneClick={() => onSelect(null)}
-        nodesDraggable={false}
-        nodesConnectable={false}
-        elementsSelectable
-        zoomOnScroll
-        panOnScroll
-        minZoom={0.4}
-        maxZoom={1.6}
-        proOptions={{ hideAttribution: true }}
-      >
-        <Background
-          variant={BackgroundVariant.Dots}
-          gap={24}
-          size={1}
-          color="rgba(255,255,255,0.04)"
-        />
-        <Controls
-          showInteractive={false}
-          style={{
-            background: 'var(--color-surface)',
-            borderColor: 'var(--color-border)',
-            borderWidth: 1,
-          }}
-        />
-      </ReactFlow>
-    </div>
+    <CanvasBase<NodeData>
+      className="agent-canvas"
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      onNodeClick={handleNodeClick}
+      onPaneClick={() => onSelect(null)}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elementsSelectable
+      zoomOnScroll
+      panOnScroll
+      minZoom={0.4}
+      maxZoom={1.6}
+      backgrounds={[
+        { variant: BackgroundVariant.Dots, gap: 24, size: 1, color: 'rgba(255,255,255,0.04)' },
+      ]}
+    >
+      <Controls
+        showInteractive={false}
+        style={{
+          background: 'var(--color-surface)',
+          borderColor: 'var(--color-border)',
+          borderWidth: 1,
+        }}
+      />
+    </CanvasBase>
   );
 }
 

--- a/web/src/components/agent/ide/SkillSidebar.tsx
+++ b/web/src/components/agent/ide/SkillSidebar.tsx
@@ -3,6 +3,7 @@ import { type SkillSummary } from '../../../lib/agent-api';
 import { cn } from '../../../lib/cn';
 import { SkillRunButton } from './SkillRunButton';
 import { RunsList } from './RunsList';
+import { InspectorTabList, InspectorTabButton } from '../../inspector';
 
 type SidebarTab = 'skills' | 'runs';
 
@@ -67,24 +68,20 @@ export function SkillSidebar({
         </p>
       </header>
 
-      <div
-        role="tablist"
-        aria-label="Sidebar sections"
-        className="px-5 pt-3 flex items-center gap-1 border-b border-border-subtle/50"
-      >
-        <TabButton
+      <InspectorTabList ariaLabel="Sidebar sections">
+        <InspectorTabButton
           active={tab === 'skills'}
           onClick={() => setTab('skills')}
           label="Skills"
           controls="sidebar-tab-skills"
         />
-        <TabButton
+        <InspectorTabButton
           active={tab === 'runs'}
           onClick={() => setTab('runs')}
           label="Runs"
           controls="sidebar-tab-runs"
         />
-      </div>
+      </InspectorTabList>
 
       <div className="flex-1 overflow-y-auto py-3">
         {tab === 'skills' && (
@@ -142,36 +139,6 @@ export function SkillSidebar({
         )}
       </div>
     </aside>
-  );
-}
-
-interface TabButtonProps {
-  active: boolean;
-  onClick: () => void;
-  label: string;
-  controls: string;
-}
-
-function TabButton({ active, onClick, label, controls }: TabButtonProps) {
-  return (
-    <button
-      type="button"
-      role="tab"
-      aria-selected={active}
-      aria-controls={controls}
-      onClick={onClick}
-      className={cn(
-        'px-3 py-1.5 -mb-px',
-        'font-mono text-[10px] uppercase tracking-[0.2em]',
-        'border-b-2 transition-colors',
-        active
-          ? 'border-primary text-text-primary'
-          : 'border-transparent text-text-muted hover:text-text-primary',
-        'focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/60',
-      )}
-    >
-      {label}
-    </button>
   );
 }
 

--- a/web/src/components/canvas/CanvasBase.tsx
+++ b/web/src/components/canvas/CanvasBase.tsx
@@ -1,0 +1,145 @@
+import type { CSSProperties, MouseEvent, ReactNode } from 'react';
+import {
+  ReactFlow,
+  Background,
+  BackgroundVariant,
+  type Node as RFNode,
+  type Edge as RFEdge,
+  type NodeTypes,
+  type EdgeTypes,
+  type NodeChange,
+  type EdgeChange,
+  type Connection,
+  type DefaultEdgeOptions,
+  type FitViewOptions,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { cn } from '../../lib/cn';
+
+export interface BackgroundLayer {
+  id?: string;
+  variant?: BackgroundVariant;
+  gap?: number;
+  size?: number;
+  color?: string;
+}
+
+export interface CanvasBaseProps<NodeData extends Record<string, unknown> = Record<string, unknown>> {
+  nodes: RFNode<NodeData>[];
+  edges: RFEdge[];
+  nodeTypes?: NodeTypes;
+  edgeTypes?: EdgeTypes;
+  onNodesChange?: (changes: NodeChange[]) => void;
+  onEdgesChange?: (changes: EdgeChange[]) => void;
+  onNodeClick?: (event: MouseEvent, node: RFNode<NodeData>) => void;
+  onPaneClick?: () => void;
+  onConnect?: (connection: Connection) => void;
+  defaultEdgeOptions?: DefaultEdgeOptions;
+  fitView?: boolean;
+  fitViewOptions?: FitViewOptions;
+  minZoom?: number;
+  maxZoom?: number;
+  nodesDraggable?: boolean;
+  nodesConnectable?: boolean;
+  elementsSelectable?: boolean;
+  zoomOnScroll?: boolean;
+  panOnScroll?: boolean;
+  // One or more <Background /> layers — defaults to a single dots layer.
+  // Pass `null` for a transparent canvas (rare).
+  backgrounds?: BackgroundLayer[] | null;
+  // Slotted children render inside <ReactFlow>; use for <Panel>-based
+  // workspace control bars or in-canvas overlays.
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const DEFAULT_BACKGROUNDS: BackgroundLayer[] = [
+  {
+    variant: BackgroundVariant.Dots,
+    gap: 24,
+    size: 1,
+    color: 'rgba(255,255,255,0.04)',
+  },
+];
+
+/**
+ * CanvasBase is the shared ReactFlow scaffolding for the Topology and Skills
+ * workspaces. It owns the wrapper element, the ReactFlow component, the
+ * Background layers, and the standard `proOptions`. Workspace-specific
+ * pieces — custom node types, control panels, overlay layers — flow in via
+ * props and the children slot so the two canvases compose this base rather
+ * than inheriting from it.
+ *
+ * Keep this file small. New workspace behaviors should live in the workspace
+ * canvas, not here; CanvasBase pays its way only because both canvases need
+ * the same React Flow boilerplate.
+ */
+export function CanvasBase<
+  NodeData extends Record<string, unknown> = Record<string, unknown>,
+>({
+  nodes,
+  edges,
+  nodeTypes,
+  edgeTypes,
+  onNodesChange,
+  onEdgesChange,
+  onNodeClick,
+  onPaneClick,
+  onConnect,
+  defaultEdgeOptions,
+  fitView,
+  fitViewOptions,
+  minZoom,
+  maxZoom,
+  nodesDraggable,
+  nodesConnectable,
+  elementsSelectable,
+  zoomOnScroll,
+  panOnScroll,
+  backgrounds = DEFAULT_BACKGROUNDS,
+  children,
+  className,
+  style,
+}: CanvasBaseProps<NodeData>) {
+  return (
+    <div className={cn('absolute inset-0', className)} style={style}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeClick={onNodeClick as never}
+        onPaneClick={onPaneClick}
+        onConnect={onConnect}
+        defaultEdgeOptions={defaultEdgeOptions}
+        fitView={fitView}
+        fitViewOptions={fitViewOptions}
+        minZoom={minZoom}
+        maxZoom={maxZoom}
+        nodesDraggable={nodesDraggable}
+        nodesConnectable={nodesConnectable}
+        elementsSelectable={elementsSelectable}
+        zoomOnScroll={zoomOnScroll}
+        panOnScroll={panOnScroll}
+        proOptions={{ hideAttribution: true }}
+      >
+        {backgrounds?.map((layer, i) => (
+          <Background
+            key={layer.id ?? `bg-${i}`}
+            id={layer.id}
+            variant={layer.variant ?? BackgroundVariant.Dots}
+            gap={layer.gap}
+            size={layer.size}
+            color={layer.color}
+          />
+        ))}
+        {children}
+      </ReactFlow>
+    </div>
+  );
+}
+
+export default CanvasBase;

--- a/web/src/components/graph/Canvas.tsx
+++ b/web/src/components/graph/Canvas.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
-  ReactFlow,
   Background,
   Panel,
   BackgroundVariant,
@@ -8,7 +7,6 @@ import {
   useViewport,
   type Connection,
 } from '@xyflow/react';
-import '@xyflow/react/dist/style.css';
 import { RotateCcw, Spline, Minus, Plus, Maximize, Rows3, LayoutGrid, Flame, Layers, Server, Database, GitCompareArrows, Eye, Cable, KeyRound } from 'lucide-react';
 
 import { nodeTypes } from './nodeTypes';
@@ -19,6 +17,7 @@ import { useWizardStore } from '../../stores/useWizardStore';
 import { COLORS } from '../../lib/constants';
 import { usePathHighlight } from '../../hooks/usePathHighlight';
 import { cn } from '../../lib/cn';
+import { CanvasBase } from '../canvas/CanvasBase';
 import { DriftOverlay } from '../spec/DriftOverlay';
 import { SpecModeOverlay } from '../spec/SpecModeOverlay';
 import { SecretHeatmapOverlay } from '../spec/SecretHeatmapOverlay';
@@ -223,7 +222,7 @@ export function Canvas() {
           </div>
         </div>
       )}
-      <ReactFlow
+      <CanvasBase
         nodes={styledNodes}
         edges={styledEdges}
         nodeTypes={nodeTypes}
@@ -234,22 +233,19 @@ export function Canvas() {
         onPaneClick={onPaneClick}
         defaultEdgeOptions={defaultEdgeOptions}
         fitView
-        fitViewOptions={{
-          padding: 0.2,
-          maxZoom: 1.5,
-        }}
+        fitViewOptions={{ padding: 0.2, maxZoom: 1.5 }}
         minZoom={0.1}
         maxZoom={2}
-        proOptions={{ hideAttribution: true }}
+        backgrounds={[
+          {
+            variant: BackgroundVariant.Lines,
+            gap: 100,
+            color: 'rgba(100, 116, 139, 0.15)',
+          },
+        ]}
       >
-        {/* Main grid - Lines at 100px intervals */}
-        <Background
-          variant={BackgroundVariant.Lines}
-          gap={100}
-          color="rgba(100, 116, 139, 0.15)"
-        />
-
-        {/* Sub-grid - Dots at 20px, fades in when zoom > 0.8 */}
+        {/* Sub-grid — dots at 20px, fades in when zoom > 0.8. Rendered as a
+            child so the zoom-conditional layer stays local to this canvas. */}
         {showSubGrid && (
           <Background
             id="sub-grid"
@@ -366,7 +362,7 @@ export function Canvas() {
             <KeyRound className="w-4 h-4" />
           </button>
         </Panel>
-      </ReactFlow>
+      </CanvasBase>
       {showDriftOverlay && (
         <div className="absolute inset-0 pointer-events-none bg-primary/[0.02] z-10" />
       )}

--- a/web/src/components/inspector/InspectorHeader.tsx
+++ b/web/src/components/inspector/InspectorHeader.tsx
@@ -1,0 +1,121 @@
+import { X, type LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { cn } from '../../lib/cn';
+
+type AccentTone = 'primary' | 'secondary' | 'tertiary' | 'violet' | 'muted';
+
+const ACCENT_BG: Record<AccentTone, string> = {
+  primary: 'bg-primary/10 border-primary/20',
+  secondary: 'bg-secondary/10 border-secondary/20',
+  tertiary: 'bg-tertiary/10 border-tertiary/20',
+  violet: 'bg-violet-500/10 border-violet-500/20',
+  muted: 'bg-surface-elevated/50 border-border/30',
+};
+
+const ACCENT_TEXT: Record<AccentTone, string> = {
+  primary: 'text-primary',
+  secondary: 'text-secondary',
+  tertiary: 'text-tertiary',
+  violet: 'text-violet-400',
+  muted: 'text-text-muted',
+};
+
+interface InspectorHeaderProps {
+  title: string;
+  subtitle?: ReactNode;
+  icon?: LucideIcon;
+  accent?: AccentTone;
+  onClose?: () => void;
+  onDetach?: () => void;
+  detachDisabled?: boolean;
+  // Right-aligned actions slot — for popout buttons or workspace-specific
+  // controls. Rendered before the close button.
+  actions?: ReactNode;
+}
+
+/**
+ * InspectorHeader is the shared top-of-aside header for the Topology and
+ * Skills inspectors. It owns the icon block, title, subtitle, and the
+ * close/popout affordances; the badge/tag row sits in the subtitle slot
+ * so each workspace can drop in its own metadata pills without forking.
+ */
+export function InspectorHeader({
+  title,
+  subtitle,
+  icon: Icon,
+  accent = 'primary',
+  onClose,
+  onDetach,
+  detachDisabled,
+  actions,
+}: InspectorHeaderProps) {
+  return (
+    <div className="flex items-center justify-between p-4 border-b border-border/50 bg-surface-elevated/30">
+      <div className="flex items-center gap-3 min-w-0">
+        {Icon && (
+          <div
+            className={cn(
+              'p-2 rounded-xl flex-shrink-0 border relative',
+              ACCENT_BG[accent],
+            )}
+          >
+            <Icon size={16} className={ACCENT_TEXT[accent]} />
+          </div>
+        )}
+        <div className="min-w-0">
+          <h2 className="font-semibold text-text-primary truncate tracking-tight">{title}</h2>
+          {subtitle && <div className="flex items-center gap-1.5">{subtitle}</div>}
+        </div>
+      </div>
+      <div className="flex items-center gap-1">
+        {actions}
+        {onDetach && (
+          <button
+            type="button"
+            onClick={onDetach}
+            disabled={detachDisabled}
+            className={cn(
+              'p-1.5 rounded-lg transition-colors group',
+              detachDisabled
+                ? 'opacity-30 cursor-not-allowed'
+                : 'hover:bg-surface-highlight',
+            )}
+            aria-label="Open in new window"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="none"
+              className={cn(
+                'text-text-muted transition-colors',
+                !detachDisabled && 'group-hover:text-text-primary',
+              )}
+            >
+              <path
+                d="M10 2h4v4M14 2L7 9M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        )}
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-surface-highlight transition-colors group"
+            aria-label="Close inspector"
+          >
+            <X
+              size={16}
+              className="text-text-muted group-hover:text-text-primary transition-colors"
+            />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/inspector/InspectorSection.tsx
+++ b/web/src/components/inspector/InspectorSection.tsx
@@ -1,0 +1,68 @@
+import { useState, type ComponentType, type ReactNode } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+interface InspectorSectionProps {
+  title: string;
+  icon?: ComponentType<{ size?: number; className?: string }>;
+  count?: number;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * Collapsible section used inside both the Topology Sidebar and the
+ * detached-sidebar popout. Section headers carry an optional Lucide icon
+ * and an optional count badge; the body slides via the same `max-h` +
+ * opacity transition as before so existing visual tests are unaffected.
+ */
+export function InspectorSection({
+  title,
+  icon: Icon,
+  count,
+  defaultOpen = false,
+  children,
+}: InspectorSectionProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <div className="border-b border-border/30">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center justify-between p-4 hover:bg-surface-highlight/50 transition-colors group"
+      >
+        <div className="flex items-center gap-2.5">
+          {Icon && (
+            <div className="p-1 rounded-md bg-surface-highlight/50 group-hover:bg-surface-highlight transition-colors">
+              <Icon
+                size={12}
+                className="text-text-muted group-hover:text-primary transition-colors"
+              />
+            </div>
+          )}
+          <span className="text-sm font-medium text-text-primary">{title}</span>
+          {count !== undefined && (
+            <span className="text-[10px] text-text-muted bg-surface-elevated px-1.5 py-0.5 rounded-md font-mono">
+              {count}
+            </span>
+          )}
+        </div>
+        <div className="p-1 rounded-md group-hover:bg-surface-highlight transition-colors">
+          {isOpen ? (
+            <ChevronDown size={14} className="text-text-muted" />
+          ) : (
+            <ChevronRight size={14} className="text-text-muted" />
+          )}
+        </div>
+      </button>
+      <div
+        className={cn(
+          'overflow-hidden transition-all duration-200',
+          isOpen ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0',
+        )}
+      >
+        <div className="px-4 pb-4">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/inspector/InspectorTabList.tsx
+++ b/web/src/components/inspector/InspectorTabList.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react';
+import { cn } from '../../lib/cn';
+
+interface InspectorTabListProps {
+  ariaLabel: string;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Tab strip wrapper used at the top of inspectors and workspace rails. The
+ * actual tab buttons render as <InspectorTabButton> children — keeps the
+ * a11y wiring (role="tablist", aria-label) consistent without forcing a
+ * fixed shape on the caller.
+ */
+export function InspectorTabList({ ariaLabel, children, className }: InspectorTabListProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className={cn(
+        'px-5 pt-3 flex items-center gap-1 border-b border-border-subtle/50',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface InspectorTabButtonProps {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  controls: string;
+}
+
+export function InspectorTabButton({
+  active,
+  onClick,
+  label,
+  controls,
+}: InspectorTabButtonProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      aria-controls={controls}
+      onClick={onClick}
+      className={cn(
+        'px-3 py-1.5 -mb-px',
+        'font-mono text-[10px] uppercase tracking-[0.2em]',
+        'border-b-2 transition-colors',
+        active
+          ? 'border-primary text-text-primary'
+          : 'border-transparent text-text-muted hover:text-text-primary',
+        'focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/60',
+      )}
+    >
+      {label}
+    </button>
+  );
+}

--- a/web/src/components/inspector/index.ts
+++ b/web/src/components/inspector/index.ts
@@ -1,0 +1,3 @@
+export { InspectorHeader } from './InspectorHeader';
+export { InspectorSection } from './InspectorSection';
+export { InspectorTabList, InspectorTabButton } from './InspectorTabList';

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,10 +1,6 @@
-import { useState } from 'react';
 import {
-  X,
   Terminal,
   Box,
-  ChevronDown,
-  ChevronRight,
   Wrench,
   FileText,
   Sparkles,
@@ -23,6 +19,7 @@ import { cn } from '../../lib/cn';
 import { Badge } from '../ui/Badge';
 import { ControlBar } from '../ui/ControlBar';
 import { PopoutButton } from '../ui/PopoutButton';
+import { InspectorHeader, InspectorSection } from '../inspector';
 import { GatewaySidebar } from '../gateway/GatewaySidebar';
 import { TokenUsageSection } from '../sidebar/TokenUsageSection';
 import { ToolsEditor } from '../sidebar/ToolsEditor';
@@ -117,74 +114,51 @@ export function Sidebar() {
         )}
       />
 
-      {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-border/50 bg-surface-elevated/30">
-        <div className="flex items-center gap-3 min-w-0">
-          <div
-            className={cn(
-              'p-2 rounded-xl flex-shrink-0 border relative',
-              colorClass === 'primary' && 'bg-primary/10 border-primary/20',
-              colorClass === 'violet' && 'bg-violet-500/10 border-violet-500/20',
-              colorClass === 'secondary' && 'bg-secondary/10 border-secondary/20'
+      <InspectorHeader
+        title={data.name}
+        icon={Icon}
+        accent={colorClass}
+        subtitle={
+          <>
+            <p className="text-[10px] text-text-muted uppercase tracking-wider">
+              {isClient ? 'LLM Client' : isServer ? 'MCP Server' : 'Resource'}
+            </p>
+            {isServer && isExternal && (
+              <span className="text-[9px] px-1 py-0.5 rounded font-medium bg-violet-500/10 text-violet-400 flex items-center gap-0.5">
+                <Globe size={8} />
+                External
+              </span>
             )}
-          >
-            <Icon
-              size={16}
-              className={cn(
-                colorClass === 'primary' && 'text-primary',
-                colorClass === 'violet' && 'text-violet-400',
-                colorClass === 'secondary' && 'text-secondary'
-              )}
-            />
-          </div>
-          <div className="min-w-0">
-            <h2 className="font-semibold text-text-primary truncate tracking-tight">{data.name}</h2>
-            <div className="flex items-center gap-1.5">
-              <p className="text-[10px] text-text-muted uppercase tracking-wider">
-                {isClient ? 'LLM Client' : isServer ? 'MCP Server' : 'Resource'}
-              </p>
-              {isServer && isExternal && (
-                <span className="text-[9px] px-1 py-0.5 rounded font-medium bg-violet-500/10 text-violet-400 flex items-center gap-0.5">
-                  <Globe size={8} />
-                  External
-                </span>
-              )}
-              {isServer && isLocalProcess && (
-                <span className="text-[9px] px-1 py-0.5 rounded font-medium bg-surface-highlight text-text-muted flex items-center gap-0.5">
-                  <Cpu size={8} />
-                  Local
-                </span>
-              )}
-              {isServer && isSSH && (
-                <span className="text-[9px] px-1 py-0.5 rounded font-medium bg-surface-highlight text-text-muted flex items-center gap-0.5">
-                  <KeyRound size={8} />
-                  SSH
-                </span>
-              )}
-              {isServer && isOpenAPI && (
-                <span className="text-[9px] px-1 py-0.5 rounded font-medium bg-surface-highlight text-text-muted flex items-center gap-0.5">
-                  <FileJson size={8} />
-                  OpenAPI
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
-        <div className="flex items-center gap-1">
-          <PopoutButton
-            onClick={handlePopout}
-            disabled={sidebarDetached}
-          />
-          <button onClick={handleClose} className="p-1.5 rounded-lg hover:bg-surface-highlight transition-colors group">
-            <X size={16} className="text-text-muted group-hover:text-text-primary transition-colors" />
-          </button>
-        </div>
-      </div>
+            {isServer && isLocalProcess && (
+              <span className="text-[9px] px-1 py-0.5 rounded font-medium bg-surface-highlight text-text-muted flex items-center gap-0.5">
+                <Cpu size={8} />
+                Local
+              </span>
+            )}
+            {isServer && isSSH && (
+              <span className="text-[9px] px-1 py-0.5 rounded font-medium bg-surface-highlight text-text-muted flex items-center gap-0.5">
+                <KeyRound size={8} />
+                SSH
+              </span>
+            )}
+            {isServer && isOpenAPI && (
+              <span className="text-[9px] px-1 py-0.5 rounded font-medium bg-surface-highlight text-text-muted flex items-center gap-0.5">
+                <FileJson size={8} />
+                OpenAPI
+              </span>
+            )}
+          </>
+        }
+        onClose={handleClose}
+        actions={
+          <PopoutButton onClick={handlePopout} disabled={sidebarDetached} />
+        }
+      />
 
       {/* Content */}
       <div className="flex-1 overflow-y-auto scrollbar-dark">
         {/* Status Section */}
-        <Section title="Status" icon={Sparkles} defaultOpen>
+        <InspectorSection title="Status" icon={Sparkles} defaultOpen>
           <div className="space-y-3">
             <div className="flex justify-between items-center">
               <span className="text-sm text-text-muted">State</span>
@@ -335,29 +309,29 @@ export function Sidebar() {
               </div>
             )}
           </div>
-        </Section>
+        </InspectorSection>
 
         {/* Token Usage Section (MCP servers only) */}
         {isServer && (
-          <Section title="Token Usage" icon={Gauge}>
+          <InspectorSection title="Token Usage" icon={Gauge}>
             <TokenUsageSection serverName={data.name} />
-          </Section>
+          </InspectorSection>
         )}
 
         {/* Scaling Section (MCP servers with autoscale only) */}
         {isServer && serverData?.autoscale && (
-          <Section title="Scaling" icon={Activity} defaultOpen>
+          <InspectorSection title="Scaling" icon={Activity} defaultOpen>
             <AutoscalePanel
               status={serverData.autoscale}
               history={autoscaleHistory[data.name] ?? []}
               decisions={autoscaleDecisions[data.name] ?? []}
             />
-          </Section>
+          </InspectorSection>
         )}
 
         {/* Controls Section (not for clients - they aren't containers) */}
         {!isClient && (
-          <Section title="Actions" icon={Terminal} defaultOpen>
+          <InspectorSection title="Actions" icon={Terminal} defaultOpen>
             <ControlBar name={data.name} variant={isServer ? 'mcp-server' : 'mcp-server'} />
             <button
               onClick={handleShowLogs}
@@ -371,73 +345,27 @@ export function Sidebar() {
               <FileText size={14} />
               Show Logs Panel
             </button>
-          </Section>
+          </InspectorSection>
         )}
 
         {/* Telemetry Section (MCP servers only) — between Actions and Tools */}
         {isServer && (
-          <Section title="Telemetry" icon={Database}>
+          <InspectorSection title="Telemetry" icon={Database}>
             <SidebarTelemetrySection serverName={data.name} />
-          </Section>
+          </InspectorSection>
         )}
 
         {/* Tools Section (MCP servers only) */}
         {isServer && (
-          <Section title="Tools" icon={Wrench} count={(data as MCPServerNodeData).toolCount}>
+          <InspectorSection title="Tools" icon={Wrench} count={(data as MCPServerNodeData).toolCount}>
             <ToolsEditor
               serverName={data.name}
               savedTools={(data as MCPServerNodeData).toolWhitelist ?? []}
               serverTools={(data as MCPServerNodeData).tools ?? []}
             />
-          </Section>
+          </InspectorSection>
         )}
 
-      </div>
-    </div>
-  );
-}
-
-// Collapsible section component
-interface SectionProps {
-  title: string;
-  icon?: React.ComponentType<{ size?: number; className?: string }>;
-  count?: number;
-  defaultOpen?: boolean;
-  children: React.ReactNode;
-}
-
-function Section({ title, icon: Icon, count, defaultOpen = false, children }: SectionProps) {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
-
-  return (
-    <div className="border-b border-border/30">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center justify-between p-4 hover:bg-surface-highlight/50 transition-colors group"
-      >
-        <div className="flex items-center gap-2.5">
-          {Icon && (
-            <div className="p-1 rounded-md bg-surface-highlight/50 group-hover:bg-surface-highlight transition-colors">
-              <Icon size={12} className="text-text-muted group-hover:text-primary transition-colors" />
-            </div>
-          )}
-          <span className="text-sm font-medium text-text-primary">{title}</span>
-          {count !== undefined && (
-            <span className="text-[10px] text-text-muted bg-surface-elevated px-1.5 py-0.5 rounded-md font-mono">
-              {count}
-            </span>
-          )}
-        </div>
-        <div className="p-1 rounded-md group-hover:bg-surface-highlight transition-colors">
-          {isOpen ? (
-            <ChevronDown size={14} className="text-text-muted" />
-          ) : (
-            <ChevronRight size={14} className="text-text-muted" />
-          )}
-        </div>
-      </button>
-      <div className={cn('overflow-hidden transition-all duration-200', isOpen ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0')}>
-        <div className="px-4 pb-4">{children}</div>
       </div>
     </div>
   );

--- a/web/src/components/ui/EmptyState.tsx
+++ b/web/src/components/ui/EmptyState.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+type EmptyTone = 'muted' | 'primary' | 'secondary' | 'tertiary';
+
+const ICON_BG: Record<EmptyTone, string> = {
+  muted: 'bg-surface-elevated/50 border-border/30 text-text-muted/50',
+  primary: 'bg-primary/10 border-primary/20 text-primary',
+  secondary: 'bg-secondary/10 border-secondary/20 text-secondary',
+  tertiary: 'bg-tertiary/10 border-tertiary/20 text-tertiary',
+};
+
+interface EmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  description?: ReactNode;
+  action?: ReactNode;
+  tone?: EmptyTone;
+  // Use `inline` for in-grid empty rows (no full-bleed centering); the
+  // default centers in the parent's flex/grid box like a canvas overlay.
+  inline?: boolean;
+  className?: string;
+}
+
+/**
+ * Shared empty-state pattern used by canvases and grids. Concrete copy and
+ * actions live with the caller — this component owns the visual shell
+ * (icon block, headline, description, CTA slot) so spacing stays
+ * consistent across workspaces.
+ */
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  tone = 'muted',
+  inline,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        inline
+          ? 'flex flex-col items-center gap-3 px-6 py-8 text-center'
+          : 'h-full flex flex-col items-center justify-center gap-3 text-center px-12',
+        className,
+      )}
+    >
+      {Icon && (
+        <div
+          className={cn(
+            'p-4 rounded-xl border flex-shrink-0',
+            ICON_BG[tone],
+          )}
+        >
+          <Icon size={32} />
+        </div>
+      )}
+      <div>
+        <h2 className="font-sans text-text-secondary text-base font-medium mb-1.5">
+          {title}
+        </h2>
+        {description && (
+          <p className="text-text-muted text-sm max-w-sm leading-relaxed">{description}</p>
+        )}
+      </div>
+      {action && <div className="mt-1">{action}</div>}
+    </div>
+  );
+}

--- a/web/src/pages/DetachedSidebarPage.tsx
+++ b/web/src/pages/DetachedSidebarPage.tsx
@@ -4,7 +4,6 @@ import {
   Terminal,
   Box,
   ChevronDown,
-  ChevronRight,
   Wrench,
   Sparkles,
   Globe,
@@ -31,6 +30,7 @@ import type {
   ResourceStatus,
 } from '../types';
 import { DetachedSkillsSidebar } from '../components/skills/DetachedSkillsSidebar';
+import { InspectorSection } from '../components/inspector';
 
 // Error boundary for detached window
 interface ErrorBoundaryState {
@@ -363,7 +363,7 @@ function NodeDetails({ node }: { node: NodeOption }) {
       </div>
 
       {/* Status Section */}
-      <Section title="Status" icon={Sparkles} defaultOpen>
+      <InspectorSection title="Status" icon={Sparkles} defaultOpen>
         <div className="space-y-3">
           <div className="flex justify-between items-center">
             <span className="log-text text-text-muted">State</span>
@@ -419,11 +419,11 @@ function NodeDetails({ node }: { node: NodeOption }) {
             </div>
           )}
         </div>
-      </Section>
+      </InspectorSection>
 
       {/* Tools Section (MCP servers only) */}
       {isServer && (
-        <Section title="Tools" icon={Wrench} count={advertisedTools.length}>
+        <InspectorSection title="Tools" icon={Wrench} count={advertisedTools.length}>
           {advertisedTools.length === 0 ? (
             <p className="log-text text-text-muted italic">No tools registered</p>
           ) : (
@@ -433,65 +433,9 @@ function NodeDetails({ node }: { node: NodeOption }) {
               serverTools={advertisedTools}
             />
           )}
-        </Section>
+        </InspectorSection>
       )}
     </div>
   );
 }
-
-// Collapsible section
-function Section({
-  title,
-  icon: Icon,
-  count,
-  defaultOpen = false,
-  children,
-}: {
-  title: string;
-  icon?: React.ComponentType<{ size?: number; className?: string }>;
-  count?: number;
-  defaultOpen?: boolean;
-  children: React.ReactNode;
-}) {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
-
-  return (
-    <div className="border-b border-border/30">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center justify-between p-4 hover:bg-surface-highlight/50 transition-colors group"
-      >
-        <div className="flex items-center gap-2.5">
-          {Icon && (
-            <div className="p-1 rounded-md bg-surface-highlight/50 group-hover:bg-surface-highlight transition-colors">
-              <Icon size={12} className="text-text-muted group-hover:text-primary transition-colors" />
-            </div>
-          )}
-          <span className="log-text font-medium text-text-primary">{title}</span>
-          {count !== undefined && (
-            <span className="text-[10px] text-text-muted bg-surface-elevated px-1.5 py-0.5 rounded-md font-mono">
-              {count}
-            </span>
-          )}
-        </div>
-        <div className="p-1 rounded-md group-hover:bg-surface-highlight transition-colors">
-          {isOpen ? (
-            <ChevronDown size={14} className="text-text-muted" />
-          ) : (
-            <ChevronRight size={14} className="text-text-muted" />
-          )}
-        </div>
-      </button>
-      <div
-        className={cn(
-          'overflow-hidden transition-all duration-200',
-          isOpen ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0'
-        )}
-      >
-        <div className="px-4 pb-4">{children}</div>
-      </div>
-    </div>
-  );
-}
-
 


### PR DESCRIPTION
## Description

Phase 4 (final) of the One Cockpit Unification: cleanup and polish. Extracts the duplicated inspector and canvas scaffolding from the Topology and Skills workspaces into shared primitives, with a new architecture doc covering the shell, store slices, and do/don't conventions. No behavioral changes.

## Type of Change

- [x] Code refactor (no functional changes)

## Changes Made

- New `CanvasBase` in `web/src/components/canvas/` — shared React Flow scaffolding (wrapper, backgrounds, proOptions) consumed by both Topology and Skills canvases. The two canvases remain separate implementations that compose this base, not a polymorphic merge.
- New `InspectorHeader` / `InspectorSection` / `InspectorTabList` in `web/src/components/inspector/` — shared primitives for the workspace inspectors. Topology `Sidebar.tsx`, Skills `SkillSidebar.tsx`, and `DetachedSidebarPage.tsx` all switched to the shared versions.
- New `EmptyState` in `web/src/components/ui/` — shared empty-state shell for canvases and grids.
- `web/src/components/README.md` documents the shell architecture, store-slice layout, and do/don't conventions.
- Net LOC reduction across refactored files: -176 lines (293 deleted, 117 inserted).

## Testing

- `npm run build` clean (CanvasBase ships as its own 1 KB chunk)
- `npm test` — 571 tests pass (up from 556; added 15 tests for the new primitives; existing Canvas behavior unchanged)
- `go build ./...` clean
- Lint count unchanged from baseline (53)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #634