### PR TITLE
feat: add gridctl test acceptance criteria runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,15 +626,18 @@ Exit codes: `0` no findings or info-only, `1` at least one `warn`/`critical` fin
 
 #### `gridctl test <skill-name>`
 
-Run acceptance criteria for a skill against the running gateway.
+Run acceptance criteria for a skill against the running gateway. The runner POSTs to `/api/registry/skills/{name}/test`; the server hands each criterion to an LLM judge when a chat provider is configured (set `ANTHROPIC_API_KEY` in the vault), otherwise falls back to a deterministic adapter that reads explicit `PASS:` / `FAIL:` markers — useful in CI when criteria are fixture-encoded.
 
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--stack` | `-s` | Stack to test against (auto-detect if only one running) |
+| `--format` | | Output format: `json` for machine-readable `TestReport` (default: table) |
+| `--dry-run` | | List criteria without evaluating them |
+| `--criterion` | | Zero-based index of a single criterion to evaluate (default: all) |
 
-Exit codes: `0` all criteria passed, `1` one or more criteria failed, `2` infrastructure error (gateway unreachable, skill not found).
+Exit codes: `0` all criteria passed, `1` one or more criteria failed, `2` infrastructure error (gateway unreachable, skill not found, criterion index out of range).
 
-Acceptance criteria in `SKILL.md` frontmatter must follow the `GIVEN <context> WHEN <action> THEN <assertion>` format. Criteria that don't match the pattern are skipped.
+Acceptance criteria in `SKILL.md` frontmatter are free-form Given/When/Then prose; the LLM judge reads them directly. The deterministic adapter requires criteria to start with `PASS:` or `FAIL:` and reports `error` severity for ambiguous prose, so production prose criteria do not pretend to pass against a missing provider.
 
 #### `gridctl activate <skill-name>`
 

--- a/cmd/gridctl/root.go
+++ b/cmd/gridctl/root.go
@@ -38,6 +38,7 @@ func init() {
 	rootCmd.AddCommand(skillCmd)
 	rootCmd.AddCommand(pinsCmd)
 	rootCmd.AddCommand(optimizeCmd)
+	rootCmd.AddCommand(testCmd)
 }
 
 func Execute() {

--- a/cmd/gridctl/test.go
+++ b/cmd/gridctl/test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/registry"
+	"github.com/gridctl/gridctl/pkg/state"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+const testHTTPTimeout = 120 * time.Second
+
+// Exit codes — matched against the convention in cmd/gridctl/optimize.go
+// (0 pass, 1 actionable findings, 2 infrastructure failure). The runner
+// inherits the contract directly so CI scripts can read either command
+// the same way.
+const (
+	testExitOK             = 0
+	testExitFailures       = 1
+	testExitInfrastructure = 2
+)
+
+var (
+	testStack     string
+	testFormat    string
+	testDryRun    bool
+	testCriterion int
+)
+
+var testCmd = &cobra.Command{
+	Use:   "test <skill-name>",
+	Short: "Run a skill's acceptance_criteria against the registry",
+	Long: `Evaluate the acceptance_criteria frontmatter on a registered skill.
+
+The runner asks the configured LLM provider to judge each criterion
+against the skill's body and prints a pass/fail report. Without a
+provider (no ANTHROPIC_API_KEY in the vault), the runner falls back to
+a deterministic adapter that reads explicit 'PASS:' / 'FAIL:' markers —
+useful in CI when criteria are fixture-encoded.
+
+Use '--dry-run' to list the criteria without evaluating them.
+Use '--criterion <n>' to evaluate a single criterion by zero-based index.
+
+Exit codes:
+  0  every criterion passed
+  1  at least one criterion failed
+  2  infrastructure error (gateway unreachable, skill not found, etc.)`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		name := args[0]
+		port, err := resolveTestPort(testStack)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(testExitInfrastructure)
+		}
+
+		report, err := fetchTestReport(port, name, testCriterion, testDryRun)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(testExitInfrastructure)
+		}
+
+		switch strings.ToLower(testFormat) {
+		case "json":
+			if err := renderTestJSON(os.Stdout, report); err != nil {
+				return err
+			}
+		default:
+			renderTestTable(os.Stdout, report)
+		}
+
+		if report.HasErrors() {
+			os.Exit(testExitInfrastructure)
+		}
+		if report.HasFailures() {
+			os.Exit(testExitFailures)
+		}
+		return nil
+	},
+}
+
+func init() {
+	testCmd.Flags().StringVarP(&testStack, "stack", "s", "", "Stack to query (auto-detected when only one stack is running)")
+	testCmd.Flags().StringVar(&testFormat, "format", "", "Output format: 'json' for machine-readable output (default: table)")
+	testCmd.Flags().BoolVar(&testDryRun, "dry-run", false, "List criteria without evaluating them")
+	testCmd.Flags().IntVar(&testCriterion, "criterion", -1, "Zero-based index of a single criterion to evaluate (default: all)")
+}
+
+// resolveTestPort mirrors resolveOptimizePort. Kept separate so error
+// messages name the right command.
+func resolveTestPort(stackName string) (int, error) {
+	states, err := state.List()
+	if err != nil {
+		return 0, fmt.Errorf("test: could not read state: %w", err)
+	}
+	running := make([]state.DaemonState, 0, len(states))
+	for _, s := range states {
+		if state.IsRunning(&s) {
+			running = append(running, s)
+		}
+	}
+	if stackName != "" {
+		for _, s := range running {
+			if s.StackName == stackName {
+				return s.Port, nil
+			}
+		}
+		return 0, fmt.Errorf("test: stack %q is not running", stackName)
+	}
+	switch len(running) {
+	case 0:
+		return 0, fmt.Errorf("test: gateway not running; try `gridctl status` or `gridctl serve`")
+	case 1:
+		return running[0].Port, nil
+	default:
+		names := make([]string, len(running))
+		for i, s := range running {
+			names[i] = s.StackName
+		}
+		return 0, fmt.Errorf("test: multiple stacks running (%s); use --stack to pick one", strings.Join(names, ", "))
+	}
+}
+
+// fetchTestReport calls POST /api/registry/skills/{name}/test on the
+// local gateway and decodes the response. Non-2xx HTTP statuses become
+// errors so the caller maps them to exit code 2.
+func fetchTestReport(port int, name string, criterion int, dryRun bool) (registry.TestReport, error) {
+	q := url.Values{}
+	if criterion >= 0 {
+		q.Set("criterion", strconv.Itoa(criterion))
+	}
+	if dryRun {
+		q.Set("dry_run", "1")
+	}
+	target := fmt.Sprintf("http://localhost:%d/api/registry/skills/%s/test", port, url.PathEscape(name))
+	if encoded := q.Encode(); encoded != "" {
+		target += "?" + encoded
+	}
+
+	client := &http.Client{Timeout: testHTTPTimeout}
+	resp, err := client.Post(target, "application/json", nil)
+	if err != nil {
+		return registry.TestReport{}, fmt.Errorf("test: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return registry.TestReport{}, fmt.Errorf("test: reading response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return registry.TestReport{}, fmt.Errorf("test: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	var report registry.TestReport
+	if err := json.Unmarshal(body, &report); err != nil {
+		return registry.TestReport{}, fmt.Errorf("test: parsing response: %w", err)
+	}
+	return report, nil
+}
+
+// renderTestTable prints results as a styled table mirroring optimize's
+// formatting. The footer summarises pass/fail/error counts so CI logs
+// have a one-line outcome above the table.
+func renderTestTable(w io.Writer, report registry.TestReport) {
+	if len(report.Results) == 0 {
+		fmt.Fprintf(w, "No criteria to run for skill %q.\n", report.SkillName)
+		return
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleRounded)
+	if report.DryRun {
+		t.AppendHeader(table.Row{"#", "CRITERION"})
+		for _, r := range report.Results {
+			t.AppendRow(table.Row{r.Index, firstLine(r.Criterion)})
+		}
+	} else {
+		t.AppendHeader(table.Row{"#", "VERDICT", "CRITERION", "RATIONALE"})
+		for _, r := range report.Results {
+			t.AppendRow(table.Row{
+				r.Index,
+				testVerdictLabel(r.Severity),
+				firstLine(r.Criterion),
+				firstLine(r.Message),
+			})
+		}
+	}
+	t.Render()
+
+	fmt.Fprintln(w)
+	if report.DryRun {
+		fmt.Fprintf(w, "Skill: %s  ·  %d criteria  ·  dry run (no evaluation)\n", report.SkillName, len(report.Results))
+		return
+	}
+	fmt.Fprintf(w, "Skill: %s  ·  pass: %d  ·  fail: %d  ·  error: %d  ·  evaluator: %s\n",
+		report.SkillName, report.PassCount, report.FailCount, report.ErrorCount, report.Evaluator)
+}
+
+func renderTestJSON(w io.Writer, report registry.TestReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+func testVerdictLabel(s registry.TestSeverity) string {
+	switch s {
+	case registry.TestSeverityPass:
+		return "✓ pass"
+	case registry.TestSeverityFail:
+		return "✗ fail"
+	case registry.TestSeverityError:
+		return "! error"
+	case "":
+		return "—"
+	default:
+		return string(s)
+	}
+}

--- a/cmd/gridctl/test_test.go
+++ b/cmd/gridctl/test_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/registry"
+)
+
+func TestTestVerdictLabel(t *testing.T) {
+	cases := []struct {
+		in   registry.TestSeverity
+		want string
+	}{
+		{registry.TestSeverityPass, "✓ pass"},
+		{registry.TestSeverityFail, "✗ fail"},
+		{registry.TestSeverityError, "! error"},
+		{"", "—"},
+		{"unknown", "unknown"},
+	}
+	for _, tc := range cases {
+		if got := testVerdictLabel(tc.in); got != tc.want {
+			t.Errorf("testVerdictLabel(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRenderTestTable_DryRun(t *testing.T) {
+	var buf bytes.Buffer
+	report := registry.TestReport{
+		SkillName: "fixture",
+		DryRun:    true,
+		Results: []registry.TestResult{
+			{Index: 0, Criterion: "given X, when Y, then Z"},
+		},
+	}
+	renderTestTable(&buf, report)
+	out := buf.String()
+	if !strings.Contains(out, "given X") {
+		t.Errorf("expected criterion text in output; got: %s", out)
+	}
+	if !strings.Contains(out, "dry run") {
+		t.Errorf("expected 'dry run' footer; got: %s", out)
+	}
+}
+
+func TestRenderTestTable_Verdicts(t *testing.T) {
+	var buf bytes.Buffer
+	report := registry.TestReport{
+		SkillName:  "fixture",
+		Evaluator:  "deterministic",
+		PassCount:  1,
+		FailCount:  1,
+		ErrorCount: 0,
+		Results: []registry.TestResult{
+			{Index: 0, Criterion: "PASS: ok", Severity: registry.TestSeverityPass, Message: "good", EvaluatedAt: time.Now()},
+			{Index: 1, Criterion: "FAIL: nope", Severity: registry.TestSeverityFail, Message: "missing handler", EvaluatedAt: time.Now()},
+		},
+	}
+	renderTestTable(&buf, report)
+	out := buf.String()
+	for _, want := range []string{"pass", "fail", "PASS: ok", "FAIL: nope", "missing handler", "deterministic", "Skill: fixture"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q; got: %s", want, out)
+		}
+	}
+}
+
+func TestRenderTestTable_NoResults(t *testing.T) {
+	var buf bytes.Buffer
+	report := registry.TestReport{SkillName: "empty"}
+	renderTestTable(&buf, report)
+	if !strings.Contains(buf.String(), "No criteria") {
+		t.Errorf("expected 'No criteria' message; got: %s", buf.String())
+	}
+}
+
+func TestFetchTestReport_HappyPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/api/registry/skills/my-skill/test") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("criterion"); got != "1" {
+			t.Errorf("criterion query = %q, want %q", got, "1")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(registry.TestReport{
+			SkillName: "my-skill",
+			PassCount: 1,
+			Results: []registry.TestResult{
+				{Index: 1, Severity: registry.TestSeverityPass, Criterion: "PASS: c1"},
+			},
+			Evaluator: "deterministic",
+		})
+	}))
+	defer server.Close()
+
+	port := mustPort(t, server.URL)
+	report, err := fetchTestReport(port, "my-skill", 1, false)
+	if err != nil {
+		t.Fatalf("fetchTestReport: %v", err)
+	}
+	if report.SkillName != "my-skill" {
+		t.Errorf("SkillName = %q, want my-skill", report.SkillName)
+	}
+	if report.PassCount != 1 {
+		t.Errorf("PassCount = %d, want 1", report.PassCount)
+	}
+}
+
+func TestFetchTestReport_DryRunQuery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("dry_run"); got != "1" {
+			t.Errorf("dry_run query = %q, want %q", got, "1")
+		}
+		if got := r.URL.Query().Get("criterion"); got != "" {
+			t.Errorf("criterion query should be empty in default case; got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(registry.TestReport{SkillName: "x", DryRun: true})
+	}))
+	defer server.Close()
+
+	port := mustPort(t, server.URL)
+	report, err := fetchTestReport(port, "x", -1, true)
+	if err != nil {
+		t.Fatalf("fetchTestReport: %v", err)
+	}
+	if !report.DryRun {
+		t.Error("DryRun should be true")
+	}
+}
+
+func TestFetchTestReport_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"Skill not found"}`, http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	port := mustPort(t, server.URL)
+	_, err := fetchTestReport(port, "missing", -1, false)
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected status code in error; got %v", err)
+	}
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -51,6 +51,7 @@ Commands are grouped by domain. Run `gridctl <command> --help` for the full flag
 | `gridctl skill info <name>` | Show origin and update status. |
 | `gridctl skill try <repo-url>` | Temporarily import a skill for evaluation. |
 | `gridctl skill validate <name>` | Validate a skill definition. |
+| `gridctl test <skill-name>` | Run a skill's `acceptance_criteria` (exit `0`/`1`/`2`); `--dry-run` lists criteria without executing, `--criterion <n>` scopes to one criterion, `--format json` for machine output. |
 
 ## Skills - authoring
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -441,6 +441,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("DELETE /api/registry/skills/{name}", s.handleRegistrySkillDelete)
 	mux.HandleFunc("POST /api/registry/skills/{name}/activate", s.handleRegistrySkillActivate)
 	mux.HandleFunc("POST /api/registry/skills/{name}/disable", s.handleRegistrySkillDisable)
+	mux.HandleFunc("POST /api/registry/skills/{name}/test", s.handleRegistrySkillTest)
 	mux.HandleFunc("GET /api/registry/skills/{name}/files", s.handleRegistrySkillFileList)
 	mux.HandleFunc("GET /api/registry/skills/{name}/files/{path...}", s.handleRegistrySkillFileGet)
 	mux.HandleFunc("PUT /api/registry/skills/{name}/files/{path...}", s.handleRegistrySkillFilePut)

--- a/internal/api/registry.go
+++ b/internal/api/registry.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/gridctl/gridctl/pkg/registry"
 )
@@ -166,6 +168,77 @@ func (s *Server) handleRegistrySkillStateChange(w http.ResponseWriter, name, act
 	}
 	s.refreshRegistryRouter()
 	writeJSON(w, sk)
+}
+
+// handleRegistrySkillTest runs the skill's acceptance_criteria and
+// returns a TestReport. Query parameters (all optional):
+//   - criterion=N: scope to a single criterion index (zero-based).
+//   - dry_run=1:   list criteria without evaluating them.
+//
+// Returns:
+//   - 200 with the JSON report when criteria ran (including when
+//     verdicts came back fail; the CLI maps fail-count to exit 1).
+//   - 400 when criterion= is out of range or malformed.
+//   - 404 when the skill does not exist.
+//   - 422 when the skill has no acceptance_criteria — Unprocessable
+//     Entity reads correctly here: the request was understood, the
+//     skill just has nothing to test.
+//
+// POST /api/registry/skills/{name}/test
+func (s *Server) handleRegistrySkillTest(w http.ResponseWriter, r *http.Request) {
+	if s.registryServer == nil {
+		writeJSONError(w, "Registry not available", http.StatusServiceUnavailable)
+		return
+	}
+	name := r.PathValue("name")
+	sk, err := s.registryServer.Store().GetSkill(name)
+	if err != nil {
+		writeJSONError(w, "Skill not found: "+name, http.StatusNotFound)
+		return
+	}
+
+	opts := registry.NewRunOptions()
+	if v := r.URL.Query().Get("criterion"); v != "" {
+		idx, parseErr := strconv.Atoi(v)
+		if parseErr != nil || idx < 0 {
+			writeJSONError(w, "criterion must be a non-negative integer", http.StatusBadRequest)
+			return
+		}
+		opts.CriterionIndex = idx
+	}
+	if v := r.URL.Query().Get("dry_run"); v == "1" || strings.EqualFold(v, "true") {
+		opts.DryRun = true
+	}
+
+	var ev registry.Evaluator
+	if !opts.DryRun {
+		if provider := s.chatProvider(); provider != nil {
+			ev = registry.LLMEvaluator{Provider: provider}
+		} else {
+			// No LLM wired — fall back to the deterministic evaluator so
+			// fixture skills with explicit PASS:/FAIL: markers still run
+			// in CI. Prose criteria will surface as error-severity rows
+			// with a clear "configure an LLM provider" message.
+			ev = registry.DeterministicEvaluator{}
+		}
+	}
+
+	report, err := registry.RunAcceptance(r.Context(), sk, ev, opts)
+	if err != nil {
+		switch {
+		case errors.Is(err, registry.ErrNoCriteria):
+			writeJSONError(w, "skill has no acceptance_criteria", http.StatusUnprocessableEntity)
+		case errors.Is(err, registry.ErrCriterionOutOfRange):
+			writeJSONError(w, "criterion index out of range", http.StatusBadRequest)
+		default:
+			writeJSONError(w, "test failed: "+err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+	if report.Results == nil {
+		report.Results = []registry.TestResult{}
+	}
+	writeJSON(w, report)
 }
 
 // handleRegistrySkillFileList lists files in a skill directory.

--- a/internal/api/registry_test.go
+++ b/internal/api/registry_test.go
@@ -793,3 +793,154 @@ func TestDetectContentType(t *testing.T) {
 		})
 	}
 }
+
+// --- Skills: test (acceptance-criteria runner) ---
+
+// seedSkillWithCriteria saves a skill that carries acceptance_criteria
+// markers the deterministic evaluator can read.
+func seedSkillWithCriteria(t *testing.T, regServer *registry.Server, name string, criteria []string) {
+	t.Helper()
+	sk := &registry.AgentSkill{
+		Name:               name,
+		Description:        "Test skill with criteria: " + name,
+		State:              registry.StateActive,
+		Body:               "# " + name + "\n\nSkill instructions.",
+		AcceptanceCriteria: criteria,
+	}
+	if err := regServer.Store().SaveSkill(sk); err != nil {
+		t.Fatalf("failed to seed skill: %v", err)
+	}
+}
+
+func TestHandleRegistry_TestSkill_HappyPath(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkillWithCriteria(t, regServer, "with-criteria", []string{
+		"PASS: criterion 0",
+		"FAIL: criterion 1",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/registry/skills/with-criteria/test", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var report registry.TestReport
+	if err := json.NewDecoder(rec.Body).Decode(&report); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if report.SkillName != "with-criteria" {
+		t.Errorf("SkillName = %q, want with-criteria", report.SkillName)
+	}
+	if report.PassCount != 1 || report.FailCount != 1 {
+		t.Errorf("counts pass=%d fail=%d, want 1/1", report.PassCount, report.FailCount)
+	}
+	if report.Evaluator != "deterministic" {
+		t.Errorf("Evaluator = %q, want deterministic (no chat provider set)", report.Evaluator)
+	}
+}
+
+func TestHandleRegistry_TestSkill_NotFound(t *testing.T) {
+	srv, _ := setupRegistryTestServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/registry/skills/missing/test", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleRegistry_TestSkill_NoCriteria(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkill(t, regServer, "no-criteria", registry.StateActive)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/registry/skills/no-criteria/test", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleRegistry_TestSkill_DryRun(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkillWithCriteria(t, regServer, "with-criteria", []string{
+		"PASS: c0",
+		"FAIL: c1",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/registry/skills/with-criteria/test?dry_run=1", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var report registry.TestReport
+	if err := json.NewDecoder(rec.Body).Decode(&report); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if !report.DryRun {
+		t.Error("DryRun should be true")
+	}
+	if report.PassCount != 0 || report.FailCount != 0 {
+		t.Errorf("dry-run should report no verdicts; got pass=%d fail=%d", report.PassCount, report.FailCount)
+	}
+	if len(report.Results) != 2 {
+		t.Errorf("Results len = %d, want 2", len(report.Results))
+	}
+}
+
+func TestHandleRegistry_TestSkill_ScopedToCriterion(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkillWithCriteria(t, regServer, "with-criteria", []string{
+		"PASS: c0",
+		"FAIL: c1",
+		"PASS: c2",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/registry/skills/with-criteria/test?criterion=1", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	var report registry.TestReport
+	if err := json.NewDecoder(rec.Body).Decode(&report); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(report.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1", len(report.Results))
+	}
+	if report.Results[0].Index != 1 {
+		t.Errorf("Results[0].Index = %d, want 1", report.Results[0].Index)
+	}
+	if report.FailCount != 1 {
+		t.Errorf("FailCount = %d, want 1", report.FailCount)
+	}
+}
+
+func TestHandleRegistry_TestSkill_BadCriterion(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkillWithCriteria(t, regServer, "with-criteria", []string{"PASS: c0"})
+
+	cases := []struct {
+		name string
+		url  string
+		want int
+	}{
+		{"non-integer", "/api/registry/skills/with-criteria/test?criterion=abc", http.StatusBadRequest},
+		{"negative", "/api/registry/skills/with-criteria/test?criterion=-1", http.StatusBadRequest},
+		{"out of range", "/api/registry/skills/with-criteria/test?criterion=99", http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tc.url, nil)
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Errorf("expected %d, got %d (body=%s)", tc.want, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}

--- a/pkg/registry/acceptance.go
+++ b/pkg/registry/acceptance.go
@@ -1,0 +1,431 @@
+// Package registry — acceptance criteria runner.
+//
+// A skill's `acceptance_criteria` frontmatter is a list of Given/When/Then
+// prose strings. The runner evaluates each criterion against the skill's
+// body and frontmatter, returning a TestReport that callers (CLI, API,
+// Web UI) render directly.
+//
+// Two evaluators ship:
+//
+//   - LLMEvaluator: hands the skill + criterion to an agent.ChatModel
+//     and asks for a structured pass/fail verdict. Production path; the
+//     prose contract stays free-form.
+//   - DeterministicEvaluator: a no-LLM adapter for CI and unit tests.
+//     It looks for "PASS:" or "FAIL:" markers inside each criterion so
+//     fixture skills can encode expected outcomes without standing up an
+//     LLM provider.
+//
+// The runner is read-only — it never mutates the skill or its files.
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/agent"
+)
+
+// TestSeverity classifies a single criterion's outcome. The vocabulary
+// mirrors pkg/optimize.Severity so renderers can share badge styling.
+type TestSeverity string
+
+const (
+	// TestSeverityPass means the evaluator verified the criterion is
+	// satisfied by the skill as written.
+	TestSeverityPass TestSeverity = "pass"
+
+	// TestSeverityFail means the evaluator believes the criterion is
+	// NOT satisfied. This is the case the runner reports back to CI.
+	TestSeverityFail TestSeverity = "fail"
+
+	// TestSeverityError means evaluation could not complete (LLM
+	// unavailable, malformed criterion, etc.). Mapped to exit code 2
+	// by the CLI so infrastructure failures never look like a real
+	// fail verdict.
+	TestSeverityError TestSeverity = "error"
+)
+
+// TestResult is the verdict for one criterion. Mirrors optimize.Finding's
+// shape so the JSON envelope feels familiar.
+type TestResult struct {
+	// Index is the criterion's position in the skill's
+	// AcceptanceCriteria slice (zero-based). Stable across runs.
+	Index int `json:"index"`
+
+	// Criterion is the verbatim Given/When/Then string from the
+	// skill's frontmatter.
+	Criterion string `json:"criterion"`
+
+	// Severity classifies the outcome.
+	Severity TestSeverity `json:"severity"`
+
+	// Message is a short human-readable rationale. Required for fail
+	// and error; optional for pass.
+	Message string `json:"message,omitempty"`
+
+	// EvaluatedAt is the wall-clock time the verdict was rendered.
+	EvaluatedAt time.Time `json:"evaluated_at"`
+}
+
+// TestReport is the runner's full output for one skill.
+type TestReport struct {
+	// SkillName echoes the skill the runner ran against.
+	SkillName string `json:"skill_name"`
+
+	// Results is the per-criterion verdicts in criterion order.
+	Results []TestResult `json:"results"`
+
+	// PassCount, FailCount, ErrorCount summarize Results so callers
+	// don't re-tally.
+	PassCount  int `json:"pass_count"`
+	FailCount  int `json:"fail_count"`
+	ErrorCount int `json:"error_count"`
+
+	// Evaluator names the backend that ran the criteria (e.g. "llm",
+	// "deterministic"). Surfaced in JSON output so CI logs make the
+	// provenance explicit.
+	Evaluator string `json:"evaluator"`
+
+	// DryRun is true when Results was populated by listing criteria
+	// without executing them. Each TestResult in that case carries
+	// Severity = "" so renderers can show "—" instead of a verdict.
+	DryRun bool `json:"dry_run,omitempty"`
+
+	// GeneratedAt is the wall-clock time the report was assembled.
+	GeneratedAt time.Time `json:"generated_at"`
+}
+
+// HasFailures reports whether any criterion failed. The CLI uses this
+// to map to exit code 1. Error-severity results are separate and map
+// to exit code 2 in the CLI; here we only flag fail.
+func (r TestReport) HasFailures() bool {
+	return r.FailCount > 0
+}
+
+// HasErrors reports whether any criterion errored during evaluation.
+// The CLI uses this to map to exit code 2.
+func (r TestReport) HasErrors() bool {
+	return r.ErrorCount > 0
+}
+
+// Evaluator runs a single acceptance criterion against a skill and
+// returns the verdict. Implementations MUST honor ctx cancellation.
+type Evaluator interface {
+	// Name identifies the evaluator backend for the TestReport.
+	Name() string
+
+	// Evaluate produces a verdict for criterion idx against skill.
+	// Implementations MUST NOT return both a TestResult and an error;
+	// transient infrastructure failures should be returned via a
+	// TestResult with Severity = TestSeverityError so the report
+	// remains complete for the user.
+	Evaluate(ctx context.Context, skill *AgentSkill, idx int, criterion string) TestResult
+}
+
+// RunOptions tunes a single Run pass.
+type RunOptions struct {
+	// CriterionIndex, when non-negative, scopes the run to a single
+	// criterion. -1 (the zero value via NewRunOptions) means "all".
+	CriterionIndex int
+
+	// DryRun lists criteria without evaluating them. Severity on each
+	// result is empty.
+	DryRun bool
+
+	// Now overrides the wall-clock used for EvaluatedAt and
+	// GeneratedAt. Tests inject a fixed time; production callers
+	// leave this zero so the runner defaults to time.Now().
+	Now time.Time
+}
+
+// NewRunOptions returns RunOptions with CriterionIndex set to -1, the
+// "run every criterion" sentinel. Use this instead of a literal zero
+// value so future-added fields stay backward-compatible.
+func NewRunOptions() RunOptions {
+	return RunOptions{CriterionIndex: -1}
+}
+
+// ErrNoCriteria signals that the skill has no acceptance_criteria
+// frontmatter. The runner returns this distinct error so callers can
+// emit a clear "nothing to test" message and exit cleanly rather than
+// reporting zero failures (which is ambiguous: did the skill pass, or
+// was there nothing to check?).
+var ErrNoCriteria = errors.New("skill has no acceptance_criteria")
+
+// ErrCriterionOutOfRange is returned when RunOptions.CriterionIndex
+// names a criterion that does not exist on the skill. The CLI maps
+// this to exit code 2.
+var ErrCriterionOutOfRange = errors.New("criterion index out of range")
+
+// RunAcceptance evaluates the skill's acceptance_criteria using the
+// supplied evaluator and returns a populated TestReport.
+//
+// Returns:
+//   - ErrNoCriteria when the skill has no acceptance_criteria.
+//   - ErrCriterionOutOfRange when opts.CriterionIndex is set and
+//     points outside the skill's criteria slice.
+//
+// Per-criterion infrastructure failures are reported as TestResults
+// with Severity = TestSeverityError; only the two errors above stop
+// the whole run.
+func RunAcceptance(ctx context.Context, skill *AgentSkill, ev Evaluator, opts RunOptions) (TestReport, error) {
+	if skill == nil {
+		return TestReport{}, errors.New("registry: skill is nil")
+	}
+	if len(skill.AcceptanceCriteria) == 0 {
+		return TestReport{}, ErrNoCriteria
+	}
+	if opts.CriterionIndex >= len(skill.AcceptanceCriteria) ||
+		(opts.CriterionIndex < 0 && opts.CriterionIndex != -1) {
+		return TestReport{}, ErrCriterionOutOfRange
+	}
+
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	report := TestReport{
+		SkillName:   skill.Name,
+		GeneratedAt: now,
+	}
+	if ev != nil {
+		report.Evaluator = ev.Name()
+	}
+	if opts.DryRun {
+		report.DryRun = true
+		report.Evaluator = "dry-run"
+	}
+
+	for idx, criterion := range skill.AcceptanceCriteria {
+		if opts.CriterionIndex >= 0 && idx != opts.CriterionIndex {
+			continue
+		}
+		if opts.DryRun {
+			report.Results = append(report.Results, TestResult{
+				Index:       idx,
+				Criterion:   criterion,
+				EvaluatedAt: now,
+			})
+			continue
+		}
+		if ev == nil {
+			report.Results = append(report.Results, TestResult{
+				Index:       idx,
+				Criterion:   criterion,
+				Severity:    TestSeverityError,
+				Message:     "no evaluator configured",
+				EvaluatedAt: now,
+			})
+			report.ErrorCount++
+			continue
+		}
+		result := ev.Evaluate(ctx, skill, idx, criterion)
+		if result.EvaluatedAt.IsZero() {
+			result.EvaluatedAt = now
+		}
+		// Trust evaluator-supplied index but fall back to the loop
+		// index when the evaluator left it zero on a non-zero
+		// criterion — defensive, since the evaluator should set it.
+		if result.Index == 0 && idx != 0 {
+			result.Index = idx
+		}
+		report.Results = append(report.Results, result)
+		switch result.Severity {
+		case TestSeverityPass:
+			report.PassCount++
+		case TestSeverityFail:
+			report.FailCount++
+		case TestSeverityError:
+			report.ErrorCount++
+		}
+	}
+	return report, nil
+}
+
+// DeterministicEvaluator is the zero-LLM evaluator used by CI and
+// unit tests. It inspects each criterion for the case-sensitive prefix
+// markers "PASS:" or "FAIL:" and produces the corresponding verdict;
+// criteria without a marker return TestSeverityError so test authors
+// know the fixture needs to be explicit.
+//
+// This adapter exists so the acceptance contract can be exercised end
+// to end (CLI → API → evaluator) without standing up an LLM provider.
+type DeterministicEvaluator struct{}
+
+// Name returns "deterministic".
+func (DeterministicEvaluator) Name() string { return "deterministic" }
+
+// Evaluate parses the marker convention. Markers are checked
+// case-sensitively to avoid false positives in natural-language
+// criteria like "should pass validation" — only explicit "PASS:" or
+// "FAIL:" at the start of the trimmed criterion fires.
+func (DeterministicEvaluator) Evaluate(_ context.Context, _ *AgentSkill, idx int, criterion string) TestResult {
+	trimmed := strings.TrimSpace(criterion)
+	switch {
+	case strings.HasPrefix(trimmed, "PASS:"):
+		return TestResult{
+			Index:     idx,
+			Criterion: criterion,
+			Severity:  TestSeverityPass,
+			Message:   strings.TrimSpace(strings.TrimPrefix(trimmed, "PASS:")),
+		}
+	case strings.HasPrefix(trimmed, "FAIL:"):
+		return TestResult{
+			Index:     idx,
+			Criterion: criterion,
+			Severity:  TestSeverityFail,
+			Message:   strings.TrimSpace(strings.TrimPrefix(trimmed, "FAIL:")),
+		}
+	default:
+		return TestResult{
+			Index:     idx,
+			Criterion: criterion,
+			Severity:  TestSeverityError,
+			Message:   "deterministic evaluator requires 'PASS:' or 'FAIL:' prefix; configure an LLM provider for prose criteria",
+		}
+	}
+}
+
+// LLMEvaluator is the production evaluator. It asks an agent.ChatModel
+// to render a verdict on each criterion against the skill's body, then
+// parses a strict JSON envelope from the model's response.
+//
+// The prompt instructs the judge to emit exactly one JSON object with
+// `verdict` (pass|fail) and `rationale` (one sentence). Anything else
+// is treated as TestSeverityError so the user sees the model misbehaved
+// rather than guessing whether absence-of-marker meant pass or fail.
+type LLMEvaluator struct {
+	// Model is the canonical model ID handed to ChatRequest.Model.
+	// Falls back to defaultJudgeModel when empty.
+	Model string
+
+	// Provider is the gridctl LLM provider. Required; constructing
+	// the evaluator without one and calling Evaluate produces
+	// TestSeverityError on every criterion.
+	Provider agent.ChatModel
+
+	// MaxTokens caps the judge's output. Defaults to 256 — verdicts
+	// fit comfortably in a few sentences.
+	MaxTokens int
+}
+
+const defaultJudgeModel = "claude-haiku-4-5-20251001"
+
+// Name returns "llm".
+func (LLMEvaluator) Name() string { return "llm" }
+
+// Evaluate prompts the judge and parses its verdict. Errors at any
+// stage become TestSeverityError so the report stays complete.
+func (e LLMEvaluator) Evaluate(ctx context.Context, skill *AgentSkill, idx int, criterion string) TestResult {
+	out := TestResult{Index: idx, Criterion: criterion}
+	if e.Provider == nil {
+		out.Severity = TestSeverityError
+		out.Message = "no LLM provider configured (set ANTHROPIC_API_KEY in the vault and restart)"
+		return out
+	}
+
+	model := e.Model
+	if model == "" {
+		model = defaultJudgeModel
+	}
+	maxTokens := e.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = 256
+	}
+
+	prompt := buildJudgePrompt(skill, criterion)
+	req := agent.ChatRequest{
+		Model:     model,
+		MaxTokens: maxTokens,
+		System:    judgeSystemPrompt,
+		Messages:  []agent.Message{{Role: agent.RoleUser, Content: prompt}},
+	}
+
+	resp, err := e.Provider.Generate(ctx, req)
+	if err != nil {
+		out.Severity = TestSeverityError
+		out.Message = "LLM judge: " + err.Error()
+		return out
+	}
+	verdict, rationale, parseErr := parseJudgeResponse(resp.Content)
+	if parseErr != nil {
+		out.Severity = TestSeverityError
+		out.Message = "LLM judge returned unparseable response: " + parseErr.Error()
+		return out
+	}
+	out.Severity = verdict
+	out.Message = rationale
+	return out
+}
+
+const judgeSystemPrompt = `You are an acceptance-criteria judge for an Agent Skills file.
+
+You will be given:
+1. The skill's name and body (the markdown a model would read at runtime).
+2. A single Given/When/Then-style criterion the skill is supposed to satisfy.
+
+Your job is to decide whether the skill's behavior, as documented in its body, satisfies the criterion.
+
+Reply with EXACTLY one JSON object on a single line, no surrounding prose, no markdown fence:
+
+{"verdict":"pass","rationale":"one short sentence"}
+
+verdict MUST be "pass" or "fail". rationale MUST be one sentence under 200 characters explaining the verdict.`
+
+func buildJudgePrompt(skill *AgentSkill, criterion string) string {
+	var b strings.Builder
+	b.WriteString("Skill name: ")
+	b.WriteString(skill.Name)
+	b.WriteString("\n\nSkill description: ")
+	b.WriteString(skill.Description)
+	b.WriteString("\n\nSkill body:\n---\n")
+	b.WriteString(skill.Body)
+	b.WriteString("\n---\n\nCriterion to evaluate:\n")
+	b.WriteString(criterion)
+	b.WriteString("\n\nReturn the JSON envelope now.")
+	return b.String()
+}
+
+// parseJudgeResponse extracts the first JSON object from raw and
+// validates it. Models often emit prefatory whitespace or, despite the
+// system prompt, a leading fence; we scan for the first '{' rather
+// than rejecting on framing noise.
+func parseJudgeResponse(raw string) (TestSeverity, string, error) {
+	trimmed := strings.TrimSpace(raw)
+	start := strings.Index(trimmed, "{")
+	end := strings.LastIndex(trimmed, "}")
+	if start < 0 || end < 0 || end <= start {
+		return TestSeverityError, "", fmt.Errorf("no JSON object found in response: %q", clip(trimmed))
+	}
+	payload := trimmed[start : end+1]
+	var env struct {
+		Verdict   string `json:"verdict"`
+		Rationale string `json:"rationale"`
+	}
+	if err := json.Unmarshal([]byte(payload), &env); err != nil {
+		return TestSeverityError, "", fmt.Errorf("invalid JSON: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(env.Verdict)) {
+	case "pass":
+		return TestSeverityPass, env.Rationale, nil
+	case "fail":
+		return TestSeverityFail, env.Rationale, nil
+	default:
+		return TestSeverityError, "", fmt.Errorf("unknown verdict %q", env.Verdict)
+	}
+}
+
+// clip caps a string at 120 characters so error messages stay readable
+// when the model emits a long blob.
+func clip(s string) string {
+	const max = 120
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/pkg/registry/acceptance_test.go
+++ b/pkg/registry/acceptance_test.go
@@ -1,0 +1,274 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/agent"
+)
+
+func TestRunAcceptance_NoCriteria(t *testing.T) {
+	skill := &AgentSkill{Name: "empty"}
+	_, err := RunAcceptance(context.Background(), skill, DeterministicEvaluator{}, NewRunOptions())
+	if !errors.Is(err, ErrNoCriteria) {
+		t.Fatalf("expected ErrNoCriteria, got %v", err)
+	}
+}
+
+func TestRunAcceptance_NilSkill(t *testing.T) {
+	_, err := RunAcceptance(context.Background(), nil, DeterministicEvaluator{}, NewRunOptions())
+	if err == nil {
+		t.Fatal("expected error on nil skill")
+	}
+}
+
+func TestRunAcceptance_CriterionOutOfRange(t *testing.T) {
+	skill := &AgentSkill{
+		Name:               "one-criterion",
+		AcceptanceCriteria: []string{"PASS: something"},
+	}
+	opts := NewRunOptions()
+	opts.CriterionIndex = 5
+	_, err := RunAcceptance(context.Background(), skill, DeterministicEvaluator{}, opts)
+	if !errors.Is(err, ErrCriterionOutOfRange) {
+		t.Fatalf("expected ErrCriterionOutOfRange, got %v", err)
+	}
+}
+
+func TestRunAcceptance_DeterministicHappyPath(t *testing.T) {
+	skill := &AgentSkill{
+		Name: "fixture",
+		AcceptanceCriteria: []string{
+			"PASS: given valid input, when run, then return success",
+			"FAIL: given missing config, when run, then error",
+			"PASS: idempotent re-runs do not double-write",
+		},
+	}
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	opts := NewRunOptions()
+	opts.Now = now
+
+	report, err := RunAcceptance(context.Background(), skill, DeterministicEvaluator{}, opts)
+	if err != nil {
+		t.Fatalf("RunAcceptance: %v", err)
+	}
+	if report.SkillName != "fixture" {
+		t.Errorf("SkillName = %q, want fixture", report.SkillName)
+	}
+	if report.Evaluator != "deterministic" {
+		t.Errorf("Evaluator = %q, want deterministic", report.Evaluator)
+	}
+	if !report.GeneratedAt.Equal(now) {
+		t.Errorf("GeneratedAt = %v, want %v", report.GeneratedAt, now)
+	}
+	if report.PassCount != 2 || report.FailCount != 1 || report.ErrorCount != 0 {
+		t.Errorf("counts pass=%d fail=%d err=%d, want 2/1/0", report.PassCount, report.FailCount, report.ErrorCount)
+	}
+	if !report.HasFailures() {
+		t.Error("HasFailures should be true")
+	}
+	if report.HasErrors() {
+		t.Error("HasErrors should be false")
+	}
+	if len(report.Results) != 3 {
+		t.Fatalf("Results len = %d, want 3", len(report.Results))
+	}
+	if report.Results[0].Severity != TestSeverityPass {
+		t.Errorf("Results[0].Severity = %q, want pass", report.Results[0].Severity)
+	}
+	if report.Results[0].Index != 0 {
+		t.Errorf("Results[0].Index = %d, want 0", report.Results[0].Index)
+	}
+	if report.Results[1].Severity != TestSeverityFail {
+		t.Errorf("Results[1].Severity = %q, want fail", report.Results[1].Severity)
+	}
+	if report.Results[1].Index != 1 {
+		t.Errorf("Results[1].Index = %d, want 1", report.Results[1].Index)
+	}
+}
+
+func TestRunAcceptance_DeterministicMissingMarker(t *testing.T) {
+	skill := &AgentSkill{
+		Name:               "ambiguous",
+		AcceptanceCriteria: []string{"Given X, when Y, then Z"},
+	}
+	report, err := RunAcceptance(context.Background(), skill, DeterministicEvaluator{}, NewRunOptions())
+	if err != nil {
+		t.Fatalf("RunAcceptance: %v", err)
+	}
+	if report.ErrorCount != 1 {
+		t.Errorf("ErrorCount = %d, want 1", report.ErrorCount)
+	}
+	if report.Results[0].Severity != TestSeverityError {
+		t.Errorf("Severity = %q, want error", report.Results[0].Severity)
+	}
+}
+
+func TestRunAcceptance_DryRun(t *testing.T) {
+	skill := &AgentSkill{
+		Name: "fixture",
+		AcceptanceCriteria: []string{
+			"PASS: c1",
+			"FAIL: c2",
+		},
+	}
+	opts := NewRunOptions()
+	opts.DryRun = true
+	report, err := RunAcceptance(context.Background(), skill, DeterministicEvaluator{}, opts)
+	if err != nil {
+		t.Fatalf("RunAcceptance: %v", err)
+	}
+	if !report.DryRun {
+		t.Error("DryRun should be true")
+	}
+	if report.Evaluator != "dry-run" {
+		t.Errorf("Evaluator = %q, want dry-run", report.Evaluator)
+	}
+	if report.PassCount != 0 || report.FailCount != 0 || report.ErrorCount != 0 {
+		t.Errorf("dry-run should not tally counts, got pass=%d fail=%d err=%d",
+			report.PassCount, report.FailCount, report.ErrorCount)
+	}
+	if len(report.Results) != 2 {
+		t.Fatalf("Results len = %d, want 2", len(report.Results))
+	}
+	for i, r := range report.Results {
+		if r.Severity != "" {
+			t.Errorf("Results[%d].Severity = %q, want empty", i, r.Severity)
+		}
+	}
+}
+
+func TestRunAcceptance_ScopedToOneCriterion(t *testing.T) {
+	skill := &AgentSkill{
+		Name: "fixture",
+		AcceptanceCriteria: []string{
+			"PASS: c0",
+			"PASS: c1",
+			"FAIL: c2",
+		},
+	}
+	opts := NewRunOptions()
+	opts.CriterionIndex = 2
+	report, err := RunAcceptance(context.Background(), skill, DeterministicEvaluator{}, opts)
+	if err != nil {
+		t.Fatalf("RunAcceptance: %v", err)
+	}
+	if len(report.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1", len(report.Results))
+	}
+	if report.Results[0].Index != 2 {
+		t.Errorf("Results[0].Index = %d, want 2", report.Results[0].Index)
+	}
+	if report.Results[0].Severity != TestSeverityFail {
+		t.Errorf("Results[0].Severity = %q, want fail", report.Results[0].Severity)
+	}
+}
+
+func TestRunAcceptance_NilEvaluator(t *testing.T) {
+	skill := &AgentSkill{
+		Name:               "fixture",
+		AcceptanceCriteria: []string{"PASS: c0"},
+	}
+	report, err := RunAcceptance(context.Background(), skill, nil, NewRunOptions())
+	if err != nil {
+		t.Fatalf("RunAcceptance: %v", err)
+	}
+	if report.ErrorCount != 1 {
+		t.Errorf("ErrorCount = %d, want 1", report.ErrorCount)
+	}
+	if report.Results[0].Severity != TestSeverityError {
+		t.Errorf("Severity = %q, want error", report.Results[0].Severity)
+	}
+}
+
+// stubChatModel implements agent.ChatModel for evaluator tests.
+type stubChatModel struct {
+	resp agent.ChatResponse
+	err  error
+}
+
+func (s *stubChatModel) Generate(_ context.Context, _ agent.ChatRequest) (agent.ChatResponse, error) {
+	return s.resp, s.err
+}
+
+func (s *stubChatModel) Stream(_ context.Context, _ agent.ChatRequest) (*agent.StreamReader[agent.ChatChunk], error) {
+	return nil, errors.New("stream not implemented for stub")
+}
+
+func TestLLMEvaluator_ParsesVerdict(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    TestSeverity
+	}{
+		{"plain pass", `{"verdict":"pass","rationale":"looks good"}`, TestSeverityPass},
+		{"plain fail", `{"verdict":"fail","rationale":"missing input handling"}`, TestSeverityFail},
+		{"upper-case verdict", `{"verdict":"PASS","rationale":"ok"}`, TestSeverityPass},
+		{"prefatory whitespace", "  \n  {\"verdict\":\"pass\",\"rationale\":\"ok\"}", TestSeverityPass},
+		{"surrounded by prose", "Here is the verdict: {\"verdict\":\"fail\",\"rationale\":\"r\"} thanks", TestSeverityFail},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := LLMEvaluator{Provider: &stubChatModel{
+				resp: agent.ChatResponse{Content: tc.content},
+			}}
+			got := ev.Evaluate(context.Background(), &AgentSkill{Name: "x", Body: "body"}, 0, "criterion")
+			if got.Severity != tc.want {
+				t.Errorf("Severity = %q, want %q (message: %q)", got.Severity, tc.want, got.Message)
+			}
+		})
+	}
+}
+
+func TestLLMEvaluator_BadJSON(t *testing.T) {
+	ev := LLMEvaluator{Provider: &stubChatModel{
+		resp: agent.ChatResponse{Content: "this is not JSON"},
+	}}
+	got := ev.Evaluate(context.Background(), &AgentSkill{Name: "x"}, 0, "criterion")
+	if got.Severity != TestSeverityError {
+		t.Errorf("Severity = %q, want error", got.Severity)
+	}
+	if got.Message == "" {
+		t.Error("error message should be populated")
+	}
+}
+
+func TestLLMEvaluator_UnknownVerdict(t *testing.T) {
+	ev := LLMEvaluator{Provider: &stubChatModel{
+		resp: agent.ChatResponse{Content: `{"verdict":"maybe","rationale":"unsure"}`},
+	}}
+	got := ev.Evaluate(context.Background(), &AgentSkill{Name: "x"}, 0, "criterion")
+	if got.Severity != TestSeverityError {
+		t.Errorf("Severity = %q, want error", got.Severity)
+	}
+}
+
+func TestLLMEvaluator_ProviderError(t *testing.T) {
+	ev := LLMEvaluator{Provider: &stubChatModel{err: errors.New("upstream 500")}}
+	got := ev.Evaluate(context.Background(), &AgentSkill{Name: "x"}, 0, "criterion")
+	if got.Severity != TestSeverityError {
+		t.Errorf("Severity = %q, want error", got.Severity)
+	}
+}
+
+func TestLLMEvaluator_NilProvider(t *testing.T) {
+	ev := LLMEvaluator{}
+	got := ev.Evaluate(context.Background(), &AgentSkill{Name: "x"}, 0, "criterion")
+	if got.Severity != TestSeverityError {
+		t.Errorf("Severity = %q, want error", got.Severity)
+	}
+}
+
+func TestLLMEvaluator_DefaultsApplied(t *testing.T) {
+	// Confirm that omitted Model + MaxTokens don't blow up — the
+	// evaluator should fall back to its compile-time defaults.
+	ev := LLMEvaluator{Provider: &stubChatModel{
+		resp: agent.ChatResponse{Content: `{"verdict":"pass","rationale":"ok"}`},
+	}}
+	got := ev.Evaluate(context.Background(), &AgentSkill{Name: "x"}, 0, "criterion")
+	if got.Severity != TestSeverityPass {
+		t.Errorf("Severity = %q, want pass", got.Severity)
+	}
+}


### PR DESCRIPTION
## Description

Implements `gridctl test <skill-name>` (resolves #656) — an LLM-as-judge runner for a skill's `acceptance_criteria` frontmatter, with a deterministic adapter for CI when no LLM provider is configured.

## Type of Change

- [x] New feature

## Changes Made

- `pkg/registry/acceptance.go` — `TestReport` / `TestResult` shapes, `Evaluator` interface, `LLMEvaluator` (uses `agent.ChatModel` with a strict JSON envelope), `DeterministicEvaluator` (reads `PASS:` / `FAIL:` markers), and the `RunAcceptance` driver with `--criterion` and `--dry-run` semantics.
- `internal/api/registry.go` + `api.go` — `POST /api/registry/skills/{name}/test` handler and route. Falls back to the deterministic evaluator when no chat provider is wired; maps `ErrNoCriteria` → 422, out-of-range / malformed criterion → 400, missing skill → 404.
- `cmd/gridctl/test.go` — Cobra command with `--stack`, `--format`, `--dry-run`, `--criterion`. Exit codes `0` pass / `1` failures / `2` infrastructure error, matching `gridctl optimize`.
- Tests at `pkg/registry/acceptance_test.go`, `internal/api/registry_test.go`, and `cmd/gridctl/test_test.go`.
- `docs/cli-reference.md` row restored; `AGENTS.md` flag table refreshed to match reality.

## Testing

- `make build`
- `go test -race ./...`
- `golangci-lint run ./...` (0 issues)

Manual smoke: `./gridctl test --help` renders; handler tests cover happy path, not-found, no-criteria (422), dry-run, scoped, and bad criterion (400).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #656