### PR TITLE
style: refine topology canvas visual hierarchy

### DIFF
--- a/web/src/components/graph/Canvas.tsx
+++ b/web/src/components/graph/Canvas.tsx
@@ -209,7 +209,7 @@ export function Canvas() {
             variant={BackgroundVariant.Dots}
             gap={20}
             size={1}
-            color={`rgba(0, 202, 255, ${0.1 * subGridOpacity})`}
+            color={`rgba(13, 148, 136, ${0.1 * subGridOpacity})`}
           />
         )}
 

--- a/web/src/components/graph/ClientNode.tsx
+++ b/web/src/components/graph/ClientNode.tsx
@@ -22,6 +22,7 @@ const ClientNode = memo(({ data, selected }: ClientNodeProps) => {
           'w-40 rounded-xl relative',
           'backdrop-blur-xl border transition-all duration-200 ease-out',
           'bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.03]',
+          'shadow-bevel',
           'flex items-center px-2.5 gap-2',
           selected && 'border-primary shadow-glow-primary ring-2 ring-primary/20',
           !selected && 'border-border hover:shadow-node-hover hover:border-primary/60'
@@ -58,6 +59,7 @@ const ClientNode = memo(({ data, selected }: ClientNodeProps) => {
         'w-40 rounded-xl relative',
         'backdrop-blur-xl border transition-all duration-200 ease-out',
         'bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.03]',
+        'shadow-bevel',
         'flex flex-col items-center justify-center text-center p-3 gap-1',
         selected && 'border-primary shadow-glow-primary ring-2 ring-primary/20',
         !selected && 'border-primary/25 hover:shadow-node-hover hover:border-primary/40'

--- a/web/src/components/graph/CustomNode.tsx
+++ b/web/src/components/graph/CustomNode.tsx
@@ -54,6 +54,7 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
       className={cn(
         'w-64 rounded-xl relative',
         'backdrop-blur-xl border transition-all duration-200 ease-out',
+        'shadow-bevel',
         isServer
           ? 'bg-gradient-to-br from-surface/95 to-violet-500/[0.03] border-border'
           : 'bg-gradient-to-br from-surface/95 to-secondary/[0.02] border-border',

--- a/web/src/components/graph/GatewayNode.tsx
+++ b/web/src/components/graph/GatewayNode.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { Handle, Position } from '@xyflow/react';
-import { Activity, Server, Database, Wrench, Zap, Radio, Monitor, Code, Library, ExternalLink } from 'lucide-react';
+import { Activity, Server, Database, Wrench, Radio, Monitor, Code, Library, ExternalLink } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { StatusDot } from '../ui/StatusDot';
 import { useWindowManager } from '../../hooks/useWindowManager';
@@ -20,7 +20,7 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
         'w-60 rounded-2xl',
         'bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.03]',
         'backdrop-blur-xl border border-border',
-        'shadow-lg transition-all duration-300 ease-out',
+        'shadow-lg-bevel transition-all duration-300 ease-out',
         selected && 'border-primary shadow-glow-primary ring-2 ring-primary/20',
         !selected && 'hover:shadow-node-hover hover:border-primary/60'
       )}
@@ -52,8 +52,8 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
         {/* MCP Servers */}
         <div className="flex items-center justify-between group">
           <div className="flex items-center gap-2.5">
-            <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-              <Server size={12} className="text-primary/70" />
+            <div className="p-1.5 rounded-lg bg-white/[0.04] border border-[var(--color-border-subtle)] group-hover:bg-primary/15 group-hover:border-primary/20 transition-colors">
+              <Server size={12} className="text-text-secondary group-hover:text-primary/70 transition-colors" />
             </div>
             <span className="text-xs text-text-secondary font-medium">MCP Servers</span>
           </div>
@@ -66,8 +66,8 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
         {data.resourceCount > 0 && (
           <div className="flex items-center justify-between group">
             <div className="flex items-center gap-2.5">
-              <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-                <Database size={12} className="text-primary/70" />
+              <div className="p-1.5 rounded-lg bg-white/[0.04] border border-[var(--color-border-subtle)] group-hover:bg-primary/15 group-hover:border-primary/20 transition-colors">
+                <Database size={12} className="text-text-secondary group-hover:text-primary/70 transition-colors" />
               </div>
               <span className="text-xs text-text-secondary font-medium">Resources</span>
             </div>
@@ -81,8 +81,8 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
         {(data.sessions ?? 0) > 0 && (
           <div className="flex items-center justify-between group">
             <div className="flex items-center gap-2.5">
-              <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-                <Radio size={12} className="text-primary/70" />
+              <div className="p-1.5 rounded-lg bg-white/[0.04] border border-[var(--color-border-subtle)] group-hover:bg-primary/15 group-hover:border-primary/20 transition-colors">
+                <Radio size={12} className="text-text-secondary group-hover:text-primary/70 transition-colors" />
               </div>
               <span className="text-xs text-text-secondary font-medium">Sessions</span>
             </div>
@@ -96,8 +96,8 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
         {(data.clientCount ?? 0) > 0 && (
           <div className="flex items-center justify-between group">
             <div className="flex items-center gap-2.5">
-              <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-                <Monitor size={12} className="text-primary/70" />
+              <div className="p-1.5 rounded-lg bg-white/[0.04] border border-[var(--color-border-subtle)] group-hover:bg-primary/15 group-hover:border-primary/20 transition-colors">
+                <Monitor size={12} className="text-text-secondary group-hover:text-primary/70 transition-colors" />
               </div>
               <span className="text-xs text-text-secondary font-medium">Clients</span>
             </div>
@@ -110,8 +110,8 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
         {/* Tools */}
         <div className="flex items-center justify-between group">
           <div className="flex items-center gap-2.5">
-            <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-              <Wrench size={12} className="text-primary/70" />
+            <div className="p-1.5 rounded-lg bg-white/[0.04] border border-[var(--color-border-subtle)] group-hover:bg-primary/15 group-hover:border-primary/20 transition-colors">
+              <Wrench size={12} className="text-text-secondary group-hover:text-primary/70 transition-colors" />
             </div>
             <span className="text-xs text-text-secondary font-medium">Total Tools</span>
           </div>
@@ -128,8 +128,8 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
             title="Open skills dashboard"
           >
             <div className="flex items-center gap-2.5">
-              <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20 group-hover:bg-primary/15 transition-colors">
-                <Library size={12} className="text-primary/70" />
+              <div className="p-1.5 rounded-lg bg-white/[0.04] border border-[var(--color-border-subtle)] group-hover:bg-primary/15 group-hover:border-primary/20 transition-colors">
+                <Library size={12} className="text-text-secondary group-hover:text-primary/70 transition-colors" />
               </div>
               <span className="text-xs text-text-secondary font-medium">Skills</span>
             </div>
@@ -156,7 +156,6 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
             <StatusDot status="running" />
             Gateway Active
           </span>
-          <Zap size={14} className="text-primary animate-pulse" style={{ animationDuration: '2s' }} />
         </div>
       </div>
 

--- a/web/src/components/graph/SkillGroupNode.tsx
+++ b/web/src/components/graph/SkillGroupNode.tsx
@@ -50,6 +50,7 @@ const SkillGroupNode = memo(({ data, selected }: SkillGroupNodeProps) => {
           'w-44 rounded-xl relative',
           'backdrop-blur-xl border transition-all duration-200 ease-out',
           'bg-gradient-to-b from-surface/95 via-surface/90 to-tertiary/[0.03]',
+          'shadow-bevel',
           'flex items-center px-2.5 gap-2',
           selected && 'border-tertiary shadow-glow-tertiary ring-2 ring-tertiary/20',
           !selected && 'border-border hover:shadow-node-hover hover:border-tertiary-light/60'
@@ -87,6 +88,7 @@ const SkillGroupNode = memo(({ data, selected }: SkillGroupNodeProps) => {
         'w-44 rounded-xl relative',
         'backdrop-blur-xl border transition-all duration-200 ease-out',
         'bg-gradient-to-b from-surface/95 via-surface/90 to-tertiary/[0.03]',
+        'shadow-bevel',
         'flex flex-col items-center justify-center text-center p-3 gap-1.5',
         selected && 'border-tertiary shadow-glow-tertiary ring-2 ring-tertiary/20',
         !selected && 'border-tertiary/25 hover:shadow-node-hover hover:border-tertiary/40'

--- a/web/src/components/graph/SkillNode.tsx
+++ b/web/src/components/graph/SkillNode.tsx
@@ -60,6 +60,7 @@ const SkillNode = memo(({ data, selected }: SkillNodeProps) => {
           'w-44 rounded-xl relative',
           'backdrop-blur-xl border transition-all duration-200 ease-out',
           'bg-gradient-to-b from-surface/95 via-surface/90 to-tertiary/[0.03]',
+          'shadow-bevel',
           'flex items-center px-2.5 gap-2',
           selected && 'border-tertiary shadow-glow-tertiary ring-2 ring-tertiary/20',
           !selected && 'border-border hover:shadow-node-hover hover:border-tertiary-light/60'
@@ -95,6 +96,7 @@ const SkillNode = memo(({ data, selected }: SkillNodeProps) => {
         'w-44 rounded-xl relative',
         'backdrop-blur-xl border transition-all duration-200 ease-out',
         'bg-gradient-to-b from-surface/95 via-surface/90 to-tertiary/[0.03]',
+        'shadow-bevel',
         'flex flex-col items-center justify-center text-center p-3 gap-1.5',
         selected && 'border-tertiary shadow-glow-tertiary ring-2 ring-tertiary/20',
         !selected && 'border-tertiary/25 hover:shadow-node-hover hover:border-tertiary/40'

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -305,12 +305,13 @@ body::before {
   backdrop-filter: blur(16px);
   border: 1px solid var(--glass-border);
   border-radius: 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .node-glass:hover {
   border-color: var(--color-border);
-  box-shadow: var(--shadow-lg);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), var(--shadow-lg);
 }
 
 /* Primary variant (MCP servers) - Amber accent */
@@ -323,11 +324,13 @@ body::before {
   backdrop-filter: blur(16px);
   border: 1px solid var(--glass-border);
   border-radius: 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .node-glass-primary.selected {
   border-color: var(--color-primary);
   box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
     0 0 0 1px var(--color-primary),
     var(--shadow-glow-primary),
     var(--shadow-lg);
@@ -343,11 +346,13 @@ body::before {
   backdrop-filter: blur(16px);
   border: 1px solid var(--glass-border);
   border-radius: 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .node-glass-secondary.selected {
   border-color: var(--color-secondary);
   box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
     0 0 0 1px var(--color-secondary),
     var(--shadow-glow-secondary),
     var(--shadow-lg);
@@ -363,12 +368,13 @@ body::before {
   backdrop-filter: blur(20px);
   border: 1px solid rgba(245, 158, 11, 0.2);
   border-radius: 16px;
-  box-shadow: var(--shadow-lg);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), var(--shadow-lg);
 }
 
 .node-gateway.selected {
   border-color: var(--color-primary);
   box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
     0 0 0 2px var(--color-primary),
     var(--shadow-glow-primary),
     var(--shadow-lg);
@@ -594,6 +600,16 @@ body::before {
   border: 1px solid var(--glass-border);
   border-radius: 12px;
   box-shadow: var(--shadow-lg);
+}
+
+/* Top-edge inset highlight — fakes light catching a beveled glass surface.
+   Compose with other shadows via comma separation. */
+.shadow-bevel {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.shadow-lg-bevel {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), var(--shadow-lg);
 }
 
 /* ============================================


### PR DESCRIPTION
## Description

Visual polish pass on the topology canvas: demote informational icons to neutral (lift to amber on row hover), add a 1px inset top-edge bevel to all glass nodes, remove the redundant `Zap` flourish from the gateway card, and recolor the sub-grid from a rogue cyan (not in the palette) to the existing teal palette token.

## Type of Change

- [x] Style / visual refinement (no functional or API change)

## Changes Made

- **Icon color hierarchy** — `GatewayNode` stat-row icons (MCP Servers, Resources, Sessions, Clients, Tools, Skills) demoted from `text-primary/70` to `text-text-secondary`, with their amber halo containers (`bg-primary/10 border-primary/20`) swapped to `bg-white/[0.04] border-[var(--color-border-subtle)]`. Both glyph and container lift to amber on row hover so the hoverable affordance is preserved. The `Code Mode` badge, gateway header `Activity` logo, and Handle dots remain amber — amber now signals identity or action, not chrome.
- **Inset top-edge bevel** — new `.shadow-bevel` and `.shadow-lg-bevel` utility classes (`inset 0 1px 0 rgba(255,255,255,0.06)`) composed into `.node-glass*`, `.node-gateway`, and applied to `GatewayNode`, `ClientNode`, `CustomNode`, `SkillNode`, `SkillGroupNode` root elements. Backdrop blur unchanged — the bevel does the heavy lifting on perceived depth.
- **`Zap` removal** — the amber `Zap` icon at the bottom of `GatewayNode` is gone (and its `lucide-react` import). It was neither identity nor action, and the adjacent ``Gateway Active`` status dot already communicates the same thing.
- **Sub-grid recolor** — `Canvas.tsx` sub-grid dots changed from `rgba(0, 202, 255, X)` (rogue cyan, not in the palette) to `rgba(13, 148, 136, X)` (matches `--color-secondary`). Reinforces the live/connected theme.

## Scope change

The original plan also included **per-edge directional coloring** (source-color stroke + target-color arrowhead via a new `DirectionalEdge` + `EdgeMarkers` + `nodeAccent` helper). It was implemented end-to-end and reverted after visual review — the extra color load on edges added complexity without enough payoff in this canvas. Default edges remain neutral gray. The existing path-highlight (selection → amber + drop-shadow) and animated-edge styles already carry the necessary signal.

## Testing

- ``cd web && npm run build`` — passes (TypeScript + Vite build clean)
- ``cd web && npm run lint`` — 58 problems (unchanged from ``main`` baseline; zero new findings)
- Manual visual QA recommended before merge: ``make build && ./gridctl serve --foreground``, open the Topology workspace with a populated stack, walk through canvas controls (zoom, fit, reset, edge style, compact, heat map, drift, spec, wiring, secret heatmap), and verify hover/selection/empty-state still behave.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #686