### PR TITLE
feat: add WorkspaceShell shared primitive

### DIFF
--- a/web/src/__tests__/useWorkspaceLayout.test.ts
+++ b/web/src/__tests__/useWorkspaceLayout.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { workspaceLayoutStorageKey } from '../hooks/useWorkspaceLayout';
+
+describe('workspaceLayoutStorageKey', () => {
+  it('namespaces by workspace, key, and version suffix', () => {
+    expect(workspaceLayoutStorageKey('skills', 'rails')).toBe(
+      'gridctl:layout:skills:rails:v1',
+    );
+    expect(workspaceLayoutStorageKey('runs', 'rails')).toBe(
+      'gridctl:layout:runs:rails:v1',
+    );
+    expect(workspaceLayoutStorageKey('topology', 'inspector')).toBe(
+      'gridctl:layout:topology:inspector:v1',
+    );
+  });
+
+  it('keeps workspaces isolated from one another', () => {
+    const skills = workspaceLayoutStorageKey('skills', 'rails');
+    const runs = workspaceLayoutStorageKey('runs', 'rails');
+    expect(skills).not.toEqual(runs);
+  });
+});

--- a/web/src/components/layout/WorkspaceShell.tsx
+++ b/web/src/components/layout/WorkspaceShell.tsx
@@ -1,0 +1,223 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import {
+  Group,
+  Panel,
+  Separator,
+  usePanelRef,
+} from 'react-resizable-panels';
+import { cn } from '../../lib/cn';
+import { useWorkspaceLayout } from '../../hooks/useWorkspaceLayout';
+import type { Workspace } from '../../types/workspace';
+
+interface WorkspaceShellProps {
+  workspace: Workspace;
+  /** Left rail content; omit to render a single-rail layout. */
+  left?: React.ReactNode;
+  /** Right rail content; omit to render a single-rail layout. */
+  right?: React.ReactNode;
+  children: React.ReactNode;
+  /** Default percentage for the left panel on first mount. */
+  defaultLeftPct?: number;
+  /** Default percentage for the right panel on first mount. */
+  defaultRightPct?: number;
+  /** Minimum size (pixels) of the left rail. */
+  minLeftPx?: number;
+  /** Minimum size (pixels) of the right rail. */
+  minRightPx?: number;
+  className?: string;
+}
+
+const LEFT_ID = 'left';
+const CENTER_ID = 'center';
+const RIGHT_ID = 'right';
+
+/**
+ * WorkspaceShell wraps a workspace surface with resizable left/right rails
+ * over react-resizable-panels v4. Widths are persisted per workspace via
+ * `useWorkspaceLayout`, double-clicking a separator resets to defaults,
+ * and `[` / `]` toggle rail collapse (suppressed when focus is in a
+ * text input).
+ */
+export function WorkspaceShell({
+  workspace,
+  left,
+  right,
+  children,
+  defaultLeftPct = 18,
+  defaultRightPct = 24,
+  minLeftPx = 220,
+  minRightPx = 300,
+  className,
+}: WorkspaceShellProps) {
+  const leftPanelRef = usePanelRef();
+  const rightPanelRef = usePanelRef();
+
+  const panelIds = useMemo(() => {
+    const ids: string[] = [];
+    if (left) ids.push(LEFT_ID);
+    ids.push(CENTER_ID);
+    if (right) ids.push(RIGHT_ID);
+    return ids;
+  }, [left, right]);
+
+  const { defaultLayout, onLayoutChanged } = useWorkspaceLayout({
+    workspace,
+    key: 'rails',
+    panelIds,
+  });
+
+  const togglePanel = useCallback(
+    (
+      ref: React.RefObject<{
+        isCollapsed: () => boolean;
+        collapse: () => void;
+        expand: () => void;
+      } | null>,
+    ) => {
+      const panel = ref.current;
+      if (!panel) return;
+      if (panel.isCollapsed()) panel.expand();
+      else panel.collapse();
+    },
+    [],
+  );
+
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      if (e.key !== '[' && e.key !== ']') return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isTextInputTarget(e.target)) return;
+      if (e.key === '[' && left) {
+        e.preventDefault();
+        togglePanel(leftPanelRef);
+      }
+      if (e.key === ']' && right) {
+        e.preventDefault();
+        togglePanel(rightPanelRef);
+      }
+    }
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [left, right, togglePanel, leftPanelRef, rightPanelRef]);
+
+  return (
+    <Group
+      orientation="horizontal"
+      className={cn('flex-1 min-h-0 w-full', className)}
+      defaultLayout={defaultLayout}
+      onLayoutChanged={onLayoutChanged}
+    >
+      {left && (
+        <Panel
+          id={LEFT_ID}
+          defaultSize={defaultLeftPct}
+          minSize={percentFromPx(minLeftPx)}
+          collapsible
+          collapsedSize={0}
+          panelRef={leftPanelRef}
+        >
+          <div className="h-full overflow-hidden">{left}</div>
+        </Panel>
+      )}
+
+      {left && (
+        <Separator id="sep-left" className="group/separator relative w-1.5 select-none">
+          <SeparatorBody orientation="vertical" />
+        </Separator>
+      )}
+
+      <Panel
+        id={CENTER_ID}
+        defaultSize={100 - (left ? defaultLeftPct : 0) - (right ? defaultRightPct : 0)}
+        minSize={20}
+      >
+        <div className="h-full overflow-hidden">{children}</div>
+      </Panel>
+
+      {right && (
+        <Separator id="sep-right" className="group/separator relative w-1.5 select-none">
+          <SeparatorBody orientation="vertical" />
+        </Separator>
+      )}
+
+      {right && (
+        <Panel
+          id={RIGHT_ID}
+          defaultSize={defaultRightPct}
+          minSize={percentFromPx(minRightPx)}
+          collapsible
+          collapsedSize={0}
+          panelRef={rightPanelRef}
+        >
+          <div className="h-full overflow-hidden">{right}</div>
+        </Panel>
+      )}
+    </Group>
+  );
+}
+
+interface SeparatorBodyProps {
+  orientation: 'vertical' | 'horizontal';
+}
+
+/**
+ * Visual body of the Separator — mirrors `components/ui/ResizeHandle.tsx`
+ * but drops the mouse-event logic since RRP's Separator owns
+ * pointer/keyboard interaction.
+ */
+function SeparatorBody({ orientation }: SeparatorBodyProps) {
+  const isVertical = orientation === 'vertical';
+  return (
+    <div
+      className={cn(
+        'absolute inset-0 flex items-center justify-center',
+        'transition-colors duration-150',
+        'group-hover/separator:bg-primary/8',
+        'group-data-[separator-active=true]/separator:bg-primary/10',
+      )}
+    >
+      <div
+        className={cn(
+          'absolute transition-colors duration-150',
+          'bg-border/40',
+          'group-hover/separator:bg-primary/30',
+          'group-data-[separator-active=true]/separator:bg-primary/50',
+          isVertical ? 'w-px inset-y-0 left-1/2 -translate-x-px' : 'h-px inset-x-0 top-1/2 -translate-y-px',
+        )}
+      />
+      <div
+        className={cn(
+          'absolute flex gap-1 transition-all duration-150',
+          'opacity-40 group-hover/separator:opacity-100',
+          'group-data-[separator-active=true]/separator:opacity-100',
+          isVertical ? 'flex-col' : 'flex-row',
+        )}
+      >
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className={cn(
+              'rounded-full transition-all duration-150',
+              isVertical ? 'w-0.5 h-1.5' : 'w-1.5 h-0.5',
+              'bg-text-muted/30',
+              'group-hover/separator:bg-primary/70',
+              'group-data-[separator-active=true]/separator:bg-primary',
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function percentFromPx(px: number, reference = 1440): number {
+  return Math.max(5, Math.min(80, (px / reference) * 100));
+}
+
+function isTextInputTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (target.isContentEditable) return true;
+  return false;
+}

--- a/web/src/components/workspaces/RunsWorkspace.tsx
+++ b/web/src/components/workspaces/RunsWorkspace.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { RunsFilterBar } from '../runs/RunsFilterBar';
 import { RunsGrid } from '../runs/RunsGrid';
 import { RunInspector } from '../runs/RunInspector';
+import { WorkspaceShell } from '../layout/WorkspaceShell';
 import { useRunsStore, RUNS_DEFAULT_FILTERS } from '../../stores/useRunsStore';
 import type { RunsFilters } from '../../stores/useRunsStore';
 
@@ -94,20 +95,24 @@ export function RunsWorkspace() {
     <div className="absolute inset-0 flex flex-col bg-background">
       <RunsFilterBar skillOptions={skillOptions} />
 
-      <div className="flex flex-1 min-h-0">
-        <div className="flex-1 min-w-0">
-          <RunsGrid onOpenDetail={(id) => navigate(`/runs/${id}`)} />
-        </div>
-        {selectedRunID && (
-          <div className="w-[360px] flex-shrink-0 border-l border-border/30 bg-surface/40">
-            <RunInspector
-              runID={selectedRunID}
-              onClose={() => setSelectedRun(null)}
-              onOpenDetail={() => navigate(`/runs/${selectedRunID}`)}
-            />
-          </div>
-        )}
-      </div>
+      <WorkspaceShell
+        workspace="runs"
+        defaultRightPct={25}
+        minRightPx={300}
+        right={
+          selectedRunID ? (
+            <div className="h-full bg-surface/40 border-l border-border/30">
+              <RunInspector
+                runID={selectedRunID}
+                onClose={() => setSelectedRun(null)}
+                onOpenDetail={() => navigate(`/runs/${selectedRunID}`)}
+              />
+            </div>
+          ) : undefined
+        }
+      >
+        <RunsGrid onOpenDetail={(id) => navigate(`/runs/${id}`)} />
+      </WorkspaceShell>
     </div>
   );
 }

--- a/web/src/components/workspaces/SkillsWorkspace.tsx
+++ b/web/src/components/workspaces/SkillsWorkspace.tsx
@@ -16,13 +16,16 @@ import { useRunTrace } from '../agent/ide/useRunTrace';
 import { useSkillsCommands } from '../skills/useSkillsCommands';
 import { useUIStore } from '../../stores/useUIStore';
 import { cn } from '../../lib/cn';
+import { WorkspaceShell } from '../layout/WorkspaceShell';
 
 type ViewMode = 'list' | 'canvas';
 
-const SIDEBAR_WIDTH = 280;
-const INSPECTOR_WIDTH = 360;
-const COMPACT_SIDEBAR_WIDTH = 220;
-const COMPACT_INSPECTOR_WIDTH = 300;
+// Default rail sizes as percentages of a 1440px reference width:
+// 280/1440 ≈ 19%, 360/1440 = 25%; compact 220/1440 ≈ 15%, 300/1440 ≈ 21%.
+const DEFAULT_SIDEBAR_PCT = 19;
+const DEFAULT_INSPECTOR_PCT = 25;
+const COMPACT_SIDEBAR_PCT = 15;
+const COMPACT_INSPECTOR_PCT = 21;
 
 /**
  * SkillsWorkspace is the developer view inside the unified shell. It
@@ -176,28 +179,40 @@ export function SkillsWorkspace() {
     onRefresh: refreshSkills,
   });
 
-  const sidebarWidth = compact ? COMPACT_SIDEBAR_WIDTH : SIDEBAR_WIDTH;
-  const inspectorWidth = compact ? COMPACT_INSPECTOR_WIDTH : INSPECTOR_WIDTH;
+  const defaultLeftPct = compact ? COMPACT_SIDEBAR_PCT : DEFAULT_SIDEBAR_PCT;
+  const defaultRightPct = compact ? COMPACT_INSPECTOR_PCT : DEFAULT_INSPECTOR_PCT;
 
   return (
-    <div className="absolute inset-0 bg-background text-text-primary overflow-hidden">
-      <div
-        className="grid h-full"
-        style={{
-          gridTemplateColumns: `${sidebarWidth}px minmax(0, 1fr) ${inspectorWidth}px`,
-        }}
+    <div className="absolute inset-0 flex bg-background text-text-primary overflow-hidden">
+      <WorkspaceShell
+        workspace="skills"
+        defaultLeftPct={defaultLeftPct}
+        defaultRightPct={defaultRightPct}
+        minLeftPx={220}
+        minRightPx={300}
+        left={
+          <SkillSidebar
+            skills={skills}
+            active={activeSkill}
+            onSelect={handleSelectSkill}
+            onRunSkill={handleRunSkill}
+            loading={skillsLoading}
+            error={skillsError}
+            runsRefreshKey={runsRefreshKey}
+            activeRunID={runID}
+          />
+        }
+        right={
+          <NodeDetail
+            node={selectedNodeObj}
+            skillDir={skillDir}
+            trace={selectedNode ? runTrace.byNode[selectedNode] : undefined}
+            runID={runID}
+            runTrace={runTrace}
+            onClose={() => setSelectedNode(null)}
+          />
+        }
       >
-        <SkillSidebar
-          skills={skills}
-          active={activeSkill}
-          onSelect={handleSelectSkill}
-          onRunSkill={handleRunSkill}
-          loading={skillsLoading}
-          error={skillsError}
-          runsRefreshKey={runsRefreshKey}
-          activeRunID={runID}
-        />
-
         <main className="flex flex-col h-full overflow-hidden bg-background">
           <Toolbar
             graph={graph}
@@ -240,16 +255,7 @@ export function SkillsWorkspace() {
             )}
           </div>
         </main>
-
-        <NodeDetail
-          node={selectedNodeObj}
-          skillDir={skillDir}
-          trace={selectedNode ? runTrace.byNode[selectedNode] : undefined}
-          runID={runID}
-          runTrace={runTrace}
-          onClose={() => setSelectedNode(null)}
-        />
-      </div>
+      </WorkspaceShell>
 
       {launcher && (
         <RunLauncherModal

--- a/web/src/hooks/useWorkspaceLayout.ts
+++ b/web/src/hooks/useWorkspaceLayout.ts
@@ -1,0 +1,25 @@
+import { useDefaultLayout } from 'react-resizable-panels';
+import type { Workspace } from '../types/workspace';
+
+interface UseWorkspaceLayoutOptions {
+  workspace: Workspace;
+  key: string;
+  /** Panel ids present on this layout — required when panels are conditionally rendered. */
+  panelIds?: string[];
+}
+
+/**
+ * Workspace-scoped wrapper over react-resizable-panels' useDefaultLayout.
+ * Storage key is namespaced as `gridctl:layout:${workspace}:${key}:v1` so
+ * future schema changes can introduce `:v2` without breaking existing users.
+ */
+export function useWorkspaceLayout({ workspace, key, panelIds }: UseWorkspaceLayoutOptions) {
+  return useDefaultLayout({
+    id: `gridctl:layout:${workspace}:${key}:v1`,
+    panelIds,
+  });
+}
+
+export function workspaceLayoutStorageKey(workspace: Workspace, key: string): string {
+  return `gridctl:layout:${workspace}:${key}:v1`;
+}


### PR DESCRIPTION
## Description

PR 3 of 3 in the skills dashboard polish series. Introduces a shared `<WorkspaceShell>` primitive over `react-resizable-panels` v4 and adopts it in the Skills and Runs workspaces. Rails are now draggable, widths persist per workspace, double-clicking a separator resets to defaults, and `[` / `]` toggle the rails. Topology is intentionally left on its hand-rolled `ResizeHandle` for this round to keep the blast radius small — follow-up tracked separately.

## Type of Change

- [x] New feature (non-breaking)
- [x] Refactor (Skills + Runs workspaces)

## Changes Made

- `web/src/hooks/useWorkspaceLayout.ts` — thin wrapper over RRP's `useDefaultLayout`; namespaces the storage key as `gridctl:layout:${workspace}:${key}:v1`.
- `web/src/components/layout/WorkspaceShell.tsx` — orientation="horizontal" `<Group>` with conditional left/right `<Panel>`s and `<Separator>`s; `usePanelRef` drives `[` / `]` collapse-toggle; `<Separator>`'s built-in double-click reset is kept; the visual body mirrors `components/ui/ResizeHandle.tsx` (edge line + grip dots) without touching that file.
- `SkillsWorkspace.tsx` — replaces the fixed 3-column CSS grid with `<WorkspaceShell workspace="skills">` carrying `SkillSidebar` (left) and `NodeDetail` (right). Default percentages computed from the existing 280/360px widths at a 1440px reference (19% / 25% normal, 15% / 21% compact). Mins: 220px / 300px.
- `RunsWorkspace.tsx` — wraps the grid in `<WorkspaceShell workspace="runs">` with a conditional `right={<RunInspector/>}` that appears only when a run is selected.
- Vitest coverage for the storage-key namespacing.

Not touched: `TopologyWorkspace.tsx`, `CreationWizard.tsx`, `ResizeHandle.tsx`, `Canvas.tsx`, `SkillSidebar.tsx`, `SpecTab.tsx`. No new npm dependencies.

## Testing

- `npm run lint` — scoped to changed files: clean. Remaining repo-wide errors are pre-existing in unrelated files.
- `npm test` — 53 files, 579 tests pass (two new in `useWorkspaceLayout.test.ts`).
- `npm run build` succeeds; emits a separately chunked `WorkspaceShell` bundle (~3.6 kB / 1.5 kB gzip).
- `make build` succeeds — Go binary regenerated with embedded web assets.

Behavioral verification:
- Drag either rail in `/skills` → release → reload → width persists.
- Double-click a separator → snaps back to default.
- Press `[` / `]` outside a text input → toggles the corresponding rail.
- Toggle compact mode without a persisted layout → first mount uses compact defaults.
- `/runs` with no run selected → no right rail; select a run → inspector appears as a resizable panel.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #644
Follow-up: #647