### PR TITLE
chore: bump @rjsf/* to v6.5.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,7 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore"
+    groups:
+      rjsf:
+        patterns:
+          - "@rjsf/*"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
-        "@rjsf/core": "^5.24.13",
-        "@rjsf/utils": "^5.24.13",
-        "@rjsf/validator-ajv8": "^5.24.13",
+        "@rjsf/core": "^6.5.2",
+        "@rjsf/utils": "^6.5.2",
+        "@rjsf/validator-ajv8": "^6.5.2",
         "@xyflow/react": "^12.10.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -1335,41 +1335,43 @@
       }
     },
     "node_modules/@rjsf/core": {
-      "version": "5.24.13",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.24.13.tgz",
-      "integrity": "sha512-ONTr14s7LFIjx2VRFLuOpagL76sM/HPy6/OhdBfq6UukINmTIs6+aFN0GgcR0aXQHFDXQ7f/fel0o/SO05Htdg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-6.5.3.tgz",
+      "integrity": "sha512-S9v7EcqCvcC9buGmlThe/hd6PK9TIyzOF8E9EstbWPXkQtEWGP0heC1BloQTEiXBsAwpR5NDVbhIau2GYPbiKw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "markdown-to-jsx": "^7.4.1",
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.18.1",
+        "markdown-to-jsx": "^8.0.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@rjsf/utils": "^5.24.x",
-        "react": "^16.14.0 || >=17"
+        "@rjsf/utils": "^6.5.x",
+        "react": ">=18"
       }
     },
     "node_modules/@rjsf/utils": {
-      "version": "5.24.13",
-      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.24.13.tgz",
-      "integrity": "sha512-rNF8tDxIwTtXzz5O/U23QU73nlhgQNYJ+Sv5BAwQOIyhIE2Z3S5tUiSVMwZHt0julkv/Ryfwi+qsD4FiE5rOuw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-6.5.3.tgz",
+      "integrity": "sha512-lrGxVR26xjCjea8OqIDpSXH1FDAfhCON6DHja/PhzJBLJjs45+sdilmJA78c+tL4oN5Jpj2dTOoFMAZ7bIhRvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "json-schema-merge-allof": "^0.8.1",
+        "@x0k/json-schema-merge": "^1.0.3",
+        "fast-equals": "^6.0.0",
+        "fast-uri": "^3.1.2",
         "jsonpointer": "^5.0.1",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "react-is": "^18.2.0"
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.18.1",
+        "react-is": "^18.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || >=17"
+        "react": ">=18"
       }
     },
     "node_modules/@rjsf/utils/node_modules/react-is": {
@@ -1379,21 +1381,21 @@
       "license": "MIT"
     },
     "node_modules/@rjsf/validator-ajv8": {
-      "version": "5.24.13",
-      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-5.24.13.tgz",
-      "integrity": "sha512-oWHP7YK581M8I5cF1t+UXFavnv+bhcqjtL1a7MG/Kaffi0EwhgcYjODrD8SsnrhncsEYMqSECr4ZOEoirnEUWw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-6.5.3.tgz",
+      "integrity": "sha512-CdaoNIbG+fbj9S9ezex16/Eka5KbsPfpUDgthVedS1rQ/mXd4VhvnvLQopYpIAymYrIWrCVDCanN/kB8wP3OYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "ajv": "^8.12.0",
+        "ajv": "^8.18.0",
         "ajv-formats": "^2.1.1",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21"
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.18.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@rjsf/utils": "^5.24.x"
+        "@rjsf/utils": "^6.5.x"
       }
     },
     "node_modules/@rjsf/validator-ajv8/node_modules/ajv": {
@@ -2255,7 +2257,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2707,6 +2708,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@x0k/json-schema-merge": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@x0k/json-schema-merge/-/json-schema-merge-1.0.3.tgz",
+      "integrity": "sha512-lerJC4sI9CNUQWdff3PnU1YJOqazD6TjMcvxZIPXUBjn4j1cUiXE0LvzhMnGYzKKr271TkvXJtH7gEwksrtn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      }
+    },
     "node_modules/@xyflow/react": {
       "version": "12.10.0",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.0.tgz",
@@ -3084,27 +3094,6 @@
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/compute-gcd": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
-      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
-      "dependencies": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
-    "node_modules/compute-lcm": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
-      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
-      "dependencies": {
-        "compute-gcd": "^1.2.1",
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
       }
     },
     "node_modules/convert-source-map": {
@@ -3730,6 +3719,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.0.tgz",
+      "integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4182,29 +4180,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-compare": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
-      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.4"
-      }
-    },
-    "node_modules/json-schema-merge-allof": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
-      "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
-      "license": "MIT",
-      "dependencies": {
-        "compute-lcm": "^1.1.2",
-        "json-schema-compare": "^0.2.2",
-        "lodash": "^4.17.20"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4647,9 +4622,9 @@
       }
     },
     "node_modules/markdown-to-jsx": {
-      "version": "7.7.17",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.7.17.tgz",
-      "integrity": "sha512-7mG/1feQ0TX5I7YyMZVDgCC/y2I3CiEhIRQIhyov9nGBP5eoVrOXXHuL5ZP8GRfxVZKRiXWJgwXkb9It+nQZfQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-8.0.0.tgz",
+      "integrity": "sha512-hWEaRxeCDjes1CVUQqU+Ov0mCqBqkGhLKjL98KdbwHSgEWZZSJQeGlJQatVfeZ3RaxrfTrZZ3eczl2dhp5c/pA==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -5689,39 +5664,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/validate.io-array": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==",
-      "license": "MIT"
-    },
-    "node_modules/validate.io-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
-    },
-    "node_modules/validate.io-integer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
-      "dependencies": {
-        "validate.io-number": "^1.0.3"
-      }
-    },
-    "node_modules/validate.io-integer-array": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
-      "dependencies": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-integer": "^1.0.4"
-      }
-    },
-    "node_modules/validate.io-number": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",

--- a/web/package.json
+++ b/web/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
-    "@rjsf/core": "^5.24.13",
-    "@rjsf/utils": "^5.24.13",
-    "@rjsf/validator-ajv8": "^5.24.13",
+    "@rjsf/core": "^6.5.2",
+    "@rjsf/utils": "^6.5.2",
+    "@rjsf/validator-ajv8": "^6.5.2",
     "@xyflow/react": "^12.10.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
## Summary

- Bumps `@rjsf/core`, `@rjsf/utils`, and `@rjsf/validator-ajv8` together from 5.24.13 to 6.5.2. Bumping `@rjsf/core` alone (PR #654) failed `npm ci` because v6 of core requires peer `@rjsf/utils@^6.5.x`.
- Adds an `@rjsf/*` group to `.github/dependabot.yml` so future updates ship as a single PR and don't recreate the same peer-dep conflict.
- Closes #654.

## Test plan

- [x] `npm ci` resolves cleanly
- [x] `npm run build` (tsc + vite) passes
- [x] `npm test` — 579 tests pass
- [x] `SchemaForm.tsx` (only rjsf consumer) builds with no API changes needed