### PR TITLE
refactor: registry-driven workspace metadata

### DIFF
--- a/web/src/__tests__/useKeyboardShortcuts.test.tsx
+++ b/web/src/__tests__/useKeyboardShortcuts.test.tsx
@@ -8,30 +8,33 @@ function fireMod(key: string) {
 }
 
 describe('useKeyboardShortcuts — workspace navigation', () => {
-  it('⌘1 calls onSwitchToTopology', () => {
-    const onSwitchToTopology = vi.fn();
-    renderHook(() => useKeyboardShortcuts({ onSwitchToTopology }));
+  it('⌘1 calls onSwitchToWorkspace with "topology"', () => {
+    const onSwitchToWorkspace = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onSwitchToWorkspace }));
     fireMod('1');
-    expect(onSwitchToTopology).toHaveBeenCalledTimes(1);
+    expect(onSwitchToWorkspace).toHaveBeenCalledTimes(1);
+    expect(onSwitchToWorkspace).toHaveBeenCalledWith('topology');
   });
 
-  it('⌘2 calls onSwitchToSkills', () => {
-    const onSwitchToSkills = vi.fn();
-    renderHook(() => useKeyboardShortcuts({ onSwitchToSkills }));
+  it('⌘2 calls onSwitchToWorkspace with "skills"', () => {
+    const onSwitchToWorkspace = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onSwitchToWorkspace }));
     fireMod('2');
-    expect(onSwitchToSkills).toHaveBeenCalledTimes(1);
+    expect(onSwitchToWorkspace).toHaveBeenCalledTimes(1);
+    expect(onSwitchToWorkspace).toHaveBeenCalledWith('skills');
   });
 
-  it('⌘3 calls onSwitchToRuns', () => {
-    const onSwitchToRuns = vi.fn();
-    renderHook(() => useKeyboardShortcuts({ onSwitchToRuns }));
+  it('⌘3 calls onSwitchToWorkspace with "runs"', () => {
+    const onSwitchToWorkspace = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onSwitchToWorkspace }));
     fireMod('3');
-    expect(onSwitchToRuns).toHaveBeenCalledTimes(1);
+    expect(onSwitchToWorkspace).toHaveBeenCalledTimes(1);
+    expect(onSwitchToWorkspace).toHaveBeenCalledWith('runs');
   });
 
   it('does not fire workspace shortcuts when focus is inside an input', () => {
-    const onSwitchToSkills = vi.fn();
-    renderHook(() => useKeyboardShortcuts({ onSwitchToSkills }));
+    const onSwitchToWorkspace = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onSwitchToWorkspace }));
 
     const input = document.createElement('input');
     document.body.appendChild(input);
@@ -41,7 +44,7 @@ describe('useKeyboardShortcuts — workspace navigation', () => {
     Object.defineProperty(ev, 'target', { value: input });
     window.dispatchEvent(ev);
 
-    expect(onSwitchToSkills).not.toHaveBeenCalled();
+    expect(onSwitchToWorkspace).not.toHaveBeenCalled();
     input.remove();
   });
 

--- a/web/src/components/shell/AppShell.tsx
+++ b/web/src/components/shell/AppShell.tsx
@@ -18,7 +18,7 @@ import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { useGlobalCommands } from '../../hooks/useGlobalCommands';
 import { useGlobalRunsStream } from '../runs/useGlobalRunsStream';
 import { useRunsCommands } from '../runs/useRunsCommands';
-import { isWorkspace, type Workspace, WORKSPACES } from '../../types/workspace';
+import { isWorkspace, type Workspace } from '../../types/workspace';
 import {
   LAST_WORKSPACE_GLOBAL_KEY,
   LAST_WORKSPACE_PER_STACK_PREFIX,
@@ -114,9 +114,7 @@ function AppShellInner() {
     onToggleBottomPanel: toggleBottomPanel,
     onSwitchToTraces: () => setBottomPanelTab('traces'),
     onOpenPalette: toggleCommandPalette,
-    onSwitchToTopology: () => navigate(`/${WORKSPACES[0]}`),
-    onSwitchToSkills: () => navigate(`/${WORKSPACES[1]}`),
-    onSwitchToRuns: () => navigate(`/${WORKSPACES[2]}`),
+    onSwitchToWorkspace: (id) => navigate(`/${id}`),
     onToggleCompactMode: () => toggleCompactMode(activeWorkspace),
   });
 

--- a/web/src/components/shell/WorkspaceSwitcher.tsx
+++ b/web/src/components/shell/WorkspaceSwitcher.tsx
@@ -1,35 +1,37 @@
 import { NavLink, useLocation } from 'react-router-dom';
 import { cn } from '../../lib/cn';
-import { WORKSPACES, WORKSPACE_LABELS, type Workspace } from '../../types/workspace';
+import { WORKSPACE_CONFIG, type WorkspaceConfig } from '../../types/workspace';
 
 interface WorkspacePillProps {
-  workspace: Workspace;
-  label: string;
+  workspace: WorkspaceConfig;
 }
 
-function WorkspacePill({ workspace, label }: WorkspacePillProps) {
+function WorkspacePill({ workspace }: WorkspacePillProps) {
   const { pathname } = useLocation();
-  const isActive = pathname === `/${workspace}` || pathname.startsWith(`/${workspace}/`);
+  const isActive =
+    pathname === `/${workspace.id}` || pathname.startsWith(`/${workspace.id}/`);
+  const Icon = workspace.icon;
   return (
     <NavLink
-      to={`/${workspace}`}
+      to={`/${workspace.id}`}
       role="tab"
       aria-selected={isActive}
-      data-workspace={workspace}
+      data-workspace={workspace.id}
       className={cn(
-        'px-3 py-1 rounded-full text-xs font-medium transition-colors',
+        'inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors',
         'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/60',
         isActive
           ? 'bg-primary/15 text-primary border border-primary/30'
           : 'text-text-secondary hover:text-text-primary hover:bg-surface-highlight/60 border border-transparent',
       )}
     >
-      {label}
+      <Icon size={12} aria-hidden="true" />
+      {workspace.label}
     </NavLink>
   );
 }
 
-// Segmented control of three NavLink pills in the Header. Always visible.
+// Segmented control of pills in the Header, one per WORKSPACE_CONFIG entry.
 // role="tablist" with aria-selected on each tab for screen-reader navigation.
 export function WorkspaceSwitcher() {
   return (
@@ -38,8 +40,8 @@ export function WorkspaceSwitcher() {
       aria-label="Workspace"
       className="flex items-center gap-1 p-1 rounded-full bg-surface-elevated/60 backdrop-blur-sm border border-border/50"
     >
-      {WORKSPACES.map((ws) => (
-        <WorkspacePill key={ws} workspace={ws} label={WORKSPACE_LABELS[ws]} />
+      {WORKSPACE_CONFIG.map((ws) => (
+        <WorkspacePill key={ws.id} workspace={ws} />
       ))}
     </div>
   );

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { WORKSPACE_CONFIG, type Workspace } from '../types/workspace';
 
 interface ShortcutOptions {
   onFitView?: () => void;
@@ -10,13 +11,17 @@ interface ShortcutOptions {
   onToggleBottomPanel?: () => void;
   onSwitchToTraces?: () => void;
   onOpenPalette?: () => void;
-  // Workspace navigation — ⌘1 / ⌘2 / ⌘3 switch top-level workspaces.
-  onSwitchToTopology?: () => void;
-  onSwitchToSkills?: () => void;
-  onSwitchToRuns?: () => void;
-  // ⌘\ toggles Compact Mode for the active workspace.
+  // Workspace navigation — Cmd/Ctrl + <shortcutKey> switches top-level
+  // workspaces. The key→id mapping comes from WORKSPACE_CONFIG, so adding a
+  // workspace there automatically binds its shortcut.
+  onSwitchToWorkspace?: (id: Workspace) => void;
+  // Cmd/Ctrl+\ toggles Compact Mode for the active workspace.
   onToggleCompactMode?: () => void;
 }
+
+const WORKSPACE_BY_KEY: ReadonlyMap<string, Workspace> = new Map(
+  WORKSPACE_CONFIG.map((w) => [w.shortcutKey, w.id]),
+);
 
 export function useKeyboardShortcuts(options: ShortcutOptions) {
   useEffect(() => {
@@ -70,18 +75,13 @@ export function useKeyboardShortcuts(options: ShortcutOptions) {
         options.onToggleBottomPanel?.();
       }
 
-      // Workspace switching: ⌘1 (Topology), ⌘2 (Skills), ⌘3 (Runs)
-      if (isMod && e.key === '1') {
-        e.preventDefault();
-        options.onSwitchToTopology?.();
-      }
-      if (isMod && e.key === '2') {
-        e.preventDefault();
-        options.onSwitchToSkills?.();
-      }
-      if (isMod && e.key === '3') {
-        e.preventDefault();
-        options.onSwitchToRuns?.();
+      // Workspace switching: Cmd/Ctrl + <shortcutKey from WORKSPACE_CONFIG>
+      if (isMod) {
+        const ws = WORKSPACE_BY_KEY.get(e.key);
+        if (ws) {
+          e.preventDefault();
+          options.onSwitchToWorkspace?.(ws);
+        }
       }
       // Traces panel quick-jump: Cmd/Ctrl+4 (tabs themselves remain clickable)
       if (isMod && e.key === '4') {

--- a/web/src/types/workspace.ts
+++ b/web/src/types/workspace.ts
@@ -1,15 +1,34 @@
-// The three top-level workspaces in the unified shell. The `/topology`,
-// `/skills`, and `/runs` routes each render one workspace inside AppShell.
+import type { LucideIcon } from 'lucide-react';
+import { Code, Network, PlayCircle } from 'lucide-react';
+
+// The three top-level workspaces in the unified shell. Routed at /topology,
+// /skills, /runs inside AppShell.
 export type Workspace = 'topology' | 'skills' | 'runs';
 
-export const WORKSPACES: readonly Workspace[] = ['topology', 'skills', 'runs'] as const;
-
-export function isWorkspace(value: unknown): value is Workspace {
-  return value === 'topology' || value === 'skills' || value === 'runs';
+export interface WorkspaceConfig {
+  id: Workspace;
+  label: string;
+  icon: LucideIcon;
+  // Single character matched against KeyboardEvent.key with Cmd/Ctrl pressed.
+  shortcutKey: string;
 }
 
-export const WORKSPACE_LABELS: Record<Workspace, string> = {
-  topology: 'Topology',
-  skills: 'Skills',
-  runs: 'Runs',
-};
+// Single source of truth for workspace metadata. Adding a workspace = append
+// here; the switcher, shortcuts, and labels follow automatically.
+export const WORKSPACE_CONFIG: readonly WorkspaceConfig[] = [
+  { id: 'topology', label: 'Topology', icon: Network,    shortcutKey: '1' },
+  { id: 'skills',   label: 'Skills',   icon: Code,       shortcutKey: '2' },
+  { id: 'runs',     label: 'Runs',     icon: PlayCircle, shortcutKey: '3' },
+] as const;
+
+// Derived for back-compat with existing call-sites in useUIStore, AppShell,
+// landing-workspace, etc. Migrate them to WORKSPACE_CONFIG opportunistically.
+export const WORKSPACES: readonly Workspace[] = WORKSPACE_CONFIG.map((w) => w.id);
+
+export const WORKSPACE_LABELS: Record<Workspace, string> = Object.fromEntries(
+  WORKSPACE_CONFIG.map((w) => [w.id, w.label]),
+) as Record<Workspace, string>;
+
+export function isWorkspace(value: unknown): value is Workspace {
+  return typeof value === 'string' && (WORKSPACES as readonly string[]).includes(value);
+}


### PR DESCRIPTION
## Description

Replace ad-hoc workspace constants and per-workspace shortcut callbacks with a single `WORKSPACE_CONFIG` registry that carries id, label, icon, and shortcut key for each workspace. `AppShell`, `useKeyboardShortcuts`, and `WorkspaceSwitcher` now iterate the registry instead of hardcoding `WORKSPACES[0..2]` indices or enumerating three workspace-specific callbacks. Pure refactor — the only user-visible change is a small icon left of each workspace pill's label.

This is **Phase 2 of three** in the unified shell refinements tracked by #640. Phase 1 (PR #641) standardized the inspector layout; Phase 3 (global SSE stream control) follows.

## Type of Change

- [x] Refactor (no functional change; one small visual addition: icons in workspace pills)

## Changes Made

- `web/src/types/workspace.ts` — added `WorkspaceConfig` interface and `WORKSPACE_CONFIG` array (id + label + `LucideIcon` + shortcutKey). `WORKSPACES` and `WORKSPACE_LABELS` continue to be exported, derived from the config.
- `web/src/hooks/useKeyboardShortcuts.ts` — collapsed `onSwitchToTopology` / `onSwitchToSkills` / `onSwitchToRuns` into a single `onSwitchToWorkspace(id)` callback. Module-scope `WORKSPACE_BY_KEY` map drives the lookup.
- `web/src/components/shell/AppShell.tsx` — dropped `WORKSPACES` import and the three hardcoded-index callbacks; wires `onSwitchToWorkspace: (id) => navigate(\`/${id}\`)`.
- `web/src/components/shell/WorkspaceSwitcher.tsx` — iterates `WORKSPACE_CONFIG`; each pill renders its registry-supplied icon (`size=12 aria-hidden=true`) left of the label.
- `web/src/__tests__/useKeyboardShortcuts.test.tsx` — fixture updated for the renamed callback.

**Icon rationale** — each icon was chosen from icons already in use elsewhere in the codebase, so visual language stays consistent:
- Topology → `Network` (already imported in `useSkillsCommands.ts`)
- Skills → `Code` (matches "Code is canon" framing in `SkillsWorkspace`; already imported in `StatusBar.tsx`)
- Runs → `PlayCircle` (matches the Runs tab icon in `BottomPanel.tsx`)

## Testing

- `cd web && npx tsc --noEmit` — passes
- `cd web && npx eslint` on all 5 touched files — passes
- `cd web && npm run test` — 571 tests pass across 51 files (no regressions; one test fixture updated for the renamed callback)

**Manual verification checklist:**
- [ ] `Cmd+1`, `Cmd+2`, `Cmd+3` still switch to Topology / Skills / Runs
- [ ] Clicking workspace pills still routes correctly
- [ ] URL persistence and browser back/forward still work
- [ ] Keyboard switching is still suppressed when focus is inside an input or textarea
- [ ] The new icons render at the expected size left of each pill label

## Note

`WORKSPACE_LABELS` is now a dead export (its only previous consumer was `WorkspaceSwitcher`, which now reads `workspace.label` directly). Kept here per the planning spec's back-compat instruction; can be opportunistically removed in a future PR.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #640
