### PR TITLE
fix: clean up vestigial agent surface residue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to gridctl will be documented in this file.
   runtime, sandbox, persist, dev, skill SDK, internal/eino, llm provider
   abstraction). `pkg/optimize/` heuristics that read the run ledger are
   also gone; `pkg/optimize/` itself stays.
+- **`X-Agent-Name` CORS header dropped** from the gateway's
+  `Access-Control-Allow-Headers` allowlist and from `docs/api-reference.md`.
+  The header was advertised but never read by any production handler after
+  the agent surface removal.
+- **Dead frontend `restartAgent` / `stopAgent` helpers** removed from
+  `web/src/lib/api.ts`. The functions targeted server routes that no
+  longer exist (`/api/agents/{name}/{restart,stop}`) and had no callers.
 
 ### Changed
 
@@ -41,6 +48,18 @@ All notable changes to gridctl will be documented in this file.
   library"; the "Skills (Early Access)" and "Visual Agent IDE" feature
   blocks are replaced with a single Skill Library section. `AGENTS.md` is
   removed (pre-1.0 working notes; no replacement).
+- **`pkg/mcp` internal naming clarified.** Local variables, named-return
+  parameters, doc comments, and error messages in `pkg/mcp/router.go` and
+  `pkg/mcp/gateway.go` now use `serverName` and "server" terminology
+  consistently. `PrefixTool` / `ParsePrefixedTool` keep their public
+  signatures; only their named-return parameters changed (godoc only —
+  no Go ABI change). Public interface and method names (`AgentClient`,
+  `AddClient`, `RemoveClient`) are unchanged.
+- **CLI command registration consolidated** in `cmd/gridctl/root.go`.
+  `reload`, `telemetry`, `traces`, `upgrade`, `export`, and `version`
+  previously self-registered via their own `init()` functions; they now
+  appear in the canonical `rootCmd.AddCommand(...)` list in `root.go`
+  alongside the other 16 commands.
 
 ### Migration
 
@@ -55,6 +74,12 @@ All notable changes to gridctl will be documented in this file.
 
 ### Breaking
 
+- **API route `GET /api/agents/{name}/logs` renamed to
+  `GET /api/mcp-servers/{name}/logs`** to match the existing
+  `/api/mcp-servers/{name}/restart` and `/api/mcp-servers/{name}/tools`
+  convention. No backwards-compatibility redirect (pre-1.0, no documented
+  external consumer). The frontend `fetchAgentLogs` helper was renamed to
+  `fetchServerLogs`; every caller in `web/src/` was updated.
 - **`gridctl vault` renamed to `gridctl var`.** The unified variable store
   now holds both secrets and non-sensitive configuration. `gridctl vault
   <sub>` continues to work through the beta cycle and emits a one-time

--- a/cmd/gridctl/export.go
+++ b/cmd/gridctl/export.go
@@ -36,7 +36,6 @@ If remote skills are active, a skills.yaml is also generated.`,
 func init() {
 	exportCmd.Flags().StringVarP(&exportOutputDir, "output", "o", "", "Output directory (default: stdout)")
 	exportCmd.Flags().StringVar(&exportFormat, "format", "yaml", "Output format: yaml or json")
-	rootCmd.AddCommand(exportCmd)
 }
 
 func runExport() error {

--- a/cmd/gridctl/reload.go
+++ b/cmd/gridctl/reload.go
@@ -34,10 +34,6 @@ If no stack name is provided, reloads all running stacks.`,
 	},
 }
 
-func init() {
-	rootCmd.AddCommand(reloadCmd)
-}
-
 func reloadStack(name string) error {
 	// Try to find by stack name first
 	st, err := state.Load(name)

--- a/cmd/gridctl/root.go
+++ b/cmd/gridctl/root.go
@@ -29,6 +29,7 @@ func init() {
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(stopCmd)
+	rootCmd.AddCommand(reloadCmd)
 	rootCmd.AddCommand(linkCmd)
 	rootCmd.AddCommand(unlinkCmd)
 	rootCmd.AddCommand(varCmd)
@@ -40,6 +41,11 @@ func init() {
 	rootCmd.AddCommand(pinsCmd)
 	rootCmd.AddCommand(optimizeCmd)
 	rootCmd.AddCommand(activateCmd)
+	rootCmd.AddCommand(exportCmd)
+	rootCmd.AddCommand(telemetryCmd)
+	rootCmd.AddCommand(tracesCmd)
+	rootCmd.AddCommand(upgradeCmd)
+	rootCmd.AddCommand(versionCmd)
 }
 
 func Execute() {

--- a/cmd/gridctl/telemetry.go
+++ b/cmd/gridctl/telemetry.go
@@ -101,7 +101,6 @@ func init() {
 	telemetryCmd.AddCommand(telemetryStatusCmd)
 	telemetryCmd.AddCommand(telemetryWipeCmd)
 	telemetryCmd.AddCommand(telemetryTailCmd)
-	rootCmd.AddCommand(telemetryCmd)
 }
 
 // stackInventory pairs a stack name with its inventory records so the CLI can

--- a/cmd/gridctl/traces.go
+++ b/cmd/gridctl/traces.go
@@ -63,7 +63,6 @@ func init() {
 	tracesCmd.Flags().StringVar(&tracesMinDuration, "min-duration", "", "Minimum trace duration (e.g. 100ms, 1s)")
 	tracesCmd.Flags().BoolVar(&tracesJSON, "json", false, "Output as JSON")
 	tracesCmd.Flags().BoolVar(&tracesFollow, "follow", false, "Stream new traces as they arrive")
-	rootCmd.AddCommand(tracesCmd)
 }
 
 // resolveTracesPort finds the port of a running gateway, optionally filtered by stack name.

--- a/cmd/gridctl/upgrade.go
+++ b/cmd/gridctl/upgrade.go
@@ -59,7 +59,6 @@ func init() {
 	upgradeCmd.Flags().StringVar(&upgradeVersion, "version", "", "Install a specific release tag (allows downgrades)")
 	upgradeCmd.Flags().BoolVar(&upgradeForce, "force", false, "Bypass Homebrew detection and the up-to-date short-circuit")
 	upgradeCmd.Flags().BoolVarP(&upgradeYes, "yes", "y", false, "Non-interactive: skip the confirmation prompt")
-	rootCmd.AddCommand(upgradeCmd)
 }
 
 func runUpgrade() error {

--- a/cmd/gridctl/version.go
+++ b/cmd/gridctl/version.go
@@ -14,10 +14,6 @@ var (
 	date    = "unknown"
 )
 
-func init() {
-	rootCmd.AddCommand(versionCmd)
-}
-
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1117,7 +1117,7 @@ The gateway sets CORS headers based on `gateway.allowed_origins`:
 ```
 Access-Control-Allow-Origin: {origin}
 Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
-Access-Control-Allow-Headers: Content-Type, X-Agent-Name, Authorization
+Access-Control-Allow-Headers: Content-Type, Authorization
 Vary: Origin
 ```
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -218,8 +218,8 @@ func (s *Server) Handler() http.Handler {
 	// API endpoints
 	mux.HandleFunc("/api/status", s.handleStatus)
 	mux.HandleFunc("/api/sessions", s.handleSessions)
-	mux.HandleFunc("GET /api/agents/{name}/logs", s.handleAgentLogs)
 
+	mux.HandleFunc("GET /api/mcp-servers/{name}/logs", s.handleMCPServerLogs)
 	mux.HandleFunc("POST /api/mcp-servers/{name}/restart", s.handleMCPServerRestart)
 	mux.HandleFunc("PUT /api/mcp-servers/{name}/tools", s.handleSetServerTools)
 	mux.HandleFunc("/api/mcp-servers", s.handleMCPServers)
@@ -528,7 +528,7 @@ func corsMiddleware(allowedOrigins []string, extraHeaders []string, next http.Ha
 		}
 		originSet[o] = true
 	}
-	allowHeaders := "Content-Type, X-Agent-Name, Authorization"
+	allowHeaders := "Content-Type, Authorization"
 	for _, h := range extraHeaders {
 		allowHeaders += ", " + h
 	}
@@ -609,9 +609,9 @@ func (s *Server) getResourceStatuses() []ResourceStatus {
 	return resources
 }
 
-// handleAgentLogs returns structured logs from the global buffer filtered by server name.
-// GET /api/agents/{name}/logs?lines=100
-func (s *Server) handleAgentLogs(w http.ResponseWriter, r *http.Request) {
+// handleMCPServerLogs returns structured logs from the global buffer filtered by server name.
+// GET /api/mcp-servers/{name}/logs?lines=100
+func (s *Server) handleMCPServerLogs(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 
 	if s.logBuffer == nil {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -698,12 +698,12 @@ func TestHandleGatewayLogs_MethodNotAllowed(t *testing.T) {
 
 // --- Agent logs endpoint tests ---
 
-func TestHandleAgentLogs_NoBuffer(t *testing.T) {
+func TestHandleMCPServerLogs_NoBuffer(t *testing.T) {
 	srv := newTestServer(t)
 	// logBuffer is nil by default
 	handler := srv.Handler()
 
-	req := httptest.NewRequest(http.MethodGet, "/api/agents/atlassian/logs", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp-servers/atlassian/logs", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -720,7 +720,7 @@ func TestHandleAgentLogs_NoBuffer(t *testing.T) {
 	}
 }
 
-func TestHandleAgentLogs_FiltersByServer(t *testing.T) {
+func TestHandleMCPServerLogs_FiltersByServer(t *testing.T) {
 	srv := newTestServerWithLogBuffer(t, 100)
 
 	srv.logBuffer.Add(logging.BufferedEntry{
@@ -740,7 +740,7 @@ func TestHandleAgentLogs_FiltersByServer(t *testing.T) {
 	})
 
 	handler := srv.Handler()
-	req := httptest.NewRequest(http.MethodGet, "/api/agents/atlassian/logs", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp-servers/atlassian/logs", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -762,7 +762,7 @@ func TestHandleAgentLogs_FiltersByServer(t *testing.T) {
 	}
 }
 
-func TestHandleAgentLogs_EmptyWhenNoMatch(t *testing.T) {
+func TestHandleMCPServerLogs_EmptyWhenNoMatch(t *testing.T) {
 	srv := newTestServerWithLogBuffer(t, 100)
 
 	srv.logBuffer.Add(logging.BufferedEntry{
@@ -772,7 +772,7 @@ func TestHandleAgentLogs_EmptyWhenNoMatch(t *testing.T) {
 	})
 
 	handler := srv.Handler()
-	req := httptest.NewRequest(http.MethodGet, "/api/agents/atlassian/logs", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp-servers/atlassian/logs", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -789,7 +789,7 @@ func TestHandleAgentLogs_EmptyWhenNoMatch(t *testing.T) {
 	}
 }
 
-func TestHandleAgentLogs_LinesParam(t *testing.T) {
+func TestHandleMCPServerLogs_LinesParam(t *testing.T) {
 	srv := newTestServerWithLogBuffer(t, 200)
 
 	for i := 0; i < 20; i++ {
@@ -801,7 +801,7 @@ func TestHandleAgentLogs_LinesParam(t *testing.T) {
 	}
 
 	handler := srv.Handler()
-	req := httptest.NewRequest(http.MethodGet, "/api/agents/atlassian/logs?lines=5", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp-servers/atlassian/logs?lines=5", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -818,11 +818,11 @@ func TestHandleAgentLogs_LinesParam(t *testing.T) {
 	}
 }
 
-func TestHandleAgentLogs_MethodNotAllowed(t *testing.T) {
+func TestHandleMCPServerLogs_MethodNotAllowed(t *testing.T) {
 	srv := newTestServer(t)
 	handler := srv.Handler()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/agents/atlassian/logs", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/mcp-servers/atlassian/logs", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -1255,8 +1255,8 @@ func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*
 		// at zero healthy replicas, synchronously spawn one before retrying.
 		// Bounded here by the caller's context (tool-call timeout) rather than
 		// by a hard-coded deadline so long-spin containers can complete.
-		if agentName, _, parseErr := ParsePrefixedTool(params.Name); parseErr == nil {
-			if scaler := g.GetAutoscaler(agentName); scaler != nil {
+		if serverName, _, parseErr := ParsePrefixedTool(params.Name); parseErr == nil {
+			if scaler := g.GetAutoscaler(serverName); scaler != nil {
 				if cs := scaler.TriggerColdStart(ctx); cs == nil {
 					replica, toolName, err = g.router.RouteToolCallReplica(params.Name)
 				} else if err == nil {

--- a/pkg/mcp/router.go
+++ b/pkg/mcp/router.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 )
 
-// Router routes tool calls to the appropriate agent.
+// Router routes tool calls to the appropriate MCP server.
 //
 // Internally the Router keys on server name and stores a *ReplicaSet per name.
 // A single-client registration (via AddClient) is wrapped in a
@@ -15,8 +15,8 @@ import (
 // same behavior as before replicas existed.
 type Router struct {
 	mu    sync.RWMutex
-	sets  map[string]*ReplicaSet // agentName -> replica set
-	tools map[string]string      // prefixedToolName -> agentName
+	sets  map[string]*ReplicaSet // serverName -> replica set
+	tools map[string]string      // prefixedToolName -> serverName
 }
 
 // NewRouter creates a new tool router.
@@ -27,7 +27,7 @@ func NewRouter() *Router {
 	}
 }
 
-// AddClient adds an agent client to the router as a single-replica set.
+// AddClient adds a client to the router as a single-replica set.
 // Preserves the pre-replicas API so existing callers keep working unchanged.
 func (r *Router) AddClient(client AgentClient) {
 	set := NewReplicaSet(client.Name(), ReplicaPolicyRoundRobin, []AgentClient{client})
@@ -42,22 +42,22 @@ func (r *Router) AddReplicaSet(set *ReplicaSet) {
 	r.sets[set.Name()] = set
 }
 
-// RemoveClient removes an agent (replica set) and its tools from the router.
+// RemoveClient removes a server (replica set) and its tools from the router.
 func (r *Router) RemoveClient(name string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.sets, name)
 
-	// Remove tools for this agent
-	for tool, agent := range r.tools {
-		if agent == name {
+	// Remove tools for this server
+	for tool, server := range r.tools {
+		if server == name {
 			delete(r.tools, tool)
 		}
 	}
 }
 
-// GetClient returns one client for the named agent, chosen by the set's
-// dispatch policy. Returns nil if the agent is not registered or no replica
+// GetClient returns one client for the named server, chosen by the set's
+// dispatch policy. Returns nil if the server is not registered or no replica
 // is currently healthy.
 func (r *Router) GetClient(name string) AgentClient {
 	r.mu.RLock()
@@ -69,8 +69,8 @@ func (r *Router) GetClient(name string) AgentClient {
 	return set.Client()
 }
 
-// GetReplicaSet returns the replica set for the named agent, or nil if the
-// agent is not registered. Useful for callers that need per-replica access
+// GetReplicaSet returns the replica set for the named server, or nil if the
+// server is not registered. Useful for callers that need per-replica access
 // (health monitor, status reporting).
 func (r *Router) GetReplicaSet(name string) *ReplicaSet {
 	r.mu.RLock()
@@ -78,8 +78,8 @@ func (r *Router) GetReplicaSet(name string) *ReplicaSet {
 	return r.sets[name]
 }
 
-// Clients returns one representative AgentClient per registered agent,
-// sorted by agent name. Each representative is chosen via the set's policy,
+// Clients returns one representative AgentClient per registered server,
+// sorted by server name. Each representative is chosen via the set's policy,
 // so a single-replica set returns its only client. Skips sets with no
 // currently-healthy replica.
 func (r *Router) Clients() []AgentClient {
@@ -99,7 +99,7 @@ func (r *Router) Clients() []AgentClient {
 	return clients
 }
 
-// ReplicaSets returns all registered replica sets, sorted by agent name.
+// ReplicaSets returns all registered replica sets, sorted by server name.
 func (r *Router) ReplicaSets() []*ReplicaSet {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -133,7 +133,7 @@ func toolsOf(set *ReplicaSet) []Tool {
 	return tools
 }
 
-// RefreshTools updates the tool registry from all agents.
+// RefreshTools updates the tool registry from all servers.
 func (r *Router) RefreshTools() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -149,7 +149,7 @@ func (r *Router) RefreshTools() {
 	}
 }
 
-// AggregatedTools returns all tools from all agents with prefixed names.
+// AggregatedTools returns all tools from all servers with prefixed names.
 func (r *Router) AggregatedTools() []Tool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -176,7 +176,7 @@ func (r *Router) AggregatedTools() []Tool {
 	return tools
 }
 
-// RouteToolCall routes a tool call to the appropriate agent. The concrete
+// RouteToolCall routes a tool call to the appropriate server. The concrete
 // replica is chosen by the set's dispatch policy.
 func (r *Router) RouteToolCall(prefixedName string) (AgentClient, string, error) {
 	replica, toolName, err := r.RouteToolCallReplica(prefixedName)
@@ -190,40 +190,40 @@ func (r *Router) RouteToolCall(prefixedName string) (AgentClient, string, error)
 // replica itself. Callers that need the replica id (for per-replica logging,
 // tracing, and in-flight accounting) should use this variant.
 func (r *Router) RouteToolCallReplica(prefixedName string) (*Replica, string, error) {
-	agentName, toolName, err := ParsePrefixedTool(prefixedName)
+	serverName, toolName, err := ParsePrefixedTool(prefixedName)
 	if err != nil {
 		return nil, "", err
 	}
 
 	r.mu.RLock()
-	set, ok := r.sets[agentName]
+	set, ok := r.sets[serverName]
 	r.mu.RUnlock()
 	if !ok {
-		return nil, "", fmt.Errorf("unknown agent: %s", agentName)
+		return nil, "", fmt.Errorf("unknown server: %s", serverName)
 	}
 
 	replica, err := set.Pick()
 	if err != nil {
-		return nil, "", fmt.Errorf("agent %s: %w", agentName, err)
+		return nil, "", fmt.Errorf("server %s: %w", serverName, err)
 	}
 	return replica, toolName, nil
 }
 
-// ToolNameDelimiter is the separator between agent name and tool name in prefixed tool names.
-// Format: "agentname__toolname"
+// ToolNameDelimiter is the separator between server name and tool name in prefixed tool names.
+// Format: "servername__toolname"
 // Uses double underscore to be compatible with Claude Desktop's tool name validation: ^[a-zA-Z0-9_-]{1,64}$
 const ToolNameDelimiter = "__"
 
-// PrefixTool creates a prefixed tool name: "agent__tool"
-func PrefixTool(agentName, toolName string) string {
-	return agentName + ToolNameDelimiter + toolName
+// PrefixTool creates a prefixed tool name: "server__tool"
+func PrefixTool(serverName, toolName string) string {
+	return serverName + ToolNameDelimiter + toolName
 }
 
-// ParsePrefixedTool parses a prefixed tool name into agent and tool names.
-func ParsePrefixedTool(prefixed string) (agentName, toolName string, err error) {
+// ParsePrefixedTool parses a prefixed tool name into server and tool names.
+func ParsePrefixedTool(prefixed string) (serverName, toolName string, err error) {
 	parts := strings.SplitN(prefixed, ToolNameDelimiter, 2)
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid tool name format: %s (expected agent__tool)", prefixed)
+		return "", "", fmt.Errorf("invalid tool name format: %s (expected server__tool)", prefixed)
 	}
 	return parts[0], parts[1], nil
 }

--- a/pkg/mcp/router_test.go
+++ b/pkg/mcp/router_test.go
@@ -200,12 +200,12 @@ func TestRouter_RouteToolCall(t *testing.T) {
 	}
 }
 
-func TestRouter_RouteToolCall_UnknownAgent(t *testing.T) {
+func TestRouter_RouteToolCall_UnknownServer(t *testing.T) {
 	r := NewRouter()
 
 	_, _, err := r.RouteToolCall("unknown__tool1")
 	if err == nil {
-		t.Fatal("expected error for unknown agent")
+		t.Fatal("expected error for unknown server")
 	}
 }
 
@@ -220,32 +220,32 @@ func TestRouter_RouteToolCall_InvalidFormat(t *testing.T) {
 
 func TestPrefixTool(t *testing.T) {
 	tests := []struct {
-		agent    string
+		server   string
 		tool     string
 		expected string
 	}{
-		{"agent1", "tool1", "agent1__tool1"},
-		{"my-agent", "my-tool", "my-agent__my-tool"},
+		{"server1", "tool1", "server1__tool1"},
+		{"my-server", "my-tool", "my-server__my-tool"},
 		{"a", "b", "a__b"},
 	}
 
 	for _, tc := range tests {
-		got := PrefixTool(tc.agent, tc.tool)
+		got := PrefixTool(tc.server, tc.tool)
 		if got != tc.expected {
-			t.Errorf("PrefixTool(%s, %s) = %s, want %s", tc.agent, tc.tool, got, tc.expected)
+			t.Errorf("PrefixTool(%s, %s) = %s, want %s", tc.server, tc.tool, got, tc.expected)
 		}
 	}
 }
 
 func TestParsePrefixedTool(t *testing.T) {
 	tests := []struct {
-		input     string
-		wantAgent string
-		wantTool  string
-		wantErr   bool
+		input      string
+		wantServer string
+		wantTool   string
+		wantErr    bool
 	}{
-		{"agent1__tool1", "agent1", "tool1", false},
-		{"my-agent__my-tool", "my-agent", "my-tool", false},
+		{"server1__tool1", "server1", "tool1", false},
+		{"my-server__my-tool", "my-server", "my-tool", false},
 		{"a__b__c", "a", "b__c", false}, // SplitN with 2 preserves extra __
 		{"invalidformat", "", "", true},
 		{"single-dash", "", "", true},
@@ -254,14 +254,14 @@ func TestParsePrefixedTool(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		agent, tool, err := ParsePrefixedTool(tc.input)
+		server, tool, err := ParsePrefixedTool(tc.input)
 		if (err != nil) != tc.wantErr {
 			t.Errorf("ParsePrefixedTool(%s) error = %v, wantErr %v", tc.input, err, tc.wantErr)
 			continue
 		}
 		if !tc.wantErr {
-			if agent != tc.wantAgent {
-				t.Errorf("ParsePrefixedTool(%s) agent = %s, want %s", tc.input, agent, tc.wantAgent)
+			if server != tc.wantServer {
+				t.Errorf("ParsePrefixedTool(%s) server = %s, want %s", tc.input, server, tc.wantServer)
 			}
 			if tool != tc.wantTool {
 				t.Errorf("ParsePrefixedTool(%s) tool = %s, want %s", tc.input, tool, tc.wantTool)

--- a/pkg/mcp/streamable_test.go
+++ b/pkg/mcp/streamable_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // initializeStreamable sends an initialize request and returns the session ID.
-func initializeStreamable(t *testing.T, srv *StreamableHTTPServer, agentName string) string {
+func initializeStreamable(t *testing.T, srv *StreamableHTTPServer) string {
 	t.Helper()
 	body, _ := json.Marshal(map[string]any{
 		"jsonrpc": "2.0",
@@ -28,9 +28,6 @@ func initializeStreamable(t *testing.T, srv *StreamableHTTPServer, agentName str
 		},
 	})
 	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
-	if agentName != "" {
-		req.Header.Set("X-Agent-Name", agentName)
-	}
 	w := httptest.NewRecorder()
 	srv.ServeHTTP(w, req)
 
@@ -69,7 +66,7 @@ func streamablePost(t *testing.T, srv *StreamableHTTPServer, sessionID string, m
 
 func TestStreamableHTTPServer_Initialize(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	if len(sessionID) == 0 {
 		t.Error("expected non-empty session ID")
@@ -109,7 +106,7 @@ func TestStreamableHTTPServer_Initialize_SessionIDInHeader(t *testing.T) {
 
 func TestStreamableHTTPServer_Initialize_ParsesProtocolVersion(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	// Verify the session is tracked
 	ids := srv.SessionIDs()
@@ -184,7 +181,7 @@ func TestStreamableHTTPServer_Post_InvalidJSON(t *testing.T) {
 
 func TestStreamableHTTPServer_Ping(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	resp := streamablePost(t, srv, sessionID, "ping", nil)
 	if resp.Error != nil {
@@ -203,7 +200,7 @@ func TestStreamableHTTPServer_ToolsList(t *testing.T) {
 	g.Router().RefreshTools()
 
 	srv := NewStreamableHTTPServer(g, nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	resp := streamablePost(t, srv, sessionID, "tools/list", nil)
 	if resp.Error != nil {
@@ -231,7 +228,7 @@ func TestStreamableHTTPServer_ToolsCall(t *testing.T) {
 	g.Router().RefreshTools()
 
 	srv := NewStreamableHTTPServer(g, nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	params, _ := json.Marshal(ToolCallParams{Name: "server1__echo", Arguments: map[string]any{}})
 	body := map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": json.RawMessage(params)}
@@ -259,7 +256,7 @@ func TestStreamableHTTPServer_ToolsCall(t *testing.T) {
 
 func TestStreamableHTTPServer_Delete(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	req := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
 	req.Header.Set("Mcp-Session-Id", sessionID)
@@ -301,7 +298,7 @@ func TestStreamableHTTPServer_Delete_UnknownSession(t *testing.T) {
 
 func TestStreamableHTTPServer_PostAfterDelete(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	// Delete the session
 	del := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
@@ -323,7 +320,7 @@ func TestStreamableHTTPServer_PostAfterDelete(t *testing.T) {
 
 func TestStreamableHTTPServer_Get_SSEHeaders(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, "/mcp", nil).WithContext(ctx)
@@ -376,7 +373,7 @@ func TestStreamableHTTPServer_Get_UnknownSession(t *testing.T) {
 
 func TestStreamableHTTPServer_Get_LastEventID_Replay(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	// Manually look up the session and push some events
 	srv.mu.RLock()
@@ -510,12 +507,12 @@ func TestStreamableHTTPServer_SessionCount(t *testing.T) {
 		t.Errorf("expected 0 sessions initially, got %d", srv.SessionCount())
 	}
 
-	id1 := initializeStreamable(t, srv, "")
+	id1 := initializeStreamable(t, srv)
 	if srv.SessionCount() != 1 {
 		t.Errorf("expected 1 session, got %d", srv.SessionCount())
 	}
 
-	_ = initializeStreamable(t, srv, "")
+	_ = initializeStreamable(t, srv)
 	if srv.SessionCount() != 2 {
 		t.Errorf("expected 2 sessions, got %d", srv.SessionCount())
 	}
@@ -533,8 +530,8 @@ func TestStreamableHTTPServer_SessionCount(t *testing.T) {
 func TestStreamableHTTPServer_Close(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
 
-	initializeStreamable(t, srv, "")
-	initializeStreamable(t, srv, "")
+	initializeStreamable(t, srv)
+	initializeStreamable(t, srv)
 
 	if srv.SessionCount() != 2 {
 		t.Fatalf("expected 2 sessions before close, got %d", srv.SessionCount())
@@ -549,7 +546,7 @@ func TestStreamableHTTPServer_Close(t *testing.T) {
 
 func TestStreamableHTTPServer_Close_CancelsSSEStream(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -581,7 +578,7 @@ func TestStreamableHTTPServer_Close_CancelsSSEStream(t *testing.T) {
 
 func TestStreamableHTTPServer_NotificationsInitialized(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	resp := streamablePost(t, srv, sessionID, "notifications/initialized", nil)
 	if resp.Error != nil {
@@ -591,7 +588,7 @@ func TestStreamableHTTPServer_NotificationsInitialized(t *testing.T) {
 
 func TestStreamableHTTPServer_UnknownMethod(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	resp := streamablePost(t, srv, sessionID, "nonexistent/method", nil)
 	if resp.Error == nil {
@@ -604,7 +601,7 @@ func TestStreamableHTTPServer_UnknownMethod(t *testing.T) {
 
 func TestStreamableHTTPServer_Get_CancelCancelsOldStream(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	defer cancel1()
@@ -654,7 +651,7 @@ func TestStreamableHTTPServer_GatewaySessionCount(t *testing.T) {
 		t.Errorf("expected 0 gateway sessions initially, got %d", g.SessionCount())
 	}
 
-	id1 := initializeStreamable(t, srv, "")
+	id1 := initializeStreamable(t, srv)
 	if g.SessionCount() != 1 {
 		t.Errorf("expected 1 gateway session after initialize, got %d", g.SessionCount())
 	}
@@ -671,7 +668,7 @@ func TestStreamableHTTPServer_GatewaySessionCount(t *testing.T) {
 
 func TestStreamableHTTPServer_ToolsCall_InvalidParams(t *testing.T) {
 	srv := NewStreamableHTTPServer(NewGateway(), nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 
 	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":"invalid"}`
 	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
@@ -729,7 +726,7 @@ func setupStreamableWithRegistry(t *testing.T) (*StreamableHTTPServer, string) {
 	g.Router().AddClient(pp)
 
 	srv := NewStreamableHTTPServer(g, nil)
-	sessionID := initializeStreamable(t, srv, "")
+	sessionID := initializeStreamable(t, srv)
 	return srv, sessionID
 }
 

--- a/web/src/__tests__/LogViewer.test.tsx
+++ b/web/src/__tests__/LogViewer.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import '@testing-library/jest-dom';
 
 vi.mock('../lib/api', () => ({
-  fetchAgentLogs: vi.fn(),
+  fetchServerLogs: vi.fn(),
 }));
 
 vi.mock('../lib/constants', () => ({
@@ -19,7 +19,7 @@ vi.mock('../components/ui/IconButton', () => ({
 }));
 
 import { LogViewer } from '../components/ui/LogViewer';
-import { fetchAgentLogs } from '../lib/api';
+import { fetchServerLogs } from '../lib/api';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -27,19 +27,19 @@ beforeEach(() => {
 
 describe('LogViewer', () => {
   it('renders agent name in header', () => {
-    vi.mocked(fetchAgentLogs).mockReturnValue(new Promise(() => {}));
+    vi.mocked(fetchServerLogs).mockReturnValue(new Promise(() => {}));
     render(<LogViewer agentName="test-agent" onClose={vi.fn()} />);
     expect(screen.getByText('Logs: test-agent')).toBeInTheDocument();
   });
 
   it('shows loading state initially', () => {
-    vi.mocked(fetchAgentLogs).mockReturnValue(new Promise(() => {}));
+    vi.mocked(fetchServerLogs).mockReturnValue(new Promise(() => {}));
     render(<LogViewer agentName="test-agent" onClose={vi.fn()} />);
     expect(screen.getByText('Loading logs...')).toBeInTheDocument();
   });
 
   it('renders log entries after fetch', async () => {
-    vi.mocked(fetchAgentLogs).mockResolvedValue([
+    vi.mocked(fetchServerLogs).mockResolvedValue([
       'INFO starting server',
       'WARN slow query detected',
       'ERROR connection failed',
@@ -55,7 +55,7 @@ describe('LogViewer', () => {
   });
 
   it('shows empty state when no logs', async () => {
-    vi.mocked(fetchAgentLogs).mockResolvedValue([]);
+    vi.mocked(fetchServerLogs).mockResolvedValue([]);
     render(<LogViewer agentName="test-agent" onClose={vi.fn()} />);
 
     await waitFor(() => {
@@ -64,7 +64,7 @@ describe('LogViewer', () => {
   });
 
   it('shows error message on fetch failure', async () => {
-    vi.mocked(fetchAgentLogs).mockRejectedValue(new Error('Network error'));
+    vi.mocked(fetchServerLogs).mockRejectedValue(new Error('Network error'));
     render(<LogViewer agentName="test-agent" onClose={vi.fn()} />);
 
     await waitFor(() => {
@@ -73,7 +73,7 @@ describe('LogViewer', () => {
   });
 
   it('calls onClose when close button clicked', async () => {
-    vi.mocked(fetchAgentLogs).mockResolvedValue([]);
+    vi.mocked(fetchServerLogs).mockResolvedValue([]);
     const onClose = vi.fn();
     render(<LogViewer agentName="test-agent" onClose={onClose} />);
 
@@ -86,7 +86,7 @@ describe('LogViewer', () => {
   });
 
   it('toggles pause/resume', async () => {
-    vi.mocked(fetchAgentLogs).mockResolvedValue(['log line']);
+    vi.mocked(fetchServerLogs).mockResolvedValue(['log line']);
     render(<LogViewer agentName="test-agent" onClose={vi.fn()} />);
 
     await waitFor(() => {
@@ -98,31 +98,31 @@ describe('LogViewer', () => {
   });
 
   it('fetches logs with correct agent name and limit', async () => {
-    vi.mocked(fetchAgentLogs).mockResolvedValue([]);
+    vi.mocked(fetchServerLogs).mockResolvedValue([]);
     render(<LogViewer agentName="my-agent" onClose={vi.fn()} />);
 
     await waitFor(() => {
-      expect(fetchAgentLogs).toHaveBeenCalledWith('my-agent', 500);
+      expect(fetchServerLogs).toHaveBeenCalledWith('my-agent', 500);
     });
   });
 
   it('polls for new logs on interval', async () => {
     vi.useFakeTimers();
-    vi.mocked(fetchAgentLogs).mockResolvedValue(['initial log']);
+    vi.mocked(fetchServerLogs).mockResolvedValue(['initial log']);
 
     await act(async () => {
       render(<LogViewer agentName="test-agent" onClose={vi.fn()} />);
     });
 
     // Initial fetch
-    expect(fetchAgentLogs).toHaveBeenCalledTimes(1);
+    expect(fetchServerLogs).toHaveBeenCalledTimes(1);
 
     // Advance past one polling interval and flush promises
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2000);
     });
 
-    expect(fetchAgentLogs).toHaveBeenCalledTimes(2);
+    expect(fetchServerLogs).toHaveBeenCalledTimes(2);
 
     vi.useRealTimers();
   });

--- a/web/src/components/log/LogsTab.tsx
+++ b/web/src/components/log/LogsTab.tsx
@@ -18,7 +18,7 @@ import { useUIStore } from '../../stores/useUIStore';
 import { useSelectedNodeData } from '../../stores/useStackStore';
 import { useWindowManager } from '../../hooks/useWindowManager';
 import { useLogFontSize } from '../../hooks/useLogFontSize';
-import { fetchAgentLogs, fetchGatewayLogs } from '../../lib/api';
+import { fetchServerLogs, fetchGatewayLogs } from '../../lib/api';
 import { POLLING } from '../../lib/constants';
 import type { NodeData } from '../../types';
 
@@ -64,7 +64,7 @@ export function LogsTab() {
         const entries = await fetchGatewayLogs(500);
         setLogs((entries ?? []).map(parseLogEntry));
       } else if (agentName) {
-        const lines = await fetchAgentLogs(agentName, 500);
+        const lines = await fetchServerLogs(agentName, 500);
         setLogs((lines ?? []).map(parseLogEntry));
       }
       setError(null);

--- a/web/src/components/ui/LogViewer.tsx
+++ b/web/src/components/ui/LogViewer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { X, Pause, Play, ArrowDown } from 'lucide-react';
 import { cn } from '../../lib/cn';
-import { fetchAgentLogs } from '../../lib/api';
+import { fetchServerLogs } from '../../lib/api';
 import { POLLING } from '../../lib/constants';
 import { IconButton } from './IconButton';
 
@@ -21,7 +21,7 @@ export function LogViewer({ agentName, onClose }: LogViewerProps) {
 
   const fetchLogs = useCallback(async () => {
     try {
-      const newLogs = await fetchAgentLogs(agentName, 500);
+      const newLogs = await fetchServerLogs(agentName, 500);
       setLogs(newLogs);
       setError(null);
     } catch (err) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -129,15 +129,15 @@ export async function fetchClients(): Promise<ClientStatus[]> {
   return fetchJSON<ClientStatus[]>('/api/clients');
 }
 
-// === Agent Control Functions (require backend endpoints) ===
+// === MCP Server Control Functions ===
 
 /**
- * Fetch logs for a specific agent
- * GET /api/agents/{name}/logs
+ * Fetch logs for a specific MCP server
+ * GET /api/mcp-servers/{name}/logs
  */
-export async function fetchAgentLogs(name: string, lines = 100): Promise<string[]> {
+export async function fetchServerLogs(name: string, lines = 100): Promise<string[]> {
   const response = await fetch(
-    `${API_BASE}/api/agents/${encodeURIComponent(name)}/logs?lines=${lines}`,
+    `${API_BASE}/api/mcp-servers/${encodeURIComponent(name)}/logs?lines=${lines}`,
     { headers: buildHeaders() },
   );
 
@@ -160,46 +160,6 @@ export async function fetchAgentLogs(name: string, lines = 100): Promise<string[
 
   return response.json();
 }
-
-/**
- * Restart an agent's container
- * POST /api/agents/{name}/restart
- */
-export async function restartAgent(name: string): Promise<void> {
-  const response = await fetch(`${API_BASE}/api/agents/${encodeURIComponent(name)}/restart`, {
-    method: 'POST',
-    headers: buildHeaders(),
-  });
-
-  if (response.status === 401) {
-    throw new AuthError('Authentication required');
-  }
-
-  if (!response.ok) {
-    throw new Error(`Restart failed: ${response.status} ${response.statusText}`);
-  }
-}
-
-/**
- * Stop an agent's container
- * POST /api/agents/{name}/stop
- */
-export async function stopAgent(name: string): Promise<void> {
-  const response = await fetch(`${API_BASE}/api/agents/${encodeURIComponent(name)}/stop`, {
-    method: 'POST',
-    headers: buildHeaders(),
-  });
-
-  if (response.status === 401) {
-    throw new AuthError('Authentication required');
-  }
-
-  if (!response.ok) {
-    throw new Error(`Stop failed: ${response.status} ${response.statusText}`);
-  }
-}
-
-// === MCP Server Control Functions ===
 
 /**
  * Restart an MCP server connection

--- a/web/src/pages/DetachedLogsPage.tsx
+++ b/web/src/pages/DetachedLogsPage.tsx
@@ -18,7 +18,7 @@ import { cn } from '../lib/cn';
 import { IconButton } from '../components/ui/IconButton';
 import { LogLine, LevelFilter, parseLogEntry, type LogLevel, type ParsedLog } from '../components/log';
 import { ZoomControls } from '../components/ui/ZoomControls';
-import { fetchAgentLogs, fetchGatewayLogs, fetchStatus } from '../lib/api';
+import { fetchServerLogs, fetchGatewayLogs, fetchStatus } from '../lib/api';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
 import { useLogFontSize } from '../hooks/useLogFontSize';
 import { POLLING } from '../lib/constants';
@@ -149,7 +149,7 @@ function DetachedLogsPageContent() {
         const entries = await fetchGatewayLogs(500);
         setLogs((entries ?? []).map(parseLogEntry));
       } else {
-        const lines = await fetchAgentLogs(selectedAgent, 500);
+        const lines = await fetchServerLogs(selectedAgent, 500);
         setLogs((lines ?? []).map(parseLogEntry));
       }
       setError(null);


### PR DESCRIPTION
## Description

Follow-up to #680, #681, and #682 sweeping the leftover agent-era code that survived the agent/A2A runtime removal. Five concrete cleanups across the HTTP surface, CORS allowlist, `pkg/mcp` internals, frontend helpers, and CLI command registration. Mechanical changes only — no behavior change, no new tests, existing suites cover everything.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (one HTTP route rename — pre-1.0, no shim, called out in CHANGELOG)

## Changes Made

- **Rename** `GET /api/agents/{name}/logs` → `GET /api/mcp-servers/{name}/logs` to match the existing `/api/mcp-servers/{name}/{restart,tools}` convention. Handler `handleAgentLogs` → `handleMCPServerLogs`; 5 backend tests renamed; frontend `fetchAgentLogs` → `fetchServerLogs` and all 4 callers + 16 test references updated.
- **Drop** the `X-Agent-Name` CORS header from `internal/api/api.go:531`, `docs/api-reference.md:1120`, and the conditional setter in `pkg/mcp/streamable_test.go`. Zero production readers — the header was advertised but inert.
- **Rename** `agentName` → `serverName` in `pkg/mcp/router.go` and `pkg/mcp/gateway.go`: local variables, named-return parameters of `PrefixTool` / `ParsePrefixedTool`, doc comments on `Router` and its methods, and error messages (`"unknown agent"` → `"unknown server"`, `"expected agent__tool"` → `"expected server__tool"`). Public `AgentClient` interface and method names left unchanged (out of scope for this PR).
- **Delete** dead frontend helpers `restartAgent` and `stopAgent` in `web/src/lib/api.ts`. Both targeted server routes that don't exist (canonical is `/api/mcp-servers/{name}/restart`); neither had any callers.
- **Consolidate** CLI command registration in `cmd/gridctl/root.go`: `reload`, `telemetry`, `traces`, `upgrade`, `export`, and `version` previously self-registered via their own `init()` functions; they now appear in the canonical `rootCmd.AddCommand(...)` list alongside the other 16 commands.
- **CHANGELOG** `[Unreleased]` updated under `Breaking` (route rename), `Removed` (CORS header + dead frontend helpers), and `Changed` (`pkg/mcp` internal naming + CLI registration consolidation).

`AgentClient` interface and its methods (`AddClient` / `RemoveClient`) are explicitly out of scope — that public-API rename has wider blast radius and belongs in a separate PR.

## Testing

- `go build ./...` ✓
- `go test -race ./...` ✓ (full suite, no failures)
- `go vet ./...` ✓ (no new warnings)
- `npm run build` in `web/` ✓
- `npm test` in `web/` ✓ (567/567 tests pass)
- `./gridctl --help` lists all 22 commands ✓
- Smoke: `curl localhost:<port>/api/mcp-servers/<server>/logs` returns the same JSON shape that `/api/agents/<server>/logs` returned before this PR.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed
- [x] CHANGELOG updated with breaking change called out

Closes #683