### PR TITLE
feat: promote Variables to a first-class workspace

### DIFF
--- a/web/src/__tests__/VaultWorkspace.test.tsx
+++ b/web/src/__tests__/VaultWorkspace.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { VaultWorkspace } from '../components/workspaces/VaultWorkspace';
+import { useVaultStore } from '../stores/useVaultStore';
+import * as api from '../lib/api';
+
+// Resolve every vault API call to a benign no-op so the workspace renders
+// without ever hitting the network.
+vi.mock('../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
+  return {
+    ...actual,
+    fetchVariables: vi.fn().mockResolvedValue([]),
+    fetchVariableSets: vi.fn().mockResolvedValue([]),
+    createVariable: vi.fn().mockResolvedValue(undefined),
+    getVariable: vi.fn().mockResolvedValue({ value: '' }),
+    updateVariable: vi.fn().mockResolvedValue(undefined),
+    deleteVariable: vi.fn().mockResolvedValue(undefined),
+    createVariableSet: vi.fn().mockResolvedValue(undefined),
+    deleteVariableSet: vi.fn().mockResolvedValue(undefined),
+    assignVariableToSet: vi.fn().mockResolvedValue(undefined),
+    fetchVariableStoreStatus: vi
+      .fn()
+      .mockResolvedValue({ locked: false, encrypted: false }),
+    unlockVariableStore: vi.fn().mockResolvedValue(undefined),
+    lockVariableStore: vi.fn().mockResolvedValue(undefined),
+    importVariables: vi.fn().mockResolvedValue({ imported: 0 }),
+  };
+});
+
+function renderWorkspace() {
+  return render(
+    <MemoryRouter initialEntries={['/vault']}>
+      <VaultWorkspace />
+    </MemoryRouter>,
+  );
+}
+
+describe('VaultWorkspace — empty state', () => {
+  beforeEach(() => {
+    useVaultStore.setState({
+      variables: [],
+      sets: [],
+      loading: false,
+      error: null,
+      locked: false,
+      encrypted: false,
+    });
+  });
+
+  it('renders the workspace header label', async () => {
+    renderWorkspace();
+    expect(await screen.findByText('variables')).toBeInTheDocument();
+  });
+
+  it('renders an Import .env button in the header', async () => {
+    renderWorkspace();
+    expect(
+      await screen.findByRole('button', { name: /^import \.env$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows Import from .env as the primary empty-state CTA', async () => {
+    renderWorkspace();
+    expect(
+      await screen.findByRole('button', { name: /import from \.env/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /add one manually/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the import modal when the header CTA is clicked', async () => {
+    renderWorkspace();
+    const cta = await screen.findByRole('button', { name: /^import \.env$/i });
+    fireEvent.click(cta);
+    expect(
+      await screen.findByRole('dialog', { name: /import variables/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders an "All variables" pill in the left rail', async () => {
+    renderWorkspace();
+    expect(
+      await screen.findByRole('button', { name: /all variables/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('VaultWorkspace — locked state', () => {
+  beforeEach(() => {
+    vi.mocked(api.fetchVariableStoreStatus).mockResolvedValue({
+      locked: true,
+      encrypted: true,
+    });
+    useVaultStore.setState({
+      variables: null,
+      sets: null,
+      loading: false,
+      error: null,
+      locked: true,
+      encrypted: true,
+    });
+  });
+
+  it('renders the unlock prompt and no header actions', async () => {
+    renderWorkspace();
+    // Wait for the workspace shell to settle so the lock prompt has rendered.
+    await screen.findByText('variables');
+    await screen.findByText('Vault Locked');
+    const passphraseInput = document.querySelector('input[type="password"]');
+    expect(passphraseInput).not.toBeNull();
+    // Header Import/Encrypt actions should not be present when locked.
+    expect(
+      screen.queryByRole('button', { name: /^import \.env$/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^encrypt$/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/WorkspaceSwitcher.test.tsx
+++ b/web/src/__tests__/WorkspaceSwitcher.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { WorkspaceSwitcher } from '../components/shell/WorkspaceSwitcher';
+import { WORKSPACE_CONFIG } from '../types/workspace';
 
 function renderAt(path: string) {
   return render(
@@ -13,35 +14,51 @@ function renderAt(path: string) {
 }
 
 describe('WorkspaceSwitcher', () => {
-  it('renders two workspace pills inside a tablist in the configured order', () => {
+  it('renders one pill per workspace, in WORKSPACE_CONFIG order', () => {
     renderAt('/topology');
     const tablist = screen.getByRole('tablist', { name: /workspace/i });
     expect(tablist).toBeInTheDocument();
     const tabs = screen.getAllByRole('tab');
-    expect(tabs).toHaveLength(2);
-    expect(tabs.map((t) => t.textContent?.trim())).toEqual([
-      'Topology',
-      'Library',
-    ]);
+    expect(tabs).toHaveLength(WORKSPACE_CONFIG.length);
+    expect(tabs.map((t) => t.textContent?.trim())).toEqual(
+      WORKSPACE_CONFIG.map((w) => w.label),
+    );
   });
 
   it('marks the active workspace with aria-selected=true and others false', () => {
     renderAt('/library');
-    const topology = screen.getByRole('tab', { name: 'Topology' });
-    const library = screen.getByRole('tab', { name: 'Library' });
-
-    expect(library).toHaveAttribute('aria-selected', 'true');
-    expect(topology).toHaveAttribute('aria-selected', 'false');
+    for (const ws of WORKSPACE_CONFIG) {
+      const tab = screen.getByRole('tab', { name: ws.label });
+      expect(tab).toHaveAttribute(
+        'aria-selected',
+        ws.id === 'library' ? 'true' : 'false',
+      );
+    }
   });
 
   it('marks the Library pill active for /library and deep-link paths', () => {
     renderAt('/library/incident-triage');
-    expect(screen.getByRole('tab', { name: 'Library' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Library' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  it('marks the Variables pill active for /vault', () => {
+    renderAt('/vault');
+    expect(screen.getByRole('tab', { name: 'Variables' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
   });
 
   it('links each pill to its workspace route', () => {
     renderAt('/topology');
-    expect(screen.getByRole('tab', { name: 'Topology' })).toHaveAttribute('href', '/topology');
-    expect(screen.getByRole('tab', { name: 'Library' })).toHaveAttribute('href', '/library');
+    for (const ws of WORKSPACE_CONFIG) {
+      expect(screen.getByRole('tab', { name: ws.label })).toHaveAttribute(
+        'href',
+        `/${ws.id}`,
+      );
+    }
   });
 });

--- a/web/src/__tests__/envParser.test.ts
+++ b/web/src/__tests__/envParser.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { parseEnv } from '../lib/envParser';
+
+describe('parseEnv', () => {
+  it('parses a basic KEY=value pair', () => {
+    const { entries, ignored } = parseEnv('FOO=bar');
+    expect(ignored).toHaveLength(0);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      key: 'FOO',
+      value: 'bar',
+      type: 'string',
+      quoted: false,
+      line: 1,
+    });
+  });
+
+  it('handles double-quoted values with spaces and "="', () => {
+    const { entries } = parseEnv('TOKEN="a value with = and spaces"');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      key: 'TOKEN',
+      value: 'a value with = and spaces',
+      quoted: true,
+    });
+  });
+
+  it('handles single-quoted values literally', () => {
+    const { entries } = parseEnv("RAW='no $expansion here'");
+    expect(entries[0]).toMatchObject({
+      key: 'RAW',
+      value: 'no $expansion here',
+      quoted: true,
+    });
+  });
+
+  it('strips inline # comments after unquoted values', () => {
+    const { entries } = parseEnv('LEVEL=debug # logging level');
+    expect(entries[0]).toMatchObject({ key: 'LEVEL', value: 'debug' });
+  });
+
+  it('keeps # inside quoted values', () => {
+    const { entries } = parseEnv('HASH="value#with#hashes"');
+    expect(entries[0]).toMatchObject({ value: 'value#with#hashes' });
+  });
+
+  it('skips full-line comments and blank lines', () => {
+    const input = '# top comment\n\nFOO=1\n\n# bottom\n';
+    const { entries, ignored } = parseEnv(input);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ key: 'FOO', value: '1', line: 3 });
+    expect(ignored).toHaveLength(0);
+  });
+
+  it('strips leading "export " from shell-style declarations', () => {
+    const { entries } = parseEnv('export DATABASE_URL=postgres://localhost/x');
+    expect(entries[0]).toMatchObject({
+      key: 'DATABASE_URL',
+      value: 'postgres://localhost/x',
+    });
+  });
+
+  it('reports invalid lines without aborting the parse', () => {
+    const input = '!bad-line\nFOO=ok';
+    const { entries, ignored } = parseEnv(input);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ key: 'FOO', value: 'ok' });
+    expect(ignored).toHaveLength(1);
+    expect(ignored[0]).toMatchObject({ line: 1 });
+  });
+
+  it('reports keys with invalid characters', () => {
+    const { entries, ignored } = parseEnv('foo-bar=ok\nFOO=ok');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].key).toBe('FOO');
+    expect(ignored).toHaveLength(1);
+    expect(ignored[0].reason).toMatch(/invalid key/i);
+  });
+
+  it('detects bool type for true/false', () => {
+    expect(parseEnv('ENABLED=true').entries[0].type).toBe('bool');
+    expect(parseEnv('ENABLED=false').entries[0].type).toBe('bool');
+  });
+
+  it('detects number type for numeric values', () => {
+    expect(parseEnv('COUNT=42').entries[0].type).toBe('number');
+    expect(parseEnv('RATIO=-1.5').entries[0].type).toBe('number');
+  });
+
+  it('detects json type for object and array literals', () => {
+    expect(parseEnv('CONFIG={"k":1}').entries[0].type).toBe('json');
+    expect(parseEnv('LIST=[1,2,3]').entries[0].type).toBe('json');
+  });
+
+  it('keeps quoted "true" as a string (no auto bool)', () => {
+    expect(parseEnv('PRETEND="true"').entries[0].type).toBe('string');
+  });
+
+  it('flags unterminated quoted values', () => {
+    const { entries, ignored } = parseEnv('OPEN="never closed');
+    expect(entries).toHaveLength(0);
+    expect(ignored[0].reason).toMatch(/unterminated/i);
+  });
+});

--- a/web/src/__tests__/useKeyboardShortcuts.test.tsx
+++ b/web/src/__tests__/useKeyboardShortcuts.test.tsx
@@ -24,11 +24,12 @@ describe('useKeyboardShortcuts — workspace navigation', () => {
     expect(onSwitchToWorkspace).toHaveBeenCalledWith('library');
   });
 
-  it('⌘3 is not bound to any workspace', () => {
+  it('⌘3 calls onSwitchToWorkspace with "vault"', () => {
     const onSwitchToWorkspace = vi.fn();
     renderHook(() => useKeyboardShortcuts({ onSwitchToWorkspace }));
     fireMod('3');
-    expect(onSwitchToWorkspace).not.toHaveBeenCalled();
+    expect(onSwitchToWorkspace).toHaveBeenCalledTimes(1);
+    expect(onSwitchToWorkspace).toHaveBeenCalledWith('vault');
   });
 
   it('does not fire workspace shortcuts when focus is inside an input', () => {

--- a/web/src/__tests__/useUIStore-workspace.test.ts
+++ b/web/src/__tests__/useUIStore-workspace.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useUIStore, COMPACT_MODE_DEFAULTS } from '../stores/useUIStore';
+import { WORKSPACES } from '../types/workspace';
 
 describe('useUIStore workspace slice', () => {
   beforeEach(() => {
@@ -22,7 +23,7 @@ describe('useUIStore workspace slice', () => {
 
   it('setActiveWorkspace cycles through every workspace', () => {
     const { result } = renderHook(() => useUIStore((s) => s.activeWorkspace));
-    for (const ws of ['topology', 'library'] as const) {
+    for (const ws of WORKSPACES) {
       act(() => {
         useUIStore.getState().setActiveWorkspace(ws);
       });
@@ -36,10 +37,11 @@ describe('useUIStore compact mode slice', () => {
     useUIStore.setState({ compactMode: { ...COMPACT_MODE_DEFAULTS } });
   });
 
-  it('defaults compactMode to all-off', () => {
+  it('defaults compactMode to all-off for every workspace', () => {
     const state = useUIStore.getState();
-    expect(state.compactMode.topology).toBe(false);
-    expect(state.compactMode.library).toBe(false);
+    for (const ws of WORKSPACES) {
+      expect(state.compactMode[ws]).toBe(false);
+    }
   });
 
   it('setCompactMode updates a single workspace without touching the others', () => {
@@ -48,7 +50,10 @@ describe('useUIStore compact mode slice', () => {
     });
     const state = useUIStore.getState();
     expect(state.compactMode.topology).toBe(true);
-    expect(state.compactMode.library).toBe(false);
+    for (const ws of WORKSPACES) {
+      if (ws === 'topology') continue;
+      expect(state.compactMode[ws]).toBe(false);
+    }
   });
 
   it('toggleCompactMode flips only the targeted workspace', () => {
@@ -59,7 +64,11 @@ describe('useUIStore compact mode slice', () => {
     act(() => {
       useUIStore.getState().toggleCompactMode('library');
     });
-    expect(useUIStore.getState().compactMode.library).toBe(false);
-    expect(useUIStore.getState().compactMode.topology).toBe(false);
+    const state = useUIStore.getState();
+    expect(state.compactMode.library).toBe(false);
+    for (const ws of WORKSPACES) {
+      if (ws === 'library') continue;
+      expect(state.compactMode[ws]).toBe(false);
+    }
   });
 });

--- a/web/src/components/vault/EnvImportModal.tsx
+++ b/web/src/components/vault/EnvImportModal.tsx
@@ -1,0 +1,533 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type DragEvent,
+} from 'react';
+import {
+  AlertTriangle,
+  Eye,
+  EyeOff,
+  FileUp,
+  Upload,
+  X,
+} from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { Button } from '../ui/Button';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { VariableTypeSelector } from './VariableTypeSelector';
+import { parseEnv } from '../../lib/envParser';
+import type { ParsedEnvEntry } from '../../lib/envParser';
+import type {
+  ImportVariableInput,
+  Variable,
+  VariableSet,
+  VariableType,
+} from '../../lib/api';
+
+export interface EnvImportModalProps {
+  onClose: () => void;
+  onImport: (vars: ImportVariableInput[]) => Promise<{ imported: number }>;
+  existingVariables: Variable[];
+  sets: VariableSet[];
+  // Optional initial set assignment for every parsed row. Used when the user
+  // opens the modal while a set filter is active in the workspace.
+  defaultSet?: string;
+}
+
+interface RowOverride {
+  type?: VariableType;
+  set?: string;
+  isSecret?: boolean;
+  skipped?: boolean;
+  revealed?: boolean;
+}
+
+interface RowState {
+  // Stable client id; not sent to the server.
+  id: string;
+  key: string;
+  value: string;
+  type: VariableType;
+  set: string; // '' = unassigned
+  isSecret: boolean;
+  skipped: boolean;
+  revealed: boolean;
+}
+
+function rowFromParsed(
+  entry: ParsedEnvEntry,
+  defaultSet: string,
+  index: number,
+  override?: RowOverride,
+): RowState {
+  return {
+    id: `${entry.line}-${index}`,
+    key: entry.key,
+    value: entry.value,
+    type: override?.type ?? entry.type,
+    set: override?.set ?? defaultSet,
+    // Default new imports to "secret" per Article XII secure default — the
+    // user can toggle to plaintext per row if needed.
+    isSecret: override?.isSecret ?? true,
+    skipped: override?.skipped ?? false,
+    revealed: override?.revealed ?? false,
+  };
+}
+
+// Parent mounts this conditionally; unmount on close gives us free state
+// reset and removes the need for an open/close-driven effect.
+export function EnvImportModal({
+  onClose,
+  onImport,
+  existingVariables,
+  sets,
+  defaultSet = '',
+}: EnvImportModalProps) {
+  const titleId = useId();
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const panelRef = useFocusTrap<HTMLDivElement>({
+    active: true,
+    initialFocusRef: textareaRef,
+  });
+
+  const [text, setText] = useState('');
+  // Per-key user overrides — survive re-parses so small textarea edits don't
+  // wipe per-row tweaks. Keyed by variable key, not by parser line, since
+  // line numbers shift as the user types.
+  const [overrides, setOverrides] = useState<Record<string, RowOverride>>({});
+  const [ignoredOpen, setIgnoredOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+
+  const parsed = useMemo(() => parseEnv(text), [text]);
+
+  const rows = useMemo<RowState[]>(
+    () =>
+      parsed.entries.map((entry, idx) =>
+        rowFromParsed(entry, defaultSet, idx, overrides[entry.key]),
+      ),
+    [parsed.entries, defaultSet, overrides],
+  );
+
+  // Escape closes; click on backdrop closes; both common in this codebase.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const existingKeys = useMemo(
+    () => new Set(existingVariables.map((v) => v.key)),
+    [existingVariables],
+  );
+  const setNames = useMemo(() => sets.map((s) => s.name), [sets]);
+
+  const counts = useMemo(() => {
+    let newCount = 0;
+    let conflicts = 0;
+    let skipped = 0;
+    for (const r of rows) {
+      const exists = existingKeys.has(r.key);
+      if (r.skipped) {
+        skipped++;
+        continue;
+      }
+      if (exists) conflicts++;
+      else newCount++;
+    }
+    return { newCount, conflicts, skipped };
+  }, [rows, existingKeys]);
+
+  const handleFile = useCallback(async (file: File) => {
+    const content = await file.text();
+    setText((prev) => (prev ? prev + '\n' + content : content));
+  }, []);
+
+  const onDrop = useCallback(
+    (e: DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setDragOver(false);
+      const file = e.dataTransfer.files?.[0];
+      if (file) handleFile(file);
+    },
+    [handleFile],
+  );
+
+  const onFilePicked = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) handleFile(file);
+      // Reset so the same file can be re-picked after editing.
+      e.target.value = '';
+    },
+    [handleFile],
+  );
+
+  const updateRow = useCallback(
+    (key: string, patch: RowOverride) => {
+      setOverrides((prev) => ({
+        ...prev,
+        [key]: { ...(prev[key] ?? {}), ...patch },
+      }));
+    },
+    [],
+  );
+
+  const handleImport = useCallback(async () => {
+    const toSubmit = rows
+      .filter((r) => !r.skipped)
+      .map<ImportVariableInput>((r) => ({
+        key: r.key,
+        value: r.value,
+        type: r.type,
+        isSecret: r.isSecret,
+        set: r.set || undefined,
+      }));
+    if (toSubmit.length === 0) {
+      setSubmitError('Nothing to import — every row is skipped.');
+      return;
+    }
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      await onImport(toSubmit);
+      onClose();
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error ? err.message : 'Import failed',
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }, [rows, onImport, onClose]);
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 z-[60] animate-fade-in-scale',
+        'bg-background/80 backdrop-blur-sm flex items-center justify-center',
+      )}
+    >
+      <div className="absolute inset-0" onClick={onClose} />
+
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className={cn(
+          'relative glass-panel-elevated rounded-xl shadow-lg',
+          'w-[min(1100px,calc(100vw-2rem))] max-h-[min(840px,calc(100vh-2rem))] flex flex-col',
+        )}
+      >
+        {/* Header */}
+        <header className="flex-shrink-0 flex items-center justify-between px-5 py-3 border-b border-border-subtle">
+          <div className="flex items-center gap-3">
+            <div className="p-1.5 rounded-lg bg-primary/10 border border-primary/20">
+              <FileUp size={14} className="text-primary" />
+            </div>
+            <div>
+              <h2
+                id={titleId}
+                className="text-sm font-semibold text-text-primary tracking-tight"
+              >
+                Import variables
+              </h2>
+              <p className="text-[10px] text-text-muted uppercase tracking-[0.18em]">
+                paste · drop · pick a .env file
+              </p>
+            </div>
+          </div>
+          <button
+            ref={closeRef}
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-surface-highlight transition-colors text-text-muted hover:text-text-primary"
+            aria-label="Close import"
+          >
+            <X size={14} />
+          </button>
+        </header>
+
+        {/* Body — two-column split on wide viewports, stacked otherwise */}
+        <div className="flex-1 min-h-0 grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] overflow-hidden">
+          {/* Left column: input */}
+          <div className="flex flex-col min-h-0 border-r border-border-subtle">
+            <div
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragOver(true);
+              }}
+              onDragLeave={() => setDragOver(false)}
+              onDrop={onDrop}
+              className={cn(
+                'flex-1 min-h-0 flex flex-col relative transition-colors',
+                dragOver && 'bg-primary/5',
+              )}
+            >
+              <textarea
+                ref={textareaRef}
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                placeholder={`# Paste .env content or drop a file\nDATABASE_URL=postgres://localhost/app\nAPI_KEY="sk_live_..."`}
+                spellCheck={false}
+                className={cn(
+                  'flex-1 min-h-0 w-full bg-transparent text-xs font-mono text-text-primary',
+                  'placeholder:text-text-muted/40 focus:outline-none resize-none',
+                  'px-4 py-4 leading-relaxed',
+                )}
+              />
+              {dragOver && (
+                <div className="pointer-events-none absolute inset-3 rounded-lg border-2 border-dashed border-primary/50 flex items-center justify-center bg-primary/5 text-primary text-xs">
+                  <Upload size={14} className="mr-2" /> Drop the .env file
+                </div>
+              )}
+            </div>
+
+            <div className="flex-shrink-0 flex items-center justify-between gap-2 px-4 py-2 border-t border-border-subtle">
+              <label className="flex items-center gap-1.5 text-[10px] text-text-muted hover:text-text-primary cursor-pointer transition-colors">
+                <Upload size={11} />
+                Pick a file
+                <input
+                  type="file"
+                  accept=".env,text/plain"
+                  onChange={onFilePicked}
+                  className="hidden"
+                />
+              </label>
+              <span className="text-[10px] text-text-muted font-mono">
+                {text.length} chars
+              </span>
+            </div>
+          </div>
+
+          {/* Right column: preview */}
+          <div className="flex flex-col min-h-0">
+            {rows.length === 0 && parsed.ignored.length === 0 && (
+              <div className="flex-1 flex items-center justify-center px-8 py-12 text-center">
+                <div className="space-y-3">
+                  <div className="mx-auto w-12 h-12 rounded-xl bg-primary/5 border border-primary/15 flex items-center justify-center">
+                    <FileUp size={18} className="text-primary/50" />
+                  </div>
+                  <p className="text-xs text-text-muted leading-relaxed max-w-xs">
+                    Paste a few <code className="font-mono text-text-secondary">KEY=value</code>{' '}
+                    pairs to preview what will be imported.
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {rows.length > 0 && (
+              <div className="flex-1 overflow-y-auto scrollbar-dark">
+                <table className="w-full text-left">
+                  <thead className="sticky top-0 bg-surface-elevated/95 backdrop-blur-sm">
+                    <tr className="text-[10px] uppercase tracking-[0.18em] text-text-muted border-b border-border-subtle">
+                      <th className="px-3 py-2 font-medium">Key</th>
+                      <th className="px-2 py-2 font-medium">Value</th>
+                      <th className="px-2 py-2 font-medium">Type</th>
+                      <th className="px-2 py-2 font-medium">Set</th>
+                      <th className="px-2 py-2 font-medium w-12 text-right">Skip</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((r) => {
+                      const exists = existingKeys.has(r.key);
+                      return (
+                        <tr
+                          key={r.id}
+                          className={cn(
+                            'border-b border-border-subtle/60 transition-opacity',
+                            r.skipped && 'opacity-40',
+                          )}
+                        >
+                          <td className="px-3 py-2 align-top">
+                            <div className="flex items-center gap-2">
+                              <span
+                                className={cn(
+                                  'text-xs font-mono font-medium text-text-primary',
+                                  r.skipped && 'line-through',
+                                )}
+                              >
+                                {r.key}
+                              </span>
+                              {exists && !r.skipped && (
+                                <span
+                                  className="text-[9px] font-mono uppercase tracking-wider px-1.5 py-0.5 rounded bg-status-pending/15 text-status-pending"
+                                  title="A variable with this key already exists; importing will overwrite it"
+                                >
+                                  overwrites
+                                </span>
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-2 py-2 align-top">
+                            <div className="flex items-center gap-1.5">
+                              <code
+                                className={cn(
+                                  'text-[11px] font-mono text-text-secondary break-all min-w-0',
+                                  r.skipped && 'line-through',
+                                )}
+                                style={{ wordBreak: 'break-all' }}
+                              >
+                                {r.revealed ? r.value : maskValue(r.value)}
+                              </code>
+                              {r.value.length > 0 && (
+                                <button
+                                  onClick={() =>
+                                    updateRow(r.key, { revealed: !r.revealed })
+                                  }
+                                  className="flex-shrink-0 p-0.5 rounded text-text-muted hover:text-text-primary transition-colors"
+                                  title={r.revealed ? 'Hide value' : 'Reveal value'}
+                                  aria-label={r.revealed ? 'Hide value' : 'Reveal value'}
+                                >
+                                  {r.revealed ? <EyeOff size={11} /> : <Eye size={11} />}
+                                </button>
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-2 py-2 align-top">
+                            <VariableTypeSelector
+                              value={r.type}
+                              onChange={(t) => updateRow(r.key, { type: t })}
+                            />
+                          </td>
+                          <td className="px-2 py-2 align-top">
+                            <select
+                              value={r.set}
+                              onChange={(e) =>
+                                updateRow(r.key, { set: e.target.value })
+                              }
+                              className="bg-surface border border-border rounded-md px-1.5 py-0.5 text-[10px] text-text-secondary focus:border-primary/50 outline-none transition-colors"
+                            >
+                              <option value="">No set</option>
+                              {setNames.map((name) => (
+                                <option key={name} value={name}>
+                                  {name}
+                                </option>
+                              ))}
+                            </select>
+                          </td>
+                          <td className="px-2 py-2 align-top text-right">
+                            <input
+                              type="checkbox"
+                              checked={r.skipped}
+                              onChange={(e) =>
+                                updateRow(r.key, { skipped: e.target.checked })
+                              }
+                              className="accent-status-error"
+                              aria-label={`Skip ${r.key}`}
+                            />
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {parsed.ignored.length > 0 && (
+              <div className="flex-shrink-0 border-t border-border-subtle">
+                <button
+                  onClick={() => setIgnoredOpen((v) => !v)}
+                  className="w-full flex items-center gap-2 px-3 py-2 text-[10px] uppercase tracking-[0.18em] text-status-pending hover:bg-surface-highlight/40 transition-colors"
+                >
+                  <AlertTriangle size={11} />
+                  {parsed.ignored.length} line
+                  {parsed.ignored.length === 1 ? '' : 's'} ignored
+                  <span className="ml-auto text-text-muted normal-case tracking-normal">
+                    {ignoredOpen ? 'hide' : 'show'}
+                  </span>
+                </button>
+                {ignoredOpen && (
+                  <ul className="max-h-32 overflow-y-auto scrollbar-dark px-3 pb-3 space-y-1 text-[11px] font-mono">
+                    {parsed.ignored.map((il) => (
+                      <li
+                        key={`${il.line}-${il.raw}`}
+                        className="flex gap-2 text-text-muted"
+                      >
+                        <span className="flex-shrink-0 w-8 text-right text-status-error">
+                          {il.line}
+                        </span>
+                        <code className="flex-1 break-all">{il.raw || '«empty»'}</code>
+                        <span className="flex-shrink-0 text-text-muted/70 italic">
+                          {il.reason}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <footer className="flex-shrink-0 flex items-center justify-between gap-3 px-5 py-3 border-t border-border-subtle">
+          <div className="flex items-center gap-3 text-[11px] font-mono text-text-muted">
+            <span>
+              <span className="text-status-running font-semibold">{counts.newCount}</span>{' '}
+              new
+            </span>
+            <span className="text-text-muted/40">·</span>
+            <span>
+              <span className="text-status-pending font-semibold">
+                {counts.conflicts}
+              </span>{' '}
+              overwrite{counts.conflicts === 1 ? '' : 's'}
+            </span>
+            <span className="text-text-muted/40">·</span>
+            <span>
+              <span className="text-status-error font-semibold">{counts.skipped}</span>{' '}
+              skipped
+            </span>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {submitError && (
+              <span className="text-[10px] text-status-error">{submitError}</span>
+            )}
+            <button
+              onClick={onClose}
+              className="px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleImport}
+              disabled={
+                submitting || counts.newCount + counts.conflicts === 0
+              }
+            >
+              <FileUp size={12} />
+              {submitting
+                ? 'Importing...'
+                : counts.newCount + counts.conflicts > 0
+                  ? `Import ${counts.newCount + counts.conflicts}`
+                  : 'Import'}
+            </Button>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function maskValue(value: string): string {
+  if (value.length === 0) return '';
+  // Cap at 12 dots so very long values don't blow out the column width.
+  const visible = Math.min(value.length, 12);
+  return '•'.repeat(visible);
+}

--- a/web/src/components/workspaces/VaultWorkspace.tsx
+++ b/web/src/components/workspaces/VaultWorkspace.tsx
@@ -1,0 +1,939 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  AlertCircle,
+  FileUp,
+  KeyRound,
+  Lock,
+  LockOpen,
+  Plus,
+  RefreshCw,
+  Search,
+  Trash2,
+  X,
+} from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { IconButton } from '../ui/IconButton';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
+import { showToast } from '../ui/Toast';
+import { WorkspaceShell } from '../layout/WorkspaceShell';
+import { SecretItem } from '../vault/SecretItem';
+import { NewSetForm } from '../vault/NewSetForm';
+import { VariableQuickAddForm } from '../vault/VariableQuickAddForm';
+import { VaultEncryptForm } from '../vault/VaultEncryptForm';
+import { VaultLockPrompt } from '../vault/VaultLockPrompt';
+import { EnvImportModal } from '../vault/EnvImportModal';
+import { useUIStore } from '../../stores/useUIStore';
+import { useVaultManager } from '../../hooks/useVaultManager';
+import { useRevealedValues } from '../../hooks/useRevealedValues';
+import { validateVariableInput } from '../vault/variableTypeHelpers';
+import type { Variable, VariableType } from '../../lib/api';
+
+const ALL_SETS_KEY = '__all__';
+
+// VaultWorkspace is the top-level Variables surface, sibling to Topology
+// and Library. It owns the set-navigator, the variable table, the
+// lock/encrypt controls, and the bulk `.env` import flow that the sidebar
+// deliberately doesn't host.
+export function VaultWorkspace() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const compact = useUIStore((s) => s.compactMode.vault);
+
+  const revealedState = useRevealedValues();
+  const vault = useVaultManager({ onPlaintextLoaded: revealedState.bulkSet });
+  const {
+    variables: vaultVariables,
+    sets: vaultSets,
+    loading,
+    error,
+    locked,
+    encrypted,
+    refresh,
+    unlock,
+    lock,
+    createVar,
+    updateVar,
+    deleteVar,
+    getVar,
+    createSet,
+    deleteSet,
+    assignToSet,
+    importVars,
+  } = vault;
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // ---- URL state ----------------------------------------------------------
+  const activeSet = searchParams.get('set') ?? ALL_SETS_KEY;
+  const searchQuery = searchParams.get('q') ?? '';
+
+  const setActiveSet = useCallback(
+    (name: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (name === ALL_SETS_KEY) next.delete('set');
+          else next.set('set', name);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const setSearchQuery = useCallback(
+    (q: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (q.trim()) next.set('q', q);
+          else next.delete('q');
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  // ---- Local UI state -----------------------------------------------------
+  // Edit state — mirrors VaultPanel: validate type on save, preserve is_secret.
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [editType, setEditType] = useState<VariableType>('string');
+  const [editIsSecret, setEditIsSecret] = useState(true);
+  const [showEditValue, setShowEditValue] = useState(false);
+
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [confirmDeleteSet, setConfirmDeleteSet] = useState<string | null>(null);
+
+  const [encryptOpen, setEncryptOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
+  const [addOneOpen, setAddOneOpen] = useState(false);
+  const [newSetOpen, setNewSetOpen] = useState(false);
+  const [newSetName, setNewSetName] = useState('');
+
+  // ---- Derived state ------------------------------------------------------
+  const allVariables = useMemo(
+    () => vaultVariables ?? [],
+    [vaultVariables],
+  );
+  const allSets = useMemo(() => vaultSets ?? [], [vaultSets]);
+  const setNames = useMemo(() => allSets.map((s) => s.name), [allSets]);
+  const isEmpty = allVariables.length === 0 && allSets.length === 0;
+
+  const filteredBySet = useMemo(() => {
+    if (activeSet === ALL_SETS_KEY) return allVariables;
+    return allVariables.filter((v) => v.set === activeSet);
+  }, [allVariables, activeSet]);
+
+  const filteredBySearch = useMemo(() => {
+    if (!searchQuery) return filteredBySet;
+    const lower = searchQuery.toLowerCase();
+    return filteredBySet.filter(
+      (v) =>
+        v.key.toLowerCase().includes(lower) ||
+        (v.set ?? '').toLowerCase().includes(lower),
+    );
+  }, [filteredBySet, searchQuery]);
+
+  // ---- Handlers -----------------------------------------------------------
+  const handleUnlock = useCallback(
+    async (passphrase: string) => {
+      const ok = await unlock(passphrase);
+      if (ok) showToast('success', 'Vault unlocked');
+      return ok;
+    },
+    [unlock],
+  );
+
+  const handleEncrypt = useCallback(
+    async (passphrase: string) => {
+      await lock(passphrase);
+      setEncryptOpen(false);
+      showToast('success', encrypted ? 'Vault locked' : 'Vault encrypted');
+    },
+    [lock, encrypted],
+  );
+
+  const handleReveal = useCallback(
+    async (key: string) => {
+      const target = allVariables.find((v) => v.key === key);
+      const isPlaintext = target ? !target.is_secret : false;
+      try {
+        await revealedState.reveal(
+          key,
+          async () => (await getVar(key)).value,
+          !isPlaintext,
+        );
+      } catch {
+        showToast('error', `Failed to reveal ${key}`);
+      }
+    },
+    [allVariables, revealedState, getVar],
+  );
+
+  const handleCreate = useCallback(
+    async (input: Parameters<typeof createVar>[0]) => {
+      await createVar(input);
+      showToast('success', `Variable "${input.key}" created`);
+      setAddOneOpen(false);
+    },
+    [createVar],
+  );
+
+  const handleEdit = useCallback(
+    (key: string) => {
+      const current = allVariables.find((v) => v.key === key);
+      setEditingKey(key);
+      setEditValue('');
+      setEditType(current?.type ?? 'string');
+      setEditIsSecret(current?.is_secret ?? true);
+      setShowEditValue(false);
+    },
+    [allVariables],
+  );
+
+  const handleEditSave = useCallback(async () => {
+    if (!editingKey || !editValue) return;
+    const validation = validateVariableInput(editType, editValue);
+    if (!validation.ok) {
+      showToast('error', validation.error);
+      return;
+    }
+    try {
+      await updateVar(editingKey, {
+        value: validation.normalized,
+        type: editType,
+        isSecret: editIsSecret,
+      });
+      setEditingKey(null);
+      setEditValue('');
+      showToast('success', `Variable "${editingKey}" updated`);
+    } catch {
+      showToast('error', 'Failed to update variable');
+    }
+  }, [editingKey, editValue, editType, editIsSecret, updateVar]);
+
+  const handleEditCancel = useCallback(() => {
+    setEditingKey(null);
+    setEditValue('');
+    setShowEditValue(false);
+  }, []);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!confirmDelete) return;
+    try {
+      await deleteVar(confirmDelete);
+      setConfirmDelete(null);
+      showToast('success', `Variable "${confirmDelete}" deleted`);
+    } catch {
+      showToast('error', 'Failed to delete variable');
+    }
+  }, [confirmDelete, deleteVar]);
+
+  const handleCreateSet = useCallback(async () => {
+    const name = newSetName.trim();
+    if (!name) return;
+    try {
+      await createSet(name);
+      setNewSetName('');
+      setNewSetOpen(false);
+      setActiveSet(name);
+      showToast('success', `Set "${name}" created`);
+    } catch (err) {
+      showToast(
+        'error',
+        err instanceof Error ? err.message : 'Failed to create set',
+      );
+    }
+  }, [newSetName, createSet, setActiveSet]);
+
+  const handleDeleteSet = useCallback(async () => {
+    if (!confirmDeleteSet) return;
+    try {
+      await deleteSet(confirmDeleteSet);
+      if (activeSet === confirmDeleteSet) setActiveSet(ALL_SETS_KEY);
+      showToast('success', `Set "${confirmDeleteSet}" deleted`);
+    } catch {
+      showToast('error', 'Failed to delete set');
+    } finally {
+      setConfirmDeleteSet(null);
+    }
+  }, [confirmDeleteSet, deleteSet, activeSet, setActiveSet]);
+
+  const handleAssignSet = useCallback(
+    async (key: string, name: string) => {
+      try {
+        await assignToSet(key, name);
+      } catch {
+        showToast('error', 'Failed to assign set');
+      }
+    },
+    [assignToSet],
+  );
+
+  const handleImport = useCallback(
+    async (vars: Parameters<typeof importVars>[0]) => {
+      const result = await importVars(vars);
+      showToast(
+        'success',
+        `Imported ${result.imported} variable${result.imported === 1 ? '' : 's'}`,
+      );
+      return result;
+    },
+    [importVars],
+  );
+
+  // ---- Rendering ----------------------------------------------------------
+  const leftRail = (
+    <VaultLeftRail
+      compact={compact}
+      sets={allSets}
+      activeSet={activeSet}
+      onSelectSet={setActiveSet}
+      totalCount={allVariables.length}
+      unassignedCount={allVariables.filter((v) => !v.set).length}
+      newSetOpen={newSetOpen}
+      onNewSetOpen={setNewSetOpen}
+      newSetName={newSetName}
+      onNewSetNameChange={setNewSetName}
+      onNewSetSave={handleCreateSet}
+      onDeleteSet={(name) => setConfirmDeleteSet(name)}
+      locked={locked}
+    />
+  );
+
+  return (
+    <div className="absolute inset-0 flex flex-col bg-background text-text-primary overflow-hidden">
+      <WorkspaceShell
+        workspace="vault"
+        defaultLeftPct={20}
+        defaultRightPct={0}
+        left={leftRail}
+        minLeftPx={200}
+      >
+        <main className="flex flex-col h-full overflow-hidden">
+          <VaultHeader
+            compact={compact}
+            totalVariables={allVariables.length}
+            totalSets={allSets.length}
+            locked={locked}
+            encrypted={encrypted}
+            onRefresh={refresh}
+            onOpenEncrypt={() => setEncryptOpen(true)}
+            onOpenImport={() => setImportOpen(true)}
+          />
+
+          {/* Inline encrypt drawer slides in below the header when invoked. */}
+          {encryptOpen && !locked && (
+            <div className="flex-shrink-0 px-6 py-3 border-b border-border-subtle bg-surface-elevated/40">
+              <div className="max-w-md">
+                <p className="text-[10px] uppercase tracking-[0.18em] text-text-muted mb-2">
+                  {encrypted ? 're-enter passphrase to lock' : 'set a passphrase to encrypt'}
+                </p>
+                <VaultEncryptForm
+                  onLock={handleEncrypt}
+                  onCancel={() => setEncryptOpen(false)}
+                />
+              </div>
+            </div>
+          )}
+
+          {locked ? (
+            <div className="flex-1 min-h-0 flex items-center justify-center">
+              <VaultLockPrompt onUnlock={handleUnlock} />
+            </div>
+          ) : (
+            <>
+              {/* Search + add-one strip */}
+              <div className="flex-shrink-0 px-6 py-3 border-b border-border-subtle bg-surface/30 flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <div className="relative flex-1">
+                    <Search
+                      size={13}
+                      className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted/50 pointer-events-none"
+                    />
+                    <input
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      placeholder={
+                        activeSet === ALL_SETS_KEY
+                          ? 'Search all variables…'
+                          : `Search ${activeSet}…`
+                      }
+                      aria-label="Filter variables"
+                      className="w-full bg-background/60 border border-border/40 rounded-lg pl-9 pr-8 py-2 text-sm text-text-primary placeholder:text-text-muted/40 focus:outline-none focus:border-primary/50 transition-colors"
+                    />
+                    {searchQuery && (
+                      <button
+                        onClick={() => setSearchQuery('')}
+                        aria-label="Clear search"
+                        className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-surface-highlight transition-colors"
+                      >
+                        <X size={13} className="text-text-muted" />
+                      </button>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => setAddOneOpen((v) => !v)}
+                    className={cn(
+                      'flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border transition-colors',
+                      addOneOpen
+                        ? 'text-primary bg-primary/15 border-primary/30'
+                        : 'text-text-secondary hover:text-text-primary bg-surface-elevated border-border/40 hover:border-border',
+                    )}
+                  >
+                    <Plus size={12} /> Add one
+                  </button>
+                </div>
+                {addOneOpen && (
+                  <div className="pt-2 border-t border-border-subtle/40">
+                    <VariableQuickAddForm
+                      setNames={setNames}
+                      onSubmit={handleCreate}
+                      className="max-w-2xl"
+                    />
+                  </div>
+                )}
+              </div>
+
+              {/* Body */}
+              <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark">
+                {error && (
+                  <div className="mx-6 mt-4 flex items-center gap-2 px-3 py-2 rounded-lg bg-status-error/10 border border-status-error/20 text-xs text-status-error">
+                    <AlertCircle size={12} className="flex-shrink-0" />
+                    <span>{error}</span>
+                  </div>
+                )}
+
+                {loading && !vaultVariables && (
+                  <div className="p-6 space-y-3 max-w-3xl">
+                    {[1, 2, 3, 4].map((i) => (
+                      <div
+                        key={i}
+                        className="h-12 rounded-lg bg-surface-elevated animate-pulse"
+                      />
+                    ))}
+                  </div>
+                )}
+
+                {!loading && isEmpty && (
+                  <VaultEmptyState
+                    onImport={() => setImportOpen(true)}
+                    onAddOne={() => setAddOneOpen(true)}
+                  />
+                )}
+
+                {!loading && !isEmpty && filteredBySearch.length === 0 && (
+                  <NoMatchesState
+                    activeSet={activeSet}
+                    searchQuery={searchQuery}
+                    onClear={() => setSearchQuery('')}
+                  />
+                )}
+
+                {!loading && filteredBySearch.length > 0 && (
+                  <VariableList
+                    variables={filteredBySearch}
+                    revealed={revealedState.revealed}
+                    editingKey={editingKey}
+                    editValue={editValue}
+                    showEditValue={showEditValue}
+                    setNames={setNames}
+                    onReveal={handleReveal}
+                    onEdit={handleEdit}
+                    onDelete={(key) => setConfirmDelete(key)}
+                    onEditValueChange={setEditValue}
+                    onEditToggleShow={() => setShowEditValue(!showEditValue)}
+                    onEditSave={handleEditSave}
+                    onEditCancel={handleEditCancel}
+                    onAssignSet={handleAssignSet}
+                  />
+                )}
+              </div>
+            </>
+          )}
+        </main>
+      </WorkspaceShell>
+
+      <ConfirmDialog
+        isOpen={confirmDelete !== null}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete variable"
+        message={
+          <>
+            <p>
+              Delete <span className="font-mono text-primary">{confirmDelete}</span>?
+            </p>
+            <p>This action cannot be undone.</p>
+          </>
+        }
+        confirmLabel={
+          <span>
+            Delete <span className="font-mono">"{confirmDelete}"</span>
+          </span>
+        }
+        variant="danger"
+      />
+
+      <ConfirmDialog
+        isOpen={confirmDeleteSet !== null}
+        onClose={() => setConfirmDeleteSet(null)}
+        onConfirm={handleDeleteSet}
+        title="Delete variable set"
+        message={
+          <>
+            <p>
+              Delete the set{' '}
+              <span className="font-mono text-primary">{confirmDeleteSet}</span>?
+            </p>
+            <p>
+              Variables in this set keep their values but become unassigned.
+            </p>
+          </>
+        }
+        confirmLabel={
+          <span>
+            Delete <span className="font-mono">"{confirmDeleteSet}"</span>
+          </span>
+        }
+        variant="danger"
+      />
+
+      {importOpen && (
+        <EnvImportModal
+          onClose={() => setImportOpen(false)}
+          onImport={handleImport}
+          existingVariables={allVariables}
+          sets={allSets}
+          defaultSet={activeSet === ALL_SETS_KEY ? '' : activeSet}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header
+// ---------------------------------------------------------------------------
+
+interface VaultHeaderProps {
+  compact: boolean;
+  totalVariables: number;
+  totalSets: number;
+  locked: boolean;
+  encrypted: boolean;
+  onRefresh: () => void;
+  onOpenEncrypt: () => void;
+  onOpenImport: () => void;
+}
+
+function VaultHeader({
+  compact,
+  totalVariables,
+  totalSets,
+  locked,
+  encrypted,
+  onRefresh,
+  onOpenEncrypt,
+  onOpenImport,
+}: VaultHeaderProps) {
+  return (
+    <header
+      className={cn(
+        'flex-shrink-0 bg-surface/30 backdrop-blur-sm border-b border-border-subtle flex items-center justify-between px-6',
+        compact ? 'py-2' : 'py-3',
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <div className="font-sans text-text-muted/60 text-[10px] uppercase tracking-[0.4em]">
+          variables
+        </div>
+        <div className="font-mono text-[10px] text-text-muted">
+          {totalVariables} {totalVariables === 1 ? 'variable' : 'variables'}
+        </div>
+        {totalSets > 0 && (
+          <div className="font-mono text-[10px] text-secondary">
+            · {totalSets} {totalSets === 1 ? 'set' : 'sets'}
+          </div>
+        )}
+        {encrypted && !locked && (
+          <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-status-running/10 text-status-running flex items-center gap-1">
+            <LockOpen size={9} />
+            encrypted
+          </span>
+        )}
+        {locked && (
+          <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-primary/10 text-primary flex items-center gap-1">
+            <Lock size={9} />
+            locked
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        {!locked && (
+          <>
+            <button
+              onClick={onOpenImport}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-primary hover:text-primary/80 bg-primary/10 hover:bg-primary/15 border border-primary/20 rounded-lg transition-colors"
+            >
+              <FileUp size={12} /> Import .env
+            </button>
+            {encrypted ? (
+              <IconButton
+                icon={Lock}
+                onClick={onOpenEncrypt}
+                tooltip="Lock vault"
+                size="sm"
+                variant="ghost"
+              />
+            ) : (
+              totalVariables > 0 && (
+                <button
+                  onClick={onOpenEncrypt}
+                  className="flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium text-text-secondary hover:text-text-primary border border-border/40 hover:border-border rounded-lg transition-colors"
+                >
+                  <Lock size={11} /> Encrypt
+                </button>
+              )
+            )}
+            <IconButton
+              icon={RefreshCw}
+              onClick={onRefresh}
+              tooltip="Refresh"
+              size="sm"
+              variant="ghost"
+            />
+          </>
+        )}
+      </div>
+    </header>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Left rail
+// ---------------------------------------------------------------------------
+
+interface VaultLeftRailProps {
+  compact: boolean;
+  sets: { name: string; count: number }[];
+  activeSet: string;
+  onSelectSet: (name: string) => void;
+  totalCount: number;
+  unassignedCount: number;
+  newSetOpen: boolean;
+  onNewSetOpen: (open: boolean) => void;
+  newSetName: string;
+  onNewSetNameChange: (value: string) => void;
+  onNewSetSave: () => void;
+  onDeleteSet: (name: string) => void;
+  locked: boolean;
+}
+
+function VaultLeftRail({
+  compact,
+  sets,
+  activeSet,
+  onSelectSet,
+  totalCount,
+  unassignedCount,
+  newSetOpen,
+  onNewSetOpen,
+  newSetName,
+  onNewSetNameChange,
+  onNewSetSave,
+  onDeleteSet,
+  locked,
+}: VaultLeftRailProps) {
+  return (
+    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-r border-border-subtle">
+      <div
+        className={cn(
+          'flex-shrink-0 px-3 border-b border-border-subtle/60',
+          compact ? 'py-2' : 'py-3',
+        )}
+      >
+        <div className="text-[10px] font-medium text-text-muted/60 uppercase tracking-[0.3em]">
+          sets
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark px-2 py-2 space-y-0.5">
+        <SetPill
+          label="All variables"
+          count={totalCount}
+          active={activeSet === ALL_SETS_KEY}
+          onClick={() => onSelectSet(ALL_SETS_KEY)}
+        />
+        {unassignedCount > 0 && (
+          <p className="px-3 pt-2 pb-1 text-[9px] uppercase tracking-[0.24em] text-text-muted/50">
+            grouped
+          </p>
+        )}
+        {sets.map((set) => (
+          <SetPill
+            key={set.name}
+            label={set.name}
+            count={set.count}
+            mono
+            active={activeSet === set.name}
+            onClick={() => onSelectSet(set.name)}
+            onDelete={locked ? undefined : () => onDeleteSet(set.name)}
+          />
+        ))}
+        {sets.length === 0 && (
+          <p className="px-3 py-2 text-[10px] text-text-muted/60 leading-relaxed">
+            No sets yet. Groups appear here as you assign variables.
+          </p>
+        )}
+      </div>
+
+      <div className="flex-shrink-0 px-2 py-2 border-t border-border-subtle/60">
+        {newSetOpen ? (
+          <NewSetForm
+            show
+            value={newSetName}
+            onChange={onNewSetNameChange}
+            onSave={onNewSetSave}
+            onCancel={() => {
+              onNewSetOpen(false);
+              onNewSetNameChange('');
+            }}
+            className="px-1"
+          />
+        ) : (
+          <button
+            onClick={() => onNewSetOpen(true)}
+            disabled={locked}
+            className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 text-[10px] uppercase tracking-[0.18em] text-text-muted hover:text-text-primary hover:bg-surface-highlight rounded transition-colors disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-text-muted"
+          >
+            <Plus size={11} /> new set
+          </button>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+interface SetPillProps {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+  mono?: boolean;
+  onDelete?: () => void;
+}
+
+function SetPill({
+  label,
+  count,
+  active,
+  onClick,
+  mono,
+  onDelete,
+}: SetPillProps) {
+  return (
+    <div
+      className={cn(
+        'group flex items-center gap-1.5 rounded-md transition-colors',
+        active
+          ? 'bg-primary/10 text-primary'
+          : 'text-text-secondary hover:bg-surface-highlight/50 hover:text-text-primary',
+      )}
+    >
+      <button
+        onClick={onClick}
+        className="flex-1 min-w-0 flex items-center justify-between gap-2 px-3 py-1.5 text-left"
+      >
+        <span
+          className={cn(
+            'text-xs truncate',
+            mono ? 'font-mono' : 'font-medium',
+            active && 'text-primary',
+          )}
+        >
+          {label}
+        </span>
+        <span
+          className={cn(
+            'flex-shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded',
+            active
+              ? 'bg-primary/15 text-primary'
+              : 'bg-surface-elevated text-text-muted',
+          )}
+        >
+          {count}
+        </span>
+      </button>
+      {onDelete && (
+        <button
+          onClick={onDelete}
+          className="flex-shrink-0 p-1 mr-1.5 rounded hover:bg-status-error/10 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+          title={`Delete ${label}`}
+          aria-label={`Delete set ${label}`}
+        >
+          <Trash2 size={10} className="text-text-muted hover:text-status-error" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Body states
+// ---------------------------------------------------------------------------
+
+interface VariableListProps {
+  variables: Variable[];
+  revealed: Record<string, string>;
+  editingKey: string | null;
+  editValue: string;
+  showEditValue: boolean;
+  setNames: string[];
+  onReveal: (key: string) => void;
+  onEdit: (key: string) => void;
+  onDelete: (key: string) => void;
+  onEditValueChange: (val: string) => void;
+  onEditToggleShow: () => void;
+  onEditSave: () => void;
+  onEditCancel: () => void;
+  onAssignSet: (key: string, set: string) => void;
+}
+
+function VariableList({
+  variables,
+  revealed,
+  editingKey,
+  editValue,
+  showEditValue,
+  setNames,
+  onReveal,
+  onEdit,
+  onDelete,
+  onEditValueChange,
+  onEditToggleShow,
+  onEditSave,
+  onEditCancel,
+  onAssignSet,
+}: VariableListProps) {
+  return (
+    <div className="px-6 py-4 space-y-2 max-w-3xl">
+      {variables.map((variable) => (
+        <SecretItem
+          key={variable.key}
+          secret={variable}
+          revealed={revealed[variable.key]}
+          isEditing={editingKey === variable.key}
+          editValue={editValue}
+          showEditValue={showEditValue}
+          onReveal={() => onReveal(variable.key)}
+          onEdit={() => onEdit(variable.key)}
+          onDelete={() => onDelete(variable.key)}
+          onEditValueChange={onEditValueChange}
+          onEditToggleShow={onEditToggleShow}
+          onEditSave={onEditSave}
+          onEditCancel={onEditCancel}
+          sets={setNames}
+          onAssignSet={(set) => onAssignSet(variable.key, set)}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface VaultEmptyStateProps {
+  onImport: () => void;
+  onAddOne: () => void;
+}
+
+function VaultEmptyState({ onImport, onAddOne }: VaultEmptyStateProps) {
+  return (
+    <div className="h-full flex items-center justify-center px-6 py-12">
+      <div className="max-w-md w-full text-center space-y-5 animate-fade-in-scale">
+        <div className="relative mx-auto w-16 h-16">
+          <div className="absolute inset-0 rounded-2xl bg-primary/10 border border-primary/20 flex items-center justify-center">
+            <KeyRound size={26} className="text-primary/70" />
+          </div>
+          <div className="absolute -inset-2 rounded-3xl bg-primary/5 blur-2xl -z-10" />
+        </div>
+        <div className="space-y-1.5">
+          <h2 className="text-base font-semibold text-text-primary">
+            Your variables home
+          </h2>
+          <p className="text-xs text-text-muted leading-relaxed">
+            Bring a <code className="font-mono text-text-secondary">.env</code> file
+            over, or add a key by hand. Secrets stay encrypted at rest when you
+            set a passphrase.
+          </p>
+        </div>
+        <div className="flex items-center justify-center gap-2 pt-1">
+          <button
+            onClick={onImport}
+            className="flex items-center gap-1.5 px-4 py-2 text-xs font-semibold rounded-lg bg-gradient-to-r from-primary to-primary-dark text-background shadow-[0_1px_12px_rgba(245,158,11,0.3)] hover:shadow-[0_2px_18px_rgba(245,158,11,0.4)] hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200"
+          >
+            <FileUp size={13} /> Import from .env
+          </button>
+          <button
+            onClick={onAddOne}
+            className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium text-text-secondary hover:text-text-primary border border-border/40 hover:border-border rounded-lg transition-colors"
+          >
+            <Plus size={12} /> Add one manually
+          </button>
+        </div>
+        <p className="text-[10px] text-text-muted/70 pt-2">
+          Or use the CLI:
+          <code className="ml-1 font-mono text-text-secondary">
+            gridctl var import .env
+          </code>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+interface NoMatchesProps {
+  activeSet: string;
+  searchQuery: string;
+  onClear: () => void;
+}
+
+function NoMatchesState({ activeSet, searchQuery, onClear }: NoMatchesProps) {
+  const scopeLabel =
+    activeSet === ALL_SETS_KEY ? 'this view' : `the ${activeSet} set`;
+  return (
+    <div className="h-full flex items-center justify-center px-6 py-10">
+      <div className="text-center space-y-2 max-w-sm">
+        <div className="mx-auto w-12 h-12 rounded-xl bg-surface-elevated/60 border border-border/30 flex items-center justify-center">
+          <Search size={20} className="text-text-muted/50" />
+        </div>
+        <p className="text-xs text-text-secondary">
+          {searchQuery
+            ? `No variables match "${searchQuery}" in ${scopeLabel}.`
+            : `No variables in ${scopeLabel} yet.`}
+        </p>
+        {searchQuery && (
+          <button
+            onClick={onClear}
+            className="text-[11px] text-primary hover:text-primary/80 underline underline-offset-2 transition-colors"
+          >
+            Clear search
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default VaultWorkspace;

--- a/web/src/hooks/useVaultManager.ts
+++ b/web/src/hooks/useVaultManager.ts
@@ -13,9 +13,11 @@ import {
   fetchVariableStoreStatus,
   unlockVariableStore,
   lockVariableStore,
+  importVariables,
 } from '../lib/api';
 import type {
   CreateVariableInput,
+  ImportVariableInput,
   UpdateVariableInput,
   Variable,
   VariableSet,
@@ -48,6 +50,7 @@ export interface UseVaultManagerResult {
   createSet: (name: string) => Promise<void>;
   deleteSet: (name: string) => Promise<void>;
   assignToSet: (key: string, set: string) => Promise<void>;
+  importVars: (vars: ImportVariableInput[]) => Promise<{ imported: number }>;
 }
 
 // Single source of truth for vault data + IO actions, consumed by both the
@@ -184,6 +187,15 @@ export function useVaultManager(
     [refresh],
   );
 
+  const importVars = useCallback(
+    async (vars: ImportVariableInput[]) => {
+      const result = await importVariables(vars);
+      await refresh();
+      return result;
+    },
+    [refresh],
+  );
+
   return {
     variables,
     sets,
@@ -201,5 +213,6 @@ export function useVaultManager(
     createSet,
     deleteSet,
     assignToSet,
+    importVars,
   };
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -636,6 +636,36 @@ export async function lockVariableStore(passphrase: string): Promise<{ status: s
   return mutateJSON<{ status: string }>('/api/var/lock', 'POST', { passphrase });
 }
 
+export interface ImportVariableInput {
+  key: string;
+  value: string;
+  type: VariableType;
+  isSecret: boolean;
+  set?: string;
+}
+
+export interface ImportVariablesResult {
+  imported: number;
+}
+
+// importVariables bulk-imports entries via POST /api/var/import using the
+// modern `{ variables: [...] }` shape. The server overwrites by key —
+// callers must filter out conflicts they want to preserve before calling.
+export async function importVariables(
+  vars: ImportVariableInput[],
+): Promise<ImportVariablesResult> {
+  const body = {
+    variables: vars.map((v) => ({
+      key: v.key,
+      value: v.value,
+      type: v.type,
+      is_secret: v.isSecret,
+      ...(v.set ? { set: v.set } : {}),
+    })),
+  };
+  return mutateJSON<ImportVariablesResult>('/api/var/import', 'POST', body);
+}
+
 // === Stack Spec API ===
 
 /**

--- a/web/src/lib/envParser.ts
+++ b/web/src/lib/envParser.ts
@@ -1,0 +1,185 @@
+import type { VariableType } from './api';
+
+export interface ParsedEnvEntry {
+  // 1-based source line for surfacing parse errors next to the textarea.
+  line: number;
+  key: string;
+  value: string;
+  // Auto-detected from the value shape — overridable in the import preview.
+  type: VariableType;
+  // True when the source value was wrapped in single or double quotes. The UI
+  // uses this to render the literal value rather than stripping quotes.
+  quoted: boolean;
+}
+
+export interface IgnoredEnvLine {
+  line: number;
+  raw: string;
+  reason: string;
+}
+
+export interface ParseEnvResult {
+  entries: ParsedEnvEntry[];
+  ignored: IgnoredEnvLine[];
+}
+
+const KEY_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// parseEnv parses a textual `.env`-style block into a list of key/value
+// entries plus any lines we couldn't make sense of. Behaviour is intentionally
+// strict-but-tolerant: a bad line never aborts parsing of subsequent lines.
+//
+// Supported:
+//   KEY=value
+//   KEY="quoted with spaces and ="
+//   KEY='single-quoted'
+//   KEY=value # trailing comment (only outside quotes)
+//   export KEY=value
+//   # comment line
+//   <blank line>
+//
+// Not supported (logged as ignored):
+//   Multi-line values that span source lines.
+//   Variable interpolation like KEY=$OTHER.
+//   Lowercase or symbol-leading keys.
+export function parseEnv(input: string): ParseEnvResult {
+  const entries: ParsedEnvEntry[] = [];
+  const ignored: IgnoredEnvLine[] = [];
+
+  const lines = input.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNo = i + 1;
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    if (trimmed.startsWith('#')) continue;
+
+    // Strip an optional leading `export ` so values copied from shell
+    // scripts work without modification.
+    const stripped = trimmed.startsWith('export ')
+      ? trimmed.slice('export '.length).trimStart()
+      : trimmed;
+
+    const eqIdx = stripped.indexOf('=');
+    if (eqIdx <= 0) {
+      ignored.push({
+        line: lineNo,
+        raw: line,
+        reason: 'missing = separator',
+      });
+      continue;
+    }
+
+    const rawKey = stripped.slice(0, eqIdx).trim();
+    if (!KEY_REGEX.test(rawKey)) {
+      ignored.push({
+        line: lineNo,
+        raw: line,
+        reason: `invalid key "${rawKey}"`,
+      });
+      continue;
+    }
+
+    const rawValue = stripped.slice(eqIdx + 1);
+    const parsed = parseValue(rawValue);
+    if (!parsed.ok) {
+      ignored.push({ line: lineNo, raw: line, reason: parsed.reason });
+      continue;
+    }
+
+    entries.push({
+      line: lineNo,
+      key: rawKey,
+      value: parsed.value,
+      type: detectType(parsed.value, parsed.quoted),
+      quoted: parsed.quoted,
+    });
+  }
+
+  return { entries, ignored };
+}
+
+interface ParseValueOk {
+  ok: true;
+  value: string;
+  quoted: boolean;
+}
+interface ParseValueErr {
+  ok: false;
+  reason: string;
+}
+
+function parseValue(raw: string): ParseValueOk | ParseValueErr {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { ok: true, value: '', quoted: false };
+  }
+
+  const first = trimmed[0];
+  if (first === '"' || first === "'") {
+    // Find the matching closing quote, allowing the same quote to be escaped
+    // with a backslash inside a double-quoted string.
+    const quote = first;
+    let i = 1;
+    let value = '';
+    while (i < trimmed.length) {
+      const ch = trimmed[i];
+      if (ch === '\\' && quote === '"' && i + 1 < trimmed.length) {
+        const next = trimmed[i + 1];
+        if (next === 'n') value += '\n';
+        else if (next === 't') value += '\t';
+        else if (next === 'r') value += '\r';
+        else value += next;
+        i += 2;
+        continue;
+      }
+      if (ch === quote) {
+        // Allow a trailing comment after the closing quote.
+        const tail = trimmed.slice(i + 1).trim();
+        if (tail.length > 0 && !tail.startsWith('#')) {
+          return {
+            ok: false,
+            reason: 'unexpected content after closing quote',
+          };
+        }
+        return { ok: true, value, quoted: true };
+      }
+      value += ch;
+      i++;
+    }
+    return { ok: false, reason: 'unterminated quoted value' };
+  }
+
+  // Unquoted: strip a trailing comment (anything after the first unquoted #
+  // preceded by whitespace), then trim trailing whitespace.
+  const hashIdx = findInlineComment(trimmed);
+  const before = hashIdx >= 0 ? trimmed.slice(0, hashIdx) : trimmed;
+  return { ok: true, value: before.trimEnd(), quoted: false };
+}
+
+function findInlineComment(s: string): number {
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '#' && (i === 0 || /\s/.test(s[i - 1]))) return i;
+  }
+  return -1;
+}
+
+function detectType(value: string, quoted: boolean): VariableType {
+  if (quoted) return 'string';
+  const trimmed = value.trim();
+  if (trimmed === '') return 'string';
+  if (trimmed === 'true' || trimmed === 'false') return 'bool';
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) return 'number';
+  if (
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  ) {
+    try {
+      JSON.parse(trimmed);
+      return 'json';
+    } catch {
+      return 'string';
+    }
+  }
+  return 'string';
+}

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -14,6 +14,7 @@ import { DetachedTracesPage } from './pages/DetachedTracesPage';
 // Each workspace is code-split into its own chunk.
 const TopologyWorkspace = lazy(() => import('./components/workspaces/TopologyWorkspace'));
 const LibraryWorkspace = lazy(() => import('./components/workspaces/LibraryWorkspace'));
+const VaultWorkspace = lazy(() => import('./components/workspaces/VaultWorkspace'));
 
 export function AppRoutes() {
   return (
@@ -48,6 +49,14 @@ export function AppRoutes() {
             </Suspense>
           }
         />
+        <Route
+          path="/vault"
+          element={
+            <Suspense fallback={<WorkspaceLoadingShell />}>
+              <VaultWorkspace />
+            </Suspense>
+          }
+        />
       </Route>
 
       {/* Root redirect — chooses a workspace based on stack + storage. */}
@@ -70,9 +79,6 @@ export function AppRoutes() {
       <Route path="/registry" element={<Navigate to="/library-window" replace />} />
       <Route path="/metrics" element={<DetachedMetricsPage />} />
       <Route path="/var" element={<DetachedVaultPage />} />
-      {/* /vault → /var: silent redirect for bookmarks and existing window
-          handles. Kept through the beta cycle and removed at v1.0. */}
-      <Route path="/vault" element={<Navigate to="/var" replace />} />
       <Route path="/traces" element={<DetachedTracesPage />} />
     </Routes>
   );

--- a/web/src/stores/useUIStore.ts
+++ b/web/src/stores/useUIStore.ts
@@ -31,6 +31,7 @@ export type CompactModeMap = Record<Workspace, boolean>;
 export const COMPACT_MODE_DEFAULTS: CompactModeMap = {
   topology: false,
   library: false,
+  vault: false,
 };
 
 export interface CompactModeSlice {

--- a/web/src/types/workspace.ts
+++ b/web/src/types/workspace.ts
@@ -1,9 +1,9 @@
 import type { LucideIcon } from 'lucide-react';
-import { Library, Network } from 'lucide-react';
+import { KeyRound, Library, Network } from 'lucide-react';
 
-// Top-level workspaces in the unified shell. Routed at /topology and /library
-// inside AppShell.
-export type Workspace = 'topology' | 'library';
+// Top-level workspaces in the unified shell. Routed at /topology, /library,
+// and /vault inside AppShell.
+export type Workspace = 'topology' | 'library' | 'vault';
 
 export interface WorkspaceConfig {
   id: Workspace;
@@ -15,10 +15,11 @@ export interface WorkspaceConfig {
 
 // Single source of truth for workspace metadata. Adding a workspace = append
 // here; the switcher, shortcuts, and labels follow automatically. Array order
-// is the rendered top-nav order, so shortcuts read left-to-right as 1-2.
+// is the rendered top-nav order, so shortcuts read left-to-right as 1-2-3.
 export const WORKSPACE_CONFIG: readonly WorkspaceConfig[] = [
-  { id: 'topology', label: 'Topology', icon: Network, shortcutKey: '1' },
-  { id: 'library',  label: 'Library',  icon: Library, shortcutKey: '2' },
+  { id: 'topology', label: 'Topology',  icon: Network,  shortcutKey: '1' },
+  { id: 'library',  label: 'Library',   icon: Library,  shortcutKey: '2' },
+  { id: 'vault',    label: 'Variables', icon: KeyRound, shortcutKey: '3' },
 ] as const;
 
 // Derived for back-compat with existing call-sites in useUIStore, AppShell,


### PR DESCRIPTION
## Description

Phase 3 of [#688](https://github.com/gridctl/gridctl/issues/688): build the `/vault` workspace as a top-level peer to Topology and Library. Adds the switcher pill, the `Cmd+3` shortcut, the route, and the workspace itself — with bulk `.env` import as the signature feature. Phase 1 (#689) and Phase 2 (#690) are already merged.

## Type of Change

- [x] Feature (new user-visible functionality)

## Changes Made

### Workspace registration
- `web/src/types/workspace.ts`: extend the `Workspace` union with `'vault'`; append `{ id: 'vault', label: 'Variables', icon: KeyRound, shortcutKey: '3' }` to `WORKSPACE_CONFIG`. The switcher and keyboard shortcut auto-wire.
- `web/src/routes.tsx`: lazy-load `VaultWorkspace` at `/vault`. **Removes the stale `/vault → /var` redirect** — `/vault` is now a real workspace and `/var` remains the detached window.
- `web/src/stores/useUIStore.ts`: add `vault: false` to `COMPACT_MODE_DEFAULTS`.

### Workspace component (`VaultWorkspace.tsx`, 939 lines, 7 co-located components)
- Uses `WorkspaceShell` with a left rail (set navigation) and a single main pane.
- **Header strip** mirrors `LibraryWorkspace`'s chrome: section label, counts, encrypted/locked badges, action cluster (`Import .env`, `Encrypt`/`Lock`, `Refresh`).
- **Left rail**: "All variables" pill at top with total count, then one `SetPill` per Variable Set with member counts. Selecting a pill filters the main pane. "+ New set" inline form at the bottom of the rail.
- **Search + add-one strip** above the table: instant key filter (URL-synced via `?q=`), plus an "Add one" pill that expands an inline `<VariableQuickAddForm>` drawer.
- **Variable list**: reuses the shared `<SecretItem>` atom.
- **Empty state**: large central card with `Import from .env` as the primary CTA (gradient button), `Add one manually` as secondary, and a CLI hint as tertiary. Earns peer status with Topology/Library by *inviting action* rather than stubbing.
- **Locked vault**: full-pane `<VaultLockPrompt>` overlay; header actions hidden until unlocked.
- **Encrypt / Lock** both use `<VaultEncryptForm>` inline below the header (drawer-style). Different copy based on `encrypted` state; same form, same backend.
- **URL state** for filter + search matches Library's pattern — `?set=` and `?q=` deep-link and survive back/forward.

### Bulk `.env` import (`EnvImportModal.tsx`, 533 lines + `envParser.ts`, 185 lines)
- Modal chrome modeled on `ConfirmDialog`: backdrop, focus trap, Escape close, click-outside close. `aria-modal`, `aria-labelledby`.
- Two-column layout (responsive stacks to one on narrow widths): textarea + drag/drop + file picker on the left, live preview table on the right.
- **Parser** supports `KEY=value`, double/single quoting (with `\n\t\r` escapes inside doubles), inline `# comment`, full-line `#` comments, blank lines, leading `export `, and surfaces invalid lines in an expandable "ignored" pane with reasons and line numbers.
- **Type auto-detect** per row: `bool` for `true|false`, `number` for numerics, `json` for `{…}` or `[…]` that parses, else `string`. Quoted values stay `string`.
- **Preview table** with per-row controls: type override (`VariableTypeSelector`), set assignment (defaults to the workspace's active set filter), click-to-reveal value (dotted by default), skip toggle. An "overwrites" badge marks keys that already exist in the vault.
- **Conflict semantics**: server overwrites by key (`pkg/vault.Store.ImportVariables`). The modal filters skipped rows client-side; everything else is sent. Footer counts: `X new · Y overwrites · Z skipped`.
- **Per-key overrides** are derived via `useMemo` from `parseEnv(text)` plus an overrides map — small textarea edits don't blow away per-row tweaks, and there's no `setState` in `useEffect`.
- Modal mounts conditionally at the parent (`{importOpen && <EnvImportModal …>}`) so close = unmount = automatic state reset.

### Shared-piece additions
- `web/src/lib/api.ts`: `importVariables()` client wrapping `POST /api/var/import` with the modern `{ variables: [...] }` payload shape.
- `web/src/hooks/useVaultManager.ts`: `importVars` action; calls `refresh()` after a successful import.

### Tests
- `web/src/__tests__/WorkspaceSwitcher.test.tsx`, `useUIStore-workspace.test.ts`: generalized to iterate `WORKSPACES`/`WORKSPACE_CONFIG` rather than hardcoding the count. Adding workspaces in the future requires no test changes.
- `web/src/__tests__/useKeyboardShortcuts.test.tsx`: inverted the Cmd+3 assertion — now expects vault navigation, no longer expects no-op.
- `web/src/__tests__/envParser.test.ts`: 14 cases covering basic pair, double/single quoting, inline comment, `#` inside quotes, comment lines, `export` prefix, invalid line tolerance, key validation, type detection (bool/number/json/string), unterminated quote error.
- `web/src/__tests__/VaultWorkspace.test.tsx`: 6 smoke cases for empty-state CTA, header import button, left-rail "All variables" pill, import modal open, and the locked-vault path.

### Out of scope (deferred to Phase 4)
- Topology server-node "Secrets" affordance that deep-links into `/vault?filter=server:<name>` — next phase.
- "Used by" indicator, missing-key diff, write-only sensitive variables — out of this PR.
- Removing the sidebar — the scoped-down sidebar (#690) stays.

## Testing

- `npm run build` — clean (covers `tsc -b`).
- `npm run lint` — 45/40/5, identical to the baseline before this PR; no new warnings or errors introduced.
- `npm test` — **593/593 pass** across 54 test files (+21 from main: 14 parser + 6 workspace + 1 from inverted Cmd+3).
- Manual QA: not performed in this branch — recommend a dev-server spot-check of the workspace empty state, import flow with both a small paste and a `.env` file, encrypt/lock flow, set creation/deletion, and the locked-vault unlock path.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #688