### PR TITLE
feat: bridge topology server nodes to vault workspace

### DIFF
--- a/web/src/__tests__/VaultWorkspace.test.tsx
+++ b/web/src/__tests__/VaultWorkspace.test.tsx
@@ -89,6 +89,57 @@ describe('VaultWorkspace — empty state', () => {
   });
 });
 
+describe('VaultWorkspace — server filter', () => {
+  const testVariables = [
+    { key: 'POSTGRES_URL', type: 'string' as const, is_secret: true },
+    { key: 'POSTGRES_PASSWORD', type: 'string' as const, is_secret: true },
+    { key: 'REDIS_URL', type: 'string' as const, is_secret: false },
+  ];
+
+  beforeEach(() => {
+    vi.mocked(api.fetchVariableStoreStatus).mockResolvedValue({
+      locked: false,
+      encrypted: false,
+    });
+    vi.mocked(api.fetchVariables).mockResolvedValue(testVariables);
+    useVaultStore.setState({
+      variables: testVariables,
+      sets: [],
+      loading: false,
+      error: null,
+      locked: false,
+      encrypted: false,
+    });
+  });
+
+  it('applies ?filter=server:<name> on mount and shows the inline banner', async () => {
+    render(
+      <MemoryRouter initialEntries={['/vault?filter=server:postgres']}>
+        <VaultWorkspace />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText('POSTGRES_URL')).toBeInTheDocument();
+    expect(screen.getByText('POSTGRES_PASSWORD')).toBeInTheDocument();
+    expect(screen.queryByText('REDIS_URL')).not.toBeInTheDocument();
+    expect(screen.getByText(/filtering for server/i)).toBeInTheDocument();
+    expect(screen.getByText('postgres')).toBeInTheDocument();
+  });
+
+  it('clears the banner and removes the filter when Clear is clicked', async () => {
+    render(
+      <MemoryRouter initialEntries={['/vault?filter=server:postgres']}>
+        <VaultWorkspace />
+      </MemoryRouter>,
+    );
+    const clearBtn = await screen.findByRole('button', {
+      name: /clear server filter/i,
+    });
+    fireEvent.click(clearBtn);
+    expect(await screen.findByText('REDIS_URL')).toBeInTheDocument();
+    expect(screen.queryByText(/filtering for server/i)).not.toBeInTheDocument();
+  });
+});
+
 describe('VaultWorkspace — locked state', () => {
   beforeEach(() => {
     vi.mocked(api.fetchVariableStoreStatus).mockResolvedValue({

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Activity,
   Database,
 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { cn } from '../../lib/cn';
 import { Badge } from '../ui/Badge';
 import { ControlBar } from '../ui/ControlBar';
@@ -41,6 +42,7 @@ export function Sidebar() {
   const autoscaleHistory = useStackStore((s) => s.autoscaleHistory);
   const autoscaleDecisions = useStackStore((s) => s.autoscaleDecisions);
   const { openDetachedWindow } = useWindowManager();
+  const navigate = useNavigate();
 
   const handleClose = () => {
     setSidebarOpen(false);
@@ -95,6 +97,10 @@ export function Sidebar() {
 
   const handlePopout = () => {
     openDetachedWindow('sidebar', `node=${encodeURIComponent(data.name)}`);
+  };
+
+  const handleViewSecrets = () => {
+    navigate(`/vault?filter=server:${encodeURIComponent(data.name)}`);
   };
 
   return (
@@ -345,6 +351,20 @@ export function Sidebar() {
               <FileText size={14} />
               Show Logs Panel
             </button>
+            {isServer && (
+              <button
+                onClick={handleViewSecrets}
+                className={cn(
+                  'mt-3 inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg',
+                  'bg-surface-elevated/60 border border-border/50',
+                  'hover:bg-surface-highlight hover:border-text-muted/30 transition-all text-sm',
+                  'text-text-secondary hover:text-text-primary'
+                )}
+              >
+                <KeyRound size={14} />
+                Secrets
+              </button>
+            )}
           </InspectorSection>
         )}
 

--- a/web/src/components/workspaces/VaultWorkspace.tsx
+++ b/web/src/components/workspaces/VaultWorkspace.tsx
@@ -8,6 +8,7 @@ import { useSearchParams } from 'react-router-dom';
 import {
   AlertCircle,
   FileUp,
+  Filter,
   KeyRound,
   Lock,
   LockOpen,
@@ -73,6 +74,13 @@ export function VaultWorkspace() {
   // ---- URL state ----------------------------------------------------------
   const activeSet = searchParams.get('set') ?? ALL_SETS_KEY;
   const searchQuery = searchParams.get('q') ?? '';
+  // ?filter=server:<name> deep-links from Topology's server inspector. The
+  // server name is matched against variable keys as a substring — see
+  // filteredByServer below for the documented limitation.
+  const filterParam = searchParams.get('filter') ?? '';
+  const serverFilter = filterParam.startsWith('server:')
+    ? filterParam.slice('server:'.length)
+    : '';
 
   const setActiveSet = useCallback(
     (name: string) => {
@@ -104,6 +112,17 @@ export function VaultWorkspace() {
     [setSearchParams],
   );
 
+  const clearServerFilter = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('filter');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
   // ---- Local UI state -----------------------------------------------------
   // Edit state — mirrors VaultPanel: validate type on save, preserve is_secret.
   const [editingKey, setEditingKey] = useState<string | null>(null);
@@ -130,10 +149,20 @@ export function VaultWorkspace() {
   const setNames = useMemo(() => allSets.map((s) => s.name), [allSets]);
   const isEmpty = allVariables.length === 0 && allSets.length === 0;
 
+  // Approximate consumption filter: matches variable keys that contain the
+  // server name (case-insensitive). The backend doesn't yet track which
+  // server consumes which variable, so this is the best the client can do.
+  // Surfaced inline via ServerFilterBanner so users understand the limitation.
+  const filteredByServer = useMemo(() => {
+    if (!serverFilter) return allVariables;
+    const lower = serverFilter.toLowerCase();
+    return allVariables.filter((v) => v.key.toLowerCase().includes(lower));
+  }, [allVariables, serverFilter]);
+
   const filteredBySet = useMemo(() => {
-    if (activeSet === ALL_SETS_KEY) return allVariables;
-    return allVariables.filter((v) => v.set === activeSet);
-  }, [allVariables, activeSet]);
+    if (activeSet === ALL_SETS_KEY) return filteredByServer;
+    return filteredByServer.filter((v) => v.set === activeSet);
+  }, [filteredByServer, activeSet]);
 
   const filteredBySearch = useMemo(() => {
     if (!searchQuery) return filteredBySet;
@@ -354,6 +383,14 @@ export function VaultWorkspace() {
             </div>
           ) : (
             <>
+              {serverFilter && (
+                <ServerFilterBanner
+                  serverName={serverFilter}
+                  matchCount={filteredByServer.length}
+                  onClear={clearServerFilter}
+                />
+              )}
+
               {/* Search + add-one strip */}
               <div className="flex-shrink-0 px-6 py-3 border-b border-border-subtle bg-surface/30 flex flex-col gap-2">
                 <div className="flex items-center gap-2">
@@ -849,6 +886,43 @@ function VariableList({
           onAssignSet={(set) => onAssignSet(variable.key, set)}
         />
       ))}
+    </div>
+  );
+}
+
+interface ServerFilterBannerProps {
+  serverName: string;
+  matchCount: number;
+  onClear: () => void;
+}
+
+// Inline banner shown when the workspace is deep-linked from a Topology
+// server node. Documents the approximate-match limitation: variable
+// consumption tracking isn't wired server-side yet, so the filter is a
+// substring match against variable keys.
+function ServerFilterBanner({
+  serverName,
+  matchCount,
+  onClear,
+}: ServerFilterBannerProps) {
+  return (
+    <div className="flex-shrink-0 px-6 py-2 border-b border-border-subtle bg-primary/[0.04] flex items-center gap-2">
+      <Filter size={12} className="text-primary/70 flex-shrink-0" />
+      <div className="flex-1 min-w-0 text-[11px] text-text-secondary">
+        Filtering for server{' '}
+        <span className="font-mono text-primary">{serverName}</span>
+        <span className="text-text-muted/70 ml-2">
+          · {matchCount} {matchCount === 1 ? 'match' : 'matches'} · approximate
+          (matches keys containing the server name)
+        </span>
+      </div>
+      <button
+        onClick={onClear}
+        aria-label="Clear server filter"
+        className="flex items-center gap-1 px-2 py-0.5 text-[10px] text-text-muted hover:text-text-primary hover:bg-surface-highlight rounded transition-colors"
+      >
+        <X size={11} /> Clear
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Description

Adds a "Secrets" affordance on Topology server-node inspectors that deep-links to `/vault?filter=server:<name>`. The Vault workspace reads the filter param on mount, applies an approximate substring match against variable keys, and surfaces an inline banner that documents the consumption-tracking limitation.

## Type of Change

- [x] New feature

## Changes Made

- `Sidebar.tsx`: add `Secrets` button to the Actions section, gated to server nodes, navigates to the filtered vault URL.
- `VaultWorkspace.tsx`: parse `?filter=server:<name>`, slot a `filteredByServer` stage into the existing filter pipeline (`byServer → bySet → bySearch`), and render `ServerFilterBanner` with a Clear control that strips the URL param.
- Tests: cover mount-time filter application and the Clear flow.

## Testing

- [x] `npx vitest run` — 595/595 pass
- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] `go build ./...` clean

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #688