### PR TITLE
feat: add pause toggle for runs SSE stream

### DIFF
--- a/web/src/components/layout/BottomPanel.tsx
+++ b/web/src/components/layout/BottomPanel.tsx
@@ -35,6 +35,8 @@ export function BottomPanel() {
   const logsDetached = useUIStore((s) => s.logsDetached);
   const metricsDetached = useUIStore((s) => s.metricsDetached);
   const tracesDetached = useUIStore((s) => s.tracesDetached);
+  const runsStreamEnabled = useUIStore((s) => s.runsStreamEnabled);
+  const toggleRunsStreamEnabled = useUIStore((s) => s.toggleRunsStreamEnabled);
   const inFlightCount = useRunsStore((s) => s.inFlightRuns.size);
 
   return (
@@ -111,6 +113,34 @@ export function BottomPanel() {
           })}
           </div>
         </div>
+
+        {/* Right: Live/Paused toggle for the global runs SSE stream. */}
+        <button
+          type="button"
+          onClick={toggleRunsStreamEnabled}
+          aria-pressed={runsStreamEnabled}
+          title={
+            runsStreamEnabled
+              ? 'Pause real-time run updates'
+              : 'Resume real-time run updates'
+          }
+          className={cn(
+            'inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[10px] font-medium transition-colors',
+            'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/60',
+            runsStreamEnabled
+              ? 'text-status-running hover:bg-status-running/10'
+              : 'text-text-muted hover:text-text-secondary hover:bg-surface-highlight/40',
+          )}
+        >
+          <span
+            aria-hidden="true"
+            className={cn(
+              'w-1.5 h-1.5 rounded-full',
+              runsStreamEnabled ? 'bg-status-running animate-pulse' : 'bg-text-muted/60',
+            )}
+          />
+          {runsStreamEnabled ? 'Live' : 'Paused'}
+        </button>
       </div>
 
       {/* Content - Only visible when panel is open, both tabs rendered to preserve state */}

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { Wifi, WifiOff, Clock, Server, Box, Radio, Code, Gauge, ArrowDown } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { useStackStore } from '../../stores/useStackStore';
+import { useUIStore } from '../../stores/useUIStore';
 import { formatRelativeTime } from '../../lib/time';
 import { formatCompactNumber } from '../../lib/format';
 import { SpecHealthBadge } from '../spec/SpecHealthBadge';
@@ -16,6 +17,8 @@ export function StatusBar() {
   const connectionStatus = useStackStore((s) => s.connectionStatus);
   const lastUpdated = useStackStore((s) => s.lastUpdated);
   const error = useStackStore((s) => s.error);
+  const runsStreamEnabled = useUIStore((s) => s.runsStreamEnabled);
+  const toggleRunsStreamEnabled = useUIStore((s) => s.toggleRunsStreamEnabled);
 
   const runningServers = (mcpServers ?? []).filter((s) => s.initialized).length;
   const unhealthyServers = (mcpServers ?? []).filter((s) => s.healthy === false).length;
@@ -41,6 +44,37 @@ export function StatusBar() {
           </span>
           <span className="font-medium">{isConnected ? 'Connected' : error || 'Disconnected'}</span>
         </div>
+
+        {/* Divider */}
+        <div className="w-px h-3 bg-border/50" />
+
+        {/* Runs SSE stream — click to pause/resume. Mirrors the BottomPanel toggle. */}
+        <button
+          type="button"
+          onClick={toggleRunsStreamEnabled}
+          aria-pressed={runsStreamEnabled}
+          title={
+            runsStreamEnabled
+              ? 'Pause real-time run updates'
+              : 'Resume real-time run updates'
+          }
+          className={cn(
+            'flex items-center gap-2 px-2 py-0.5 rounded-full transition-colors',
+            'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/60',
+            runsStreamEnabled
+              ? 'text-status-running hover:bg-status-running/10'
+              : 'text-text-muted hover:bg-surface-highlight/40',
+          )}
+        >
+          <span
+            aria-hidden="true"
+            className={cn(
+              'w-1.5 h-1.5 rounded-full',
+              runsStreamEnabled ? 'bg-status-running animate-pulse' : 'bg-text-muted/60',
+            )}
+          />
+          <span className="font-medium">{runsStreamEnabled ? 'Live' : 'Paused'}</span>
+        </button>
 
         {/* Divider */}
         <div className="w-px h-3 bg-border/50" />

--- a/web/src/components/runs/RunsBottomTab.tsx
+++ b/web/src/components/runs/RunsBottomTab.tsx
@@ -151,6 +151,14 @@ function StreamStatusChip({ status }: { status: ReturnType<typeof useRunsStore.g
       </span>
     );
   }
+  if (status === 'paused') {
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] text-text-muted font-medium">
+        <span className="w-1.5 h-1.5 rounded-full bg-text-muted/60" />
+        Paused
+      </span>
+    );
+  }
   return (
     <span className="inline-flex items-center gap-1 text-[10px] text-text-muted">
       <span className="w-1.5 h-1.5 rounded-full bg-text-muted/40" />

--- a/web/src/components/runs/useGlobalRunsStream.ts
+++ b/web/src/components/runs/useGlobalRunsStream.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { subscribeToGlobalRunEvents } from '../../lib/agent-api';
 import { useRunsStore } from '../../stores/useRunsStore';
+import { useUIStore } from '../../stores/useUIStore';
 
 /**
  * useGlobalRunsStream mounts an EventSource against
@@ -10,15 +11,26 @@ import { useRunsStore } from '../../stores/useRunsStore';
  * workspaces; tearing it down on /runs unmount would lose in-flight
  * events while the user is on /topology or /skills.
  *
+ * The user can pause the stream via `useUIStore.runsStreamEnabled` — the
+ * BottomPanel and StatusBar both expose toggles. When paused, the
+ * EventSource is closed and `streamStatus` is set to `'paused'`. The
+ * in-flight badge is intentionally NOT cleared, so users see the last
+ * known value rather than a misleading zero.
+ *
  * SSE replay protection: the store dedupes events by `(run_id, seq)`
  * via its `lastSeenSeq` watermark — see useRunsStore.applyRunEvent.
  */
 export function useGlobalRunsStream(): void {
+  const enabled = useUIStore((s) => s.runsStreamEnabled);
   const applyRunEvent = useRunsStore((s) => s.applyRunEvent);
   const handleStreamRestart = useRunsStore((s) => s.handleStreamRestart);
   const setStreamStatus = useRunsStore((s) => s.setStreamStatus);
 
   useEffect(() => {
+    if (!enabled) {
+      setStreamStatus('paused');
+      return;
+    }
     setStreamStatus('connecting');
     const sub = subscribeToGlobalRunEvents({
       onEvent: applyRunEvent,
@@ -30,5 +42,5 @@ export function useGlobalRunsStream(): void {
       sub.close();
       setStreamStatus('idle');
     };
-  }, [applyRunEvent, handleStreamRestart, setStreamStatus]);
+  }, [enabled, applyRunEvent, handleStreamRestart, setStreamStatus]);
 }

--- a/web/src/stores/useRunsStore.ts
+++ b/web/src/stores/useRunsStore.ts
@@ -67,7 +67,7 @@ interface RunsState {
   inFlightRuns: Set<string>;
 
   /** Status of the global event stream. */
-  streamStatus: 'idle' | 'connecting' | 'open' | 'restarted' | 'error';
+  streamStatus: 'idle' | 'connecting' | 'open' | 'restarted' | 'error' | 'paused';
 
   // Actions ─────────────────────────────────────────────────────────────────
 

--- a/web/src/stores/useUIStore.ts
+++ b/web/src/stores/useUIStore.ts
@@ -56,6 +56,27 @@ export const createCompactModeSlice: StateCreator<
     })),
 });
 
+// Global toggle for the AppShell-level SSE runs stream. Lives here so both the
+// BottomPanel header toggle and the StatusBar chip share a single source of
+// truth — flipping one updates the other instantly via the store.
+export interface RunsStreamSlice {
+  runsStreamEnabled: boolean;
+  setRunsStreamEnabled: (enabled: boolean) => void;
+  toggleRunsStreamEnabled: () => void;
+}
+
+export const createRunsStreamSlice: StateCreator<
+  UIState,
+  [['zustand/persist', unknown]],
+  [],
+  RunsStreamSlice
+> = (set) => ({
+  runsStreamEnabled: true,
+  setRunsStreamEnabled: (runsStreamEnabled) => set({ runsStreamEnabled }),
+  toggleRunsStreamEnabled: () =>
+    set((s) => ({ runsStreamEnabled: !s.runsStreamEnabled })),
+});
+
 // Persisted shape may drift from the canonical {topology, skills, runs} keys
 // across versions — coerce so a stale localStorage payload never leaves a
 // workspace with `undefined` compact state at boot.
@@ -70,7 +91,7 @@ function normalizeCompactMode(raw: unknown): CompactModeMap {
   return out;
 }
 
-interface UIState extends WorkspaceSlice, CompactModeSlice {
+interface UIState extends WorkspaceSlice, CompactModeSlice, RunsStreamSlice {
   sidebarOpen: boolean;
   activeTab: SidebarTab;
   edgeStyle: EdgeStyle;
@@ -153,6 +174,7 @@ export const useUIStore = create<UIState>()(
     (set, get, store) => ({
       ...createWorkspaceSlice(set, get, store),
       ...createCompactModeSlice(set, get, store),
+      ...createRunsStreamSlice(set, get, store),
       sidebarOpen: false,
       activeTab: 'details',
       edgeStyle: 'default', // Bezier curves
@@ -244,6 +266,7 @@ export const useUIStore = create<UIState>()(
         edgeStyle: state.edgeStyle,
         compactCards: state.compactCards,
         compactMode: state.compactMode,
+        runsStreamEnabled: state.runsStreamEnabled,
       }),
       merge: (persisted, current) => ({
         ...current,


### PR DESCRIPTION
## Description

Add a user-controlled Live/Paused toggle for the global runs SSE stream. State lives in a new persisted `runsStreamEnabled` slice on `useUIStore`; `useGlobalRunsStream` gates its EventSource on the flag (closes when off, reconnects when on). Two UI affordances share the same value: a toggle button on the right of `BottomPanel`'s tabs header, and a matching chip in `StatusBar` between the connection chip and the server-count block.

This is the **final phase of three** in the unified shell refinements tracked by #640. Phase 1 (PR #641) standardized the inspector layout; Phase 2 (PR #642) introduced the workspace registry. With this PR, the umbrella issue is fully resolved.

## Type of Change

- [x] New feature (small, additive, no backend changes)

## Changes Made

- `web/src/stores/useUIStore.ts` — added `RunsStreamSlice` (`runsStreamEnabled` + `setRunsStreamEnabled` + `toggleRunsStreamEnabled`), wired into `UIState`, the store creator, and the `partialize` allowlist so the flag persists to localStorage.
- `web/src/stores/useRunsStore.ts` — extended `streamStatus` union with `'paused'`.
- `web/src/components/runs/useGlobalRunsStream.ts` — effect early-returns with `setStreamStatus('paused')` when the flag is off; existing cleanup closes the EventSource. Re-enabling reopens via the existing `subscribeToGlobalRunEvents` helper; `lastSeenSeq` dedupes any replay.
- `web/src/components/layout/BottomPanel.tsx` — Live/Paused toggle button on the right of the tabs header, always visible. Pulsing green dot + "Live" when active, muted dot + "Paused" when off. `aria-pressed` + `title` tooltip.
- `web/src/components/layout/StatusBar.tsx` — Live/Paused chip with matching visual grammar, inserted after the connection-chip divider.
- `web/src/components/runs/RunsBottomTab.tsx` — `StreamStatusChip` gains an explicit `'paused'` branch so it reads "Paused" instead of falling through to "Idle" when the stream is paused.

**Behavior note:** when paused, `inFlightRuns` is intentionally NOT cleared. The Runs tab badge freezes at its last-known value (semantically: "at the moment you paused, there were N in flight"). Resuming reconnects and resumes updates.

## Testing

- `cd web && npx tsc --noEmit` — passes
- `cd web && npx eslint` on all touched files — passes
- `cd web && npm run test` — 571 tests pass across 51 files (no regressions, no fixture changes needed)

**Manual verification checklist:**
- [ ] On first load, the toggle in BottomPanel shows "Live" with a pulsing green dot
- [ ] Clicking it switches to "Paused"; the EventSource closes (verifiable in DevTools Network panel)
- [ ] The StatusBar chip and the Runs tab `StreamStatusChip` mirror the BottomPanel state in real time (single source of truth)
- [ ] Reload the page → toggle state persists
- [ ] When paused, the Runs tab in-flight badge freezes at its last value (does not clear)
- [ ] Clicking back to "Live" reopens the stream; new events flow through

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #640
