### PR TITLE
test: deflake probe session concurrency cap

### DIFF
--- a/internal/api/probe_test.go
+++ b/internal/api/probe_test.go
@@ -273,24 +273,34 @@ func TestProbeHandler_SessionConcurrencyCap(t *testing.T) {
 	handler := srv.Handler()
 
 	body, _ := json.Marshal(map[string]any{"url": "https://example.com/mcp"})
+	send := func() int {
+		req := httptest.NewRequest(http.MethodPost, "/api/servers/probe", bytes.NewReader(body))
+		req.Header.Set("X-Session-ID", "s1")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	// Fill the cap first so the rejected probe is deterministic — launching
+	// all four concurrently let the 4th sometimes acquire after the first
+	// three released their slots, masking the cap.
 	var wg sync.WaitGroup
 	results := make(chan int, 4)
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 3; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			req := httptest.NewRequest(http.MethodPost, "/api/servers/probe", bytes.NewReader(body))
-			req.Header.Set("X-Session-ID", "s1")
-			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
-			results <- rec.Code
+			results <- send()
 		}()
 	}
-
-	// Wait for 3 to be in-flight, then release all 4 (including the rejected one).
 	for client.started.Load() < 3 {
 		time.Sleep(time.Millisecond)
 	}
+
+	// All three slots are held — this probe must be rejected by acquire().
+	rejected := send()
+	results <- rejected
+
 	close(block)
 	wg.Wait()
 	close(results)
@@ -299,8 +309,8 @@ func TestProbeHandler_SessionConcurrencyCap(t *testing.T) {
 	for c := range results {
 		codes[c]++
 	}
-	if codes[http.StatusTooManyRequests] == 0 {
-		t.Fatalf("expected at least one 429, got %+v", codes)
+	if rejected != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 for over-cap probe, got %d (all codes: %+v)", rejected, codes)
 	}
 }
 


### PR DESCRIPTION
## Description

`TestProbeHandler_SessionConcurrencyCap` was racy and failed intermittently in CI (e.g. [run 26239992772](https://github.com/gridctl/gridctl/actions/runs/26239992772)) with `expected at least one 429, got map[200:4]`. Locally it passed 10/10, but under CI scheduling pressure the 4th goroutine could finish behind the others, masking the cap.

## Type of Change

- [x] Bug fix (test-only — no production code change)

## Changes Made

- Fill the per-session cap with 3 goroutines and wait for `started >= 3` before sending the 4th probe.
- Issue the 4th probe synchronously so it deterministically hits a full semaphore and is rejected by `acquire()` before the others release their slots.
- Assert directly on the rejected probe's status instead of a counting heuristic.

## Root Cause

The original test launched all 4 goroutines concurrently and waited for `started >= 3` before releasing the block. The 4th goroutine could still be before `acquire()` at that point; once the block released, the in-flight 3 finished and freed slots, letting the 4th acquire successfully.

## Testing

- `go test -race -run TestProbeHandler_SessionConcurrencyCap -count=1 ./internal/api/` — 10/10 pass after the fix (same locally 10/10 before, but the race was load-dependent).
- `go test -race -count=1 ./internal/api/` — full package green.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed