### PR TITLE
refactor: extract shared vault hooks and atoms

### DIFF
--- a/web/src/components/vault/DetachedVaultErrorBoundary.tsx
+++ b/web/src/components/vault/DetachedVaultErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { Component, type ReactNode } from 'react';
+import { AlertCircle } from 'lucide-react';
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+// Error boundary specific to the detached `/var` window. The main app can't
+// recover errors that happen in a separate browser window, so we render a
+// reload affordance when something throws.
+export class DetachedVaultErrorBoundary extends Component<
+  { children: ReactNode },
+  State
+> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="h-screen w-screen bg-background flex items-center justify-center">
+          <div className="text-center p-8 max-w-md">
+            <div className="p-4 rounded-xl bg-status-error/10 border border-status-error/20 inline-block mb-4">
+              <AlertCircle size={32} className="text-status-error" />
+            </div>
+            <h1 className="text-lg text-status-error mb-2">
+              Something went wrong
+            </h1>
+            <pre className="text-xs text-text-muted bg-surface p-4 rounded-lg overflow-auto max-h-32 mb-4">
+              {this.state.error?.message}
+            </pre>
+            <button
+              onClick={() => window.location.reload()}
+              className="px-4 py-2 bg-primary text-background rounded-lg font-medium hover:bg-primary/90 transition-colors"
+            >
+              Reload Window
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/web/src/components/vault/EmptyVaultState.tsx
+++ b/web/src/components/vault/EmptyVaultState.tsx
@@ -1,0 +1,33 @@
+import { KeyRound } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+export interface EmptyVaultStateProps {
+  // The CLI verb to show in the example commands. VaultPanel renders the
+  // current verb ("var"); the detached page historically rendered "vault"
+  // (now a stale alias) — kept as a prop to preserve behavioral parity
+  // until Phases 2-3 clean up.
+  cliVerb: string;
+  className?: string;
+}
+
+export function EmptyVaultState({ cliVerb, className }: EmptyVaultStateProps) {
+  return (
+    <div className={cn('px-4 py-8 text-center', className)}>
+      <div className="mx-auto w-12 h-12 mb-4 rounded-xl bg-primary/10 border border-primary/20 flex items-center justify-center">
+        <KeyRound size={20} className="text-primary/60" />
+      </div>
+      <p className="text-sm text-text-secondary mb-2">No secrets stored</p>
+      <p className="text-xs text-text-muted leading-relaxed">
+        Add secrets using the form above, or via CLI:
+      </p>
+      <div className="mt-2 space-y-1">
+        <code className="block text-[10px] font-mono text-primary/80 bg-surface-elevated rounded px-2 py-1">
+          gridctl {cliVerb} set API_KEY
+        </code>
+        <code className="block text-[10px] font-mono text-primary/80 bg-surface-elevated rounded px-2 py-1">
+          gridctl {cliVerb} import .env
+        </code>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/vault/NewSetForm.tsx
+++ b/web/src/components/vault/NewSetForm.tsx
@@ -1,0 +1,63 @@
+import { Check, XCircle } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+export interface NewSetFormProps {
+  show: boolean;
+  value: string;
+  onChange: (val: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  className?: string;
+  // Apply `.log-text` so the input scales with the parent's zoom controls
+  // (detached page); VaultPanel leaves this off.
+  enableZoom?: boolean;
+}
+
+// Inline form to create a new Variable Set. Renders nothing when `show` is
+// false so callers can place it inline with their list/grid without taking
+// vertical space.
+export function NewSetForm({
+  show,
+  value,
+  onChange,
+  onSave,
+  onCancel,
+  className,
+  enableZoom,
+}: NewSetFormProps) {
+  if (!show) return null;
+  return (
+    <div className={cn('flex gap-2', className)}>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) =>
+          onChange(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))
+        }
+        placeholder="set-name"
+        autoFocus
+        className={cn(
+          'flex-1 bg-surface border border-border rounded-lg px-2 py-1 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 outline-none transition-colors',
+          enableZoom && 'log-text',
+        )}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') onSave();
+          if (e.key === 'Escape') onCancel();
+        }}
+      />
+      <button
+        onClick={onSave}
+        className="p-1 rounded hover:bg-surface-highlight transition-colors"
+        disabled={!value.trim()}
+      >
+        <Check size={12} className="text-status-running" />
+      </button>
+      <button
+        onClick={onCancel}
+        className="p-1 rounded hover:bg-surface-highlight transition-colors"
+      >
+        <XCircle size={12} className="text-text-muted" />
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/vault/SecretItem.tsx
+++ b/web/src/components/vault/SecretItem.tsx
@@ -1,0 +1,231 @@
+import { useState } from 'react';
+import {
+  ChevronDown,
+  ChevronRight,
+  Eye,
+  EyeOff,
+  Pencil,
+  Trash2,
+} from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { Button } from '../ui/Button';
+import { VariableTypeBadge } from './VariableTypeBadge';
+import { VariableVisibilityIcon } from './VariableVisibilityIcon';
+import type { Variable } from '../../lib/api';
+
+export interface SecretItemProps {
+  secret: Variable;
+  revealed?: string;
+  isEditing: boolean;
+  editValue: string;
+  showEditValue: boolean;
+  onReveal: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onEditValueChange: (val: string) => void;
+  onEditToggleShow: () => void;
+  onEditSave: () => void;
+  onEditCancel: () => void;
+  sets: string[];
+  onAssignSet: (set: string) => void;
+  compact?: boolean;
+  // When true, the key + value text uses the `.log-text` class so its size
+  // is driven by the parent's `--log-font-size` CSS variable (used by the
+  // detached page's zoom controls). VaultPanel leaves this off.
+  enableZoom?: boolean;
+}
+
+// Expandable variable row matching the SkillItem visual pattern. Used by
+// VaultPanel, DetachedVaultPage, and the upcoming VaultWorkspace.
+export function SecretItem({
+  secret,
+  revealed,
+  isEditing,
+  editValue,
+  showEditValue,
+  onReveal,
+  onEdit,
+  onDelete,
+  onEditValueChange,
+  onEditToggleShow,
+  onEditSave,
+  onEditCancel,
+  sets,
+  onAssignSet,
+  compact,
+  enableZoom,
+}: SecretItemProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const keyTextClass = cn(
+    'text-xs font-mono font-medium text-text-primary flex-1 text-left truncate',
+    enableZoom && 'log-text',
+  );
+  const valuePreviewClass = cn(
+    'text-[10px] font-mono text-text-muted truncate max-w-[120px]',
+    enableZoom && 'log-text-detail',
+  );
+  const valueDisplayClass = cn(
+    'text-xs font-mono text-text-secondary bg-background/60 px-2 py-1.5 rounded break-all',
+    enableZoom && 'log-text',
+  );
+  const editValueClass = cn(
+    'w-full bg-surface border border-border rounded-lg px-2 py-1.5 pr-8 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 outline-none transition-colors',
+    enableZoom && 'log-text',
+  );
+  const editKeyClass = cn(
+    'text-xs font-mono text-primary',
+    enableZoom && 'log-text',
+  );
+
+  if (isEditing) {
+    return (
+      <div className="rounded-lg bg-surface-elevated/50 border border-primary/20 p-2 space-y-2">
+        <div className={editKeyClass}>{secret.key}</div>
+        <div className="relative">
+          <input
+            type={showEditValue ? 'text' : 'password'}
+            value={editValue}
+            onChange={(e) => onEditValueChange(e.target.value)}
+            placeholder="New value"
+            autoFocus
+            className={editValueClass}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') onEditSave();
+              if (e.key === 'Escape') onEditCancel();
+            }}
+          />
+          <button
+            type="button"
+            onClick={onEditToggleShow}
+            className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-text-muted hover:text-text-primary transition-colors"
+          >
+            {showEditValue ? <EyeOff size={10} /> : <Eye size={10} />}
+          </button>
+        </div>
+        <div className="flex justify-end gap-1.5">
+          <button
+            onClick={onEditCancel}
+            className="px-2 py-1 text-[10px] text-text-secondary hover:text-text-primary rounded transition-colors"
+          >
+            Cancel
+          </button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={onEditSave}
+            disabled={!editValue}
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Plaintext variables show their value inline by default — the Reveal
+  // affordance is reserved for actual secrets.
+  const isPlaintext = !secret.is_secret;
+  const displayValue =
+    revealed !== undefined
+      ? revealed
+      : isPlaintext
+        ? '•••' // not yet fetched; placeholder until refresh completes
+        : '••••••••';
+
+  return (
+    <div className="rounded-lg bg-surface-elevated/50 border border-border-subtle overflow-hidden">
+      {/* Header row */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className={cn(
+          'w-full flex items-center gap-2 hover:bg-surface-highlight/50 transition-colors',
+          compact ? 'px-2 py-1.5' : 'p-3',
+        )}
+      >
+        <div className="p-0.5 text-text-muted">
+          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        </div>
+        <VariableVisibilityIcon isSecret={secret.is_secret} />
+        <span className={keyTextClass}>{secret.key}</span>
+        <VariableTypeBadge type={secret.type} />
+        <span className={valuePreviewClass}>{displayValue}</span>
+      </button>
+
+      {/* Expanded content */}
+      {expanded && (
+        <div className="px-3 pb-3 border-t border-border-subtle">
+          {/* Value display */}
+          <div className="mt-2 mb-2">
+            <div className="text-[10px] text-text-muted mb-1">Value</div>
+            <div className={valueDisplayClass}>
+              {revealed !== undefined
+                ? revealed
+                : '••••••••••••'}
+            </div>
+          </div>
+
+          {/* Set assignment */}
+          {!compact && sets.length > 0 && !secret.set && (
+            <div className="mb-2">
+              <select
+                value=""
+                onChange={(e) => {
+                  if (e.target.value) onAssignSet(e.target.value);
+                }}
+                className="w-full bg-surface border border-border rounded-lg px-2 py-1 text-[10px] text-text-muted focus:outline-none focus:border-primary/40 transition-colors"
+                title="Assign to set"
+              >
+                <option value="">Assign to set...</option>
+                {sets.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex items-center gap-1.5 mt-2 pt-2 border-t border-border-subtle/50">
+            {!isPlaintext && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onReveal();
+                }}
+                className={cn(
+                  'flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-semibold transition-all duration-200',
+                  revealed !== undefined
+                    ? 'bg-status-pending text-background shadow-[0_1px_8px_rgba(234,179,8,0.2)] hover:shadow-[0_2px_12px_rgba(234,179,8,0.3)] hover:-translate-y-0.5 active:translate-y-0'
+                    : 'bg-status-running text-background shadow-[0_1px_8px_rgba(16,185,129,0.2)] hover:shadow-[0_2px_12px_rgba(16,185,129,0.3)] hover:-translate-y-0.5 active:translate-y-0',
+                )}
+              >
+                {revealed !== undefined ? <EyeOff size={10} /> : <Eye size={10} />}
+                {revealed !== undefined ? 'Hide' : 'Reveal'}
+              </button>
+            )}
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit();
+              }}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-semibold bg-gradient-to-r from-primary to-primary-dark text-background shadow-[0_1px_8px_rgba(245,158,11,0.2)] hover:shadow-[0_2px_12px_rgba(245,158,11,0.3)] hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200"
+            >
+              <Pencil size={10} /> Edit
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-semibold bg-gradient-to-r from-status-error to-rose-600 text-white shadow-[0_1px_8px_rgba(244,63,94,0.2)] hover:shadow-[0_2px_12px_rgba(244,63,94,0.3)] hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200"
+            >
+              <Trash2 size={10} /> Delete
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/vault/SetGroup.tsx
+++ b/web/src/components/vault/SetGroup.tsx
@@ -1,0 +1,122 @@
+import {
+  ChevronDown,
+  ChevronRight,
+  FolderOpen,
+  Trash2,
+} from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { SecretItem } from './SecretItem';
+import type { Variable, VariableSet } from '../../lib/api';
+
+export interface SetGroupRowHandlers {
+  revealed: Record<string, string>;
+  editingKey: string | null;
+  editValue: string;
+  showEditValue: boolean;
+  setNames: string[];
+  onReveal: (key: string) => void;
+  onEdit: (key: string) => void;
+  onDeleteSecret: (key: string) => void;
+  onEditValueChange: (val: string) => void;
+  onEditToggleShow: () => void;
+  onEditSave: () => void;
+  onEditCancel: () => void;
+  onAssignSet: (key: string, set: string) => void;
+}
+
+export interface SetGroupProps {
+  set: VariableSet;
+  variables: Variable[];
+  expanded: boolean;
+  onToggleExpand: () => void;
+  onDeleteSet: () => void;
+  handlers: SetGroupRowHandlers;
+  // Use `.log-text` on key/value text for detached-page zoom scaling.
+  enableZoom?: boolean;
+  // Inner row padding ("space-y-1" or "p-2 space-y-2" etc.). VaultPanel and
+  // DetachedVaultPage use slightly different spacing inside the set.
+  innerClassName?: string;
+  // Name label uses `.log-text` in the detached page.
+  nameClassName?: string;
+}
+
+// One expandable Variable Set row + its member secrets. The parent owns the
+// expanded/edit/reveal state and threads it via `handlers`; SetGroup just
+// renders. Both VaultPanel and the detached page render a list of these.
+export function SetGroup({
+  set,
+  variables,
+  expanded,
+  onToggleExpand,
+  onDeleteSet,
+  handlers,
+  enableZoom,
+  innerClassName,
+  nameClassName,
+}: SetGroupProps) {
+  return (
+    <div className="group rounded-lg bg-surface-elevated/50 border border-border-subtle overflow-hidden">
+      <button
+        onClick={onToggleExpand}
+        className="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-surface-highlight/50 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          {expanded ? (
+            <ChevronDown size={12} className="text-text-muted" />
+          ) : (
+            <ChevronRight size={12} className="text-text-muted" />
+          )}
+          <FolderOpen size={12} className="text-secondary" />
+          <span className={cn('text-xs font-mono text-text-primary', nameClassName)}>
+            {set.name}
+          </span>
+          <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-secondary/10 text-secondary">
+            {set.count}
+          </span>
+        </div>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeleteSet();
+          }}
+          className="p-1 rounded hover:bg-status-error/10 transition-colors opacity-0 group-hover:opacity-100"
+          title="Delete set"
+        >
+          <Trash2 size={10} className="text-text-muted hover:text-status-error" />
+        </button>
+      </button>
+      {expanded && variables.length > 0 && (
+        <div className={cn('px-2 pb-2 space-y-1', innerClassName)}>
+          {variables.map((variable) => (
+            <SecretItem
+              key={variable.key}
+              secret={variable}
+              revealed={handlers.revealed[variable.key]}
+              isEditing={handlers.editingKey === variable.key}
+              editValue={handlers.editValue}
+              showEditValue={handlers.showEditValue}
+              onReveal={() => handlers.onReveal(variable.key)}
+              onEdit={() => handlers.onEdit(variable.key)}
+              onDelete={() => handlers.onDeleteSecret(variable.key)}
+              onEditValueChange={handlers.onEditValueChange}
+              onEditToggleShow={handlers.onEditToggleShow}
+              onEditSave={handlers.onEditSave}
+              onEditCancel={handlers.onEditCancel}
+              sets={handlers.setNames}
+              onAssignSet={(s) => handlers.onAssignSet(variable.key, s)}
+              compact
+              enableZoom={enableZoom}
+            />
+          ))}
+        </div>
+      )}
+      {expanded && variables.length === 0 && (
+        <div className="px-3 pb-2">
+          <p className="text-[10px] text-text-muted italic">
+            No secrets in this set
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/vault/VariableQuickAddForm.tsx
+++ b/web/src/components/vault/VariableQuickAddForm.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useState, type RefObject } from 'react';
+import { Eye, EyeOff, Plus } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { Button } from '../ui/Button';
+import { VariableTypeSelector } from './VariableTypeSelector';
+import { VariableSecretToggle } from './VariableSecretToggle';
+import {
+  validateVariableInput,
+  getValuePlaceholder,
+} from './variableTypeHelpers';
+import type { VariableType } from '../../lib/api';
+
+export interface QuickAddInput {
+  key: string;
+  value: string;
+  type: VariableType;
+  isSecret: boolean;
+  set?: string;
+}
+
+export interface VariableQuickAddFormProps {
+  setNames: string[];
+  onSubmit: (input: QuickAddInput) => Promise<void>;
+  className?: string;
+  keyInputRef?: RefObject<HTMLInputElement | null>;
+  // Apply `.log-text` so the key and value inputs scale with the parent's
+  // zoom controls (detached page).
+  enableZoom?: boolean;
+}
+
+// Quick-add form for a single variable. Internal state for every field;
+// validation is run before delegating to `onSubmit`, which should throw on
+// error. On success the form clears itself.
+export function VariableQuickAddForm({
+  setNames,
+  onSubmit,
+  className,
+  keyInputRef,
+  enableZoom,
+}: VariableQuickAddFormProps) {
+  const [newKey, setNewKey] = useState('');
+  const [newValue, setNewValue] = useState('');
+  const [newSet, setNewSet] = useState('');
+  const [showValue, setShowValue] = useState(false);
+  const [type, setType] = useState<VariableType>('string');
+  const [isSecret, setIsSecret] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!newKey.trim() || !newValue) return;
+      const key = newKey.trim();
+      const validation = validateVariableInput(type, newValue);
+      if (!validation.ok) {
+        setError(validation.error);
+        return;
+      }
+      setSubmitting(true);
+      setError(null);
+      try {
+        await onSubmit({
+          key,
+          value: validation.normalized,
+          type,
+          isSecret,
+          set: newSet || undefined,
+        });
+        setNewKey('');
+        setNewValue('');
+        setNewSet('');
+        setShowValue(false);
+        setType('string');
+        setIsSecret(true);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Failed to create variable',
+        );
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [newKey, newValue, newSet, type, isSecret, onSubmit],
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className={className}>
+      <div className="space-y-2">
+        <input
+          ref={keyInputRef}
+          type="text"
+          value={newKey}
+          onChange={(e) => {
+            setNewKey(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ''));
+            setError(null);
+          }}
+          placeholder="KEY_NAME"
+          className={cn(
+            'w-full bg-surface border rounded-lg px-3 py-2 text-xs font-mono text-text-primary',
+            'placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors',
+            error ? 'border-status-error/50' : 'border-border',
+            enableZoom && 'log-text',
+          )}
+        />
+        <div className="relative">
+          <input
+            type={showValue ? 'text' : 'password'}
+            value={newValue}
+            onChange={(e) => setNewValue(e.target.value)}
+            placeholder={getValuePlaceholder(type, isSecret)}
+            className={cn(
+              'w-full bg-surface border border-border rounded-lg px-3 py-2 pr-10 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors',
+              enableZoom && 'log-text',
+            )}
+          />
+          <button
+            type="button"
+            onClick={() => setShowValue(!showValue)}
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 rounded text-text-muted hover:text-text-primary transition-colors"
+          >
+            {showValue ? <EyeOff size={12} /> : <Eye size={12} />}
+          </button>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <VariableTypeSelector value={type} onChange={setType} />
+          <VariableSecretToggle isSecret={isSecret} onChange={setIsSecret} />
+        </div>
+        <div className="flex gap-2">
+          <select
+            value={newSet}
+            onChange={(e) => setNewSet(e.target.value)}
+            className="flex-1 bg-surface border border-border rounded-lg px-3 py-2 text-xs text-text-secondary focus:border-primary/50 outline-none transition-colors"
+          >
+            <option value="">No set</option>
+            {setNames.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+          <Button
+            type="submit"
+            variant="primary"
+            size="sm"
+            disabled={!newKey.trim() || !newValue || submitting}
+          >
+            <Plus size={12} />
+            Add
+          </Button>
+        </div>
+      </div>
+      {error && <p className="mt-1.5 text-[10px] text-status-error">{error}</p>}
+    </form>
+  );
+}

--- a/web/src/components/vault/VaultEncryptForm.tsx
+++ b/web/src/components/vault/VaultEncryptForm.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { Lock } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { Button } from '../ui/Button';
+
+export interface VaultEncryptFormProps {
+  onLock: (passphrase: string) => Promise<void>;
+  onCancel: () => void;
+  className?: string;
+}
+
+// Inline passphrase + confirm form used by both the sidebar and the
+// detached page when the user clicks "Encrypt." Owns its own passphrase
+// state so the parent doesn't have to thread it through.
+export function VaultEncryptForm({
+  onLock,
+  onCancel,
+  className,
+}: VaultEncryptFormProps) {
+  const [passphrase, setPassphrase] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isLocking, setIsLocking] = useState(false);
+
+  const reset = () => {
+    setPassphrase('');
+    setConfirm('');
+    setError(null);
+  };
+
+  const handleSubmit = async () => {
+    if (!passphrase.trim()) return;
+    if (passphrase !== confirm) {
+      setError('Passphrases do not match');
+      return;
+    }
+    setIsLocking(true);
+    setError(null);
+    try {
+      await onLock(passphrase);
+      reset();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to lock vault');
+    } finally {
+      setIsLocking(false);
+    }
+  };
+
+  const handleCancel = () => {
+    reset();
+    onCancel();
+  };
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      <div className="text-xs text-text-secondary mb-2">
+        Encrypt vault with a passphrase:
+      </div>
+      <input
+        type="password"
+        value={passphrase}
+        onChange={(e) => {
+          setPassphrase(e.target.value);
+          setError(null);
+        }}
+        placeholder="New passphrase"
+        autoFocus
+        className="w-full bg-surface border border-border rounded-lg px-3 py-2 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors"
+      />
+      <input
+        type="password"
+        value={confirm}
+        onChange={(e) => {
+          setConfirm(e.target.value);
+          setError(null);
+        }}
+        placeholder="Confirm passphrase"
+        className="w-full bg-surface border border-border rounded-lg px-3 py-2 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') handleSubmit();
+        }}
+      />
+      {error && <p className="text-[10px] text-status-error">{error}</p>}
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={handleCancel}
+          className="px-2 py-1 text-[10px] text-text-secondary hover:text-text-primary rounded transition-colors"
+        >
+          Cancel
+        </button>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={handleSubmit}
+          disabled={!passphrase.trim() || !confirm.trim() || isLocking}
+        >
+          <Lock size={12} />
+          {isLocking ? 'Encrypting...' : 'Encrypt'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/vault/VaultPanel.tsx
+++ b/web/src/components/vault/VaultPanel.tsx
@@ -3,51 +3,29 @@ import { createPortal } from 'react-dom';
 import {
   X,
   Plus,
-  Eye,
-  EyeOff,
-  Pencil,
-  Trash2,
-  Check,
-  XCircle,
   KeyRound,
-  FolderOpen,
-  ChevronDown,
-  ChevronRight,
   AlertCircle,
   Package,
   Lock,
   LockOpen,
   Search,
 } from 'lucide-react';
-import { cn } from '../../lib/cn';
-import { Button } from '../ui/Button';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { ResizeHandle } from '../ui/ResizeHandle';
 import { PopoutButton } from '../ui/PopoutButton';
-import { useVaultStore } from '../../stores/useVaultStore';
 import { useUIStore } from '../../stores/useUIStore';
 import { showToast } from '../ui/Toast';
-import {
-  fetchVariables,
-  fetchVariableSets,
-  createVariable,
-  getVariable,
-  updateVariable,
-  deleteVariable,
-  createVariableSet,
-  deleteVariableSet,
-  assignVariableToSet,
-  fetchVariableStoreStatus,
-  unlockVariableStore,
-  lockVariableStore,
-} from '../../lib/api';
-import type { Variable, VariableType } from '../../lib/api';
+import { useVaultManager } from '../../hooks/useVaultManager';
+import { useRevealedValues } from '../../hooks/useRevealedValues';
+import { validateVariableInput } from './variableTypeHelpers';
 import { VaultLockPrompt } from './VaultLockPrompt';
-import { VariableTypeBadge } from './VariableTypeBadge';
-import { VariableVisibilityIcon } from './VariableVisibilityIcon';
-import { VariableTypeSelector } from './VariableTypeSelector';
-import { VariableSecretToggle } from './VariableSecretToggle';
-import { validateVariableInput, getValuePlaceholder } from './variableTypeHelpers';
+import { SecretItem } from './SecretItem';
+import { NewSetForm } from './NewSetForm';
+import { VariableQuickAddForm } from './VariableQuickAddForm';
+import { VaultEncryptForm } from './VaultEncryptForm';
+import { EmptyVaultState } from './EmptyVaultState';
+import { SetGroup } from './SetGroup';
+import type { VariableType } from '../../lib/api';
 
 interface VaultPanelProps {
   onClose: () => void;
@@ -55,13 +33,27 @@ interface VaultPanelProps {
 
 export function VaultPanel({ onClose }: VaultPanelProps) {
   const vaultDetached = useUIStore((s) => s.vaultDetached);
+  const revealedState = useRevealedValues();
+  const vault = useVaultManager({ onPlaintextLoaded: revealedState.bulkSet });
 
-  const secrets = useVaultStore((s) => s.variables);
-  const sets = useVaultStore((s) => s.sets);
-  const loading = useVaultStore((s) => s.loading);
-  const error = useVaultStore((s) => s.error);
-  const locked = useVaultStore((s) => s.locked);
-  const encrypted = useVaultStore((s) => s.encrypted);
+  const {
+    variables: secrets,
+    sets,
+    loading,
+    error,
+    locked,
+    encrypted,
+    refresh,
+    unlock,
+    lock,
+    createVar,
+    updateVar,
+    deleteVar,
+    getVar,
+    createSet,
+    deleteSet,
+    assignToSet,
+  } = vault;
 
   // Panel width (resizable)
   const [panelWidth, setPanelWidth] = useState(380);
@@ -69,109 +61,42 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
     setPanelWidth((prev) => Math.min(600, Math.max(280, prev + delta)));
   }, []);
 
-  // Search state
   const [searchQuery, setSearchQuery] = useState('');
-
-  // Lock UI state
   const [showLockForm, setShowLockForm] = useState(false);
-  const [lockPassphrase, setLockPassphrase] = useState('');
-  const [lockConfirm, setLockConfirm] = useState('');
-  const [lockError, setLockError] = useState<string | null>(null);
-  const [isLocking, setIsLocking] = useState(false);
 
-  // Quick-add form state
-  const [newKey, setNewKey] = useState('');
-  const [newValue, setNewValue] = useState('');
-  const [newSet, setNewSet] = useState('');
-  const [showNewValue, setShowNewValue] = useState(false);
-  const [addError, setAddError] = useState<string | null>(null);
-  const [isAdding, setIsAdding] = useState(false);
-  // Type/Visibility controls. Defaults to string+Secret per Article XII.
-  const [newType, setNewType] = useState<VariableType>('string');
-  const [newIsSecret, setNewIsSecret] = useState(true);
-  const keyInputRef = useRef<HTMLInputElement>(null);
-
-  // Reveal state: map of key -> revealed value
-  const [revealed, setRevealed] = useState<Record<string, string>>({});
-  const revealTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
-
-  // Edit state
+  // Edit state — VaultPanel preserves the variable's current type/is_secret
+  // on save (and validates the value against the type), so we track them
+  // here in addition to the value being edited.
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editValue, setEditValue] = useState('');
   const [editType, setEditType] = useState<VariableType>('string');
   const [editIsSecret, setEditIsSecret] = useState(true);
   const [showEditValue, setShowEditValue] = useState(false);
 
-  // Delete confirmation
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 
-  // Set management
   const [expandedSets, setExpandedSets] = useState<Record<string, boolean>>({});
   const [showNewSet, setShowNewSet] = useState(false);
   const [newSetName, setNewSetName] = useState('');
 
-  // Filtered secrets based on search
-  const allSecrets = secrets ?? [];
+  const keyInputRef = useRef<HTMLInputElement>(null);
+
+  const allSecrets = useMemo(() => secrets ?? [], [secrets]);
   const filteredSecrets = useMemo(() => {
     if (!searchQuery) return allSecrets;
     const lower = searchQuery.toLowerCase();
     return allSecrets.filter(
-      (s) => s.key.toLowerCase().includes(lower) || (s.set ?? '').toLowerCase().includes(lower),
+      (s) =>
+        s.key.toLowerCase().includes(lower) ||
+        (s.set ?? '').toLowerCase().includes(lower),
     );
   }, [allSecrets, searchQuery]);
 
-  // Fetch data on mount
-  const refresh = useCallback(async () => {
-    useVaultStore.getState().setLoading(true);
-    useVaultStore.getState().setError(null);
-    try {
-      const status = await fetchVariableStoreStatus();
-      useVaultStore.getState().setLocked(status.locked);
-      useVaultStore.getState().setEncrypted(status.encrypted);
-
-      if (!status.locked) {
-        const [variablesData, setsData] = await Promise.all([
-          fetchVariables(),
-          fetchVariableSets(),
-        ]);
-        useVaultStore.getState().setVariables(variablesData);
-        useVaultStore.getState().setSets(setsData);
-
-        // Plaintext variables display their value inline by default
-        // (no Reveal click needed). Eager-fetch them after the list so
-        // the rows render with values on first paint.
-        const plaintext = variablesData.filter((v) => !v.is_secret);
-        if (plaintext.length > 0) {
-          const fetched = await Promise.all(
-            plaintext.map((v) =>
-              getVariable(v.key).then(
-                (detail) => [v.key, detail.value] as const,
-                () => [v.key, ''] as const,
-              ),
-            ),
-          );
-          setRevealed((prev) => {
-            const next = { ...prev };
-            for (const [k, val] of fetched) next[k] = val;
-            return next;
-          });
-        }
-      }
-    } catch (err) {
-      useVaultStore.getState().setError(err instanceof Error ? err.message : 'Failed to load vault');
-    } finally {
-      useVaultStore.getState().setLoading(false);
-    }
-  }, []);
-
   useEffect(() => {
     refresh();
-    return () => {
-      Object.values(revealTimers.current).forEach(clearTimeout);
-    };
   }, [refresh]);
 
-  // Handle Escape key
+  // Escape closes the panel unless the user is in an input.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -192,122 +117,60 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
     onClose();
   }, [onClose]);
 
-  const handleUnlock = useCallback(async (passphrase: string): Promise<boolean> => {
-    try {
-      await unlockVariableStore(passphrase);
-      useVaultStore.getState().setLocked(false);
-      await refresh();
-      showToast('success', 'Vault unlocked');
-      return true;
-    } catch {
-      return false;
-    }
-  }, [refresh]);
+  const handleUnlock = useCallback(
+    async (passphrase: string): Promise<boolean> => {
+      const ok = await unlock(passphrase);
+      if (ok) showToast('success', 'Vault unlocked');
+      return ok;
+    },
+    [unlock],
+  );
 
-  const handleLock = useCallback(async () => {
-    if (!lockPassphrase.trim()) return;
-    if (lockPassphrase !== lockConfirm) {
-      setLockError('Passphrases do not match');
-      return;
-    }
-
-    setIsLocking(true);
-    setLockError(null);
-    try {
-      await lockVariableStore(lockPassphrase);
+  const handleEncrypt = useCallback(
+    async (passphrase: string) => {
+      await lock(passphrase);
       setShowLockForm(false);
-      setLockPassphrase('');
-      setLockConfirm('');
       showToast('success', 'Vault encrypted');
-      await refresh();
-    } catch (err) {
-      setLockError(err instanceof Error ? err.message : 'Failed to lock vault');
-    } finally {
-      setIsLocking(false);
-    }
-  }, [lockPassphrase, lockConfirm, refresh]);
+    },
+    [lock],
+  );
 
-  const handleReveal = useCallback(async (key: string) => {
-    // Plaintext variables are always revealed; Hide is a no-op for them.
-    const target = allSecrets.find((v) => v.key === key);
-    const isPlaintext = target ? !target.is_secret : false;
-
-    if (revealed[key] !== undefined && !isPlaintext) {
-      setRevealed((prev) => {
-        const next = { ...prev };
-        delete next[key];
-        return next;
-      });
-      if (revealTimers.current[key]) {
-        clearTimeout(revealTimers.current[key]);
-        delete revealTimers.current[key];
+  const handleReveal = useCallback(
+    async (key: string) => {
+      const target = allSecrets.find((v) => v.key === key);
+      const isPlaintext = target ? !target.is_secret : false;
+      try {
+        await revealedState.reveal(
+          key,
+          async () => (await getVar(key)).value,
+          !isPlaintext,
+        );
+      } catch {
+        showToast('error', `Failed to reveal ${key}`);
       }
-      return;
-    }
+    },
+    [allSecrets, revealedState, getVar],
+  );
 
-    try {
-      const data = await getVariable(key);
-      setRevealed((prev) => ({ ...prev, [key]: data.value }));
-      // The 10-second auto-hide timer applies only to secrets — plaintext
-      // values stay visible until the panel is closed.
-      if (isPlaintext) return;
-      revealTimers.current[key] = setTimeout(() => {
-        setRevealed((prev) => {
-          const next = { ...prev };
-          delete next[key];
-          return next;
-        });
-        delete revealTimers.current[key];
-      }, 10000);
-    } catch {
-      showToast('error', `Failed to reveal ${key}`);
-    }
-  }, [revealed, allSecrets]);
+  const handleCreate = useCallback(
+    async (input: Parameters<typeof createVar>[0]) => {
+      await createVar(input);
+      showToast('success', `Variable "${input.key}" created`);
+    },
+    [createVar],
+  );
 
-  const handleAdd = useCallback(async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!newKey.trim() || !newValue) return;
-
-    const key = newKey.trim();
-    const validation = validateVariableInput(newType, newValue);
-    if (!validation.ok) {
-      setAddError(validation.error);
-      return;
-    }
-
-    setIsAdding(true);
-    setAddError(null);
-    try {
-      await createVariable({
-        key,
-        value: validation.normalized,
-        type: newType,
-        isSecret: newIsSecret,
-        set: newSet || undefined,
-      });
-      setNewKey('');
-      setNewValue('');
-      setNewSet('');
-      setShowNewValue(false);
-      setNewType('string');
-      setNewIsSecret(true);
-      await refresh();
-      showToast('success', `Variable "${key}" created`);
-    } catch (err) {
-      setAddError(err instanceof Error ? err.message : 'Failed to create variable');
-    } finally {
-      setIsAdding(false);
-    }
-  }, [newKey, newValue, newSet, newType, newIsSecret, refresh]);
-
-  const handleEdit = useCallback((key: string) => {
-    const current = allSecrets.find((v) => v.key === key);
-    setEditingKey(key);
-    setEditValue('');
-    setEditType(current?.type ?? 'string');
-    setEditIsSecret(current?.is_secret ?? true);
-    setShowEditValue(false);
-  }, [allSecrets]);
+  const handleEdit = useCallback(
+    (key: string) => {
+      const current = allSecrets.find((v) => v.key === key);
+      setEditingKey(key);
+      setEditValue('');
+      setEditType(current?.type ?? 'string');
+      setEditIsSecret(current?.is_secret ?? true);
+      setShowEditValue(false);
+    },
+    [allSecrets],
+  );
 
   const handleEditSave = useCallback(async () => {
     if (!editingKey || !editValue) return;
@@ -317,19 +180,18 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
       return;
     }
     try {
-      await updateVariable(editingKey, {
+      await updateVar(editingKey, {
         value: validation.normalized,
         type: editType,
         isSecret: editIsSecret,
       });
       setEditingKey(null);
       setEditValue('');
-      await refresh();
       showToast('success', `Variable "${editingKey}" updated`);
     } catch {
       showToast('error', 'Failed to update variable');
     }
-  }, [editingKey, editValue, editType, editIsSecret, refresh]);
+  }, [editingKey, editValue, editType, editIsSecret, updateVar]);
 
   const handleEditCancel = useCallback(() => {
     setEditingKey(null);
@@ -340,691 +202,375 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
   const handleDeleteConfirm = useCallback(async () => {
     if (!confirmDelete) return;
     try {
-      await deleteVariable(confirmDelete);
+      await deleteVar(confirmDelete);
       setConfirmDelete(null);
-      await refresh();
       showToast('success', `Secret "${confirmDelete}" deleted`);
     } catch {
       showToast('error', 'Failed to delete secret');
     }
-  }, [confirmDelete, refresh]);
+  }, [confirmDelete, deleteVar]);
 
   const handleCreateSet = useCallback(async () => {
-    if (!newSetName.trim()) return;
+    const name = newSetName.trim();
+    if (!name) return;
     try {
-      await createVariableSet(newSetName.trim());
+      await createSet(name);
       setNewSetName('');
       setShowNewSet(false);
-      await refresh();
-      showToast('success', `Set "${newSetName.trim()}" created`);
+      showToast('success', `Set "${name}" created`);
     } catch (err) {
-      showToast('error', err instanceof Error ? err.message : 'Failed to create set');
+      showToast(
+        'error',
+        err instanceof Error ? err.message : 'Failed to create set',
+      );
     }
-  }, [newSetName, refresh]);
+  }, [newSetName, createSet]);
 
-  const handleDeleteSet = useCallback(async (name: string) => {
-    try {
-      await deleteVariableSet(name);
-      await refresh();
-      showToast('success', `Set "${name}" deleted`);
-    } catch {
-      showToast('error', 'Failed to delete set');
-    }
-  }, [refresh]);
+  const handleDeleteSet = useCallback(
+    async (name: string) => {
+      try {
+        await deleteSet(name);
+        showToast('success', `Set "${name}" deleted`);
+      } catch {
+        showToast('error', 'Failed to delete set');
+      }
+    },
+    [deleteSet],
+  );
 
-  const handleAssignSet = useCallback(async (key: string, set: string) => {
-    try {
-      await assignVariableToSet(key, set);
-      await refresh();
-    } catch {
-      showToast('error', 'Failed to assign set');
-    }
-  }, [refresh]);
+  const handleAssignSet = useCallback(
+    async (key: string, set: string) => {
+      try {
+        await assignToSet(key, set);
+      } catch {
+        showToast('error', 'Failed to assign set');
+      }
+    },
+    [assignToSet],
+  );
 
   const toggleSetExpand = useCallback((name: string) => {
     setExpandedSets((prev) => ({ ...prev, [name]: !prev[name] }));
   }, []);
 
-  // Group secrets by set
   const unassigned = filteredSecrets.filter((s) => !s.set);
   const setNames = (sets ?? []).map((s) => s.name);
-
   const isEmpty = allSecrets.length === 0 && (sets ?? []).length === 0;
+
+  const rowHandlers = {
+    revealed: revealedState.revealed,
+    editingKey,
+    editValue,
+    showEditValue,
+    setNames,
+    onReveal: handleReveal,
+    onEdit: handleEdit,
+    onDeleteSecret: (key: string) => setConfirmDelete(key),
+    onEditValueChange: setEditValue,
+    onEditToggleShow: () => setShowEditValue(!showEditValue),
+    onEditSave: handleEditSave,
+    onEditCancel: handleEditCancel,
+    onAssignSet: handleAssignSet,
+  };
 
   return createPortal(
     <div
       className="fixed inset-y-0 right-0 z-40 max-w-full flex flex-row bg-surface/95 backdrop-blur-xl border-l border-border/50 shadow-2xl animate-slide-in-right"
       style={{ width: panelWidth }}
     >
-      {/* Resize handle on left edge */}
       <ResizeHandle
         direction="vertical"
         onResize={handleResize}
         className="flex-shrink-0"
       />
 
-      {/* Content column */}
       <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
-
-      {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-border/50 bg-surface-elevated/30 flex-shrink-0">
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="p-2 rounded-xl flex-shrink-0 border bg-primary/10 border-primary/20">
-            <KeyRound size={16} className="text-primary" />
-          </div>
-          <div className="min-w-0">
-            <h2 className="font-semibold text-text-primary truncate tracking-tight">Variables</h2>
-            <div className="flex items-center gap-1.5">
-              <p className="text-[10px] text-text-muted uppercase tracking-wider">Secrets</p>
-              {encrypted && !locked && (
-                <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-status-running/10 text-status-running flex items-center gap-0.5">
-                  <LockOpen size={8} />
-                  Encrypted
-                </span>
-              )}
-              {locked && (
-                <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-primary/10 text-primary flex items-center gap-0.5">
-                  <Lock size={8} />
-                  Locked
-                </span>
-              )}
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-border/50 bg-surface-elevated/30 flex-shrink-0">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="p-2 rounded-xl flex-shrink-0 border bg-primary/10 border-primary/20">
+              <KeyRound size={16} className="text-primary" />
+            </div>
+            <div className="min-w-0">
+              <h2 className="font-semibold text-text-primary truncate tracking-tight">
+                Variables
+              </h2>
+              <div className="flex items-center gap-1.5">
+                <p className="text-[10px] text-text-muted uppercase tracking-wider">
+                  Secrets
+                </p>
+                {encrypted && !locked && (
+                  <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-status-running/10 text-status-running flex items-center gap-0.5">
+                    <LockOpen size={8} />
+                    Encrypted
+                  </span>
+                )}
+                {locked && (
+                  <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-primary/10 text-primary flex items-center gap-0.5">
+                    <Lock size={8} />
+                    Locked
+                  </span>
+                )}
+              </div>
             </div>
           </div>
+          <div className="flex items-center gap-1">
+            <PopoutButton onClick={handlePopout} disabled={vaultDetached} />
+            <button
+              onClick={onClose}
+              className="p-1.5 rounded-lg hover:bg-surface-highlight transition-colors group"
+            >
+              <X
+                size={16}
+                className="text-text-muted group-hover:text-text-primary transition-colors"
+              />
+            </button>
+          </div>
         </div>
-        <div className="flex items-center gap-1">
-          <PopoutButton
-            onClick={handlePopout}
-            disabled={vaultDetached}
-          />
-          <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-surface-highlight transition-colors group">
-            <X size={16} className="text-text-muted group-hover:text-text-primary transition-colors" />
-          </button>
-        </div>
-      </div>
 
-      {/* Lock prompt */}
-      {locked && (
-        <VaultLockPrompt onUnlock={handleUnlock} />
-      )}
+        {locked && <VaultLockPrompt onUnlock={handleUnlock} />}
 
-      {/* Unlocked content */}
-      {!locked && (
-        <>
-          {/* Item count + actions bar */}
-          <div className="flex items-center justify-between px-4 py-2 border-b border-border/20 flex-shrink-0">
-            <div className="flex items-center gap-2">
+        {!locked && (
+          <>
+            {/* Item count + actions bar */}
+            <div className="flex items-center justify-between px-4 py-2 border-b border-border/20 flex-shrink-0">
               <span className="text-[10px] text-text-muted">
                 {searchQuery
                   ? `${filteredSecrets.length} of ${allSecrets.length} secrets`
                   : `${allSecrets.length} secrets`}
               </span>
-            </div>
-            <div className="flex items-center gap-2">
-              {!encrypted && allSecrets.length > 0 && (
-                <button
-                  onClick={() => setShowLockForm(!showLockForm)}
-                  className="flex items-center gap-1 text-[10px] text-text-muted hover:text-primary transition-colors"
-                >
-                  <Lock size={10} /> Encrypt
-                </button>
-              )}
-              <button
-                onClick={() => keyInputRef.current?.focus()}
-                className="flex items-center gap-1 text-[10px] text-primary hover:text-primary/80 transition-colors"
-              >
-                <Plus size={10} /> New
-              </button>
-            </div>
-          </div>
-
-          {/* Search */}
-          <div className="px-2 py-1.5 border-b border-border/20 flex-shrink-0" role="search">
-            <div className="relative">
-              <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-text-muted/50" />
-              <input
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="Search secrets..."
-                aria-label="Filter secrets"
-                className="w-full bg-background/40 border border-border/30 rounded-lg pl-7 pr-7 py-1 text-xs text-text-primary placeholder:text-text-muted/40 focus:outline-none focus:border-primary/40"
-              />
-              {searchQuery && (
-                <button
-                  onClick={() => setSearchQuery('')}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-surface-highlight transition-colors"
-                >
-                  <X size={12} className="text-text-muted" />
-                </button>
-              )}
-            </div>
-          </div>
-
-          {/* Scrollable content */}
-          <div className="flex-1 overflow-y-auto scrollbar-dark min-h-0">
-            {/* Lock form */}
-            {showLockForm && (
-              <div className="px-4 pt-3 pb-2 border-b border-border-subtle/50">
-                <div className="space-y-2">
-                  <div className="text-xs text-text-secondary mb-2">Encrypt vault with a passphrase:</div>
-                  <input
-                    type="password"
-                    value={lockPassphrase}
-                    onChange={(e) => { setLockPassphrase(e.target.value); setLockError(null); }}
-                    placeholder="New passphrase"
-                    autoFocus
-                    className="w-full bg-surface border border-border rounded-lg px-3 py-2 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors"
-                  />
-                  <input
-                    type="password"
-                    value={lockConfirm}
-                    onChange={(e) => { setLockConfirm(e.target.value); setLockError(null); }}
-                    placeholder="Confirm passphrase"
-                    className="w-full bg-surface border border-border rounded-lg px-3 py-2 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors"
-                    onKeyDown={(e) => { if (e.key === 'Enter') handleLock(); }}
-                  />
-                  {lockError && (
-                    <p className="text-[10px] text-status-error">{lockError}</p>
-                  )}
-                  <div className="flex justify-end gap-2">
-                    <button
-                      onClick={() => { setShowLockForm(false); setLockPassphrase(''); setLockConfirm(''); setLockError(null); }}
-                      className="px-2 py-1 text-[10px] text-text-secondary hover:text-text-primary rounded transition-colors"
-                    >
-                      Cancel
-                    </button>
-                    <Button variant="primary" size="sm" onClick={handleLock} disabled={!lockPassphrase.trim() || !lockConfirm.trim() || isLocking}>
-                      <Lock size={12} />
-                      {isLocking ? 'Encrypting...' : 'Encrypt'}
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Error */}
-            {error && (
-              <div className="mx-4 mt-3 flex items-center gap-2 px-3 py-2 rounded-lg bg-status-error/10 border border-status-error/20 text-xs text-status-error">
-                <AlertCircle size={12} className="flex-shrink-0" />
-                <span>{error}</span>
-              </div>
-            )}
-
-            {/* Loading skeleton */}
-            {loading && !secrets && (
-              <div className="p-4 space-y-3">
-                {[1, 2, 3].map((i) => (
-                  <div key={i} className="h-10 rounded-lg bg-surface-elevated animate-pulse" />
-                ))}
-              </div>
-            )}
-
-            {/* Quick-add form */}
-            <form onSubmit={handleAdd} className="px-4 pt-3 pb-2 border-b border-border-subtle/50">
-              <div className="space-y-2">
-                <input
-                  ref={keyInputRef}
-                  type="text"
-                  value={newKey}
-                  onChange={(e) => { setNewKey(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, '')); setAddError(null); }}
-                  placeholder="KEY_NAME"
-                  className={cn(
-                    'w-full bg-surface border rounded-lg px-3 py-2 text-xs font-mono text-text-primary',
-                    'placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors',
-                    addError ? 'border-status-error/50' : 'border-border'
-                  )}
-                />
-                <div className="relative">
-                  <input
-                    type={showNewValue ? 'text' : 'password'}
-                    value={newValue}
-                    onChange={(e) => setNewValue(e.target.value)}
-                    placeholder={getValuePlaceholder(newType, newIsSecret)}
-                    className="w-full bg-surface border border-border rounded-lg px-3 py-2 pr-10 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors"
-                  />
+              <div className="flex items-center gap-2">
+                {!encrypted && allSecrets.length > 0 && (
                   <button
-                    type="button"
-                    onClick={() => setShowNewValue(!showNewValue)}
-                    className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 rounded text-text-muted hover:text-text-primary transition-colors"
+                    onClick={() => setShowLockForm(!showLockForm)}
+                    className="flex items-center gap-1 text-[10px] text-text-muted hover:text-primary transition-colors"
                   >
-                    {showNewValue ? <EyeOff size={12} /> : <Eye size={12} />}
+                    <Lock size={10} /> Encrypt
                   </button>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <VariableTypeSelector value={newType} onChange={setNewType} />
-                  <VariableSecretToggle isSecret={newIsSecret} onChange={setNewIsSecret} />
-                </div>
-                <div className="flex gap-2">
-                  <select
-                    value={newSet}
-                    onChange={(e) => setNewSet(e.target.value)}
-                    className="flex-1 bg-surface border border-border rounded-lg px-3 py-2 text-xs text-text-secondary focus:border-primary/50 outline-none transition-colors"
+                )}
+                <button
+                  onClick={() => keyInputRef.current?.focus()}
+                  className="flex items-center gap-1 text-[10px] text-primary hover:text-primary/80 transition-colors"
+                >
+                  <Plus size={10} /> New
+                </button>
+              </div>
+            </div>
+
+            {/* Search */}
+            <div
+              className="px-2 py-1.5 border-b border-border/20 flex-shrink-0"
+              role="search"
+            >
+              <div className="relative">
+                <Search
+                  size={12}
+                  className="absolute left-2 top-1/2 -translate-y-1/2 text-text-muted/50"
+                />
+                <input
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search secrets..."
+                  aria-label="Filter secrets"
+                  className="w-full bg-background/40 border border-border/30 rounded-lg pl-7 pr-7 py-1 text-xs text-text-primary placeholder:text-text-muted/40 focus:outline-none focus:border-primary/40"
+                />
+                {searchQuery && (
+                  <button
+                    onClick={() => setSearchQuery('')}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-surface-highlight transition-colors"
                   >
-                    <option value="">No set</option>
-                    {setNames.map((name) => (
-                      <option key={name} value={name}>{name}</option>
-                    ))}
-                  </select>
-                  <Button type="submit" variant="primary" size="sm" disabled={!newKey.trim() || !newValue || isAdding}>
-                    <Plus size={12} />
-                    Add
-                  </Button>
-                </div>
+                    <X size={12} className="text-text-muted" />
+                  </button>
+                )}
               </div>
-              {addError && (
-                <p className="mt-1.5 text-[10px] text-status-error">{addError}</p>
+            </div>
+
+            <div className="flex-1 overflow-y-auto scrollbar-dark min-h-0">
+              {showLockForm && (
+                <VaultEncryptForm
+                  onLock={handleEncrypt}
+                  onCancel={() => setShowLockForm(false)}
+                  className="px-4 pt-3 pb-2 border-b border-border-subtle/50"
+                />
               )}
-            </form>
 
-            {/* Empty state */}
-            {!loading && isEmpty && (
-              <div className="px-4 py-8 text-center">
-                <div className="mx-auto w-12 h-12 mb-4 rounded-xl bg-primary/10 border border-primary/20 flex items-center justify-center">
-                  <KeyRound size={20} className="text-primary/60" />
+              {error && (
+                <div className="mx-4 mt-3 flex items-center gap-2 px-3 py-2 rounded-lg bg-status-error/10 border border-status-error/20 text-xs text-status-error">
+                  <AlertCircle size={12} className="flex-shrink-0" />
+                  <span>{error}</span>
                 </div>
-                <p className="text-sm text-text-secondary mb-2">No secrets stored</p>
-                <p className="text-xs text-text-muted leading-relaxed">
-                  Add secrets using the form above, or via CLI:
-                </p>
-                <div className="mt-2 space-y-1">
-                  <code className="block text-[10px] font-mono text-primary/80 bg-surface-elevated rounded px-2 py-1">
-                    gridctl var set API_KEY
-                  </code>
-                  <code className="block text-[10px] font-mono text-primary/80 bg-surface-elevated rounded px-2 py-1">
-                    gridctl var import .env
-                  </code>
+              )}
+
+              {loading && !secrets && (
+                <div className="p-4 space-y-3">
+                  {[1, 2, 3].map((i) => (
+                    <div
+                      key={i}
+                      className="h-10 rounded-lg bg-surface-elevated animate-pulse"
+                    />
+                  ))}
                 </div>
-              </div>
-            )}
+              )}
 
-            {/* Search empty state */}
-            {!loading && !isEmpty && filteredSecrets.length === 0 && searchQuery && (
-              <div className="p-6 text-center">
-                <KeyRound size={24} className="text-text-muted/30 mx-auto mb-2" />
-                <p className="text-text-muted text-xs">No matching secrets</p>
-              </div>
-            )}
+              <VariableQuickAddForm
+                setNames={setNames}
+                onSubmit={handleCreate}
+                keyInputRef={keyInputRef}
+                className="px-4 pt-3 pb-2 border-b border-border-subtle/50"
+              />
 
-            {/* Unassigned secrets */}
-            {!loading && unassigned.length > 0 && (
-              <div className="p-2 space-y-1">
-                {unassigned.map((secret) => (
-                  <SecretItem
-                    key={secret.key}
-                    secret={secret}
-                    revealed={revealed[secret.key]}
-                    isEditing={editingKey === secret.key}
-                    editValue={editValue}
-                    showEditValue={showEditValue}
-                    onReveal={() => handleReveal(secret.key)}
-                    onEdit={() => handleEdit(secret.key)}
-                    onDelete={() => setConfirmDelete(secret.key)}
-                    onEditValueChange={setEditValue}
-                    onEditToggleShow={() => setShowEditValue(!showEditValue)}
-                    onEditSave={handleEditSave}
-                    onEditCancel={handleEditCancel}
-                    sets={setNames}
-                    onAssignSet={(set) => handleAssignSet(secret.key, set)}
-                  />
-                ))}
-              </div>
-            )}
+              {!loading && isEmpty && <EmptyVaultState cliVerb="var" />}
 
-            {/* Variable sets */}
-            {!loading && (sets ?? []).length > 0 && (
-              <div className="px-2 py-2">
-                <div className="flex items-center justify-between px-2 mb-2">
-                  <div className="text-[10px] font-medium text-text-muted uppercase tracking-wider">
-                    Variable Sets
+              {!loading &&
+                !isEmpty &&
+                filteredSecrets.length === 0 &&
+                searchQuery && (
+                  <div className="p-6 text-center">
+                    <KeyRound
+                      size={24}
+                      className="text-text-muted/30 mx-auto mb-2"
+                    />
+                    <p className="text-text-muted text-xs">
+                      No matching secrets
+                    </p>
                   </div>
+                )}
+
+              {!loading && unassigned.length > 0 && (
+                <div className="p-2 space-y-1">
+                  {unassigned.map((secret) => (
+                    <SecretItem
+                      key={secret.key}
+                      secret={secret}
+                      revealed={revealedState.revealed[secret.key]}
+                      isEditing={editingKey === secret.key}
+                      editValue={editValue}
+                      showEditValue={showEditValue}
+                      onReveal={() => handleReveal(secret.key)}
+                      onEdit={() => handleEdit(secret.key)}
+                      onDelete={() => setConfirmDelete(secret.key)}
+                      onEditValueChange={setEditValue}
+                      onEditToggleShow={() => setShowEditValue(!showEditValue)}
+                      onEditSave={handleEditSave}
+                      onEditCancel={handleEditCancel}
+                      sets={setNames}
+                      onAssignSet={(set) => handleAssignSet(secret.key, set)}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {!loading && (sets ?? []).length > 0 && (
+                <div className="px-2 py-2">
+                  <div className="flex items-center justify-between px-2 mb-2">
+                    <div className="text-[10px] font-medium text-text-muted uppercase tracking-wider">
+                      Variable Sets
+                    </div>
+                    <button
+                      onClick={() => setShowNewSet(true)}
+                      className="p-1 rounded hover:bg-surface-highlight transition-colors"
+                      title="New set"
+                    >
+                      <Plus
+                        size={12}
+                        className="text-text-muted hover:text-primary"
+                      />
+                    </button>
+                  </div>
+
+                  <NewSetForm
+                    show={showNewSet}
+                    value={newSetName}
+                    onChange={setNewSetName}
+                    onSave={handleCreateSet}
+                    onCancel={() => {
+                      setShowNewSet(false);
+                      setNewSetName('');
+                    }}
+                    className="mb-2 px-2"
+                  />
+
+                  <div className="space-y-1">
+                    {(sets ?? []).map((set) => (
+                      <SetGroup
+                        key={set.name}
+                        set={set}
+                        variables={filteredSecrets.filter(
+                          (s) => s.set === set.name,
+                        )}
+                        expanded={expandedSets[set.name] ?? false}
+                        onToggleExpand={() => toggleSetExpand(set.name)}
+                        onDeleteSet={() => handleDeleteSet(set.name)}
+                        handlers={rowHandlers}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {!loading && !isEmpty && (sets ?? []).length === 0 && (
+                <div className="px-4 py-2">
                   <button
                     onClick={() => setShowNewSet(true)}
-                    className="p-1 rounded hover:bg-surface-highlight transition-colors"
-                    title="New set"
+                    className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border/50 text-xs text-text-muted hover:text-text-secondary hover:border-border transition-colors"
                   >
-                    <Plus size={12} className="text-text-muted hover:text-primary" />
+                    <Package size={12} />
+                    Create a variable set
                   </button>
+                  <NewSetForm
+                    show={showNewSet}
+                    value={newSetName}
+                    onChange={setNewSetName}
+                    onSave={handleCreateSet}
+                    onCancel={() => {
+                      setShowNewSet(false);
+                      setNewSetName('');
+                    }}
+                    className="mt-2"
+                  />
                 </div>
-
-                <NewSetForm
-                  show={showNewSet}
-                  value={newSetName}
-                  onChange={setNewSetName}
-                  onSave={handleCreateSet}
-                  onCancel={() => { setShowNewSet(false); setNewSetName(''); }}
-                  className="mb-2 px-2"
-                />
-
-                <div className="space-y-1">
-                  {(sets ?? []).map((set) => {
-                    const setVariables = filteredSecrets.filter((s) => s.set === set.name);
-                    const isExpanded = expandedSets[set.name] ?? false;
-                    return (
-                      <div key={set.name} className="group rounded-lg bg-surface-elevated/50 border border-border-subtle overflow-hidden">
-                        <button
-                          onClick={() => toggleSetExpand(set.name)}
-                          className="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-surface-highlight/50 transition-colors"
-                        >
-                          <div className="flex items-center gap-2">
-                            {isExpanded ? <ChevronDown size={12} className="text-text-muted" /> : <ChevronRight size={12} className="text-text-muted" />}
-                            <FolderOpen size={12} className="text-secondary" />
-                            <span className="text-xs font-mono text-text-primary">{set.name}</span>
-                            <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-secondary/10 text-secondary">
-                              {set.count}
-                            </span>
-                          </div>
-                          <button
-                            onClick={(e) => { e.stopPropagation(); handleDeleteSet(set.name); }}
-                            className="p-1 rounded hover:bg-status-error/10 transition-colors opacity-0 group-hover:opacity-100"
-                            title="Delete set"
-                          >
-                            <Trash2 size={10} className="text-text-muted hover:text-status-error" />
-                          </button>
-                        </button>
-                        {isExpanded && setVariables.length > 0 && (
-                          <div className="px-2 pb-2 space-y-1">
-                            {setVariables.map((secret) => (
-                              <SecretItem
-                                key={secret.key}
-                                secret={secret}
-                                revealed={revealed[secret.key]}
-                                isEditing={editingKey === secret.key}
-                                editValue={editValue}
-                                showEditValue={showEditValue}
-                                onReveal={() => handleReveal(secret.key)}
-                                onEdit={() => handleEdit(secret.key)}
-                                onDelete={() => setConfirmDelete(secret.key)}
-                                onEditValueChange={setEditValue}
-                                onEditToggleShow={() => setShowEditValue(!showEditValue)}
-                                onEditSave={handleEditSave}
-                                onEditCancel={handleEditCancel}
-                                sets={setNames}
-                                onAssignSet={(set) => handleAssignSet(secret.key, set)}
-                                compact
-                              />
-                            ))}
-                          </div>
-                        )}
-                        {isExpanded && setVariables.length === 0 && (
-                          <div className="px-3 pb-2">
-                            <p className="text-[10px] text-text-muted italic">No secrets in this set</p>
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-
-            {/* Create set button when no sets exist */}
-            {!loading && !isEmpty && (sets ?? []).length === 0 && (
-              <div className="px-4 py-2">
-                <button
-                  onClick={() => setShowNewSet(true)}
-                  className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border/50 text-xs text-text-muted hover:text-text-secondary hover:border-border transition-colors"
-                >
-                  <Package size={12} />
-                  Create a variable set
-                </button>
-                <NewSetForm
-                  show={showNewSet}
-                  value={newSetName}
-                  onChange={setNewSetName}
-                  onSave={handleCreateSet}
-                  onCancel={() => { setShowNewSet(false); setNewSetName(''); }}
-                  className="mt-2"
-                />
-              </div>
-            )}
-          </div>
-
-          {/* Status footer */}
-          <div className="px-4 py-2 border-t border-border/30 bg-surface/30 flex-shrink-0">
-            <div className="flex items-center justify-between text-[10px] text-text-muted">
-              <span>{allSecrets.length} total</span>
-              <span>
-                {(sets ?? []).length > 0 && (
-                  <span className="text-secondary">{(sets ?? []).length} sets</span>
-                )}
-              </span>
+              )}
             </div>
-          </div>
-        </>
-      )}
 
-      {/* Delete confirmation */}
-      <ConfirmDialog
-        isOpen={confirmDelete !== null}
-        onClose={() => setConfirmDelete(null)}
-        onConfirm={handleDeleteConfirm}
-        title="Delete secret"
-        message={
-          <>
-            <p>
-              Delete <span className="font-mono text-primary">{confirmDelete}</span>?
-            </p>
-            <p>This action cannot be undone.</p>
+            {/* Status footer */}
+            <div className="px-4 py-2 border-t border-border/30 bg-surface/30 flex-shrink-0">
+              <div className="flex items-center justify-between text-[10px] text-text-muted">
+                <span>{allSecrets.length} total</span>
+                <span>
+                  {(sets ?? []).length > 0 && (
+                    <span className="text-secondary">
+                      {(sets ?? []).length} sets
+                    </span>
+                  )}
+                </span>
+              </div>
+            </div>
           </>
-        }
-        confirmLabel={
-          <span>
-            Delete <span className="font-mono">"{confirmDelete}"</span>
-          </span>
-        }
-        variant="danger"
-      />
-      </div>{/* end content column */}
+        )}
+
+        <ConfirmDialog
+          isOpen={confirmDelete !== null}
+          onClose={() => setConfirmDelete(null)}
+          onConfirm={handleDeleteConfirm}
+          title="Delete secret"
+          message={
+            <>
+              <p>
+                Delete{' '}
+                <span className="font-mono text-primary">{confirmDelete}</span>?
+              </p>
+              <p>This action cannot be undone.</p>
+            </>
+          }
+          confirmLabel={
+            <span>
+              Delete <span className="font-mono">"{confirmDelete}"</span>
+            </span>
+          }
+          variant="danger"
+        />
+      </div>
     </div>,
     document.body,
-  );
-}
-
-// NewSetForm renders the inline set creation form
-interface NewSetFormProps {
-  show: boolean;
-  value: string;
-  onChange: (val: string) => void;
-  onSave: () => void;
-  onCancel: () => void;
-  className?: string;
-}
-
-function NewSetForm({ show, value, onChange, onSave, onCancel, className }: NewSetFormProps) {
-  if (!show) return null;
-  return (
-    <div className={cn('flex gap-2', className)}>
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => onChange(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
-        placeholder="set-name"
-        autoFocus
-        className="flex-1 bg-surface border border-border rounded-lg px-2 py-1 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 outline-none transition-colors"
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') onSave();
-          if (e.key === 'Escape') onCancel();
-        }}
-      />
-      <button onClick={onSave} className="p-1 rounded hover:bg-surface-highlight transition-colors" disabled={!value.trim()}>
-        <Check size={12} className="text-status-running" />
-      </button>
-      <button onClick={onCancel} className="p-1 rounded hover:bg-surface-highlight transition-colors">
-        <XCircle size={12} className="text-text-muted" />
-      </button>
-    </div>
-  );
-}
-
-// SecretItem — expandable row matching SkillItem pattern
-interface SecretItemProps {
-  secret: Variable;
-  revealed?: string;
-  isEditing: boolean;
-  editValue: string;
-  showEditValue: boolean;
-  onReveal: () => void;
-  onEdit: () => void;
-  onDelete: () => void;
-  onEditValueChange: (val: string) => void;
-  onEditToggleShow: () => void;
-  onEditSave: () => void;
-  onEditCancel: () => void;
-  sets: string[];
-  onAssignSet: (set: string) => void;
-  compact?: boolean;
-}
-
-function SecretItem({
-  secret,
-  revealed,
-  isEditing,
-  editValue,
-  showEditValue,
-  onReveal,
-  onEdit,
-  onDelete,
-  onEditValueChange,
-  onEditToggleShow,
-  onEditSave,
-  onEditCancel,
-  sets,
-  onAssignSet,
-  compact,
-}: SecretItemProps) {
-  const [expanded, setExpanded] = useState(false);
-
-  if (isEditing) {
-    return (
-      <div className="rounded-lg bg-surface-elevated/50 border border-primary/20 p-2 space-y-2">
-        <div className="text-xs font-mono text-primary">{secret.key}</div>
-        <div className="relative">
-          <input
-            type={showEditValue ? 'text' : 'password'}
-            value={editValue}
-            onChange={(e) => onEditValueChange(e.target.value)}
-            placeholder="New value"
-            autoFocus
-            className="w-full bg-surface border border-border rounded-lg px-2 py-1.5 pr-8 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 outline-none transition-colors"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') onEditSave();
-              if (e.key === 'Escape') onEditCancel();
-            }}
-          />
-          <button
-            type="button"
-            onClick={onEditToggleShow}
-            className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-text-muted hover:text-text-primary transition-colors"
-          >
-            {showEditValue ? <EyeOff size={10} /> : <Eye size={10} />}
-          </button>
-        </div>
-        <div className="flex justify-end gap-1.5">
-          <button
-            onClick={onEditCancel}
-            className="px-2 py-1 text-[10px] text-text-secondary hover:text-text-primary rounded transition-colors"
-          >
-            Cancel
-          </button>
-          <Button variant="primary" size="sm" onClick={onEditSave} disabled={!editValue}>
-            Save
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  // Plaintext variables show their value inline by default \u2014 the Reveal
-  // affordance is reserved for actual secrets.
-  const isPlaintext = !secret.is_secret;
-  const displayValue =
-    revealed !== undefined
-      ? revealed
-      : isPlaintext
-        ? '\u2022\u2022\u2022' // not yet fetched; placeholder until refresh completes
-        : '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022';
-
-  return (
-    <div className="rounded-lg bg-surface-elevated/50 border border-border-subtle overflow-hidden">
-      {/* Header row */}
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className={cn(
-          'w-full flex items-center gap-2 hover:bg-surface-highlight/50 transition-colors',
-          compact ? 'px-2 py-1.5' : 'p-3',
-        )}
-      >
-        <div className="p-0.5 text-text-muted">
-          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-        </div>
-        <VariableVisibilityIcon isSecret={secret.is_secret} />
-        <span className="text-xs font-mono font-medium text-text-primary flex-1 text-left truncate">
-          {secret.key}
-        </span>
-        <VariableTypeBadge type={secret.type} />
-        <span className="text-[10px] font-mono text-text-muted truncate max-w-[120px]">
-          {displayValue}
-        </span>
-      </button>
-
-      {/* Expanded content */}
-      {expanded && (
-        <div className="px-3 pb-3 border-t border-border-subtle">
-          {/* Value display */}
-          <div className="mt-2 mb-2">
-            <div className="text-[10px] text-text-muted mb-1">Value</div>
-            <div className="text-xs font-mono text-text-secondary bg-background/60 px-2 py-1.5 rounded break-all">
-              {revealed !== undefined ? revealed : '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022'}
-            </div>
-          </div>
-
-          {/* Set assignment */}
-          {!compact && sets.length > 0 && !secret.set && (
-            <div className="mb-2">
-              <select
-                value=""
-                onChange={(e) => { if (e.target.value) onAssignSet(e.target.value); }}
-                className="w-full bg-surface border border-border rounded-lg px-2 py-1 text-[10px] text-text-muted focus:outline-none focus:border-primary/40 transition-colors"
-                title="Assign to set"
-              >
-                <option value="">Assign to set...</option>
-                {sets.map((name) => (
-                  <option key={name} value={name}>{name}</option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          {/* Actions */}
-          <div className="flex items-center gap-1.5 mt-2 pt-2 border-t border-border-subtle/50">
-            {!isPlaintext && (
-              <button
-                onClick={(e) => { e.stopPropagation(); onReveal(); }}
-                className={cn(
-                  'flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-semibold transition-all duration-200',
-                  revealed !== undefined
-                    ? 'bg-status-pending text-background shadow-[0_1px_8px_rgba(234,179,8,0.2)] hover:shadow-[0_2px_12px_rgba(234,179,8,0.3)] hover:-translate-y-0.5 active:translate-y-0'
-                    : 'bg-status-running text-background shadow-[0_1px_8px_rgba(16,185,129,0.2)] hover:shadow-[0_2px_12px_rgba(16,185,129,0.3)] hover:-translate-y-0.5 active:translate-y-0'
-                )}
-              >
-                {revealed !== undefined ? <EyeOff size={10} /> : <Eye size={10} />}
-                {revealed !== undefined ? 'Hide' : 'Reveal'}
-              </button>
-            )}
-            <button
-              onClick={(e) => { e.stopPropagation(); onEdit(); }}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-semibold bg-gradient-to-r from-primary to-primary-dark text-background shadow-[0_1px_8px_rgba(245,158,11,0.2)] hover:shadow-[0_2px_12px_rgba(245,158,11,0.3)] hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200"
-            >
-              <Pencil size={10} /> Edit
-            </button>
-            <button
-              onClick={(e) => { e.stopPropagation(); onDelete(); }}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-semibold bg-gradient-to-r from-status-error to-rose-600 text-white shadow-[0_1px_8px_rgba(244,63,94,0.2)] hover:shadow-[0_2px_12px_rgba(244,63,94,0.3)] hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200"
-            >
-              <Trash2 size={10} /> Delete
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
   );
 }

--- a/web/src/hooks/useRevealedValues.ts
+++ b/web/src/hooks/useRevealedValues.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseRevealedValuesResult {
+  revealed: Record<string, string>;
+  // Fetches the value via `getValue`, stores it, and starts the auto-hide
+  // timer when `autoHide` is true. When `autoHide` is true and the key is
+  // already revealed, toggles it off instead.
+  reveal: (
+    key: string,
+    getValue: () => Promise<string>,
+    autoHide: boolean,
+  ) => Promise<void>;
+  hide: (key: string) => void;
+  // Direct multi-set used by refresh() to hydrate plaintext values without
+  // engaging the auto-hide timer (plaintext stays visible until unmount).
+  bulkSet: (entries: Record<string, string>) => void;
+}
+
+const REVEAL_TIMEOUT_MS = 10_000;
+
+// Local UI state for "which variable values are currently visible." Per-row
+// timers live here, not in Zustand — they're presentational and would cause
+// unnecessary re-renders if shared globally. Both VaultPanel and the detached
+// page consume this; each component instance gets its own reveal map.
+export function useRevealedValues(): UseRevealedValuesResult {
+  const [revealed, setRevealed] = useState<Record<string, string>>({});
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const revealedRef = useRef(revealed);
+
+  // Mirror the latest revealed map into a ref so callbacks can read it
+  // without re-binding on every change; useEffect (not render-time
+  // assignment) keeps it lint-clean per react-hooks/refs-during-render.
+  useEffect(() => {
+    revealedRef.current = revealed;
+  }, [revealed]);
+
+  useEffect(() => {
+    return () => {
+      Object.values(timers.current).forEach(clearTimeout);
+      timers.current = {};
+    };
+  }, []);
+
+  const clearTimer = useCallback((key: string) => {
+    if (timers.current[key]) {
+      clearTimeout(timers.current[key]);
+      delete timers.current[key];
+    }
+  }, []);
+
+  const hide = useCallback(
+    (key: string) => {
+      setRevealed((prev) => {
+        if (prev[key] === undefined) return prev;
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+      clearTimer(key);
+    },
+    [clearTimer],
+  );
+
+  const reveal = useCallback(
+    async (
+      key: string,
+      getValue: () => Promise<string>,
+      autoHide: boolean,
+    ) => {
+      // Toggle off when already revealed for autoHide types (secrets).
+      // Plaintext rows are sticky-revealed; toggling them off serves no
+      // UX purpose, so callers pass autoHide=false there.
+      if (revealedRef.current[key] !== undefined && autoHide) {
+        hide(key);
+        return;
+      }
+      const value = await getValue();
+      setRevealed((prev) => ({ ...prev, [key]: value }));
+      if (autoHide) {
+        timers.current[key] = setTimeout(() => {
+          setRevealed((prev) => {
+            const next = { ...prev };
+            delete next[key];
+            return next;
+          });
+          delete timers.current[key];
+        }, REVEAL_TIMEOUT_MS);
+      }
+    },
+    [hide],
+  );
+
+  const bulkSet = useCallback((entries: Record<string, string>) => {
+    if (!entries || Object.keys(entries).length === 0) return;
+    setRevealed((prev) => ({ ...prev, ...entries }));
+  }, []);
+
+  return { revealed, reveal, hide, bulkSet };
+}

--- a/web/src/hooks/useVaultManager.ts
+++ b/web/src/hooks/useVaultManager.ts
@@ -1,0 +1,205 @@
+import { useCallback } from 'react';
+import { useVaultStore } from '../stores/useVaultStore';
+import {
+  fetchVariables,
+  fetchVariableSets,
+  createVariable,
+  getVariable,
+  updateVariable,
+  deleteVariable,
+  createVariableSet,
+  deleteVariableSet,
+  assignVariableToSet,
+  fetchVariableStoreStatus,
+  unlockVariableStore,
+  lockVariableStore,
+} from '../lib/api';
+import type {
+  CreateVariableInput,
+  UpdateVariableInput,
+  Variable,
+  VariableSet,
+} from '../lib/api';
+
+export interface UseVaultManagerOptions {
+  // Invoked after refresh() pre-fetches plaintext (non-secret) variable
+  // values, so the consumer can hydrate its local revealed-values map and
+  // render plaintext rows with content on first paint.
+  onPlaintextLoaded?: (map: Record<string, string>) => void;
+}
+
+export interface UseVaultManagerResult {
+  // Store state — re-rendered when useVaultStore changes
+  variables: Variable[] | null;
+  sets: VariableSet[] | null;
+  loading: boolean;
+  error: string | null;
+  locked: boolean;
+  encrypted: boolean;
+
+  // Actions
+  refresh: () => Promise<void>;
+  unlock: (passphrase: string) => Promise<boolean>;
+  lock: (passphrase: string) => Promise<void>;
+  createVar: (input: CreateVariableInput) => Promise<void>;
+  updateVar: (key: string, input: UpdateVariableInput) => Promise<void>;
+  deleteVar: (key: string) => Promise<void>;
+  getVar: (key: string) => Promise<{ value: string }>;
+  createSet: (name: string) => Promise<void>;
+  deleteSet: (name: string) => Promise<void>;
+  assignToSet: (key: string, set: string) => Promise<void>;
+}
+
+// Single source of truth for vault data + IO actions, consumed by both the
+// sidebar (VaultPanel) and the detached `/var` page. Reads from useVaultStore;
+// every action that mutates server state calls refresh() to re-sync the
+// store. Per-row reveal state and form state stay local to consumers — this
+// hook deliberately owns no UI state.
+export function useVaultManager(
+  options?: UseVaultManagerOptions,
+): UseVaultManagerResult {
+  const variables = useVaultStore((s) => s.variables);
+  const sets = useVaultStore((s) => s.sets);
+  const loading = useVaultStore((s) => s.loading);
+  const error = useVaultStore((s) => s.error);
+  const locked = useVaultStore((s) => s.locked);
+  const encrypted = useVaultStore((s) => s.encrypted);
+
+  const onPlaintextLoaded = options?.onPlaintextLoaded;
+
+  const refresh = useCallback(async () => {
+    useVaultStore.getState().setLoading(true);
+    useVaultStore.getState().setError(null);
+    try {
+      const status = await fetchVariableStoreStatus();
+      useVaultStore.getState().setLocked(status.locked);
+      useVaultStore.getState().setEncrypted(status.encrypted);
+
+      if (!status.locked) {
+        const [variablesData, setsData] = await Promise.all([
+          fetchVariables(),
+          fetchVariableSets(),
+        ]);
+        useVaultStore.getState().setVariables(variablesData);
+        useVaultStore.getState().setSets(setsData);
+
+        // Plaintext variables display their value inline by default
+        // (no Reveal click needed). Eager-fetch them so the rows render
+        // with values on first paint.
+        const plaintext = variablesData.filter((v) => !v.is_secret);
+        if (plaintext.length > 0 && onPlaintextLoaded) {
+          const fetched = await Promise.all(
+            plaintext.map((v) =>
+              getVariable(v.key).then(
+                (detail) => [v.key, detail.value] as const,
+                () => [v.key, ''] as const,
+              ),
+            ),
+          );
+          const map: Record<string, string> = {};
+          for (const [k, val] of fetched) map[k] = val;
+          onPlaintextLoaded(map);
+        }
+      }
+    } catch (err) {
+      useVaultStore
+        .getState()
+        .setError(err instanceof Error ? err.message : 'Failed to load vault');
+    } finally {
+      useVaultStore.getState().setLoading(false);
+    }
+  }, [onPlaintextLoaded]);
+
+  const unlock = useCallback(
+    async (passphrase: string): Promise<boolean> => {
+      try {
+        await unlockVariableStore(passphrase);
+        useVaultStore.getState().setLocked(false);
+        await refresh();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [refresh],
+  );
+
+  const lock = useCallback(
+    async (passphrase: string): Promise<void> => {
+      await lockVariableStore(passphrase);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const createVar = useCallback(
+    async (input: CreateVariableInput) => {
+      await createVariable(input);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const updateVar = useCallback(
+    async (key: string, input: UpdateVariableInput) => {
+      await updateVariable(key, input);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const deleteVar = useCallback(
+    async (key: string) => {
+      await deleteVariable(key);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const getVar = useCallback(async (key: string) => {
+    return getVariable(key);
+  }, []);
+
+  const createSet = useCallback(
+    async (name: string) => {
+      await createVariableSet(name);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const deleteSet = useCallback(
+    async (name: string) => {
+      await deleteVariableSet(name);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const assignToSet = useCallback(
+    async (key: string, set: string) => {
+      await assignVariableToSet(key, set);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  return {
+    variables,
+    sets,
+    loading,
+    error,
+    locked,
+    encrypted,
+    refresh,
+    unlock,
+    lock,
+    createVar,
+    updateVar,
+    deleteVar,
+    getVar,
+    createSet,
+    deleteSet,
+    assignToSet,
+  };
+}

--- a/web/src/pages/DetachedVaultPage.tsx
+++ b/web/src/pages/DetachedVaultPage.tsx
@@ -1,16 +1,7 @@
-import { useEffect, useState, useCallback, useRef, useMemo, Component, type ReactNode } from 'react';
+import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import {
   KeyRound,
   Plus,
-  Eye,
-  EyeOff,
-  Pencil,
-  Trash2,
-  Check,
-  XCircle,
-  FolderOpen,
-  ChevronDown,
-  ChevronRight,
   AlertCircle,
   Package,
   Lock,
@@ -19,296 +10,128 @@ import {
   Search,
   X,
 } from 'lucide-react';
-import { cn } from '../lib/cn';
 import { IconButton } from '../components/ui/IconButton';
-import { Button } from '../components/ui/Button';
 import { ConfirmDialog } from '../components/ui/ConfirmDialog';
 import { ZoomControls } from '../components/ui/ZoomControls';
 import { VaultLockPrompt } from '../components/vault/VaultLockPrompt';
 import { ToastContainer, showToast } from '../components/ui/Toast';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
 import { useLogFontSize } from '../hooks/useLogFontSize';
-import { useVaultStore } from '../stores/useVaultStore';
-import {
-  fetchVariables,
-  fetchVariableSets,
-  createVariable,
-  getVariable,
-  updateVariable,
-  deleteVariable,
-  createVariableSet,
-  deleteVariableSet,
-  assignVariableToSet,
-  fetchVariableStoreStatus,
-  unlockVariableStore,
-  lockVariableStore,
-} from '../lib/api';
-import type { Variable, VariableType } from '../lib/api';
+import { useVaultManager } from '../hooks/useVaultManager';
+import { useRevealedValues } from '../hooks/useRevealedValues';
 import { POLLING } from '../lib/constants';
-import { VariableTypeBadge } from '../components/vault/VariableTypeBadge';
-import { VariableVisibilityIcon } from '../components/vault/VariableVisibilityIcon';
-import { VariableTypeSelector } from '../components/vault/VariableTypeSelector';
-import { VariableSecretToggle } from '../components/vault/VariableSecretToggle';
-import { validateVariableInput, getValuePlaceholder } from '../components/vault/variableTypeHelpers';
-
-// Error boundary for detached window
-interface ErrorBoundaryState {
-  hasError: boolean;
-  error: Error | null;
-}
-
-class DetachedErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryState> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { hasError: false, error: null };
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="h-screen w-screen bg-background flex items-center justify-center">
-          <div className="text-center p-8 max-w-md">
-            <div className="p-4 rounded-xl bg-status-error/10 border border-status-error/20 inline-block mb-4">
-              <AlertCircle size={32} className="text-status-error" />
-            </div>
-            <h1 className="text-lg text-status-error mb-2">Something went wrong</h1>
-            <pre className="text-xs text-text-muted bg-surface p-4 rounded-lg overflow-auto max-h-32 mb-4">
-              {this.state.error?.message}
-            </pre>
-            <button
-              onClick={() => window.location.reload()}
-              className="px-4 py-2 bg-primary text-background rounded-lg font-medium hover:bg-primary/90 transition-colors"
-            >
-              Reload Window
-            </button>
-          </div>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
+import { SecretItem } from '../components/vault/SecretItem';
+import { NewSetForm } from '../components/vault/NewSetForm';
+import { VariableQuickAddForm } from '../components/vault/VariableQuickAddForm';
+import { VaultEncryptForm } from '../components/vault/VaultEncryptForm';
+import { EmptyVaultState } from '../components/vault/EmptyVaultState';
+import { SetGroup } from '../components/vault/SetGroup';
+import { DetachedVaultErrorBoundary } from '../components/vault/DetachedVaultErrorBoundary';
 
 function DetachedVaultContent() {
-  const secrets = useVaultStore((s) => s.variables);
-  const sets = useVaultStore((s) => s.sets);
-  const loading = useVaultStore((s) => s.loading);
-  const error = useVaultStore((s) => s.error);
-  const locked = useVaultStore((s) => s.locked);
-  const encrypted = useVaultStore((s) => s.encrypted);
+  const revealedState = useRevealedValues();
+  const vault = useVaultManager({ onPlaintextLoaded: revealedState.bulkSet });
 
-  // Search state
+  const {
+    variables: secrets,
+    sets,
+    loading,
+    error,
+    locked,
+    encrypted,
+    refresh,
+    unlock,
+    lock,
+    createVar,
+    updateVar,
+    deleteVar,
+    getVar,
+    createSet,
+    deleteSet,
+    assignToSet,
+  } = vault;
+
   const [searchQuery, setSearchQuery] = useState('');
-
-  // Lock UI state
   const [showLockForm, setShowLockForm] = useState(false);
-  const [lockPassphrase, setLockPassphrase] = useState('');
-  const [lockConfirm, setLockConfirm] = useState('');
-  const [lockError, setLockError] = useState<string | null>(null);
-  const [isLocking, setIsLocking] = useState(false);
 
-  // Quick-add form state
-  const [newKey, setNewKey] = useState('');
-  const [newValue, setNewValue] = useState('');
-  const [newSet, setNewSet] = useState('');
-  const [showNewValue, setShowNewValue] = useState(false);
-  const [addError, setAddError] = useState<string | null>(null);
-  const [isAdding, setIsAdding] = useState(false);
-  const [newType, setNewType] = useState<VariableType>('string');
-  const [newIsSecret, setNewIsSecret] = useState(true);
-
-  // Reveal state
-  const [revealed, setRevealed] = useState<Record<string, string>>({});
-  const revealTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
-
-  // Edit state
+  // Edit state — the detached page sends only `{ value }` on save (no type
+  // validation or is_secret preservation). This differs from VaultPanel
+  // and is intentionally preserved for behavioral parity.
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editValue, setEditValue] = useState('');
   const [showEditValue, setShowEditValue] = useState(false);
 
-  // Delete confirmation
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 
-  // Set management
   const [expandedSets, setExpandedSets] = useState<Record<string, boolean>>({});
   const [showNewSet, setShowNewSet] = useState(false);
   const [newSetName, setNewSetName] = useState('');
 
-  // Text zoom
   const contentRef = useRef<HTMLElement>(null);
   const { fontSize, zoomIn, zoomOut, resetZoom, isMin, isMax, isDefault } =
     useLogFontSize(contentRef);
 
-  // Register with main window
   useDetachedWindowSync('var');
 
-  // Filtered secrets
-  const allSecrets = secrets ?? [];
+  const allSecrets = useMemo(() => secrets ?? [], [secrets]);
   const filteredSecrets = useMemo(() => {
     if (!searchQuery) return allSecrets;
     const lower = searchQuery.toLowerCase();
     return allSecrets.filter(
-      (s) => s.key.toLowerCase().includes(lower) || (s.set ?? '').toLowerCase().includes(lower),
+      (s) =>
+        s.key.toLowerCase().includes(lower) ||
+        (s.set ?? '').toLowerCase().includes(lower),
     );
   }, [allSecrets, searchQuery]);
-
-  const refresh = useCallback(async () => {
-    useVaultStore.getState().setLoading(true);
-    useVaultStore.getState().setError(null);
-    try {
-      const status = await fetchVariableStoreStatus();
-      useVaultStore.getState().setLocked(status.locked);
-      useVaultStore.getState().setEncrypted(status.encrypted);
-
-      if (!status.locked) {
-        const [variablesData, setsData] = await Promise.all([
-          fetchVariables(),
-          fetchVariableSets(),
-        ]);
-        useVaultStore.getState().setVariables(variablesData);
-        useVaultStore.getState().setSets(setsData);
-
-        // Plaintext variables display unmasked by default; pre-fetch their
-        // values so rows render with content on first paint.
-        const plaintext = variablesData.filter((v) => !v.is_secret);
-        if (plaintext.length > 0) {
-          const fetched = await Promise.all(
-            plaintext.map((v) =>
-              getVariable(v.key).then(
-                (detail) => [v.key, detail.value] as const,
-                () => [v.key, ''] as const,
-              ),
-            ),
-          );
-          setRevealed((prev) => {
-            const next = { ...prev };
-            for (const [k, val] of fetched) next[k] = val;
-            return next;
-          });
-        }
-      }
-    } catch (err) {
-      useVaultStore.getState().setError(err instanceof Error ? err.message : 'Failed to load vault');
-    } finally {
-      useVaultStore.getState().setLoading(false);
-    }
-  }, []);
 
   useEffect(() => {
     refresh();
     const interval = window.setInterval(refresh, POLLING.STATUS);
-    return () => {
-      clearInterval(interval);
-      Object.values(revealTimers.current).forEach(clearTimeout);
-    };
+    return () => clearInterval(interval);
   }, [refresh]);
 
-  const handleUnlock = useCallback(async (passphrase: string): Promise<boolean> => {
-    try {
-      await unlockVariableStore(passphrase);
-      useVaultStore.getState().setLocked(false);
-      await refresh();
-      showToast('success', 'Vault unlocked');
-      return true;
-    } catch {
-      return false;
-    }
-  }, [refresh]);
+  const handleUnlock = useCallback(
+    async (passphrase: string): Promise<boolean> => {
+      const ok = await unlock(passphrase);
+      if (ok) showToast('success', 'Vault unlocked');
+      return ok;
+    },
+    [unlock],
+  );
 
-  const handleLock = useCallback(async () => {
-    if (!lockPassphrase.trim()) return;
-    if (lockPassphrase !== lockConfirm) {
-      setLockError('Passphrases do not match');
-      return;
-    }
-    setIsLocking(true);
-    setLockError(null);
-    try {
-      await lockVariableStore(lockPassphrase);
+  const handleEncrypt = useCallback(
+    async (passphrase: string) => {
+      await lock(passphrase);
       setShowLockForm(false);
-      setLockPassphrase('');
-      setLockConfirm('');
       showToast('success', 'Vault encrypted');
-      await refresh();
-    } catch (err) {
-      setLockError(err instanceof Error ? err.message : 'Failed to lock vault');
-    } finally {
-      setIsLocking(false);
-    }
-  }, [lockPassphrase, lockConfirm, refresh]);
+    },
+    [lock],
+  );
 
-  const handleReveal = useCallback(async (key: string) => {
-    const target = allSecrets.find((v) => v.key === key);
-    const isPlaintext = target ? !target.is_secret : false;
-
-    if (revealed[key] !== undefined && !isPlaintext) {
-      setRevealed((prev) => {
-        const next = { ...prev };
-        delete next[key];
-        return next;
-      });
-      if (revealTimers.current[key]) {
-        clearTimeout(revealTimers.current[key]);
-        delete revealTimers.current[key];
+  const handleReveal = useCallback(
+    async (key: string) => {
+      const target = allSecrets.find((v) => v.key === key);
+      const isPlaintext = target ? !target.is_secret : false;
+      try {
+        await revealedState.reveal(
+          key,
+          async () => (await getVar(key)).value,
+          !isPlaintext,
+        );
+      } catch {
+        showToast('error', `Failed to reveal ${key}`);
       }
-      return;
-    }
-    try {
-      const data = await getVariable(key);
-      setRevealed((prev) => ({ ...prev, [key]: data.value }));
-      if (isPlaintext) return;
-      revealTimers.current[key] = setTimeout(() => {
-        setRevealed((prev) => {
-          const next = { ...prev };
-          delete next[key];
-          return next;
-        });
-        delete revealTimers.current[key];
-      }, 10000);
-    } catch {
-      showToast('error', `Failed to reveal ${key}`);
-    }
-  }, [revealed, allSecrets]);
+    },
+    [allSecrets, revealedState, getVar],
+  );
 
-  const handleAdd = useCallback(async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!newKey.trim() || !newValue) return;
-    const key = newKey.trim();
-
-    const validation = validateVariableInput(newType, newValue);
-    if (!validation.ok) {
-      setAddError(validation.error);
-      return;
-    }
-
-    setIsAdding(true);
-    setAddError(null);
-    try {
-      await createVariable({
-        key,
-        value: validation.normalized,
-        type: newType,
-        isSecret: newIsSecret,
-        set: newSet || undefined,
-      });
-      setNewKey('');
-      setNewValue('');
-      setNewSet('');
-      setShowNewValue(false);
-      setNewType('string');
-      setNewIsSecret(true);
-      await refresh();
-      showToast('success', `Variable "${key}" created`);
-    } catch (err) {
-      setAddError(err instanceof Error ? err.message : 'Failed to create variable');
-    } finally {
-      setIsAdding(false);
-    }
-  }, [newKey, newValue, newSet, newType, newIsSecret, refresh]);
+  const handleCreate = useCallback(
+    async (input: Parameters<typeof createVar>[0]) => {
+      await createVar(input);
+      showToast('success', `Variable "${input.key}" created`);
+    },
+    [createVar],
+  );
 
   const handleEdit = useCallback((key: string) => {
     setEditingKey(key);
@@ -319,15 +142,14 @@ function DetachedVaultContent() {
   const handleEditSave = useCallback(async () => {
     if (!editingKey || !editValue) return;
     try {
-      await updateVariable(editingKey, { value: editValue });
+      await updateVar(editingKey, { value: editValue });
       setEditingKey(null);
       setEditValue('');
-      await refresh();
       showToast('success', `Variable "${editingKey}" updated`);
     } catch {
       showToast('error', 'Failed to update secret');
     }
-  }, [editingKey, editValue, refresh]);
+  }, [editingKey, editValue, updateVar]);
 
   const handleEditCancel = useCallback(() => {
     setEditingKey(null);
@@ -338,46 +160,52 @@ function DetachedVaultContent() {
   const handleDeleteConfirm = useCallback(async () => {
     if (!confirmDelete) return;
     try {
-      await deleteVariable(confirmDelete);
+      await deleteVar(confirmDelete);
       setConfirmDelete(null);
-      await refresh();
       showToast('success', `Secret "${confirmDelete}" deleted`);
     } catch {
       showToast('error', 'Failed to delete secret');
     }
-  }, [confirmDelete, refresh]);
+  }, [confirmDelete, deleteVar]);
 
   const handleCreateSet = useCallback(async () => {
-    if (!newSetName.trim()) return;
+    const name = newSetName.trim();
+    if (!name) return;
     try {
-      await createVariableSet(newSetName.trim());
+      await createSet(name);
       setNewSetName('');
       setShowNewSet(false);
-      await refresh();
-      showToast('success', `Set "${newSetName.trim()}" created`);
+      showToast('success', `Set "${name}" created`);
     } catch (err) {
-      showToast('error', err instanceof Error ? err.message : 'Failed to create set');
+      showToast(
+        'error',
+        err instanceof Error ? err.message : 'Failed to create set',
+      );
     }
-  }, [newSetName, refresh]);
+  }, [newSetName, createSet]);
 
-  const handleDeleteSet = useCallback(async (name: string) => {
-    try {
-      await deleteVariableSet(name);
-      await refresh();
-      showToast('success', `Set "${name}" deleted`);
-    } catch {
-      showToast('error', 'Failed to delete set');
-    }
-  }, [refresh]);
+  const handleDeleteSet = useCallback(
+    async (name: string) => {
+      try {
+        await deleteSet(name);
+        showToast('success', `Set "${name}" deleted`);
+      } catch {
+        showToast('error', 'Failed to delete set');
+      }
+    },
+    [deleteSet],
+  );
 
-  const handleAssignSet = useCallback(async (key: string, set: string) => {
-    try {
-      await assignVariableToSet(key, set);
-      await refresh();
-    } catch {
-      showToast('error', 'Failed to assign set');
-    }
-  }, [refresh]);
+  const handleAssignSet = useCallback(
+    async (key: string, set: string) => {
+      try {
+        await assignToSet(key, set);
+      } catch {
+        showToast('error', 'Failed to assign set');
+      }
+    },
+    [assignToSet],
+  );
 
   const toggleSetExpand = useCallback((name: string) => {
     setExpandedSets((prev) => ({ ...prev, [name]: !prev[name] }));
@@ -386,6 +214,22 @@ function DetachedVaultContent() {
   const unassigned = filteredSecrets.filter((s) => !s.set);
   const setNames = (sets ?? []).map((s) => s.name);
   const isEmpty = allSecrets.length === 0 && (sets ?? []).length === 0;
+
+  const rowHandlers = {
+    revealed: revealedState.revealed,
+    editingKey,
+    editValue,
+    showEditValue,
+    setNames,
+    onReveal: handleReveal,
+    onEdit: handleEdit,
+    onDeleteSecret: (key: string) => setConfirmDelete(key),
+    onEditValueChange: setEditValue,
+    onEditToggleShow: () => setShowEditValue(!showEditValue),
+    onEditSave: handleEditSave,
+    onEditCancel: handleEditCancel,
+    onAssignSet: handleAssignSet,
+  };
 
   return (
     <div className="h-screen w-screen bg-background flex flex-col overflow-hidden relative">
@@ -406,8 +250,12 @@ function DetachedVaultContent() {
             <KeyRound size={14} className="text-primary" />
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-sm font-semibold text-text-primary tracking-tight">Variables</span>
-            <span className="text-[10px] text-text-muted uppercase tracking-wider">Secrets</span>
+            <span className="text-sm font-semibold text-text-primary tracking-tight">
+              Variables
+            </span>
+            <span className="text-[10px] text-text-muted uppercase tracking-wider">
+              Secrets
+            </span>
             {encrypted && !locked && (
               <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-status-running/10 text-status-running flex items-center gap-1">
                 <LockOpen size={10} />
@@ -441,39 +289,44 @@ function DetachedVaultContent() {
               <Lock size={12} /> Encrypt
             </button>
           )}
-          <IconButton icon={RefreshCw} onClick={refresh} tooltip="Refresh" size="sm" variant="ghost" />
+          <IconButton
+            icon={RefreshCw}
+            onClick={refresh}
+            tooltip="Refresh"
+            size="sm"
+            variant="ghost"
+          />
         </div>
       </header>
 
-      {/* Lock prompt */}
-      {locked && (
-        <VaultLockPrompt onUnlock={handleUnlock} />
-      )}
+      {locked && <VaultLockPrompt onUnlock={handleUnlock} />}
 
-      {/* Unlocked content */}
       {!locked && (
         <>
           {/* Item count + New button */}
           <div className="border-b border-border/20 flex-shrink-0 z-10 relative px-4 py-2">
             <div className="max-w-2xl mx-auto flex items-center justify-between">
-            <span className="text-[10px] text-text-muted">
-              {searchQuery
-                ? `${filteredSecrets.length} of ${allSecrets.length} secrets`
-                : `${allSecrets.length} secrets`}
-            </span>
-            <button
-              onClick={() => {/* scroll to add form */}}
-              className="flex items-center gap-1 text-[10px] text-primary hover:text-primary/80 transition-colors"
-            >
-              <Plus size={10} /> New
-            </button>
+              <span className="text-[10px] text-text-muted">
+                {searchQuery
+                  ? `${filteredSecrets.length} of ${allSecrets.length} secrets`
+                  : `${allSecrets.length} secrets`}
+              </span>
+              <button className="flex items-center gap-1 text-[10px] text-primary hover:text-primary/80 transition-colors">
+                <Plus size={10} /> New
+              </button>
             </div>
           </div>
 
           {/* Search */}
-          <div className="px-2 py-1.5 border-b border-border/20 flex-shrink-0 z-10 relative" role="search">
+          <div
+            className="px-2 py-1.5 border-b border-border/20 flex-shrink-0 z-10 relative"
+            role="search"
+          >
             <div className="max-w-2xl mx-auto relative">
-              <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-text-muted/50" />
+              <Search
+                size={12}
+                className="absolute left-2 top-1/2 -translate-y-1/2 text-text-muted/50"
+              />
               <input
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
@@ -498,47 +351,14 @@ function DetachedVaultContent() {
             className="flex-1 overflow-y-auto scrollbar-dark relative z-10"
             style={{ '--log-font-size': `${fontSize}px` } as React.CSSProperties}
           >
-            {/* Lock form */}
             {showLockForm && (
-              <div className="px-4 pt-3 pb-2 border-b border-border-subtle/50 max-w-2xl mx-auto">
-                <div className="space-y-2">
-                  <div className="text-xs text-text-secondary mb-2">Encrypt vault with a passphrase:</div>
-                  <input
-                    type="password"
-                    value={lockPassphrase}
-                    onChange={(e) => { setLockPassphrase(e.target.value); setLockError(null); }}
-                    placeholder="New passphrase"
-                    autoFocus
-                    className="w-full bg-surface border border-border rounded-lg px-3 py-2 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors"
-                  />
-                  <input
-                    type="password"
-                    value={lockConfirm}
-                    onChange={(e) => { setLockConfirm(e.target.value); setLockError(null); }}
-                    placeholder="Confirm passphrase"
-                    className="w-full bg-surface border border-border rounded-lg px-3 py-2 text-xs font-mono text-text-primary placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors"
-                    onKeyDown={(e) => { if (e.key === 'Enter') handleLock(); }}
-                  />
-                  {lockError && (
-                    <p className="text-[10px] text-status-error">{lockError}</p>
-                  )}
-                  <div className="flex justify-end gap-2">
-                    <button
-                      onClick={() => { setShowLockForm(false); setLockPassphrase(''); setLockConfirm(''); setLockError(null); }}
-                      className="px-2 py-1 text-[10px] text-text-secondary hover:text-text-primary rounded transition-colors"
-                    >
-                      Cancel
-                    </button>
-                    <Button variant="primary" size="sm" onClick={handleLock} disabled={!lockPassphrase.trim() || !lockConfirm.trim() || isLocking}>
-                      <Lock size={12} />
-                      {isLocking ? 'Encrypting...' : 'Encrypt'}
-                    </Button>
-                  </div>
-                </div>
-              </div>
+              <VaultEncryptForm
+                onLock={handleEncrypt}
+                onCancel={() => setShowLockForm(false)}
+                className="px-4 pt-3 pb-2 border-b border-border-subtle/50 max-w-2xl mx-auto"
+              />
             )}
 
-            {/* Error */}
             {error && (
               <div className="max-w-2xl mx-auto mt-3 px-4 flex items-center gap-2 py-2 rounded-lg bg-status-error/10 border border-status-error/20 text-xs text-status-error">
                 <AlertCircle size={12} className="flex-shrink-0" />
@@ -546,108 +366,48 @@ function DetachedVaultContent() {
               </div>
             )}
 
-            {/* Loading skeleton */}
             {loading && !secrets && (
               <div className="p-4 space-y-3 max-w-2xl mx-auto">
                 {[1, 2, 3].map((i) => (
-                  <div key={i} className="h-10 rounded-lg bg-surface-elevated animate-pulse" />
+                  <div
+                    key={i}
+                    className="h-10 rounded-lg bg-surface-elevated animate-pulse"
+                  />
                 ))}
               </div>
             )}
 
-            {/* Quick-add form */}
-            <form onSubmit={handleAdd} className="px-4 pt-3 pb-2 border-b border-border-subtle/50 max-w-2xl mx-auto">
-              <div className="space-y-2">
-                <input
-                  type="text"
-                  value={newKey}
-                  onChange={(e) => { setNewKey(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, '')); setAddError(null); }}
-                  placeholder="KEY_NAME"
-                  className={cn(
-                    'w-full bg-surface border rounded-lg px-3 py-2 text-xs font-mono text-text-primary log-text',
-                    'placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors',
-                    addError ? 'border-status-error/50' : 'border-border'
-                  )}
-                />
-                <div className="relative">
-                  <input
-                    type={showNewValue ? 'text' : 'password'}
-                    value={newValue}
-                    onChange={(e) => setNewValue(e.target.value)}
-                    placeholder={getValuePlaceholder(newType, newIsSecret)}
-                    className="w-full bg-surface border border-border rounded-lg px-3 py-2 pr-10 text-xs font-mono text-text-primary log-text placeholder:text-text-muted focus:border-primary/50 focus:ring-1 focus:ring-primary/30 outline-none transition-colors"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowNewValue(!showNewValue)}
-                    className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 rounded text-text-muted hover:text-text-primary transition-colors"
-                  >
-                    {showNewValue ? <EyeOff size={12} /> : <Eye size={12} />}
-                  </button>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <VariableTypeSelector value={newType} onChange={setNewType} />
-                  <VariableSecretToggle isSecret={newIsSecret} onChange={setNewIsSecret} />
-                </div>
-                <div className="flex gap-2">
-                  <select
-                    value={newSet}
-                    onChange={(e) => setNewSet(e.target.value)}
-                    className="flex-1 bg-surface border border-border rounded-lg px-3 py-2 text-xs text-text-secondary focus:border-primary/50 outline-none transition-colors"
-                  >
-                    <option value="">No set</option>
-                    {setNames.map((name) => (
-                      <option key={name} value={name}>{name}</option>
-                    ))}
-                  </select>
-                  <Button type="submit" variant="primary" size="sm" disabled={!newKey.trim() || !newValue || isAdding}>
-                    <Plus size={12} />
-                    Add
-                  </Button>
-                </div>
-              </div>
-              {addError && (
-                <p className="mt-1.5 text-[10px] text-status-error">{addError}</p>
-              )}
-            </form>
+            <VariableQuickAddForm
+              setNames={setNames}
+              onSubmit={handleCreate}
+              enableZoom
+              className="px-4 pt-3 pb-2 border-b border-border-subtle/50 max-w-2xl mx-auto"
+            />
 
-            {/* Empty state */}
             {!loading && isEmpty && (
-              <div className="px-4 py-8 text-center max-w-md mx-auto">
-                <div className="mx-auto w-12 h-12 mb-4 rounded-xl bg-primary/10 border border-primary/20 flex items-center justify-center">
-                  <KeyRound size={20} className="text-primary/60" />
-                </div>
-                <p className="text-sm text-text-secondary mb-2">No secrets stored</p>
-                <p className="text-xs text-text-muted leading-relaxed">
-                  Add secrets using the form above, or via CLI:
-                </p>
-                <div className="mt-2 space-y-1">
-                  <code className="block text-[10px] font-mono text-primary/80 bg-surface-elevated rounded px-2 py-1">
-                    gridctl vault set API_KEY
-                  </code>
-                  <code className="block text-[10px] font-mono text-primary/80 bg-surface-elevated rounded px-2 py-1">
-                    gridctl vault import .env
-                  </code>
-                </div>
-              </div>
+              <EmptyVaultState cliVerb="vault" className="max-w-md mx-auto" />
             )}
 
-            {/* Search empty state */}
-            {!loading && !isEmpty && filteredSecrets.length === 0 && searchQuery && (
-              <div className="p-6 text-center max-w-md mx-auto">
-                <KeyRound size={24} className="text-text-muted/30 mx-auto mb-2" />
-                <p className="text-text-muted text-xs">No matching secrets</p>
-              </div>
-            )}
+            {!loading &&
+              !isEmpty &&
+              filteredSecrets.length === 0 &&
+              searchQuery && (
+                <div className="p-6 text-center max-w-md mx-auto">
+                  <KeyRound
+                    size={24}
+                    className="text-text-muted/30 mx-auto mb-2"
+                  />
+                  <p className="text-text-muted text-xs">No matching secrets</p>
+                </div>
+              )}
 
-            {/* Unassigned secrets */}
             {!loading && unassigned.length > 0 && (
               <div className="p-3 space-y-2 max-w-2xl mx-auto">
                 {unassigned.map((secret) => (
                   <SecretItem
                     key={secret.key}
                     secret={secret}
-                    revealed={revealed[secret.key]}
+                    revealed={revealedState.revealed[secret.key]}
                     isEditing={editingKey === secret.key}
                     editValue={editValue}
                     showEditValue={showEditValue}
@@ -660,12 +420,12 @@ function DetachedVaultContent() {
                     onEditCancel={handleEditCancel}
                     sets={setNames}
                     onAssignSet={(set) => handleAssignSet(secret.key, set)}
+                    enableZoom
                   />
                 ))}
               </div>
             )}
 
-            {/* Variable sets */}
             {!loading && (sets ?? []).length > 0 && (
               <div className="px-3 py-2 max-w-2xl mx-auto">
                 <div className="flex items-center justify-between px-2 mb-2">
@@ -677,7 +437,10 @@ function DetachedVaultContent() {
                     className="p-1 rounded hover:bg-surface-highlight transition-colors"
                     title="New set"
                   >
-                    <Plus size={12} className="text-text-muted hover:text-primary" />
+                    <Plus
+                      size={12}
+                      className="text-text-muted hover:text-primary"
+                    />
                   </button>
                 </div>
 
@@ -686,73 +449,34 @@ function DetachedVaultContent() {
                   value={newSetName}
                   onChange={setNewSetName}
                   onSave={handleCreateSet}
-                  onCancel={() => { setShowNewSet(false); setNewSetName(''); }}
+                  onCancel={() => {
+                    setShowNewSet(false);
+                    setNewSetName('');
+                  }}
                   className="mb-2 px-2"
+                  enableZoom
                 />
 
                 <div className="space-y-2">
-                  {(sets ?? []).map((set) => {
-                    const setVariables = filteredSecrets.filter((s) => s.set === set.name);
-                    const isExpanded = expandedSets[set.name] ?? false;
-                    return (
-                      <div key={set.name} className="group rounded-lg bg-surface-elevated/50 border border-border-subtle overflow-hidden">
-                        <button
-                          onClick={() => toggleSetExpand(set.name)}
-                          className="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-surface-highlight/50 transition-colors"
-                        >
-                          <div className="flex items-center gap-2">
-                            {isExpanded ? <ChevronDown size={12} className="text-text-muted" /> : <ChevronRight size={12} className="text-text-muted" />}
-                            <FolderOpen size={12} className="text-secondary" />
-                            <span className="text-xs font-mono text-text-primary log-text">{set.name}</span>
-                            <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-secondary/10 text-secondary">
-                              {set.count}
-                            </span>
-                          </div>
-                          <button
-                            onClick={(e) => { e.stopPropagation(); handleDeleteSet(set.name); }}
-                            className="p-1 rounded hover:bg-status-error/10 transition-colors opacity-0 group-hover:opacity-100"
-                            title="Delete set"
-                          >
-                            <Trash2 size={10} className="text-text-muted hover:text-status-error" />
-                          </button>
-                        </button>
-                        {isExpanded && setVariables.length > 0 && (
-                          <div className="px-2 pb-2 space-y-1">
-                            {setVariables.map((secret) => (
-                              <SecretItem
-                                key={secret.key}
-                                secret={secret}
-                                revealed={revealed[secret.key]}
-                                isEditing={editingKey === secret.key}
-                                editValue={editValue}
-                                showEditValue={showEditValue}
-                                onReveal={() => handleReveal(secret.key)}
-                                onEdit={() => handleEdit(secret.key)}
-                                onDelete={() => setConfirmDelete(secret.key)}
-                                onEditValueChange={setEditValue}
-                                onEditToggleShow={() => setShowEditValue(!showEditValue)}
-                                onEditSave={handleEditSave}
-                                onEditCancel={handleEditCancel}
-                                sets={setNames}
-                                onAssignSet={(set) => handleAssignSet(secret.key, set)}
-                                compact
-                              />
-                            ))}
-                          </div>
-                        )}
-                        {isExpanded && setVariables.length === 0 && (
-                          <div className="px-3 pb-2">
-                            <p className="text-[10px] text-text-muted italic">No secrets in this set</p>
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
+                  {(sets ?? []).map((set) => (
+                    <SetGroup
+                      key={set.name}
+                      set={set}
+                      variables={filteredSecrets.filter(
+                        (s) => s.set === set.name,
+                      )}
+                      expanded={expandedSets[set.name] ?? false}
+                      onToggleExpand={() => toggleSetExpand(set.name)}
+                      onDeleteSet={() => handleDeleteSet(set.name)}
+                      handlers={rowHandlers}
+                      enableZoom
+                      nameClassName="log-text"
+                    />
+                  ))}
                 </div>
               </div>
             )}
 
-            {/* Create set button when no sets exist */}
             {!loading && !isEmpty && (sets ?? []).length === 0 && (
               <div className="px-4 py-2 max-w-2xl mx-auto">
                 <button
@@ -767,8 +491,12 @@ function DetachedVaultContent() {
                   value={newSetName}
                   onChange={setNewSetName}
                   onSave={handleCreateSet}
-                  onCancel={() => { setShowNewSet(false); setNewSetName(''); }}
+                  onCancel={() => {
+                    setShowNewSet(false);
+                    setNewSetName('');
+                  }}
                   className="mt-2"
+                  enableZoom
                 />
               </div>
             )}
@@ -781,7 +509,7 @@ function DetachedVaultContent() {
         <div className="max-w-2xl mx-auto w-full flex items-center justify-between text-[10px] text-text-muted">
           <span>
             {allSecrets.length > 0 ? `${allSecrets.length} secrets` : ''}
-            {(sets ?? []).length > 0 ? ` \u00B7 ${(sets ?? []).length} sets` : ''}
+            {(sets ?? []).length > 0 ? ` · ${(sets ?? []).length} sets` : ''}
             {locked ? 'Vault locked' : ''}
           </span>
           <span className="flex items-center gap-1">
@@ -791,7 +519,6 @@ function DetachedVaultContent() {
         </div>
       </footer>
 
-      {/* Delete confirmation */}
       <ConfirmDialog
         isOpen={confirmDelete !== null}
         onClose={() => setConfirmDelete(null)}
@@ -800,7 +527,8 @@ function DetachedVaultContent() {
         message={
           <>
             <p>
-              Delete <span className="font-mono text-primary">{confirmDelete}</span>?
+              Delete{' '}
+              <span className="font-mono text-primary">{confirmDelete}</span>?
             </p>
             <p>This action cannot be undone.</p>
           </>
@@ -818,218 +546,10 @@ function DetachedVaultContent() {
   );
 }
 
-// SecretItem — expandable row matching SkillItem pattern
-interface SecretItemProps {
-  secret: Variable;
-  revealed?: string;
-  isEditing: boolean;
-  editValue: string;
-  showEditValue: boolean;
-  onReveal: () => void;
-  onEdit: () => void;
-  onDelete: () => void;
-  onEditValueChange: (val: string) => void;
-  onEditToggleShow: () => void;
-  onEditSave: () => void;
-  onEditCancel: () => void;
-  sets: string[];
-  onAssignSet: (set: string) => void;
-  compact?: boolean;
-}
-
-function SecretItem({
-  secret,
-  revealed,
-  isEditing,
-  editValue,
-  showEditValue,
-  onReveal,
-  onEdit,
-  onDelete,
-  onEditValueChange,
-  onEditToggleShow,
-  onEditSave,
-  onEditCancel,
-  sets,
-  onAssignSet,
-  compact,
-}: SecretItemProps) {
-  const [expanded, setExpanded] = useState(false);
-
-  if (isEditing) {
-    return (
-      <div className="rounded-lg bg-surface-elevated/50 border border-primary/20 p-2 space-y-2">
-        <div className="text-xs font-mono text-primary log-text">{secret.key}</div>
-        <div className="relative">
-          <input
-            type={showEditValue ? 'text' : 'password'}
-            value={editValue}
-            onChange={(e) => onEditValueChange(e.target.value)}
-            placeholder="New value"
-            autoFocus
-            className="w-full bg-surface border border-border rounded-lg px-2 py-1.5 pr-8 text-xs font-mono text-text-primary log-text placeholder:text-text-muted focus:border-primary/50 outline-none transition-colors"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') onEditSave();
-              if (e.key === 'Escape') onEditCancel();
-            }}
-          />
-          <button
-            type="button"
-            onClick={onEditToggleShow}
-            className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-text-muted hover:text-text-primary transition-colors"
-          >
-            {showEditValue ? <EyeOff size={10} /> : <Eye size={10} />}
-          </button>
-        </div>
-        <div className="flex justify-end gap-1.5">
-          <button
-            onClick={onEditCancel}
-            className="px-2 py-1 text-[10px] text-text-secondary hover:text-text-primary rounded transition-colors"
-          >
-            Cancel
-          </button>
-          <Button variant="primary" size="sm" onClick={onEditSave} disabled={!editValue}>
-            Save
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  const isPlaintext = !secret.is_secret;
-  const displayValue =
-    revealed !== undefined
-      ? revealed
-      : isPlaintext
-        ? '\u2022\u2022\u2022'
-        : '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022';
-
-  return (
-    <div className="rounded-lg bg-surface-elevated/50 border border-border-subtle overflow-hidden">
-      {/* Header row */}
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className={cn(
-          'w-full flex items-center gap-2 hover:bg-surface-highlight/50 transition-colors',
-          compact ? 'px-2 py-1.5' : 'p-3',
-        )}
-      >
-        <div className="p-0.5 text-text-muted">
-          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-        </div>
-        <VariableVisibilityIcon isSecret={secret.is_secret} />
-        <span className="text-xs font-mono font-medium text-text-primary flex-1 text-left truncate log-text">
-          {secret.key}
-        </span>
-        <VariableTypeBadge type={secret.type} />
-        <span className="text-[10px] font-mono text-text-muted truncate max-w-[120px] log-text-detail">
-          {displayValue}
-        </span>
-      </button>
-
-      {/* Expanded content */}
-      {expanded && (
-        <div className="px-3 pb-3 border-t border-border-subtle">
-          {/* Value display */}
-          <div className="mt-2 mb-2">
-            <div className="text-[10px] text-text-muted mb-1">Value</div>
-            <div className="text-xs font-mono text-text-secondary bg-background/60 px-2 py-1.5 rounded break-all log-text">
-              {revealed !== undefined ? revealed : '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022'}
-            </div>
-          </div>
-
-          {/* Set assignment */}
-          {!compact && sets.length > 0 && !secret.set && (
-            <div className="mb-2">
-              <select
-                value=""
-                onChange={(e) => { if (e.target.value) onAssignSet(e.target.value); }}
-                className="w-full bg-surface border border-border rounded-lg px-2 py-1 text-[10px] text-text-muted focus:outline-none focus:border-primary/40 transition-colors"
-                title="Assign to set"
-              >
-                <option value="">Assign to set...</option>
-                {sets.map((name) => (
-                  <option key={name} value={name}>{name}</option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          {/* Actions */}
-          <div className="flex items-center gap-1.5 mt-2 pt-2 border-t border-border-subtle/50">
-            {!isPlaintext && (
-              <button
-                onClick={(e) => { e.stopPropagation(); onReveal(); }}
-                className={cn(
-                  'flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-semibold transition-all duration-200',
-                  revealed !== undefined
-                    ? 'bg-status-pending text-background shadow-[0_1px_8px_rgba(234,179,8,0.2)] hover:shadow-[0_2px_12px_rgba(234,179,8,0.3)] hover:-translate-y-0.5 active:translate-y-0'
-                    : 'bg-status-running text-background shadow-[0_1px_8px_rgba(16,185,129,0.2)] hover:shadow-[0_2px_12px_rgba(16,185,129,0.3)] hover:-translate-y-0.5 active:translate-y-0'
-                )}
-              >
-                {revealed !== undefined ? <EyeOff size={10} /> : <Eye size={10} />}
-                {revealed !== undefined ? 'Hide' : 'Reveal'}
-              </button>
-            )}
-            <button
-              onClick={(e) => { e.stopPropagation(); onEdit(); }}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-semibold bg-gradient-to-r from-primary to-primary-dark text-background shadow-[0_1px_8px_rgba(245,158,11,0.2)] hover:shadow-[0_2px_12px_rgba(245,158,11,0.3)] hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200"
-            >
-              <Pencil size={10} /> Edit
-            </button>
-            <button
-              onClick={(e) => { e.stopPropagation(); onDelete(); }}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-semibold bg-gradient-to-r from-status-error to-rose-600 text-white shadow-[0_1px_8px_rgba(244,63,94,0.2)] hover:shadow-[0_2px_12px_rgba(244,63,94,0.3)] hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200"
-            >
-              <Trash2 size={10} /> Delete
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-// NewSetForm
-interface NewSetFormProps {
-  show: boolean;
-  value: string;
-  onChange: (val: string) => void;
-  onSave: () => void;
-  onCancel: () => void;
-  className?: string;
-}
-
-function NewSetForm({ show, value, onChange, onSave, onCancel, className }: NewSetFormProps) {
-  if (!show) return null;
-  return (
-    <div className={cn('flex gap-2', className)}>
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => onChange(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
-        placeholder="set-name"
-        autoFocus
-        className="flex-1 bg-surface border border-border rounded-lg px-2 py-1 text-xs font-mono text-text-primary log-text placeholder:text-text-muted focus:border-primary/50 outline-none transition-colors"
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') onSave();
-          if (e.key === 'Escape') onCancel();
-        }}
-      />
-      <button onClick={onSave} className="p-1 rounded hover:bg-surface-highlight transition-colors" disabled={!value.trim()}>
-        <Check size={12} className="text-status-running" />
-      </button>
-      <button onClick={onCancel} className="p-1 rounded hover:bg-surface-highlight transition-colors">
-        <XCircle size={12} className="text-text-muted" />
-      </button>
-    </div>
-  );
-}
-
 export function DetachedVaultPage() {
   return (
-    <DetachedErrorBoundary>
+    <DetachedVaultErrorBoundary>
       <DetachedVaultContent />
-    </DetachedErrorBoundary>
+    </DetachedVaultErrorBoundary>
   );
 }


### PR DESCRIPTION
## Description

Phase 1 of [#688](https://github.com/gridctl/gridctl/issues/688): extract shared logic from `VaultPanel.tsx` (1,030 lines) and `DetachedVaultPage.tsx` (1,035 lines) into a `useVaultManager()` hook and a set of presentation atoms. Both surfaces now consume the same building blocks instead of carrying near-duplicate copies, and any third surface (the upcoming Variables workspace) can plug in without re-implementing.

Pure refactor — zero user-visible changes.

## Type of Change

- [x] Refactor (non-breaking change which improves structure)

## Changes Made

### New shared hooks
- `web/src/hooks/useVaultManager.ts` (205 lines) — façade over `useVaultStore` + vault API client (refresh, CRUD, set management, lock/unlock). Single source of truth.
- `web/src/hooks/useRevealedValues.ts` (99 lines) — local reveal map with 10s auto-hide timers for secrets; sticky for plaintext.

### New shared atoms (under `web/src/components/vault/`)
- `SecretItem.tsx` (231 lines) — expandable variable row
- `NewSetForm.tsx` (63 lines) — inline set-creation form
- `VariableQuickAddForm.tsx` (156 lines) — add-variable form with type/secret toggles + validation
- `VaultEncryptForm.tsx` (103 lines) — passphrase + confirm encryption form
- `EmptyVaultState.tsx` (33 lines) — "no secrets" empty state (CLI verb parametrized)
- `SetGroup.tsx` (122 lines) — one expandable Variable Set + its member rows
- `DetachedVaultErrorBoundary.tsx` (51 lines) — extracted from `DetachedVaultPage` so the file fits the line target

### Refactored consumers
- `VaultPanel.tsx`: 1,030 → 576 lines (-44%)
- `DetachedVaultPage.tsx`: 1,035 → 555 lines (-46%)

### Behavior preserved (intentional non-DRY)
- **Edit semantics**: VaultPanel still validates against the variable's type and sends `{value, type, isSecret}` on save; DetachedVaultPage still sends just `{value}`. Both kept exactly as-is.
- **Polling**: only DetachedVaultPage polls (`POLLING.STATUS`). VaultPanel still fetches on mount.
- **Empty-state CLI verb**: VaultPanel renders `gridctl var …`; DetachedVaultPage renders the stale `gridctl vault …` it had before. Parametrized via an `EmptyVaultState` prop rather than fixed in the refactor.

### Out of scope (deliberately)
- The four other detached pages (`DetachedEditorPage`, `DetachedLogsPage`, `DetachedMetricsPage`, `DetachedTracesPage`) carry their own `DetachedErrorBoundary` copies. Those are unchanged here.
- No feature additions, no UI tweaks, no test changes.

## Testing

- `npm run build` — clean (covers `tsc -b` typecheck).
- `npm run lint` — no new errors or warnings in any file this PR touches. Pre-existing `react-hooks/set-state-in-effect` errors in the four untouched detached pages remain pre-existing.
- `npm test` — 567/567 pass across 52 files, including `web/src/__tests__/VaultPanel.test.tsx`.
- Manual QA: not performed in this branch — recommend a dev-server spot-check of both the sidebar and `/var` window (lock/unlock, create var, edit var, delete var, create set, assign-to-set, delete set, reveal+auto-hide, copy value) before merge.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #688