### PR TITLE
fix: show plaintext variable value unmasked in inputs

### DIFF
--- a/web/src/__tests__/VaultPanel.test.tsx
+++ b/web/src/__tests__/VaultPanel.test.tsx
@@ -91,6 +91,46 @@ describe('VaultPanel — value placeholder adapts to type and visibility', () =>
   });
 });
 
+describe('VaultPanel — value input masking follows Secret/Plaintext', () => {
+  beforeEach(() => {
+    useVaultStore.setState({
+      variables: [],
+      sets: [],
+      loading: false,
+      error: null,
+      locked: false,
+      encrypted: false,
+    });
+  });
+
+  it('masks the value input by default (Secret)', () => {
+    renderPanel();
+    expect(screen.getByPlaceholderText('secret value')).toHaveAttribute(
+      'type',
+      'password',
+    );
+  });
+
+  it('reveals the value input when Plaintext is selected', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: /plaintext/i }));
+    expect(screen.getByPlaceholderText('plaintext value')).toHaveAttribute(
+      'type',
+      'text',
+    );
+  });
+
+  it('re-masks the value input when switching back to Secret', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: /plaintext/i }));
+    fireEvent.click(screen.getByRole('button', { name: /secret/i }));
+    expect(screen.getByPlaceholderText('secret value')).toHaveAttribute(
+      'type',
+      'password',
+    );
+  });
+});
+
 describe('VaultPanel — sidebar scoped down to quick-lookup', () => {
   beforeEach(() => {
     useVaultStore.setState({

--- a/web/src/components/vault/SecretItem.tsx
+++ b/web/src/components/vault/SecretItem.tsx
@@ -84,7 +84,7 @@ export function SecretItem({
         <div className={editKeyClass}>{secret.key}</div>
         <div className="relative">
           <input
-            type={showEditValue ? 'text' : 'password'}
+            type={showEditValue || !secret.is_secret ? 'text' : 'password'}
             value={editValue}
             onChange={(e) => onEditValueChange(e.target.value)}
             placeholder="New value"

--- a/web/src/components/vault/VariableQuickAddForm.tsx
+++ b/web/src/components/vault/VariableQuickAddForm.tsx
@@ -105,7 +105,7 @@ export function VariableQuickAddForm({
         />
         <div className="relative">
           <input
-            type={showValue ? 'text' : 'password'}
+            type={showValue || !isSecret ? 'text' : 'password'}
             value={newValue}
             onChange={(e) => setNewValue(e.target.value)}
             placeholder={getValuePlaceholder(type, isSecret)}


### PR DESCRIPTION
## Description

In the Variables workspace, selecting **Plaintext** mode left the value input masked as password dots, identical to **Secret** mode. The input's display type was keyed only off the eye-reveal toggle and ignored the secret/plaintext flag. This adds the missing plaintext term so plaintext values render as visible text, matching the documented behavior and the existing wizard popover.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Add form (`VariableQuickAddForm`): value input is now visible text when Plaintext is selected
- Inline edit (`SecretItem`): edit input is now visible text for plaintext variables
- Secret mode is unchanged — values stay masked until the eye toggle reveals them
- Add regression tests asserting the value input `type` for Secret default, Plaintext, and switching back

## Testing

- `npm test` (web) — 598/598 pass, including 3 new masking tests
- `npm run build` (web) — clean (tsc + vite)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #693