### PR TITLE
fix: stop popout button from closing its own window

### DIFF
--- a/web/src/__tests__/useWindowManager.test.tsx
+++ b/web/src/__tests__/useWindowManager.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useEffect } from 'react';
+import { useUIStore } from '../stores/useUIStore';
+import { useWindowManager } from '../hooks/useWindowManager';
+
+// A test harness that calls useWindowManager from inside a component which is
+// conditionally rendered based on useUIStore.sidebarOpen. This mirrors how
+// Sidebar / GatewaySidebar are mounted under TopologyWorkspace: when
+// openDetachedWindow('registry') flips sidebarOpen to false, this component
+// unmounts in the same commit. Before the fix, the unmount cleanup closed the
+// just-opened window. After the fix, the module-scope windowRefs survives the
+// unmount and the window stays open.
+function PopoutHarness({ onReady }: { onReady: (open: () => void) => void }) {
+  const { openDetachedWindow } = useWindowManager();
+  useEffect(() => {
+    onReady(() => openDetachedWindow('registry'));
+  }, [onReady, openDetachedWindow]);
+  return null;
+}
+
+function ConditionalHost({ onReady }: { onReady: (open: () => void) => void }) {
+  const sidebarOpen = useUIStore((s) => s.sidebarOpen);
+  return sidebarOpen ? <PopoutHarness onReady={onReady} /> : null;
+}
+
+const STARTING_STATE = {
+  sidebarOpen: true,
+  registryDetached: false,
+} as const;
+
+interface StubWindow {
+  closed: boolean;
+  focus: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  document: { title: string };
+}
+
+describe('useWindowManager.openDetachedWindow', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>;
+  let stubWindow: StubWindow;
+
+  beforeEach(() => {
+    useUIStore.setState({ ...STARTING_STATE });
+    stubWindow = {
+      closed: false,
+      focus: vi.fn(),
+      close: vi.fn(),
+      addEventListener: vi.fn(),
+      document: { title: '' },
+    };
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(stubWindow as unknown as Window);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Mark the stub as closed so the next test's existing-window check in
+    // openDetachedWindow (which reads module-scope windowRefs) sees it as
+    // gone and opens fresh.
+    stubWindow.closed = true;
+    vi.useRealTimers();
+    openSpy.mockRestore();
+  });
+
+  it('does not close the just-opened window when the caller unmounts', () => {
+    let openRegistry: (() => void) | null = null;
+    render(<ConditionalHost onReady={(open) => { openRegistry = open; }} />);
+
+    expect(openRegistry).not.toBeNull();
+
+    act(() => {
+      openRegistry!();
+    });
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith('/registry', 'gridctl-registry');
+
+    // Eager state flip should have run, which unmounts the harness via
+    // ConditionalHost's `sidebarOpen` gate.
+    expect(useUIStore.getState().registryDetached).toBe(true);
+    expect(useUIStore.getState().sidebarOpen).toBe(false);
+
+    // The regression we're guarding against: the unmount fires a cleanup
+    // that closes the window we just opened.
+    expect(stubWindow.close).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the eager state flip when window.open returns null (popup blocked)', () => {
+    openSpy.mockReturnValueOnce(null);
+
+    let openRegistry: (() => void) | null = null;
+    render(<ConditionalHost onReady={(open) => { openRegistry = open; }} />);
+
+    act(() => {
+      openRegistry!();
+    });
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(useUIStore.getState().registryDetached).toBe(false);
+    expect(useUIStore.getState().sidebarOpen).toBe(true);
+  });
+});

--- a/web/src/hooks/useWindowManager.ts
+++ b/web/src/hooks/useWindowManager.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { useUIStore } from '../stores/useUIStore';
 import { useBroadcastChannel, type BroadcastMessage } from './useBroadcastChannel';
 
@@ -14,9 +14,13 @@ const WINDOW_TITLES: Record<string, string> = {
 
 type DetachableWindow = 'logs' | 'sidebar' | 'editor' | 'registry' | 'metrics' | 'var' | 'traces';
 
-export function useWindowManager() {
-  const windowRefs = useRef<Map<string, Window | null>>(new Map());
+// Module-scope: detached windows live for the lifetime of the opener page,
+// not the lifetime of any particular component instance. A per-component ref
+// caused unmount cleanups to close windows that openDetachedWindow had only
+// just opened (the same call flips a UI flag that can unmount the caller).
+const windowRefs: Map<string, Window | null> = new Map();
 
+export function useWindowManager() {
   const setLogsDetached = useUIStore((s) => s.setLogsDetached);
   const setSidebarDetached = useUIStore((s) => s.setSidebarDetached);
   const setEditorDetached = useUIStore((s) => s.setEditorDetached);
@@ -67,7 +71,7 @@ export function useWindowManager() {
         } else if (payload?.windowType === 'traces') {
           setTracesDetached(false);
         }
-        windowRefs.current.delete(payload?.windowType ?? '');
+        windowRefs.delete(payload?.windowType ?? '');
       }
     }
   }, [setLogsDetached, setSidebarDetached, setEditorDetached, setRegistryDetached, setMetricsDetached, setVaultDetached, setTracesDetached, setBottomPanelOpen, setSidebarOpen]);
@@ -78,7 +82,7 @@ export function useWindowManager() {
 
   // Open a detached window
   const openDetachedWindow = useCallback((type: DetachableWindow, params?: string) => {
-    const existingWindow = windowRefs.current.get(type);
+    const existingWindow = windowRefs.get(type);
     if (existingWindow && !existingWindow.closed) {
       existingWindow.focus();
       return;
@@ -108,46 +112,68 @@ export function useWindowManager() {
     const url = params ? `/${type}?${params}` : `/${type}`;
     const newWindow = window.open(url, `gridctl-${type}`);
 
-    if (newWindow) {
-      windowRefs.current.set(type, newWindow);
-
-      // Update title after load
-      newWindow.addEventListener('load', () => {
-        newWindow.document.title = WINDOW_TITLES[type];
-      });
-
-      // Track window close
-      const checkClosed = setInterval(() => {
-        if (newWindow.closed) {
-          clearInterval(checkClosed);
-          windowRefs.current.delete(type);
-          if (type === 'logs') {
-            setLogsDetached(false);
-          } else if (type === 'sidebar') {
-            setSidebarDetached(false);
-          } else if (type === 'editor') {
-            setEditorDetached(false);
-          } else if (type === 'registry') {
-            setRegistryDetached(false);
-          } else if (type === 'metrics') {
-            setMetricsDetached(false);
-          } else if (type === 'var') {
-            setVaultDetached(false);
-          } else if (type === 'traces') {
-            setTracesDetached(false);
-          }
-        }
-      }, 500);
+    if (!newWindow) {
+      // Popup blocked or otherwise refused. Roll back the eager state flip so
+      // the user still sees the source panel.
+      if (type === 'logs') {
+        setLogsDetached(false);
+        setBottomPanelOpen(true);
+      } else if (type === 'sidebar') {
+        setSidebarDetached(false);
+        setSidebarOpen(true);
+      } else if (type === 'editor') {
+        setEditorDetached(false);
+      } else if (type === 'registry') {
+        setRegistryDetached(false);
+        setSidebarOpen(true);
+      } else if (type === 'metrics') {
+        setMetricsDetached(false);
+      } else if (type === 'var') {
+        setVaultDetached(false);
+      } else if (type === 'traces') {
+        setTracesDetached(false);
+      }
+      return;
     }
+
+    windowRefs.set(type, newWindow);
+
+    // Update title after load
+    newWindow.addEventListener('load', () => {
+      newWindow.document.title = WINDOW_TITLES[type];
+    });
+
+    // Track window close
+    const checkClosed = setInterval(() => {
+      if (newWindow.closed) {
+        clearInterval(checkClosed);
+        windowRefs.delete(type);
+        if (type === 'logs') {
+          setLogsDetached(false);
+        } else if (type === 'sidebar') {
+          setSidebarDetached(false);
+        } else if (type === 'editor') {
+          setEditorDetached(false);
+        } else if (type === 'registry') {
+          setRegistryDetached(false);
+        } else if (type === 'metrics') {
+          setMetricsDetached(false);
+        } else if (type === 'var') {
+          setVaultDetached(false);
+        } else if (type === 'traces') {
+          setTracesDetached(false);
+        }
+      }
+    }, 500);
   }, [setLogsDetached, setSidebarDetached, setEditorDetached, setRegistryDetached, setMetricsDetached, setVaultDetached, setTracesDetached, setBottomPanelOpen, setSidebarOpen]);
 
   // Close a detached window
   const closeDetachedWindow = useCallback((type: DetachableWindow) => {
-    const existingWindow = windowRefs.current.get(type);
+    const existingWindow = windowRefs.get(type);
     if (existingWindow && !existingWindow.closed) {
       existingWindow.close();
     }
-    windowRefs.current.delete(type);
+    windowRefs.delete(type);
   }, []);
 
   // Notify detached windows of state changes
@@ -167,19 +193,6 @@ export function useWindowManager() {
       source: 'main',
     });
   }, [postMessage]);
-
-  // Clean up on unmount
-  useEffect(() => {
-    const refs = windowRefs.current;
-    return () => {
-      refs.forEach((win) => {
-        if (win && !win.closed) {
-          win.close();
-        }
-      });
-      refs.clear();
-    };
-  }, []);
 
   return {
     openDetachedWindow,


### PR DESCRIPTION
## Description

The "Open in new tab" popout button in the right-hand sidebar (gateway / node detail) was opening a window and then immediately closing it. The same call that opens the window also flips `setSidebarOpen(false)`, which unmounts the calling component; the hook's per-component unmount cleanup then closed the just-opened window before its first paint.

Fix: hoist `windowRefs` from a per-component `useRef` to a module-scope `Map`, drop the unmount cleanup, and roll back the eager state flip when `window.open` returns `null` (popup blocked) so the source panel does not end up collapsed with nothing to show for it.

## Type of Change

- [x] Bug fix

## Changes Made

- Hoist `windowRefs` to module scope in `web/src/hooks/useWindowManager.ts`; remove the unmount-cleanup `useEffect` that was calling `close()` on tracked windows.
- Add a `null`-return rollback path on `window.open` that restores the source panel state per detach type.
- Add regression test `web/src/__tests__/useWindowManager.test.tsx` covering (1) the unmount-doesn't-close-window case and (2) the popup-blocked state rollback.

## Testing

- `cd web && npm test` — 595/595 tests pass across 55 files (including the new test).
- `cd web && npm run build` — typecheck + vite build clean.
- Manual repro on the gateway detail sidebar before the fix: tab flashes and disappears. After the fix: tab opens and stays.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #673