### PR TITLE
fix: adapt variable form value placeholder to type and visibility

### DIFF
--- a/web/src/__tests__/VariablesPopover.test.tsx
+++ b/web/src/__tests__/VariablesPopover.test.tsx
@@ -96,7 +96,8 @@ describe('VariablesPopover', () => {
 
     fireEvent.click(screen.getByText('Create New Variable'));
     expect(screen.getByPlaceholderText('VARIABLE_KEY')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Variable value')).toBeInTheDocument();
+    // Default form state is string + Secret, so the value hint mirrors that.
+    expect(screen.getByPlaceholderText('secret value')).toBeInTheDocument();
   });
 
   it('converts new key input to uppercase', async () => {
@@ -139,6 +140,52 @@ describe('VariablesPopover', () => {
     for (let i = 0; i < 20; i++) {
       expect(screen.getByText(`VAR_${i}`)).toBeInTheDocument();
     }
+  });
+
+  describe('placeholder adaptation', () => {
+    const openCreateForm = async () => {
+      render(<VariablesPopover onSelect={onSelect} />);
+      fireEvent.click(screen.getByTitle('Insert variable'));
+      await waitFor(() => {
+        fireEvent.click(screen.getByText('Create New Variable'));
+      });
+    };
+
+    it('shows a secret-value hint by default (string + Secret)', async () => {
+      await openCreateForm();
+      expect(screen.getByPlaceholderText('secret value')).toBeInTheDocument();
+    });
+
+    it('drops the word "secret" when Plaintext is selected', async () => {
+      await openCreateForm();
+      fireEvent.click(screen.getByRole('button', { name: /plaintext/i }));
+      expect(screen.queryByPlaceholderText('secret value')).not.toBeInTheDocument();
+      expect(screen.getByPlaceholderText('plaintext value')).toBeInTheDocument();
+    });
+
+    it('hints comma-separated input when list type is selected', async () => {
+      await openCreateForm();
+      fireEvent.click(screen.getByRole('button', { name: 'list' }));
+      expect(screen.getByPlaceholderText('item1, item2, item3')).toBeInTheDocument();
+    });
+
+    it('hints JSON object syntax when json type is selected', async () => {
+      await openCreateForm();
+      fireEvent.click(screen.getByRole('button', { name: 'json' }));
+      expect(screen.getByPlaceholderText('{"key": "value"}')).toBeInTheDocument();
+    });
+
+    it('hints a number example when number type is selected', async () => {
+      await openCreateForm();
+      fireEvent.click(screen.getByRole('button', { name: 'number' }));
+      expect(screen.getByPlaceholderText('42')).toBeInTheDocument();
+    });
+
+    it('hints true/false when bool type is selected', async () => {
+      await openCreateForm();
+      fireEvent.click(screen.getByRole('button', { name: 'bool' }));
+      expect(screen.getByPlaceholderText('true or false')).toBeInTheDocument();
+    });
   });
 
   it('closes popover on outside mousedown', async () => {

--- a/web/src/__tests__/VaultPanel.test.tsx
+++ b/web/src/__tests__/VaultPanel.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { VaultPanel } from '../components/vault/VaultPanel';
+import { useVaultStore } from '../stores/useVaultStore';
+
+// Stub every api function VaultPanel imports. The placeholder assertions
+// don't depend on data — they just need the form to render — so resolved
+// no-op promises are sufficient.
+vi.mock('../lib/api', () => ({
+  fetchVariables: vi.fn().mockResolvedValue([]),
+  fetchVariableSets: vi.fn().mockResolvedValue([]),
+  createVariable: vi.fn().mockResolvedValue(undefined),
+  getVariable: vi.fn().mockResolvedValue({ value: '' }),
+  updateVariable: vi.fn().mockResolvedValue(undefined),
+  deleteVariable: vi.fn().mockResolvedValue(undefined),
+  createVariableSet: vi.fn().mockResolvedValue(undefined),
+  deleteVariableSet: vi.fn().mockResolvedValue(undefined),
+  assignVariableToSet: vi.fn().mockResolvedValue(undefined),
+  fetchVariableStoreStatus: vi
+    .fn()
+    .mockResolvedValue({ locked: false, encrypted: false }),
+  unlockVariableStore: vi.fn().mockResolvedValue(undefined),
+  lockVariableStore: vi.fn().mockResolvedValue(undefined),
+}));
+
+const noop = () => {};
+
+describe('VaultPanel — value placeholder adapts to type and visibility', () => {
+  beforeEach(() => {
+    useVaultStore.setState({
+      variables: [],
+      sets: [],
+      loading: false,
+      error: null,
+      locked: false,
+      encrypted: false,
+    });
+  });
+
+  it('shows a secret-value hint by default (string + Secret)', () => {
+    render(<VaultPanel onClose={noop} />);
+    expect(screen.getByPlaceholderText('secret value')).toBeInTheDocument();
+  });
+
+  it('switches to a plaintext hint when Plaintext is selected', () => {
+    render(<VaultPanel onClose={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: /plaintext/i }));
+    expect(screen.queryByPlaceholderText('secret value')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('plaintext value')).toBeInTheDocument();
+  });
+
+  it('hints comma-separated input when list type is selected', () => {
+    render(<VaultPanel onClose={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: 'list' }));
+    expect(screen.getByPlaceholderText('item1, item2, item3')).toBeInTheDocument();
+  });
+
+  it('hints JSON object syntax when json type is selected', () => {
+    render(<VaultPanel onClose={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: 'json' }));
+    expect(screen.getByPlaceholderText('{"key": "value"}')).toBeInTheDocument();
+  });
+
+  it('hints a number example when number type is selected', () => {
+    render(<VaultPanel onClose={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: 'number' }));
+    expect(screen.getByPlaceholderText('42')).toBeInTheDocument();
+  });
+
+  it('hints true/false when bool type is selected', () => {
+    render(<VaultPanel onClose={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: 'bool' }));
+    expect(screen.getByPlaceholderText('true or false')).toBeInTheDocument();
+  });
+
+  it('leaves the key-input placeholder generic regardless of type', () => {
+    render(<VaultPanel onClose={noop} />);
+    expect(screen.getByPlaceholderText('KEY_NAME')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'json' }));
+    expect(screen.getByPlaceholderText('KEY_NAME')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/vault/VaultPanel.tsx
+++ b/web/src/components/vault/VaultPanel.tsx
@@ -47,7 +47,7 @@ import { VariableTypeBadge } from './VariableTypeBadge';
 import { VariableVisibilityIcon } from './VariableVisibilityIcon';
 import { VariableTypeSelector } from './VariableTypeSelector';
 import { VariableSecretToggle } from './VariableSecretToggle';
-import { validateVariableInput } from './variableTypeHelpers';
+import { validateVariableInput, getValuePlaceholder } from './variableTypeHelpers';
 
 interface VaultPanelProps {
   onClose: () => void;
@@ -578,7 +578,7 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
                     type={showNewValue ? 'text' : 'password'}
                     value={newValue}
                     onChange={(e) => setNewValue(e.target.value)}
-                    placeholder="Secret value"
+                    placeholder={getValuePlaceholder(newType, newIsSecret)}
                     className="w-full bg-surface border border-border rounded-lg px-3 py-2 pr-10 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors"
                   />
                   <button

--- a/web/src/components/vault/variableTypeHelpers.ts
+++ b/web/src/components/vault/variableTypeHelpers.ts
@@ -45,3 +45,26 @@ export function validateVariableInput(
     }
   }
 }
+
+// getValuePlaceholder produces an input placeholder that mirrors what
+// validateVariableInput accepts: comma-separated for `list` (not a JSON
+// array), lowercase tokens for `bool`, etc. Visibility only changes the
+// `string` hint — for the structured types the format is the same whether
+// stored as a secret or in plaintext.
+export function getValuePlaceholder(
+  type: VariableType,
+  isSecret: boolean,
+): string {
+  switch (type) {
+    case 'string':
+      return isSecret ? 'secret value' : 'plaintext value';
+    case 'json':
+      return '{"key": "value"}';
+    case 'list':
+      return 'item1, item2, item3';
+    case 'number':
+      return '42';
+    case 'bool':
+      return 'true or false';
+  }
+}

--- a/web/src/components/wizard/VariablesPopover.tsx
+++ b/web/src/components/wizard/VariablesPopover.tsx
@@ -9,7 +9,7 @@ import { VariableVisibilityIcon } from '../vault/VariableVisibilityIcon';
 import { VariableTypeBadge } from '../vault/VariableTypeBadge';
 import { VariableTypeSelector } from '../vault/VariableTypeSelector';
 import { VariableSecretToggle } from '../vault/VariableSecretToggle';
-import { validateVariableInput } from '../vault/variableTypeHelpers';
+import { validateVariableInput, getValuePlaceholder } from '../vault/variableTypeHelpers';
 
 interface VariablesPopoverProps {
   onSelect: (reference: string) => void;
@@ -243,7 +243,7 @@ export function VariablesPopover({ onSelect, className }: VariablesPopoverProps)
               type={showValue || !newIsSecret ? 'text' : 'password'}
               value={newValue}
               onChange={(e) => setNewValue(e.target.value)}
-              placeholder="Variable value"
+              placeholder={getValuePlaceholder(newType, newIsSecret)}
               className="w-full bg-background/60 border border-border/40 rounded-lg px-3 py-1.5 pr-8 text-xs focus:outline-none focus:border-primary/50 text-text-primary placeholder:text-text-muted/50 transition-colors"
             />
             <button

--- a/web/src/pages/DetachedVaultPage.tsx
+++ b/web/src/pages/DetachedVaultPage.tsx
@@ -49,7 +49,7 @@ import { VariableTypeBadge } from '../components/vault/VariableTypeBadge';
 import { VariableVisibilityIcon } from '../components/vault/VariableVisibilityIcon';
 import { VariableTypeSelector } from '../components/vault/VariableTypeSelector';
 import { VariableSecretToggle } from '../components/vault/VariableSecretToggle';
-import { validateVariableInput } from '../components/vault/variableTypeHelpers';
+import { validateVariableInput, getValuePlaceholder } from '../components/vault/variableTypeHelpers';
 
 // Error boundary for detached window
 interface ErrorBoundaryState {
@@ -574,7 +574,7 @@ function DetachedVaultContent() {
                     type={showNewValue ? 'text' : 'password'}
                     value={newValue}
                     onChange={(e) => setNewValue(e.target.value)}
-                    placeholder="Secret value"
+                    placeholder={getValuePlaceholder(newType, newIsSecret)}
                     className="w-full bg-surface border border-border rounded-lg px-3 py-2 pr-10 text-xs font-mono text-text-primary log-text placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors"
                   />
                   <button


### PR DESCRIPTION
## Description

The variable creation form's value-input placeholder was a hardcoded string (`Secret value` in the vault forms, `Variable value` in the wizard popover) that never adapted to the selected type or visibility. Most visibly, it still read `Secret value` after the user picked `Plaintext` — directly contradicting their selection. Picking `list`, `json`, `number`, or `bool` also gave no hint about expected input format, which is a real footgun for `list` since the validator splits by comma rather than parsing JSON.

This PR adds a `getValuePlaceholder(type, isSecret)` helper next to the existing `validateVariableInput` validator (single source of truth for per-type input semantics) and wires it into all three form locations.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Add `getValuePlaceholder(type, isSecret)` helper in `web/src/components/vault/variableTypeHelpers.ts`. Visibility only affects the `string` hint; the structured types (`json`/`list`/`number`/`bool`) keep one format regardless of secret/plaintext.
- Wire helper into `VaultPanel.tsx`, `DetachedVaultPage.tsx`, and `VariablesPopover.tsx` (three forms; all previously hardcoded).
- Add `web/src/__tests__/VaultPanel.test.tsx` — new file covering all six type/visibility placeholder combinations. `VaultPanel` had no test foothold before.
- Extend `web/src/__tests__/VariablesPopover.test.tsx` with a parallel placeholder-adaptation describe block; update the existing literal `Variable value` assertion to the new computed default.
- Key-input placeholders (`KEY_NAME` / `VARIABLE_KEY`) are intentionally unchanged — the key naming convention is the same across types.

## Testing

- `cd web && npm test` — 593/593 passing (includes the new VaultPanel suite and extended VariablesPopover suite).
- `cd web && npm run build` — clean, no TS errors.
- Manual check: toggle every type/visibility combination on all three surfaces (right-side vault panel, `/var` detached page, wizard variable popover) and confirm the placeholder updates accordingly.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #671
