### PR TITLE
refactor: polish skills canvas and sidebar header

### DIFF
--- a/web/src/components/agent/ide/Canvas.tsx
+++ b/web/src/components/agent/ide/Canvas.tsx
@@ -3,6 +3,7 @@ import {
   ReactFlowProvider,
   Controls,
   BackgroundVariant,
+  MarkerType,
   type Node as RFNode,
   type Edge as RFEdge,
   type NodeProps,
@@ -38,7 +39,7 @@ interface NodeData extends Record<string, unknown> {
 }
 
 const NODE_WIDTH = 240;
-const ROW_HEIGHT = 100;
+const ROW_HEIGHT = 160;
 
 /**
  * Canvas is the Skills workspace's React Flow surface — a read-only,
@@ -89,9 +90,17 @@ function CanvasInner({ graph, skillDir, selected, onSelect, trace }: CanvasProps
         id: `${src.id}->${dst.id}`,
         source: src.id,
         target: dst.id,
-        type: 'smoothstep',
-        animated: trace[src.id]?.status === 'running',
+        type: 'default',
+        // Animate only the incoming edge of the currently-running node so the
+        // canvas reads as a flow rather than a marquee.
+        animated: trace[dst.id]?.status === 'running',
         style: { stroke: 'var(--color-border)', strokeWidth: 1.5 },
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 14,
+          height: 14,
+          color: 'var(--color-border)',
+        },
       });
     }
     return out;
@@ -170,7 +179,11 @@ function AgentFlowNode({ data }: NodeProps<RFNode<NodeData>>) {
       )}
       style={{ width: NODE_WIDTH }}
     >
-      <Handle type="target" position={Position.Top} className="!bg-border !border-0 !w-2 !h-2" />
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!bg-border !border-0 !w-2 !h-2 !opacity-0 !pointer-events-none"
+      />
       {/* Top accent stripe — uses the per-kind colour as a thin
           identity hairline so kinds are scannable across the canvas */}
       <div className={cn('h-[3px]', style.badgeBg)} />
@@ -211,7 +224,11 @@ function AgentFlowNode({ data }: NodeProps<RFNode<NodeData>>) {
           {data.file}:{data.line}
         </button>
       </div>
-      <Handle type="source" position={Position.Bottom} className="!bg-border !border-0 !w-2 !h-2" />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-border !border-0 !w-2 !h-2 !opacity-0 !pointer-events-none"
+      />
     </div>
   );
 }

--- a/web/src/components/agent/ide/SkillSidebar.tsx
+++ b/web/src/components/agent/ide/SkillSidebar.tsx
@@ -51,24 +51,7 @@ export function SkillSidebar({
       className="h-full bg-surface/30 border-r border-border-subtle flex flex-col overflow-hidden"
       aria-label="Skills and runs"
     >
-      <header className="px-5 pt-6 pb-4 border-b border-border-subtle">
-        <div className="font-sans text-text-muted/70 text-[10px] uppercase tracking-[0.4em] mb-1">
-          gridctl
-        </div>
-        <div className="flex items-baseline gap-2">
-          <h1 className="font-sans text-text-primary text-xl font-semibold tracking-tight">
-            agent ide
-          </h1>
-          <span className="font-mono text-[10px] text-text-muted/70 uppercase tracking-[0.2em]">
-            phase F
-          </span>
-        </div>
-        <p className="font-sans text-text-muted text-xs mt-2 leading-snug">
-          Code is canon — the canvas is the derived view.
-        </p>
-      </header>
-
-      <InspectorTabList ariaLabel="Sidebar sections">
+      <InspectorTabList ariaLabel="Sidebar sections" className="pt-5">
         <InspectorTabButton
           active={tab === 'skills'}
           onClick={() => setTab('skills')}


### PR DESCRIPTION
## Description

Visual polish for the `/skills` dashboard. Removes the redundant left-rail header and redesigns the canvas with curved bezier connectors, wider spacing, arrow markers, hidden handle dots, and active-edge-only animation. Pure UI; no API or behavior changes.

## Type of Change

- [x] Refactor

## Changes Made

- Drop the `<header>` block (`gridctl` / `agent ide` / `phase F` / "Code is canon" tagline) from `SkillSidebar`. Tagline persists in the empty-state Welcome screen where it belongs.
- `Canvas`: switch edges from `smoothstep` to bezier (`type: 'default'`), bump `ROW_HEIGHT` 100 → 160 for breathing room, add `MarkerType.ArrowClosed` markers.
- Scope animation: previously every running node animated its outgoing edge; now only the incoming edge of the currently-running node animates so the canvas reads as a flow rather than a marquee.
- Hide React Flow handle dots via `!opacity-0 !pointer-events-none`. Handles remain anchored for edge routing — the canvas is read-only and shouldn't invite drag-to-connect.

## Testing

- `npm run lint` — both changed files clean.
- `npm run build` — typecheck + Vite build pass.
- `npm test` — 571/571 tests pass.
- Manual: load `/skills`, select `repo-audit`, switch to canvas view; confirm bezier curves, arrow markers, larger gaps, no visible handle dots, and run-edge animation only on the in-flight node.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #644