### PR TITLE
feat: add Library workspace and rename Skills tab to Stage

### DIFF
--- a/web/src/__tests__/GatewayPanel.test.tsx
+++ b/web/src/__tests__/GatewayPanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 
 // Mock dependencies before imports
@@ -10,35 +11,11 @@ vi.mock('../stores/useStackStore', () => ({
   })),
 }));
 
-vi.mock('../stores/useUIStore', () => ({
-  useUIStore: vi.fn((selector) => selector({
-    registryDetached: false,
-    setSidebarOpen: mockSetSidebarOpen,
+vi.mock('../stores/useRegistryStore', () => ({
+  useRegistryStore: vi.fn((selector) => selector({
+    skills: [],
   })),
 }));
-
-vi.mock('../hooks/useWindowManager', () => ({
-  useWindowManager: () => ({
-    openDetachedWindow: mockOpenDetachedWindow,
-  }),
-}));
-
-vi.mock('../components/registry/RegistrySidebar', () => ({
-  RegistrySidebar: ({ embedded }: { embedded?: boolean }) => (
-    <div data-testid="registry-sidebar" data-embedded={embedded} />
-  ),
-}));
-
-vi.mock('../components/ui/PopoutButton', () => ({
-  PopoutButton: ({ onClick, disabled }: { onClick: () => void; disabled?: boolean }) => (
-    <button data-testid="popout-button" onClick={onClick} disabled={disabled}>
-      Popout
-    </button>
-  ),
-}));
-
-const mockSetSidebarOpen = vi.fn();
-const mockOpenDetachedWindow = vi.fn();
 
 import { GatewaySidebar } from '../components/gateway/GatewaySidebar';
 import { useSelectedNodeData } from '../stores/useStackStore';
@@ -69,45 +46,42 @@ function makeGatewayData(overrides: Partial<GatewayNodeData> = {}): GatewayNodeD
   };
 }
 
+function renderWithRouter(ui: React.ReactNode) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
 describe('GatewaySidebar', () => {
   it('renders gateway name from selected node', () => {
     vi.mocked(useSelectedNodeData).mockReturnValue(makeGatewayData({ name: 'my-gateway' }));
-    render(<GatewaySidebar onClose={vi.fn()} />);
+    renderWithRouter(<GatewaySidebar onClose={vi.fn()} />);
     expect(screen.getByText('my-gateway')).toBeInTheDocument();
   });
 
   it('renders version from selected node', () => {
     vi.mocked(useSelectedNodeData).mockReturnValue(makeGatewayData({ version: 'v0.2.0' }));
-    render(<GatewaySidebar onClose={vi.fn()} />);
+    renderWithRouter(<GatewaySidebar onClose={vi.fn()} />);
     expect(screen.getByText('v0.2.0')).toBeInTheDocument();
   });
 
   it('shows fallback name when no node selected', () => {
     vi.mocked(useSelectedNodeData).mockReturnValue(undefined);
-    render(<GatewaySidebar onClose={vi.fn()} />);
+    renderWithRouter(<GatewaySidebar onClose={vi.fn()} />);
     expect(screen.getByText('Gateway')).toBeInTheDocument();
   });
 
-  it('renders embedded RegistrySidebar', () => {
+  it('renders a Manage Skills link pointing to /library', () => {
     vi.mocked(useSelectedNodeData).mockReturnValue(makeGatewayData());
-    render(<GatewaySidebar onClose={vi.fn()} />);
-    const registry = screen.getByTestId('registry-sidebar');
-    expect(registry).toBeInTheDocument();
-    expect(registry).toHaveAttribute('data-embedded', 'true');
+    renderWithRouter(<GatewaySidebar onClose={vi.fn()} />);
+    const link = screen.getByRole('link', { name: /manage skills/i });
+    expect(link).toHaveAttribute('href', '/library');
   });
 
   it('calls onClose when close button clicked', () => {
     vi.mocked(useSelectedNodeData).mockReturnValue(makeGatewayData());
     const onClose = vi.fn();
-    render(<GatewaySidebar onClose={onClose} />);
+    renderWithRouter(<GatewaySidebar onClose={onClose} />);
 
     fireEvent.click(screen.getByLabelText('Close gateway sidebar'));
     expect(onClose).toHaveBeenCalledOnce();
-  });
-
-  it('renders popout button', () => {
-    vi.mocked(useSelectedNodeData).mockReturnValue(makeGatewayData());
-    render(<GatewaySidebar onClose={vi.fn()} />);
-    expect(screen.getByTestId('popout-button')).toBeInTheDocument();
   });
 });

--- a/web/src/__tests__/GatewaySidebar.test.tsx
+++ b/web/src/__tests__/GatewaySidebar.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { GatewaySidebar } from '../components/gateway/GatewaySidebar';
+import { useRegistryStore } from '../stores/useRegistryStore';
+import { useStackStore } from '../stores/useStackStore';
+import type { AgentSkill } from '../types';
+
+const SAMPLE_SKILLS: AgentSkill[] = [
+  // @ts-expect-error partial AgentSkill is fine for the test
+  { name: 'a', state: 'active', dir: 'a', fileCount: 1 },
+  // @ts-expect-error partial AgentSkill is fine for the test
+  { name: 'b', state: 'draft', dir: 'b', fileCount: 1 },
+  // @ts-expect-error partial AgentSkill is fine for the test
+  { name: 'c', state: 'disabled', dir: 'c', fileCount: 1 },
+];
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter>
+      <GatewaySidebar onClose={() => {}} />
+    </MemoryRouter>,
+  );
+}
+
+describe('GatewaySidebar', () => {
+  beforeEach(() => {
+    useStackStore.setState({ selectedNodeId: null });
+    useRegistryStore.setState({ skills: SAMPLE_SKILLS });
+  });
+
+  it('renders a "Manage Skills" link pointing to /library', () => {
+    renderSidebar();
+    const link = screen.getByRole('link', { name: /manage skills/i });
+    expect(link).toHaveAttribute('href', '/library');
+  });
+
+  it('includes the live skill count in the CTA label', () => {
+    renderSidebar();
+    const link = screen.getByRole('link', { name: /manage skills/i });
+    expect(link.textContent).toContain('(3)');
+  });
+
+  it('omits the count when skills have not loaded yet', () => {
+    useRegistryStore.setState({ skills: null });
+    renderSidebar();
+    const link = screen.getByRole('link', { name: /manage skills/i });
+    expect(link.textContent).not.toMatch(/\(\d+\)/);
+  });
+});

--- a/web/src/__tests__/LibraryRoutes.test.tsx
+++ b/web/src/__tests__/LibraryRoutes.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <span data-testid="location">{loc.pathname}</span>;
+}
+
+// Local re-declaration of the redirect logic from src/routes.tsx so the test
+// stays focused on the redirect behavior without pulling in AppShell + all
+// the lazy-loaded workspaces (which require the full polling/store wiring).
+function TestRoutes() {
+  return (
+    <Routes>
+      <Route path="/library-window" element={
+        <>
+          <div data-testid="library-window-page">library-window</div>
+          <LocationProbe />
+        </>
+      } />
+      <Route path="/registry" element={<Navigate to="/library-window" replace />} />
+    </Routes>
+  );
+}
+
+describe('Library detached route redirect', () => {
+  it('redirects /registry → /library-window', () => {
+    render(
+      <MemoryRouter initialEntries={['/registry']}>
+        <TestRoutes />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('library-window-page')).toBeInTheDocument();
+    expect(screen.getByTestId('location').textContent).toBe('/library-window');
+  });
+
+  it('serves /library-window directly without redirecting', () => {
+    render(
+      <MemoryRouter initialEntries={['/library-window']}>
+        <TestRoutes />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('library-window-page')).toBeInTheDocument();
+    expect(screen.getByTestId('location').textContent).toBe('/library-window');
+  });
+});

--- a/web/src/__tests__/LibraryWorkspace.test.tsx
+++ b/web/src/__tests__/LibraryWorkspace.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { LibraryWorkspace } from '../components/workspaces/LibraryWorkspace';
+import { useRegistryStore } from '../stores/useRegistryStore';
+import { showToast } from '../components/ui/Toast';
+import { CommandRegistryProvider } from '../hooks/useCommandRegistry';
+import type { AgentSkill } from '../types';
+
+vi.mock('../components/ui/Toast', () => ({
+  showToast: vi.fn(),
+  ToastContainer: () => null,
+}));
+
+vi.mock('../lib/api', () => ({
+  fetchRegistryStatus: vi.fn().mockResolvedValue({ totalSkills: 0, activeSkills: 0 }),
+  fetchRegistrySkills: vi.fn().mockResolvedValue([]),
+  activateRegistrySkill: vi.fn().mockResolvedValue(undefined),
+  disableRegistrySkill: vi.fn().mockResolvedValue(undefined),
+  deleteRegistrySkill: vi.fn().mockResolvedValue(undefined),
+}));
+
+// SkillEditor is heavy and unrelated to the workspace's URL-state behavior.
+// Stub so we can detect "mounted with this skill".
+vi.mock('../components/registry/SkillEditor', () => ({
+  SkillEditor: ({ isOpen, skill, onClose }: { isOpen: boolean; skill?: AgentSkill; onClose: () => void }) =>
+    isOpen ? (
+      <div data-testid="skill-editor">
+        <span data-testid="editing-skill-name">{skill?.name ?? ''}</span>
+        <button onClick={onClose}>close-editor</button>
+      </div>
+    ) : null,
+}));
+
+const SAMPLE_SKILLS: AgentSkill[] = [
+  // @ts-expect-error partial AgentSkill is fine for the test
+  { name: 'incident-triage', description: 'triage incidents', state: 'active', dir: 'ops', fileCount: 1 },
+  // @ts-expect-error partial AgentSkill is fine for the test
+  { name: 'draft-summarizer', description: 'summarize drafts', state: 'draft', dir: 'tools', fileCount: 1 },
+  // @ts-expect-error partial AgentSkill is fine for the test
+  { name: 'disabled-skill', description: 'paused', state: 'disabled', dir: 'archive', fileCount: 1 },
+];
+
+function LocationProbe({ onChange }: { onChange: (search: string) => void }) {
+  const location = useLocation();
+  onChange(location.search);
+  return null;
+}
+
+function renderAt(path: string, onLocationChange?: (search: string) => void) {
+  return render(
+    <CommandRegistryProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/library" element={
+            <>
+              <LibraryWorkspace />
+              {onLocationChange && <LocationProbe onChange={onLocationChange} />}
+            </>
+          } />
+          <Route path="/library/:skillName" element={
+            <>
+              <LibraryWorkspace />
+              {onLocationChange && <LocationProbe onChange={onLocationChange} />}
+            </>
+          } />
+        </Routes>
+      </MemoryRouter>
+    </CommandRegistryProvider>,
+  );
+}
+
+describe('LibraryWorkspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useRegistryStore.setState({ skills: SAMPLE_SKILLS, status: { totalSkills: 3, activeSkills: 1 } });
+  });
+
+  it('renders the skill grid with all skills when filter is all', () => {
+    renderAt('/library');
+    expect(screen.getByText('incident-triage')).toBeInTheDocument();
+    expect(screen.getByText('draft-summarizer')).toBeInTheDocument();
+    expect(screen.getByText('disabled-skill')).toBeInTheDocument();
+  });
+
+  it('restores search query from URL ?q= on initial render', () => {
+    renderAt('/library?q=incident');
+    const input = screen.getByLabelText('Filter skills') as HTMLInputElement;
+    expect(input.value).toBe('incident');
+  });
+
+  it('restores filter from URL ?filter= on initial render', () => {
+    renderAt('/library?filter=draft');
+    expect(screen.getByText('draft-summarizer')).toBeInTheDocument();
+    expect(screen.queryByText('incident-triage')).not.toBeInTheDocument();
+  });
+
+  it('updates the URL when the user types in the search box', async () => {
+    let currentSearch = '';
+    renderAt('/library', (s) => { currentSearch = s; });
+    const input = screen.getByLabelText('Filter skills') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'incident' } });
+    await waitFor(() => {
+      expect(currentSearch).toContain('q=incident');
+    });
+  });
+
+  it('mounts the editor for /library/:skillName when the skill exists', async () => {
+    renderAt('/library/incident-triage');
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-editor')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('editing-skill-name').textContent).toBe('incident-triage');
+  });
+
+  it('toasts when /library/:skillName names an unknown skill', async () => {
+    renderAt('/library/never-existed');
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith('error', expect.stringContaining('never-existed'));
+    });
+  });
+
+  it('does not fire the not-found toast while the registry is still loading', () => {
+    useRegistryStore.setState({ skills: null });
+    renderAt('/library/never-existed');
+    expect(showToast).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/WorkspaceSwitcher.test.tsx
+++ b/web/src/__tests__/WorkspaceSwitcher.test.tsx
@@ -13,25 +13,36 @@ function renderAt(path: string) {
 }
 
 describe('WorkspaceSwitcher', () => {
-  it('renders three workspace pills inside a tablist', () => {
+  it('renders four workspace pills inside a tablist in the configured order', () => {
     renderAt('/topology');
     const tablist = screen.getByRole('tablist', { name: /workspace/i });
     expect(tablist).toBeInTheDocument();
-    expect(screen.getAllByRole('tab')).toHaveLength(3);
-    expect(screen.getByRole('tab', { name: 'Topology' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Skills' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Runs' })).toBeInTheDocument();
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs).toHaveLength(4);
+    expect(tabs.map((t) => t.textContent?.trim())).toEqual([
+      'Topology',
+      'Stage',
+      'Library',
+      'Runs',
+    ]);
   });
 
   it('marks the active workspace with aria-selected=true and others false', () => {
     renderAt('/skills');
     const topology = screen.getByRole('tab', { name: 'Topology' });
-    const skills = screen.getByRole('tab', { name: 'Skills' });
+    const stage = screen.getByRole('tab', { name: 'Stage' });
+    const library = screen.getByRole('tab', { name: 'Library' });
     const runs = screen.getByRole('tab', { name: 'Runs' });
 
-    expect(skills).toHaveAttribute('aria-selected', 'true');
+    expect(stage).toHaveAttribute('aria-selected', 'true');
     expect(topology).toHaveAttribute('aria-selected', 'false');
+    expect(library).toHaveAttribute('aria-selected', 'false');
     expect(runs).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('marks the Library pill active for /library and deep-link paths', () => {
+    renderAt('/library/incident-triage');
+    expect(screen.getByRole('tab', { name: 'Library' })).toHaveAttribute('aria-selected', 'true');
   });
 
   it('treats nested workspace paths as active', () => {
@@ -42,7 +53,8 @@ describe('WorkspaceSwitcher', () => {
   it('links each pill to its workspace route', () => {
     renderAt('/topology');
     expect(screen.getByRole('tab', { name: 'Topology' })).toHaveAttribute('href', '/topology');
-    expect(screen.getByRole('tab', { name: 'Skills' })).toHaveAttribute('href', '/skills');
+    expect(screen.getByRole('tab', { name: 'Stage' })).toHaveAttribute('href', '/skills');
+    expect(screen.getByRole('tab', { name: 'Library' })).toHaveAttribute('href', '/library');
     expect(screen.getByRole('tab', { name: 'Runs' })).toHaveAttribute('href', '/runs');
   });
 });

--- a/web/src/__tests__/useKeyboardShortcuts.test.tsx
+++ b/web/src/__tests__/useKeyboardShortcuts.test.tsx
@@ -24,10 +24,18 @@ describe('useKeyboardShortcuts — workspace navigation', () => {
     expect(onSwitchToWorkspace).toHaveBeenCalledWith('skills');
   });
 
-  it('⌘3 calls onSwitchToWorkspace with "runs"', () => {
+  it('⌘3 calls onSwitchToWorkspace with "library"', () => {
     const onSwitchToWorkspace = vi.fn();
     renderHook(() => useKeyboardShortcuts({ onSwitchToWorkspace }));
     fireMod('3');
+    expect(onSwitchToWorkspace).toHaveBeenCalledTimes(1);
+    expect(onSwitchToWorkspace).toHaveBeenCalledWith('library');
+  });
+
+  it('⌘4 calls onSwitchToWorkspace with "runs"', () => {
+    const onSwitchToWorkspace = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onSwitchToWorkspace }));
+    fireMod('4');
     expect(onSwitchToWorkspace).toHaveBeenCalledTimes(1);
     expect(onSwitchToWorkspace).toHaveBeenCalledWith('runs');
   });

--- a/web/src/__tests__/useUIStore-workspace.test.ts
+++ b/web/src/__tests__/useUIStore-workspace.test.ts
@@ -22,7 +22,7 @@ describe('useUIStore workspace slice', () => {
 
   it('setActiveWorkspace cycles through every workspace', () => {
     const { result } = renderHook(() => useUIStore((s) => s.activeWorkspace));
-    for (const ws of ['topology', 'skills', 'runs'] as const) {
+    for (const ws of ['topology', 'skills', 'library', 'runs'] as const) {
       act(() => {
         useUIStore.getState().setActiveWorkspace(ws);
       });
@@ -36,10 +36,11 @@ describe('useUIStore compact mode slice', () => {
     useUIStore.setState({ compactMode: { ...COMPACT_MODE_DEFAULTS } });
   });
 
-  it('defaults compactMode to skills-on, topology/runs-off', () => {
+  it('defaults compactMode to skills-on, others-off', () => {
     const state = useUIStore.getState();
     expect(state.compactMode.skills).toBe(true);
     expect(state.compactMode.topology).toBe(false);
+    expect(state.compactMode.library).toBe(false);
     expect(state.compactMode.runs).toBe(false);
   });
 
@@ -50,19 +51,21 @@ describe('useUIStore compact mode slice', () => {
     const state = useUIStore.getState();
     expect(state.compactMode.topology).toBe(true);
     expect(state.compactMode.skills).toBe(true);
+    expect(state.compactMode.library).toBe(false);
     expect(state.compactMode.runs).toBe(false);
   });
 
   it('toggleCompactMode flips only the targeted workspace', () => {
     act(() => {
-      useUIStore.getState().toggleCompactMode('skills');
+      useUIStore.getState().toggleCompactMode('library');
     });
-    expect(useUIStore.getState().compactMode.skills).toBe(false);
+    expect(useUIStore.getState().compactMode.library).toBe(true);
     act(() => {
-      useUIStore.getState().toggleCompactMode('skills');
+      useUIStore.getState().toggleCompactMode('library');
     });
-    expect(useUIStore.getState().compactMode.skills).toBe(true);
+    expect(useUIStore.getState().compactMode.library).toBe(false);
     // Other workspaces unaffected.
     expect(useUIStore.getState().compactMode.topology).toBe(false);
+    expect(useUIStore.getState().compactMode.skills).toBe(true);
   });
 });

--- a/web/src/__tests__/useWindowManager.test.tsx
+++ b/web/src/__tests__/useWindowManager.test.tsx
@@ -75,7 +75,9 @@ describe('useWindowManager.openDetachedWindow', () => {
     });
 
     expect(openSpy).toHaveBeenCalledTimes(1);
-    expect(openSpy).toHaveBeenCalledWith('/registry', 'gridctl-registry');
+    // The 'registry' window key now points at /library-window after the
+    // workspace promotion; the key itself stays for back-compat.
+    expect(openSpy).toHaveBeenCalledWith('/library-window', 'gridctl-registry');
 
     // Eager state flip should have run, which unmounts the harness via
     // ConditionalHost's `sidebarOpen` gate.

--- a/web/src/components/gateway/GatewaySidebar.tsx
+++ b/web/src/components/gateway/GatewaySidebar.tsx
@@ -1,12 +1,10 @@
 import { memo, useState } from 'react';
-import { Activity, ChevronDown, ChevronRight, Lightbulb, X } from 'lucide-react';
-import { RegistrySidebar } from '../registry/RegistrySidebar';
+import { Link } from 'react-router-dom';
+import { Activity, ArrowRight, ChevronDown, ChevronRight, Library, Lightbulb, X } from 'lucide-react';
 import { OptimizeSection } from '../sidebar/OptimizeSection';
-import { PopoutButton } from '../ui/PopoutButton';
 import { cn } from '../../lib/cn';
 import { useSelectedNodeData } from '../../stores/useStackStore';
-import { useUIStore } from '../../stores/useUIStore';
-import { useWindowManager } from '../../hooks/useWindowManager';
+import { useRegistryStore } from '../../stores/useRegistryStore';
 import type { GatewayNodeData } from '../../types';
 
 interface GatewaySidebarProps {
@@ -15,12 +13,9 @@ interface GatewaySidebarProps {
 
 const GatewaySidebar = memo(({ onClose }: GatewaySidebarProps) => {
   const selectedData = useSelectedNodeData() as GatewayNodeData | null;
-  const registryDetached = useUIStore((s) => s.registryDetached);
-  const { openDetachedWindow } = useWindowManager();
-
-  const handlePopout = () => {
-    openDetachedWindow('registry');
-  };
+  const skills = useRegistryStore((s) => s.skills);
+  // null = not loaded; render the CTA without a count badge as a skeleton.
+  const skillCount = skills?.length ?? null;
 
   return (
     <div className="h-full w-full flex flex-col overflow-hidden">
@@ -42,23 +37,41 @@ const GatewaySidebar = memo(({ onClose }: GatewaySidebarProps) => {
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-1">
-          <PopoutButton
-            onClick={handlePopout}
-            disabled={registryDetached}
-          />
-          <button onClick={onClose} aria-label="Close gateway sidebar" className="p-1.5 rounded-lg hover:bg-surface-highlight transition-colors group">
-            <X size={16} className="text-text-muted group-hover:text-text-primary transition-colors" />
-          </button>
-        </div>
+        <button onClick={onClose} aria-label="Close gateway sidebar" className="p-1.5 rounded-lg hover:bg-surface-highlight transition-colors group">
+          <X size={16} className="text-text-muted group-hover:text-text-primary transition-colors" />
+        </button>
       </div>
 
-      {/* Registry section */}
       <div className="flex-1 overflow-y-auto scrollbar-dark">
         <CollapsibleSection title="Optimize" icon={Lightbulb}>
           <OptimizeSection />
         </CollapsibleSection>
-        <RegistrySidebar embedded />
+
+        <div className="p-4 border-b border-border/30">
+          <Link
+            to="/library"
+            className={cn(
+              'group flex items-center justify-between w-full px-3 py-2.5 rounded-lg',
+              'bg-surface-elevated/40 hover:bg-surface-highlight/60 border border-border/40 hover:border-primary/30',
+              'transition-colors',
+            )}
+          >
+            <div className="flex items-center gap-2.5">
+              <div className="p-1.5 rounded-md bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
+                <Library size={12} className="text-primary" />
+              </div>
+              <span className="text-xs font-medium text-text-primary">
+                Manage Skills
+                {skillCount !== null && (
+                  <span className="ml-1.5 text-[10px] text-text-muted font-mono">
+                    ({skillCount})
+                  </span>
+                )}
+              </span>
+            </div>
+            <ArrowRight size={12} className="text-text-muted group-hover:text-primary transition-colors" />
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/library/useLibraryCommands.ts
+++ b/web/src/components/library/useLibraryCommands.ts
@@ -1,0 +1,115 @@
+import { useEffect } from 'react';
+import { createElement } from 'react';
+import {
+  CheckCircle2,
+  ExternalLink,
+  FileText,
+  List,
+  Plus,
+  PowerOff,
+  RefreshCw,
+} from 'lucide-react';
+import { useCommandRegistry } from '../../hooks/useCommandRegistry';
+import type { PaletteCommand } from '../../types/palette';
+
+export type LibraryFilter = 'all' | 'active' | 'draft' | 'disabled';
+
+interface UseLibraryCommandsOptions {
+  onNewSkill: () => void;
+  onRefresh: () => void;
+  onShowAll: () => void;
+  onFilter: (filter: LibraryFilter) => void;
+  onOpenInNewWindow: () => void;
+}
+
+/**
+ * Workspace-scoped palette commands for /library. Registered on mount,
+ * unregistered on unmount — so Topology, Stage, and Runs never see them.
+ */
+export function useLibraryCommands({
+  onNewSkill,
+  onRefresh,
+  onShowAll,
+  onFilter,
+  onOpenInNewWindow,
+}: UseLibraryCommandsOptions): void {
+  const { registerCommands, unregisterCommands } = useCommandRegistry();
+
+  useEffect(() => {
+    const commands: PaletteCommand[] = [
+      {
+        id: 'library:new-skill',
+        label: 'Library: New Skill',
+        section: 'registry',
+        workspaces: ['library'],
+        icon: createElement(Plus, { size: 14 }),
+        keywords: ['create', 'add', 'skill', 'new'],
+        onSelect: onNewSkill,
+      },
+      {
+        id: 'library:refresh',
+        label: 'Library: Refresh',
+        section: 'registry',
+        workspaces: ['library'],
+        icon: createElement(RefreshCw, { size: 14 }),
+        keywords: ['reload', 'rescan', 'refresh'],
+        onSelect: onRefresh,
+      },
+      {
+        id: 'library:show-all',
+        label: 'Library: Show All',
+        section: 'registry',
+        workspaces: ['library'],
+        icon: createElement(List, { size: 14 }),
+        keywords: ['clear', 'filter', 'reset', 'all'],
+        onSelect: onShowAll,
+      },
+      {
+        id: 'library:filter-active',
+        label: 'Library: Filter Active',
+        section: 'registry',
+        workspaces: ['library'],
+        icon: createElement(CheckCircle2, { size: 14 }),
+        keywords: ['filter', 'active', 'enabled'],
+        onSelect: () => onFilter('active'),
+      },
+      {
+        id: 'library:filter-draft',
+        label: 'Library: Filter Draft',
+        section: 'registry',
+        workspaces: ['library'],
+        icon: createElement(FileText, { size: 14 }),
+        keywords: ['filter', 'draft', 'unfinished'],
+        onSelect: () => onFilter('draft'),
+      },
+      {
+        id: 'library:filter-disabled',
+        label: 'Library: Filter Disabled',
+        section: 'registry',
+        workspaces: ['library'],
+        icon: createElement(PowerOff, { size: 14 }),
+        keywords: ['filter', 'disabled', 'inactive', 'off'],
+        onSelect: () => onFilter('disabled'),
+      },
+      {
+        id: 'library:open-new-window',
+        label: 'Library: Open in New Window',
+        section: 'registry',
+        workspaces: ['library'],
+        icon: createElement(ExternalLink, { size: 14 }),
+        keywords: ['popout', 'window', 'detach', 'tab'],
+        onSelect: onOpenInNewWindow,
+      },
+    ];
+    registerCommands('library', commands);
+    return () => unregisterCommands('library');
+  }, [
+    registerCommands,
+    unregisterCommands,
+    onNewSkill,
+    onRefresh,
+    onShowAll,
+    onFilter,
+    onOpenInNewWindow,
+  ]);
+}

--- a/web/src/components/registry/LibraryGrid.tsx
+++ b/web/src/components/registry/LibraryGrid.tsx
@@ -1,0 +1,135 @@
+import { cn } from '../../lib/cn';
+import { SkillCard } from './SkillCard';
+import type { AgentSkill } from '../../types';
+
+function getGroupKey(dir?: string): string {
+  if (!dir) return '';
+  return dir.split('/')[0];
+}
+
+function groupSkills(skills: AgentSkill[]): Map<string, AgentSkill[]> {
+  const groups = new Map<string, AgentSkill[]>();
+  for (const skill of skills) {
+    const key = getGroupKey(skill.dir);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(skill);
+  }
+  return groups;
+}
+
+function toTitleCase(key: string): string {
+  return key.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export interface LibraryGridProps {
+  skills: AgentSkill[];
+  hasSearch: boolean;
+  onEnable: (skill: AgentSkill) => void;
+  onDisable: (skill: AgentSkill) => void;
+  onEdit: (skill: AgentSkill) => void;
+  onDelete: (skill: AgentSkill) => void;
+  className?: string;
+}
+
+/**
+ * Card grid used by both the in-app Library workspace and the detached
+ * /library-window page. Groups skills by their top-level directory when the
+ * structure is meaningful (2+ groups with at least one populated group);
+ * otherwise renders a flat grid so single-skill "groups" don't waste a
+ * full-width header.
+ */
+export function LibraryGrid({
+  skills,
+  hasSearch,
+  onEnable,
+  onDisable,
+  onEdit,
+  onDelete,
+  className,
+}: LibraryGridProps) {
+  const groups = groupSkills(skills);
+  const hasMeaningfulGrouping =
+    groups.size > 1 && Array.from(groups.values()).some((g) => g.length > 1);
+
+  const gridStyle: React.CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+    gap: '12px',
+  };
+
+  if (!hasMeaningfulGrouping) {
+    return (
+      <div className={cn('p-4', className)} style={gridStyle}>
+        {skills.map((skill, i) => (
+          <SkillCard
+            key={skill.name}
+            skill={skill}
+            className={cn('motion-safe:animate-fade-in-scale', skill.metadata?.colspan === '2' ? 'col-span-2' : undefined)}
+            style={{ animationDelay: `${Math.min(i, 10) * 30}ms` }}
+            onEnable={onEnable}
+            onDisable={onDisable}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('p-4', className)} style={gridStyle}>
+      {Array.from(groups.entries()).map(([key, groupSkillList]) => (
+        <GroupSection
+          key={key || '__ungrouped__'}
+          groupKey={key}
+          skills={groupSkillList}
+          hasSearch={hasSearch}
+          onEnable={onEnable}
+          onDisable={onDisable}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface GroupSectionProps {
+  groupKey: string;
+  skills: AgentSkill[];
+  hasSearch: boolean;
+  onEnable: (skill: AgentSkill) => void;
+  onDisable: (skill: AgentSkill) => void;
+  onEdit: (skill: AgentSkill) => void;
+  onDelete: (skill: AgentSkill) => void;
+}
+
+function GroupSection({ groupKey, skills, hasSearch, onEnable, onDisable, onEdit, onDelete }: GroupSectionProps) {
+  return (
+    <>
+      <div style={{ gridColumn: '1 / -1' }} className="flex flex-col gap-1 mt-2 first:mt-0 animate-fade-in-scale">
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] uppercase tracking-widest text-text-muted font-medium">
+            {groupKey ? toTitleCase(groupKey) : 'Other'}
+          </span>
+          <span className="text-[10px] px-1.5 rounded-full bg-surface-highlight text-text-muted">
+            {skills.length} {hasSearch ? 'matched' : 'skills'}
+          </span>
+        </div>
+        <div className="border-b border-border/30" />
+      </div>
+      {skills.map((skill, i) => (
+        <SkillCard
+          key={skill.name}
+          skill={skill}
+          className={cn('motion-safe:animate-fade-in-scale', skill.metadata?.colspan === '2' ? 'col-span-2' : undefined)}
+          style={{ animationDelay: `${Math.min(i, 10) * 30}ms` }}
+          onEnable={onEnable}
+          onDisable={onDisable}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      ))}
+    </>
+  );
+}

--- a/web/src/components/shell/AppShell.tsx
+++ b/web/src/components/shell/AppShell.tsx
@@ -59,7 +59,6 @@ function AppShellInner() {
 
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
   const toggleBottomPanel = useUIStore((s) => s.toggleBottomPanel);
-  const setBottomPanelTab = useUIStore((s) => s.setBottomPanelTab);
   const bottomPanelOpen = useUIStore((s) => s.bottomPanelOpen);
   const commandPaletteOpen = useUIStore((s) => s.commandPaletteOpen);
   const setCommandPaletteOpen = useUIStore((s) => s.setCommandPaletteOpen);
@@ -100,8 +99,9 @@ function AppShellInner() {
     });
   }, []);
 
-  // Keyboard shortcuts. ⌘1/2/3 now switch workspaces; bottom-panel tab
-  // shortcuts were retired (tabs are still clickable in the panel).
+  // Keyboard shortcuts. ⌘1/2/3/4 switch workspaces (Topology / Stage /
+  // Library / Runs); bottom-panel tab shortcuts were retired (tabs are
+  // still clickable in the panel).
   useKeyboardShortcuts({
     onFitView: () => fitView({ padding: 0.2, duration: 300 }),
     onEscape: () => {
@@ -112,7 +112,6 @@ function AppShellInner() {
     onZoomOut: () => zoomOut({ duration: 200 }),
     onRefresh: handleRefresh,
     onToggleBottomPanel: toggleBottomPanel,
-    onSwitchToTraces: () => setBottomPanelTab('traces'),
     onOpenPalette: toggleCommandPalette,
     onSwitchToWorkspace: (id) => navigate(`/${id}`),
     onToggleCompactMode: () => toggleCompactMode(activeWorkspace),

--- a/web/src/components/workspaces/LibraryWorkspace.tsx
+++ b/web/src/components/workspaces/LibraryWorkspace.tsx
@@ -1,0 +1,434 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import {
+  BookOpen,
+  Plus,
+  RefreshCw,
+  Search,
+  X,
+} from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { IconButton } from '../ui/IconButton';
+import { PopoutButton } from '../ui/PopoutButton';
+import { SkillEditor } from '../registry/SkillEditor';
+import { SkillCardSkeleton } from '../registry/SkillCardSkeleton';
+import { LibraryGrid } from '../registry/LibraryGrid';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
+import { showToast } from '../ui/Toast';
+import { useFuzzySearch } from '../../hooks/useFuzzySearch';
+import { useWindowManager } from '../../hooks/useWindowManager';
+import { useRegistryStore } from '../../stores/useRegistryStore';
+import { useUIStore } from '../../stores/useUIStore';
+import { useLibraryCommands, type LibraryFilter } from '../library/useLibraryCommands';
+import {
+  activateRegistrySkill,
+  deleteRegistrySkill,
+  disableRegistrySkill,
+  fetchRegistrySkills,
+  fetchRegistryStatus,
+} from '../../lib/api';
+import { WorkspaceShell } from '../layout/WorkspaceShell';
+import type { AgentSkill, ItemState } from '../../types';
+
+type FilterTab = 'all' | ItemState;
+
+const TABS: { key: FilterTab; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'active', label: 'Active' },
+  { key: 'draft', label: 'Draft' },
+  { key: 'disabled', label: 'Disabled' },
+];
+
+function isFilterTab(value: string | null): value is FilterTab {
+  return value === 'active' || value === 'draft' || value === 'disabled' || value === 'all';
+}
+
+/**
+ * LibraryWorkspace is the catalog view of the skill registry, hosted inside
+ * the unified AppShell. Search and filter state mirror the URL so reload,
+ * back/forward, and deep-links all preserve the user's view. The
+ * `/library/:skillName` path mounts the editor for that skill if it exists,
+ * else surfaces a toast and falls back to `/library`.
+ */
+export function LibraryWorkspace() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { skillName } = useParams<{ skillName?: string }>();
+  const navigate = useNavigate();
+
+  // Registry is fetched by the global usePolling cycle in AppShell — read from
+  // the store instead of starting a second polling loop here.
+  const skills = useRegistryStore((s) => s.skills);
+  const status = useRegistryStore((s) => s.status);
+
+  // null means "not loaded yet"; the deep-link error toast must wait for a
+  // resolved fetch so a transient mid-fetch render doesn't false-positive.
+  const isLoading = skills === null;
+  const hasSkills = (skills ?? []).length > 0;
+
+  const { openDetachedWindow } = useWindowManager();
+  const compact = useUIStore((s) => s.compactMode.library);
+
+  // URL → local state for the search input. We round-trip through state so the
+  // input keeps caret behavior; the URL is the source of truth on reload.
+  const searchQuery = searchParams.get('q') ?? '';
+  const filterParam = searchParams.get('filter');
+  const activeTab: FilterTab = isFilterTab(filterParam) ? filterParam : 'all';
+
+  const setSearchQuery = useCallback((value: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (value.trim()) next.set('q', value);
+        else next.delete('q');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  const setActiveTab = useCallback((tab: FilterTab) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (tab === 'all') next.delete('filter');
+        else next.set('filter', tab);
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  // Editor + delete confirm state
+  const [showEditor, setShowEditor] = useState(false);
+  const [editingSkill, setEditingSkill] = useState<AgentSkill | undefined>();
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  // Track the last skillName we resolved so we don't refire the toast on every
+  // re-render. Reset whenever the param actually changes.
+  const lastResolvedSkillRef = useRef<string | null>(null);
+
+  // Deep-link resolution: /library/:skillName mounts the editor for that
+  // skill once the registry has loaded. Unknown name → toast + replace URL.
+  useEffect(() => {
+    if (!skillName) {
+      lastResolvedSkillRef.current = null;
+      return;
+    }
+    if (lastResolvedSkillRef.current === skillName) return;
+    if (isLoading) return;
+
+    const found = (skills ?? []).find((s) => s.name === skillName);
+    lastResolvedSkillRef.current = skillName;
+    if (found) {
+      setEditingSkill(found);
+      setShowEditor(true);
+    } else {
+      showToast('error', `Skill "${skillName}" not found`);
+      navigate('/library', { replace: true });
+    }
+  }, [skillName, isLoading, skills, navigate]);
+
+  // When the editor closes, drop the :skillName segment so the URL reflects
+  // the catalog view again. Search/filter query params survive.
+  const handleEditorClose = useCallback(() => {
+    setShowEditor(false);
+    setEditingSkill(undefined);
+    if (skillName) {
+      navigate({ pathname: '/library', search: searchParams.toString() }, { replace: true });
+    }
+  }, [navigate, searchParams, skillName]);
+
+  const refreshRegistry = useCallback(async () => {
+    try {
+      const [regStatus, regSkills] = await Promise.all([
+        fetchRegistryStatus(),
+        fetchRegistrySkills(),
+      ]);
+      useRegistryStore.getState().setStatus(regStatus);
+      useRegistryStore.getState().setSkills(regSkills);
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'Refresh failed');
+    }
+  }, []);
+
+  const handleEnable = useCallback(async (skill: AgentSkill) => {
+    try {
+      await activateRegistrySkill(skill.name);
+      showToast('success', `Skill "${skill.name}" activated`);
+      refreshRegistry();
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'State change failed');
+    }
+  }, [refreshRegistry]);
+
+  const handleDisable = useCallback(async (skill: AgentSkill) => {
+    try {
+      await disableRegistrySkill(skill.name);
+      showToast('success', `Skill "${skill.name}" disabled`);
+      refreshRegistry();
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'State change failed');
+    }
+  }, [refreshRegistry]);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!confirmDelete) return;
+    try {
+      await deleteRegistrySkill(confirmDelete);
+      showToast('success', 'Skill deleted');
+      refreshRegistry();
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setConfirmDelete(null);
+    }
+  }, [confirmDelete, refreshRegistry]);
+
+  const handleNewSkill = useCallback(() => {
+    setEditingSkill(undefined);
+    setShowEditor(true);
+  }, []);
+
+  const handlePopout = useCallback(() => {
+    openDetachedWindow('registry');
+  }, [openDetachedWindow]);
+
+  const handleShowAll = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('q');
+        next.delete('filter');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  const handleFilter = useCallback((value: LibraryFilter) => {
+    if (value === 'all') {
+      setActiveTab('all');
+    } else {
+      setActiveTab(value);
+    }
+  }, [setActiveTab]);
+
+  useLibraryCommands({
+    onNewSkill: handleNewSkill,
+    onRefresh: refreshRegistry,
+    onShowAll: handleShowAll,
+    onFilter: handleFilter,
+    onOpenInNewWindow: handlePopout,
+  });
+
+  const searchResults = useFuzzySearch(skills ?? [], searchQuery);
+
+  const tabCounts = useMemo(() => ({
+    all: searchResults.length,
+    active: searchResults.filter((s) => s.state === 'active').length,
+    draft: searchResults.filter((s) => s.state === 'draft').length,
+    disabled: searchResults.filter((s) => s.state === 'disabled').length,
+  }), [searchResults]);
+
+  const displayedSkills = useMemo(() => {
+    if (activeTab === 'all') return searchResults;
+    return searchResults.filter((s) => s.state === activeTab);
+  }, [searchResults, activeTab]);
+
+  return (
+    <div className="absolute inset-0 flex flex-col bg-background text-text-primary overflow-hidden">
+      <WorkspaceShell workspace="library" defaultLeftPct={0} defaultRightPct={0}>
+        <main className="flex flex-col h-full overflow-hidden">
+          <LibraryHeader
+            onNewSkill={handleNewSkill}
+            onRefresh={refreshRegistry}
+            onPopout={handlePopout}
+            totalSkills={status?.totalSkills ?? skills?.length ?? 0}
+            activeSkills={status?.activeSkills ?? 0}
+            compact={compact}
+          />
+
+          {/* Search + Filter bar */}
+          <div className="px-4 pt-3 pb-2.5 bg-surface/60 backdrop-blur-sm border-b border-border/40 flex flex-col gap-2 flex-shrink-0">
+            <div className="relative">
+              <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted/50 pointer-events-none" />
+              <input
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search skills…"
+                aria-label="Filter skills"
+                className="w-full bg-background/60 border border-border/40 rounded-lg pl-9 pr-8 py-2 text-sm text-text-primary placeholder:text-text-muted/40 focus:outline-none focus:border-primary/50 transition-colors"
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery('')}
+                  aria-label="Clear search"
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-surface-highlight transition-colors"
+                >
+                  <X size={13} className="text-text-muted" />
+                </button>
+              )}
+            </div>
+
+            <div className="flex gap-1 flex-wrap">
+              {TABS.map((tab) => (
+                <button
+                  key={tab.key}
+                  onClick={() => setActiveTab(tab.key)}
+                  className={cn(
+                    'flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-medium transition-colors',
+                    activeTab === tab.key
+                      ? 'bg-primary/10 text-primary border border-primary/25'
+                      : 'text-text-muted hover:text-text-secondary hover:bg-surface-highlight border border-transparent',
+                  )}
+                >
+                  {tab.label}
+                  <span
+                    className={cn(
+                      'text-[10px] px-1.5 py-0 rounded-full font-mono min-w-[18px] text-center transition-colors',
+                      activeTab === tab.key
+                        ? 'bg-primary/15 text-primary'
+                        : 'bg-surface-highlight text-text-muted',
+                    )}
+                  >
+                    {tabCounts[tab.key]}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex-1 overflow-y-auto scrollbar-dark">
+            {isLoading && (
+              <div
+                className="p-4"
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+                  gap: '12px',
+                }}
+              >
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <SkillCardSkeleton key={i} />
+                ))}
+              </div>
+            )}
+
+            {!isLoading && !hasSkills && (
+              <div className="h-full flex flex-col items-center justify-center text-text-muted gap-3 animate-fade-in-scale">
+                <div className="p-4 rounded-xl bg-surface-elevated/50 border border-border/30">
+                  <BookOpen size={32} className="text-text-muted/50" />
+                </div>
+                <span className="text-sm">No skills registered</span>
+                <span className="text-[10px] text-text-muted">Create a SKILL.md to get started</span>
+              </div>
+            )}
+
+            {!isLoading && hasSkills && displayedSkills.length === 0 && (
+              <div className="h-full flex flex-col items-center justify-center text-text-muted gap-3 animate-fade-in-scale p-8">
+                <div className="p-4 rounded-xl bg-surface-elevated/50 border border-border/30">
+                  <Search size={28} className="text-text-muted/50" />
+                </div>
+                <span className="text-sm text-text-secondary">
+                  No skills match{searchQuery ? ` "${searchQuery}"` : ' this filter'}
+                </span>
+                {searchQuery && (
+                  <button
+                    onClick={() => setSearchQuery('')}
+                    className="text-xs text-primary hover:text-primary/80 transition-colors underline underline-offset-2"
+                  >
+                    Clear search
+                  </button>
+                )}
+              </div>
+            )}
+
+            {!isLoading && displayedSkills.length > 0 && (
+              <LibraryGrid
+                skills={displayedSkills}
+                hasSearch={searchQuery.length > 0}
+                onEnable={handleEnable}
+                onDisable={handleDisable}
+                onEdit={(s) => { setEditingSkill(s); setShowEditor(true); }}
+                onDelete={(s) => setConfirmDelete(s.name)}
+              />
+            )}
+          </div>
+        </main>
+      </WorkspaceShell>
+
+      <ConfirmDialog
+        isOpen={confirmDelete !== null}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete skill"
+        message={
+          <>
+            <p>
+              Delete <span className="font-mono text-primary">{confirmDelete}</span>?
+            </p>
+            <p>This action cannot be undone.</p>
+          </>
+        }
+        confirmLabel={
+          <span>
+            Delete <span className="font-mono">"{confirmDelete}"</span>
+          </span>
+        }
+        variant="danger"
+      />
+
+      <SkillEditor
+        isOpen={showEditor}
+        onClose={handleEditorClose}
+        onSaved={refreshRegistry}
+        skill={editingSkill}
+      />
+    </div>
+  );
+}
+
+interface LibraryHeaderProps {
+  onNewSkill: () => void;
+  onRefresh: () => void;
+  onPopout: () => void;
+  totalSkills: number;
+  activeSkills: number;
+  compact: boolean;
+}
+
+function LibraryHeader({ onNewSkill, onRefresh, onPopout, totalSkills, activeSkills, compact }: LibraryHeaderProps) {
+  const registryDetached = useUIStore((s) => s.registryDetached);
+  return (
+    <header className={cn(
+      'flex-shrink-0 bg-surface/30 backdrop-blur-sm border-b border-border-subtle flex items-center justify-between px-6',
+      compact ? 'py-2' : 'py-3',
+    )}>
+      <div className="flex items-center gap-3">
+        <div className="font-sans text-text-muted/60 text-[10px] uppercase tracking-[0.4em]">
+          library
+        </div>
+        <div className="font-mono text-[10px] text-text-muted">
+          {totalSkills} {totalSkills === 1 ? 'skill' : 'skills'}
+        </div>
+        {activeSkills > 0 && (
+          <div className="font-mono text-[10px] text-status-running">
+            {activeSkills} active
+          </div>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onNewSkill}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-primary hover:text-primary/80 bg-primary/10 hover:bg-primary/15 border border-primary/20 rounded-lg transition-colors"
+        >
+          <Plus size={12} /> New Skill
+        </button>
+        <IconButton icon={RefreshCw} onClick={onRefresh} tooltip="Refresh" size="sm" variant="ghost" />
+        <PopoutButton onClick={onPopout} disabled={registryDetached} tooltip="Open in new window" />
+      </div>
+    </header>
+  );
+}
+
+export default LibraryWorkspace;

--- a/web/src/components/workspaces/SkillsWorkspace.tsx
+++ b/web/src/components/workspaces/SkillsWorkspace.tsx
@@ -28,11 +28,14 @@ const COMPACT_SIDEBAR_PCT = 15;
 const COMPACT_INSPECTOR_PCT = 21;
 
 /**
- * SkillsWorkspace is the developer view inside the unified shell. It
- * preserves every behavior of the legacy `/agent` IDE — typed-skill
- * sidebar, list/canvas toggle, trace overlay, run launcher — and adds
- * deep-link continuity (`/skills?skill=foo&run=abc`), workspace-scoped
- * command palette commands, and Compact Mode.
+ * SkillsWorkspace is the Stage tab — the developer's per-skill Agent IDE
+ * inside the unified shell. The id stays `'skills'` and the route stays
+ * `/skills` to keep stored state, deep-links, and the Go API stable, but
+ * the user-facing label is "Stage" (see workspace.ts WORKSPACE_CONFIG).
+ * Behaviors preserved from the legacy `/agent` IDE: typed-skill sidebar,
+ * list/canvas toggle, trace overlay, run launcher. Adds deep-link
+ * continuity (`/skills?skill=foo&run=abc`), workspace-scoped command
+ * palette commands, and Compact Mode.
  */
 export function SkillsWorkspace() {
   const [params, setParams] = useSearchParams();

--- a/web/src/hooks/useGlobalCommands.tsx
+++ b/web/src/hooks/useGlobalCommands.tsx
@@ -3,6 +3,7 @@ import { useReactFlow } from '@xyflow/react';
 import { useNavigate } from 'react-router-dom';
 import {
   Activity,
+  Code,
   Key,
   Library,
   Terminal,
@@ -73,19 +74,28 @@ export function useGlobalCommands({ onRefresh }: GlobalCommandsOptions = {}) {
       },
       {
         id: 'navigate:workspace-skills',
-        label: 'Go to Skills',
+        label: 'Go to Stage',
+        section: 'global',
+        icon: <Code size={14} />,
+        shortcut: ['⌘', '2'],
+        keywords: ['stage', 'skills', 'workspace', 'agent', 'ide', 'developer', 'go'],
+        onSelect: () => navigate('/skills'),
+      },
+      {
+        id: 'navigate:workspace-library',
+        label: 'Go to Library',
         section: 'global',
         icon: <Library size={14} />,
-        shortcut: ['⌘', '2'],
-        keywords: ['skills', 'workspace', 'agent', 'ide', 'developer', 'go'],
-        onSelect: () => navigate('/skills'),
+        shortcut: ['⌘', '3'],
+        keywords: ['library', 'workspace', 'registry', 'catalog', 'skills', 'go'],
+        onSelect: () => navigate('/library'),
       },
       {
         id: 'navigate:workspace-runs',
         label: 'Go to Runs',
         section: 'global',
         icon: <Workflow size={14} />,
-        shortcut: ['⌘', '3'],
+        shortcut: ['⌘', '4'],
         keywords: ['runs', 'workspace', 'executions', 'traces', 'observability', 'go'],
         onSelect: () => navigate('/runs'),
       },
@@ -318,20 +328,20 @@ export function useGlobalCommands({ onRefresh }: GlobalCommandsOptions = {}) {
     return () => unregisterCommands('dynamic-vault');
   }, [secrets, registerCommands, unregisterCommands, setShowVault]);
 
-  // Dynamic registry skill commands
+  // Dynamic registry skill commands — open the Library workspace at the
+  // skill's deep-link so the SkillEditor mounts.
   useEffect(() => {
     const commands: PaletteCommand[] = (skills ?? []).slice(0, 20).map((skill) => ({
       id: `skill:${skill.name}`,
       label: `View skill: ${skill.name}`,
       section: 'registry' as const,
       icon: <Library size={14} />,
-      keywords: [skill.name, 'skill', 'registry', skill.description],
+      keywords: [skill.name, 'skill', 'library', 'registry', skill.description],
       onSelect: () => {
-        // Registry panel integration — open bottom panel to spec for now
-        setBottomPanelTab('spec');
+        navigate(`/library/${encodeURIComponent(skill.name)}`);
       },
     }));
     registerCommands('dynamic-skills', commands);
     return () => unregisterCommands('dynamic-skills');
-  }, [skills, registerCommands, unregisterCommands, setBottomPanelTab]);
+  }, [skills, registerCommands, unregisterCommands, navigate]);
 }

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -9,7 +9,6 @@ interface ShortcutOptions {
   onZoomOut?: () => void;
   onRefresh?: () => void;
   onToggleBottomPanel?: () => void;
-  onSwitchToTraces?: () => void;
   onOpenPalette?: () => void;
   // Workspace navigation — Cmd/Ctrl + <shortcutKey> switches top-level
   // workspaces. The key→id mapping comes from WORKSPACE_CONFIG, so adding a
@@ -82,11 +81,6 @@ export function useKeyboardShortcuts(options: ShortcutOptions) {
           e.preventDefault();
           options.onSwitchToWorkspace?.(ws);
         }
-      }
-      // Traces panel quick-jump: Cmd/Ctrl+4 (tabs themselves remain clickable)
-      if (isMod && e.key === '4') {
-        e.preventDefault();
-        options.onSwitchToTraces?.();
       }
       // Open command palette: Cmd/Ctrl+K
       if (isMod && e.key === 'k') {

--- a/web/src/hooks/useWindowManager.ts
+++ b/web/src/hooks/useWindowManager.ts
@@ -6,10 +6,17 @@ const WINDOW_TITLES: Record<string, string> = {
   logs: 'Gridctl - Logs',
   sidebar: 'Gridctl - Details',
   editor: 'Gridctl - Editor',
-  registry: 'Gridctl - Registry',
+  registry: 'Gridctl - Library',
   metrics: 'Gridctl - Metrics',
   var: 'Gridctl - Variables',
   traces: 'Gridctl - Traces',
+};
+
+// The `registry` window type points at /library-window after the workspace
+// promotion; other types render at /<type>. Keeping the type key as
+// `registry` avoids churning every call-site and stored detached state.
+const WINDOW_PATHS: Record<string, string> = {
+  registry: '/library-window',
 };
 
 type DetachableWindow = 'logs' | 'sidebar' | 'editor' | 'registry' | 'metrics' | 'var' | 'traces';
@@ -109,7 +116,8 @@ export function useWindowManager() {
       setTracesDetached(true);
     }
 
-    const url = params ? `/${type}?${params}` : `/${type}`;
+    const basePath = WINDOW_PATHS[type] ?? `/${type}`;
+    const url = params ? `${basePath}?${params}` : basePath;
     const newWindow = window.open(url, `gridctl-${type}`);
 
     if (!newWindow) {

--- a/web/src/pages/DetachedRegistryPage.tsx
+++ b/web/src/pages/DetachedRegistryPage.tsx
@@ -12,8 +12,8 @@ import { cn } from '../lib/cn';
 import { IconButton } from '../components/ui/IconButton';
 import { ZoomControls } from '../components/ui/ZoomControls';
 import { SkillEditor } from '../components/registry/SkillEditor';
-import { SkillCard } from '../components/registry/SkillCard';
 import { SkillCardSkeleton } from '../components/registry/SkillCardSkeleton';
+import { LibraryGrid } from '../components/registry/LibraryGrid';
 import { ConfirmDialog } from '../components/ui/ConfirmDialog';
 import { ToastContainer, showToast } from '../components/ui/Toast';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
@@ -79,129 +79,6 @@ const TABS: { key: FilterTab; label: string }[] = [
   { key: 'draft', label: 'Draft' },
   { key: 'disabled', label: 'Disabled' },
 ];
-
-function getGroupKey(dir?: string): string {
-  if (!dir) return '';
-  return dir.split('/')[0];
-}
-
-function groupSkills(skills: AgentSkill[]): Map<string, AgentSkill[]> {
-  const groups = new Map<string, AgentSkill[]>();
-  for (const skill of skills) {
-    const key = getGroupKey(skill.dir);
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key)!.push(skill);
-  }
-  return groups;
-}
-
-function toTitleCase(key: string): string {
-  return key.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-interface GroupedSkillGridProps {
-  skills: AgentSkill[];
-  hasSearch: boolean;
-  onEnable: (skill: AgentSkill) => void;
-  onDisable: (skill: AgentSkill) => void;
-  onEdit: (skill: AgentSkill) => void;
-  onDelete: (skill: AgentSkill) => void;
-}
-
-function GroupedSkillGrid({ skills, hasSearch, onEnable, onDisable, onEdit, onDelete }: GroupedSkillGridProps) {
-  const groups = groupSkills(skills);
-  // Only group when the structure is meaningful: 2+ groups AND at least one
-  // group has 2+ skills. Otherwise the full-width section headers just waste
-  // horizontal space (every skill becomes its own "group of one").
-  const hasMeaningfulGrouping =
-    groups.size > 1 && Array.from(groups.values()).some((g) => g.length > 1);
-
-  const gridStyle: React.CSSProperties = {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
-    gap: '12px',
-  };
-
-  if (!hasMeaningfulGrouping) {
-    return (
-      <div className="p-4" style={gridStyle}>
-        {skills.map((skill, i) => (
-          <SkillCard
-            key={skill.name}
-            skill={skill}
-            className={cn('motion-safe:animate-fade-in-scale', skill.metadata?.colspan === '2' ? 'col-span-2' : undefined)}
-            style={{ animationDelay: `${Math.min(i, 10) * 30}ms` }}
-            onEnable={onEnable}
-            onDisable={onDisable}
-            onEdit={onEdit}
-            onDelete={onDelete}
-          />
-        ))}
-      </div>
-    );
-  }
-
-  return (
-    <div className="p-4" style={gridStyle}>
-      {Array.from(groups.entries()).map(([key, groupSkillList]) => (
-        <GroupSection
-          key={key || '__ungrouped__'}
-          groupKey={key}
-          skills={groupSkillList}
-          showHeader
-          hasSearch={hasSearch}
-          onEnable={onEnable}
-          onDisable={onDisable}
-          onEdit={onEdit}
-          onDelete={onDelete}
-        />
-      ))}
-    </div>
-  );
-}
-
-interface GroupSectionProps {
-  groupKey: string;
-  skills: AgentSkill[];
-  showHeader: boolean;
-  hasSearch: boolean;
-  onEnable: (skill: AgentSkill) => void;
-  onDisable: (skill: AgentSkill) => void;
-  onEdit: (skill: AgentSkill) => void;
-  onDelete: (skill: AgentSkill) => void;
-}
-
-function GroupSection({ groupKey, skills, showHeader, hasSearch, onEnable, onDisable, onEdit, onDelete }: GroupSectionProps) {
-  return (
-    <>
-      {showHeader && (
-        <div style={{ gridColumn: '1 / -1' }} className="flex flex-col gap-1 mt-2 first:mt-0 animate-fade-in-scale">
-          <div className="flex items-center justify-between">
-            <span className="text-[10px] uppercase tracking-widest text-text-muted font-medium">
-              {groupKey ? toTitleCase(groupKey) : 'Other'}
-            </span>
-            <span className="text-[10px] px-1.5 rounded-full bg-surface-highlight text-text-muted">
-              {skills.length} {hasSearch ? 'matched' : 'skills'}
-            </span>
-          </div>
-          <div className="border-b border-border/30" />
-        </div>
-      )}
-      {skills.map((skill, i) => (
-        <SkillCard
-          key={skill.name}
-          skill={skill}
-          className={cn('motion-safe:animate-fade-in-scale', skill.metadata?.colspan === '2' ? 'col-span-2' : undefined)}
-          style={{ animationDelay: `${Math.min(i, 10) * 30}ms` }}
-          onEnable={onEnable}
-          onDisable={onDisable}
-          onEdit={onEdit}
-          onDelete={onDelete}
-        />
-      ))}
-    </>
-  );
-}
 
 function DetachedRegistryContent() {
   const [skills, setSkills] = useState<AgentSkill[] | null>(null);
@@ -319,7 +196,7 @@ function DetachedRegistryContent() {
             <Library size={14} className="text-primary" />
           </div>
           <div>
-            <span className="text-sm font-semibold text-text-primary tracking-tight">Registry</span>
+            <span className="text-sm font-semibold text-text-primary tracking-tight">Library</span>
             <span className="text-[10px] text-text-muted uppercase tracking-wider ml-2">Agent Skills</span>
           </div>
         </div>
@@ -449,7 +326,7 @@ function DetachedRegistryContent() {
 
         {/* Card grid */}
         {!isLoading && displayedSkills.length > 0 && (
-          <GroupedSkillGrid
+          <LibraryGrid
             skills={displayedSkills}
             hasSearch={searchQuery.length > 0}
             onEnable={handleEnable}
@@ -464,7 +341,7 @@ function DetachedRegistryContent() {
       <footer className="h-6 flex-shrink-0 bg-surface/90 backdrop-blur-xl border-t border-border/50 flex items-center justify-between px-4 text-[10px] text-text-muted z-10">
         <span>
           {status ? `${status.totalSkills} total` : ''}
-          {status ? ` \u00B7 ` : ''}
+          {status ? ` · ` : ''}
           <span className="text-status-running">{status?.activeSkills ?? 0} active</span>
         </span>
         <span className="flex items-center gap-1">

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -12,18 +12,18 @@ import { DetachedMetricsPage } from './pages/DetachedMetricsPage';
 import { DetachedVaultPage } from './pages/DetachedVaultPage';
 import { DetachedTracesPage } from './pages/DetachedTracesPage';
 
-// Each workspace is code-split into its own chunk. Phase 2/3 will fill in
-// the Skills and Runs workspaces; today they render placeholder cards.
+// Each workspace is code-split into its own chunk.
 const TopologyWorkspace = lazy(() => import('./components/workspaces/TopologyWorkspace'));
 const SkillsWorkspace = lazy(() => import('./components/workspaces/SkillsWorkspace'));
+const LibraryWorkspace = lazy(() => import('./components/workspaces/LibraryWorkspace'));
 const RunsWorkspace = lazy(() => import('./components/workspaces/RunsWorkspace'));
 const RunDetailWorkspace = lazy(() => import('./components/workspaces/RunDetailWorkspace'));
 
 export function AppRoutes() {
   return (
     <Routes>
-      {/* Unified shell parent route. The three workspaces render as
-          children inside <AppShell>'s <Outlet />. */}
+      {/* Unified shell parent route. Workspaces render as children inside
+          <AppShell>'s <Outlet />. */}
       <Route element={<AppShell />}>
         <Route
           path="/topology"
@@ -38,6 +38,25 @@ export function AppRoutes() {
           element={
             <Suspense fallback={<WorkspaceLoadingShell />}>
               <SkillsWorkspace />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/library"
+          element={
+            <Suspense fallback={<WorkspaceLoadingShell />}>
+              <LibraryWorkspace />
+            </Suspense>
+          }
+        />
+        {/* /library/:skillName deep-links the editor for a single skill;
+            the workspace component looks up the name and either mounts
+            the SkillEditor or falls back with a toast. */}
+        <Route
+          path="/library/:skillName"
+          element={
+            <Suspense fallback={<WorkspaceLoadingShell />}>
+              <LibraryWorkspace />
             </Suspense>
           }
         />
@@ -69,7 +88,10 @@ export function AppRoutes() {
       <Route path="/logs" element={<DetachedLogsPage />} />
       <Route path="/sidebar" element={<DetachedSidebarPage />} />
       <Route path="/editor" element={<DetachedEditorPage />} />
-      <Route path="/registry" element={<DetachedRegistryPage />} />
+      <Route path="/library-window" element={<DetachedRegistryPage />} />
+      {/* /registry → /library-window: silent redirect for bookmarks and
+          existing detached window handles. */}
+      <Route path="/registry" element={<Navigate to="/library-window" replace />} />
       <Route path="/metrics" element={<DetachedMetricsPage />} />
       <Route path="/var" element={<DetachedVaultPage />} />
       {/* /vault → /var: silent redirect for bookmarks and existing window

--- a/web/src/stores/useUIStore.ts
+++ b/web/src/stores/useUIStore.ts
@@ -32,6 +32,7 @@ export type CompactModeMap = Record<Workspace, boolean>;
 export const COMPACT_MODE_DEFAULTS: CompactModeMap = {
   topology: false,
   skills: true,
+  library: false,
   runs: false,
 };
 

--- a/web/src/types/workspace.ts
+++ b/web/src/types/workspace.ts
@@ -1,9 +1,11 @@
 import type { LucideIcon } from 'lucide-react';
-import { Code, Network, PlayCircle } from 'lucide-react';
+import { Code, Library, Network, PlayCircle } from 'lucide-react';
 
-// The three top-level workspaces in the unified shell. Routed at /topology,
-// /skills, /runs inside AppShell.
-export type Workspace = 'topology' | 'skills' | 'runs';
+// Top-level workspaces in the unified shell. Routed at /topology, /skills,
+// /library, /runs inside AppShell. The workspace id `skills` keeps the
+// historical route + storage value even though the user-facing label is
+// "Stage" — see WORKSPACE_CONFIG below.
+export type Workspace = 'topology' | 'skills' | 'library' | 'runs';
 
 export interface WorkspaceConfig {
   id: Workspace;
@@ -14,11 +16,13 @@ export interface WorkspaceConfig {
 }
 
 // Single source of truth for workspace metadata. Adding a workspace = append
-// here; the switcher, shortcuts, and labels follow automatically.
+// here; the switcher, shortcuts, and labels follow automatically. Array order
+// is the rendered top-nav order, so shortcuts read left-to-right as 1-2-3-4.
 export const WORKSPACE_CONFIG: readonly WorkspaceConfig[] = [
   { id: 'topology', label: 'Topology', icon: Network,    shortcutKey: '1' },
-  { id: 'skills',   label: 'Skills',   icon: Code,       shortcutKey: '2' },
-  { id: 'runs',     label: 'Runs',     icon: PlayCircle, shortcutKey: '3' },
+  { id: 'skills',   label: 'Stage',    icon: Code,       shortcutKey: '2' },
+  { id: 'library',  label: 'Library',  icon: Library,    shortcutKey: '3' },
+  { id: 'runs',     label: 'Runs',     icon: PlayCircle, shortcutKey: '4' },
 ] as const;
 
 // Derived for back-compat with existing call-sites in useUIStore, AppShell,


### PR DESCRIPTION
## Description

Promotes the skill registry from a sidebar / detached-only surface to a first-class top-nav workspace, and renames the existing Skills tab (the per-skill Agent IDE) to Stage. Single click to browse, search, filter, and manage every skill; deep-link `/library/<name>` opens the editor directly.

## Type of Change

- [x] New feature

## Changes Made

- **Top nav: 4 tabs in `Topology / Stage / Library / Runs` order.** `WORKSPACE_CONFIG` is the single source of truth — switcher, shortcuts, and labels follow automatically.
- **Library workspace** at `/library` with URL-encoded search (`?q=`) and filter (`?filter=active|draft|disabled`) state, popout button, refresh, "New Skill", and the existing 4 filter tabs.
- **Deep-link**: `/library/:skillName` mounts the SkillEditor for that skill; unknown name shows a toast and falls back to `/library` (guarded against re-firing on every render).
- **Shared `LibraryGrid`** component used by both the in-app workspace and the detached `/library-window` page — no duplicated grid/filter UI.
- **Stage rename**: workspace label "Skills" → "Stage". Route stays `/skills`, workspace id stays `'skills'`, storage keys, tests, Go API endpoints, `useRegistryStore`, and the `registry/` directory all unchanged. Only user-visible labels change.
- **Detached window rename**: `/registry` → `/library-window`, with a redirect from `/registry` so existing bookmarks and open windows keep working. The popout button in the in-app workspace and the gateway-node card both land at `/library-window`.
- **Gateway sidebar**: embedded `<RegistrySidebar />` replaced with a `Manage Skills (N) →` link to `/library` (with live skill count from `useRegistryStore`). Eliminates ~50 lines of duplicated UI.
- **Keyboard shortcuts: Cmd+1/2/3/4 → Topology / Stage / Library / Runs.** Runs moves from Cmd+3 → Cmd+4. This is a deliberate muscle-memory break in favor of "visual order matches shortcut number." The previous Cmd+4 → bottom-panel-traces handler is removed; traces remain accessible via the panel tab and the command palette.
- **Palette commands**: workspace-scoped `useLibraryCommands` (New Skill, Refresh, Show All, Filter Active/Draft/Disabled, Open in New Window). Global navigation commands updated (Go to Stage / Go to Library / Cmd+4 = Runs); dynamic "View skill: <name>" commands now navigate to `/library/<name>` instead of opening the bottom-panel spec tab.

**Intentionally out of scope** (noted for follow-up): renaming internal model code (`registry/` → `library/`, `useRegistryStore`, `/api/registry`). Smaller blast radius, easier review.

## Testing

- `npx tsc --noEmit` — clean
- `npx vitest run` — 608 / 608 pass (new + updated tests cover: 4-tab switcher, Cmd+1/2/3/4, URL state, deep-link mount + bad-name fallback, `/registry` → `/library-window` redirect, gateway "Manage Skills" CTA with count)
- `npm run build` — succeeds; LibraryWorkspace lazy-chunks at ~10 kB gzipped
- `make test` — Go suite green
- Manual smoke (`cd web && npm run dev`): four tabs render in order, Cmd+1/2/3/4 cycle correctly, search/filter survive reload, popout opens `/library-window`, `/registry` redirects, gateway CTA navigates with count.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #675