### PR TITLE
refactor: scope Vault sidebar to quick-lookup

### DIFF
--- a/web/src/__tests__/VaultPanel.test.tsx
+++ b/web/src/__tests__/VaultPanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import { VaultPanel } from '../components/vault/VaultPanel';
 import { useVaultStore } from '../stores/useVaultStore';
@@ -26,6 +27,14 @@ vi.mock('../lib/api', () => ({
 
 const noop = () => {};
 
+function renderPanel() {
+  return render(
+    <MemoryRouter>
+      <VaultPanel onClose={noop} />
+    </MemoryRouter>,
+  );
+}
+
 describe('VaultPanel — value placeholder adapts to type and visibility', () => {
   beforeEach(() => {
     useVaultStore.setState({
@@ -39,45 +48,105 @@ describe('VaultPanel — value placeholder adapts to type and visibility', () =>
   });
 
   it('shows a secret-value hint by default (string + Secret)', () => {
-    render(<VaultPanel onClose={noop} />);
+    renderPanel();
     expect(screen.getByPlaceholderText('secret value')).toBeInTheDocument();
   });
 
   it('switches to a plaintext hint when Plaintext is selected', () => {
-    render(<VaultPanel onClose={noop} />);
+    renderPanel();
     fireEvent.click(screen.getByRole('button', { name: /plaintext/i }));
     expect(screen.queryByPlaceholderText('secret value')).not.toBeInTheDocument();
     expect(screen.getByPlaceholderText('plaintext value')).toBeInTheDocument();
   });
 
   it('hints comma-separated input when list type is selected', () => {
-    render(<VaultPanel onClose={noop} />);
+    renderPanel();
     fireEvent.click(screen.getByRole('button', { name: 'list' }));
     expect(screen.getByPlaceholderText('item1, item2, item3')).toBeInTheDocument();
   });
 
   it('hints JSON object syntax when json type is selected', () => {
-    render(<VaultPanel onClose={noop} />);
+    renderPanel();
     fireEvent.click(screen.getByRole('button', { name: 'json' }));
     expect(screen.getByPlaceholderText('{"key": "value"}')).toBeInTheDocument();
   });
 
   it('hints a number example when number type is selected', () => {
-    render(<VaultPanel onClose={noop} />);
+    renderPanel();
     fireEvent.click(screen.getByRole('button', { name: 'number' }));
     expect(screen.getByPlaceholderText('42')).toBeInTheDocument();
   });
 
   it('hints true/false when bool type is selected', () => {
-    render(<VaultPanel onClose={noop} />);
+    renderPanel();
     fireEvent.click(screen.getByRole('button', { name: 'bool' }));
     expect(screen.getByPlaceholderText('true or false')).toBeInTheDocument();
   });
 
   it('leaves the key-input placeholder generic regardless of type', () => {
-    render(<VaultPanel onClose={noop} />);
+    renderPanel();
     expect(screen.getByPlaceholderText('KEY_NAME')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'json' }));
     expect(screen.getByPlaceholderText('KEY_NAME')).toBeInTheDocument();
+  });
+});
+
+describe('VaultPanel — sidebar scoped down to quick-lookup', () => {
+  beforeEach(() => {
+    useVaultStore.setState({
+      variables: [],
+      sets: [],
+      loading: false,
+      error: null,
+      locked: false,
+      encrypted: false,
+    });
+  });
+
+  it('does not render an Encrypt action button', () => {
+    renderPanel();
+    expect(
+      screen.queryByRole('button', { name: /^encrypt$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render a "+ New set" button', () => {
+    renderPanel();
+    expect(
+      screen.queryByRole('button', { name: /new set/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render a "Create a variable set" CTA when there are no sets', () => {
+    renderPanel();
+    expect(
+      screen.queryByRole('button', { name: /create a variable set/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the footer hint linking to /vault when unlocked', () => {
+    renderPanel();
+    const link = screen.getByRole('link', {
+      name: /manage sets and bulk-import in the variables workspace/i,
+    });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/vault');
+  });
+
+  it('hides the footer hint when the vault is locked', () => {
+    useVaultStore.setState({
+      variables: null,
+      sets: null,
+      loading: false,
+      error: null,
+      locked: true,
+      encrypted: true,
+    });
+    renderPanel();
+    expect(
+      screen.queryByRole('link', {
+        name: /manage sets and bulk-import in the variables workspace/i,
+      }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/vault/SetGroup.tsx
+++ b/web/src/components/vault/SetGroup.tsx
@@ -29,7 +29,9 @@ export interface SetGroupProps {
   variables: Variable[];
   expanded: boolean;
   onToggleExpand: () => void;
-  onDeleteSet: () => void;
+  // When omitted, the per-set delete (trash) affordance is not rendered.
+  // The sidebar (quick-lookup) hides it; the workspace shows it.
+  onDeleteSet?: () => void;
   handlers: SetGroupRowHandlers;
   // Use `.log-text` on key/value text for detached-page zoom scaling.
   enableZoom?: boolean;
@@ -74,16 +76,18 @@ export function SetGroup({
             {set.count}
           </span>
         </div>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onDeleteSet();
-          }}
-          className="p-1 rounded hover:bg-status-error/10 transition-colors opacity-0 group-hover:opacity-100"
-          title="Delete set"
-        >
-          <Trash2 size={10} className="text-text-muted hover:text-status-error" />
-        </button>
+        {onDeleteSet && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDeleteSet();
+            }}
+            className="p-1 rounded hover:bg-status-error/10 transition-colors opacity-0 group-hover:opacity-100"
+            title="Delete set"
+          >
+            <Trash2 size={10} className="text-text-muted hover:text-status-error" />
+          </button>
+        )}
       </button>
       {expanded && variables.length > 0 && (
         <div className={cn('px-2 pb-2 space-y-1', innerClassName)}>

--- a/web/src/components/vault/VaultPanel.tsx
+++ b/web/src/components/vault/VaultPanel.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { createPortal } from 'react-dom';
+import { Link } from 'react-router-dom';
 import {
   X,
   Plus,
   KeyRound,
   AlertCircle,
-  Package,
   Lock,
   LockOpen,
   Search,
@@ -20,9 +20,7 @@ import { useRevealedValues } from '../../hooks/useRevealedValues';
 import { validateVariableInput } from './variableTypeHelpers';
 import { VaultLockPrompt } from './VaultLockPrompt';
 import { SecretItem } from './SecretItem';
-import { NewSetForm } from './NewSetForm';
 import { VariableQuickAddForm } from './VariableQuickAddForm';
-import { VaultEncryptForm } from './VaultEncryptForm';
 import { EmptyVaultState } from './EmptyVaultState';
 import { SetGroup } from './SetGroup';
 import type { VariableType } from '../../lib/api';
@@ -45,13 +43,10 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
     encrypted,
     refresh,
     unlock,
-    lock,
     createVar,
     updateVar,
     deleteVar,
     getVar,
-    createSet,
-    deleteSet,
     assignToSet,
   } = vault;
 
@@ -62,7 +57,6 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
   }, []);
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [showLockForm, setShowLockForm] = useState(false);
 
   // Edit state — VaultPanel preserves the variable's current type/is_secret
   // on save (and validates the value against the type), so we track them
@@ -76,8 +70,6 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 
   const [expandedSets, setExpandedSets] = useState<Record<string, boolean>>({});
-  const [showNewSet, setShowNewSet] = useState(false);
-  const [newSetName, setNewSetName] = useState('');
 
   const keyInputRef = useRef<HTMLInputElement>(null);
 
@@ -124,15 +116,6 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
       return ok;
     },
     [unlock],
-  );
-
-  const handleEncrypt = useCallback(
-    async (passphrase: string) => {
-      await lock(passphrase);
-      setShowLockForm(false);
-      showToast('success', 'Vault encrypted');
-    },
-    [lock],
   );
 
   const handleReveal = useCallback(
@@ -209,34 +192,6 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
       showToast('error', 'Failed to delete secret');
     }
   }, [confirmDelete, deleteVar]);
-
-  const handleCreateSet = useCallback(async () => {
-    const name = newSetName.trim();
-    if (!name) return;
-    try {
-      await createSet(name);
-      setNewSetName('');
-      setShowNewSet(false);
-      showToast('success', `Set "${name}" created`);
-    } catch (err) {
-      showToast(
-        'error',
-        err instanceof Error ? err.message : 'Failed to create set',
-      );
-    }
-  }, [newSetName, createSet]);
-
-  const handleDeleteSet = useCallback(
-    async (name: string) => {
-      try {
-        await deleteSet(name);
-        showToast('success', `Set "${name}" deleted`);
-      } catch {
-        showToast('error', 'Failed to delete set');
-      }
-    },
-    [deleteSet],
-  );
 
   const handleAssignSet = useCallback(
     async (key: string, set: string) => {
@@ -339,22 +294,12 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
                   ? `${filteredSecrets.length} of ${allSecrets.length} secrets`
                   : `${allSecrets.length} secrets`}
               </span>
-              <div className="flex items-center gap-2">
-                {!encrypted && allSecrets.length > 0 && (
-                  <button
-                    onClick={() => setShowLockForm(!showLockForm)}
-                    className="flex items-center gap-1 text-[10px] text-text-muted hover:text-primary transition-colors"
-                  >
-                    <Lock size={10} /> Encrypt
-                  </button>
-                )}
-                <button
-                  onClick={() => keyInputRef.current?.focus()}
-                  className="flex items-center gap-1 text-[10px] text-primary hover:text-primary/80 transition-colors"
-                >
-                  <Plus size={10} /> New
-                </button>
-              </div>
+              <button
+                onClick={() => keyInputRef.current?.focus()}
+                className="flex items-center gap-1 text-[10px] text-primary hover:text-primary/80 transition-colors"
+              >
+                <Plus size={10} /> New
+              </button>
             </div>
 
             {/* Search */}
@@ -386,14 +331,6 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
             </div>
 
             <div className="flex-1 overflow-y-auto scrollbar-dark min-h-0">
-              {showLockForm && (
-                <VaultEncryptForm
-                  onLock={handleEncrypt}
-                  onCancel={() => setShowLockForm(false)}
-                  className="px-4 pt-3 pb-2 border-b border-border-subtle/50"
-                />
-              )}
-
               {error && (
                 <div className="mx-4 mt-3 flex items-center gap-2 px-3 py-2 rounded-lg bg-status-error/10 border border-status-error/20 text-xs text-status-error">
                   <AlertCircle size={12} className="flex-shrink-0" />
@@ -462,34 +399,9 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
 
               {!loading && (sets ?? []).length > 0 && (
                 <div className="px-2 py-2">
-                  <div className="flex items-center justify-between px-2 mb-2">
-                    <div className="text-[10px] font-medium text-text-muted uppercase tracking-wider">
-                      Variable Sets
-                    </div>
-                    <button
-                      onClick={() => setShowNewSet(true)}
-                      className="p-1 rounded hover:bg-surface-highlight transition-colors"
-                      title="New set"
-                    >
-                      <Plus
-                        size={12}
-                        className="text-text-muted hover:text-primary"
-                      />
-                    </button>
+                  <div className="text-[10px] font-medium text-text-muted uppercase tracking-wider px-2 mb-2">
+                    Variable Sets
                   </div>
-
-                  <NewSetForm
-                    show={showNewSet}
-                    value={newSetName}
-                    onChange={setNewSetName}
-                    onSave={handleCreateSet}
-                    onCancel={() => {
-                      setShowNewSet(false);
-                      setNewSetName('');
-                    }}
-                    className="mb-2 px-2"
-                  />
-
                   <div className="space-y-1">
                     {(sets ?? []).map((set) => (
                       <SetGroup
@@ -500,40 +412,24 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
                         )}
                         expanded={expandedSets[set.name] ?? false}
                         onToggleExpand={() => toggleSetExpand(set.name)}
-                        onDeleteSet={() => handleDeleteSet(set.name)}
                         handlers={rowHandlers}
                       />
                     ))}
                   </div>
                 </div>
               )}
-
-              {!loading && !isEmpty && (sets ?? []).length === 0 && (
-                <div className="px-4 py-2">
-                  <button
-                    onClick={() => setShowNewSet(true)}
-                    className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border/50 text-xs text-text-muted hover:text-text-secondary hover:border-border transition-colors"
-                  >
-                    <Package size={12} />
-                    Create a variable set
-                  </button>
-                  <NewSetForm
-                    show={showNewSet}
-                    value={newSetName}
-                    onChange={setNewSetName}
-                    onSave={handleCreateSet}
-                    onCancel={() => {
-                      setShowNewSet(false);
-                      setNewSetName('');
-                    }}
-                    className="mt-2"
-                  />
-                </div>
-              )}
             </div>
 
-            {/* Status footer */}
-            <div className="px-4 py-2 border-t border-border/30 bg-surface/30 flex-shrink-0">
+            {/* Status footer — also surfaces a hint pointing power-user tasks
+                (set management, bulk import, lock/unlock) to the Variables
+                workspace, since the sidebar intentionally doesn't host them. */}
+            <div className="px-4 py-2 border-t border-border/30 bg-surface/30 flex-shrink-0 space-y-1.5">
+              <Link
+                to="/vault"
+                className="block text-[10px] text-text-muted/70 hover:text-primary transition-colors"
+              >
+                Manage sets and bulk-import in the Variables workspace →
+              </Link>
               <div className="flex items-center justify-between text-[10px] text-text-muted">
                 <span>{allSecrets.length} total</span>
                 <span>


### PR DESCRIPTION
## Description

Phase 2 of [#688](https://github.com/gridctl/gridctl/issues/688): scope the Vault sidebar (`VaultPanel`) down to a quick-lookup surface. Set management, encryption setup, and the empty-state "Create a variable set" CTA leave the sidebar in this PR and will land in the upcoming `/vault` workspace (Phase 3).

User-visible behavior change.

## Type of Change

- [x] Refactor (non-breaking change which narrows a UI surface)

## Changes Made

### Sidebar (`VaultPanel.tsx`, 576 → 472 lines)
**Removed**:
- Encrypt action button + inline `<VaultEncryptForm>` block
- "+ New set" header button + inline `<NewSetForm>` for set creation
- Per-set trash icon (sidebar stops passing `onDeleteSet` to `<SetGroup>`)
- "Create a variable set" CTA shown when no sets exist
- Related state and handlers: `showLockForm`, `showNewSet`, `newSetName`, `handleEncrypt`, `handleCreateSet`, `handleDeleteSet`

**Kept**:
- Encrypted / Locked status badges (read-only indicators)
- `<VaultLockPrompt>` when `locked=true` — quick-lookup users still need to unlock
- `<VariableQuickAddForm>`, unassigned-secret rows, set-grouped secret rows
- Set-assignment dropdown inside each `<SecretItem>` (enumerates existing sets only — no creation)

**Added**:
- Footer hint: `Manage sets and bulk-import in the Variables workspace →` linking to `/vault`. Hidden when locked. Visually subtle (muted text, primary on hover).

### Shared atom (`SetGroup.tsx`)
- `onDeleteSet` made optional. The per-set trash button only renders when the callback is provided. The sidebar omits it; the upcoming workspace will provide it.

### Tests (`VaultPanel.test.tsx`)
- Wrap renders in `<MemoryRouter>` (required by the new `<Link>`).
- Add 5 cases: no Encrypt button, no "+ New set" button, no "Create a variable set" CTA, footer hint links to `/vault` when unlocked, footer hint absent when locked.
- All existing placeholder-text assertions retained.

### Out of scope (deliberately)
- `DetachedVaultPage.tsx` is **untouched** — the detached `/var` window keeps its full feature set until Phase 3 ships, so power users have one big-canvas surface meanwhile.
- The `/vault` route itself. The footer hint will 404 if clicked during the review window; Phase 3 lands the route before any deploy.

## Testing

- `npm run build` — clean (covers `tsc -b` typecheck).
- `npm run lint` — no new errors/warnings.
- `npm test` — **572/572** (567 prior + 5 new).
- Manual QA: not performed in this branch. Worth a dev-server spot-check of the sidebar (quick add, edit, delete, reveal, copy, lock prompt path) before merge.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #688