### PR TITLE
feat: index variable usage and expose GET /api/var/usage

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -256,6 +256,7 @@ func (s *Server) Handler() http.Handler {
 		mux.HandleFunc("POST "+prefix, wrap("/api/var", s.handleVaultCreate))
 		mux.HandleFunc("POST "+prefix+"/import", wrap("/api/var/import", s.handleVaultImport))
 		mux.HandleFunc("GET "+prefix+"/status", wrap("/api/var/status", s.handleVaultStatus))
+		mux.HandleFunc("GET "+prefix+"/usage", wrap("/api/var/usage", s.handleVariableUsage))
 		mux.HandleFunc("POST "+prefix+"/unlock", wrap("/api/var/unlock", s.handleVaultUnlock))
 		mux.HandleFunc("POST "+prefix+"/lock", wrap("/api/var/lock", s.handleVaultLock))
 		mux.HandleFunc("GET "+prefix+"/sets", wrap("/api/var/sets", s.handleVaultSetsList))

--- a/internal/api/var_usage.go
+++ b/internal/api/var_usage.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gridctl/gridctl/pkg/config"
+)
+
+// buildVariableUsage normalizes a stack's reference index into the wire map for
+// GET /api/var/usage. It is nil-safe and always returns a non-nil map so the
+// JSON response is "{}" (not null) when nothing references any variable or no
+// stack is loaded.
+func buildVariableUsage(spec *config.Stack) map[string][]config.Consumer {
+	usage := map[string][]config.Consumer{}
+	if spec == nil {
+		return usage
+	}
+	for key, consumers := range spec.References {
+		usage[key] = consumers
+	}
+	return usage
+}
+
+// handleVariableUsage returns the variable-usage index for the active stack:
+// which servers/resources reference each ${var:KEY}. GET /api/var/usage.
+//
+// The index is derived from the loaded stack file, never from the vault, so it
+// exposes no secret values and is safe to serve while the vault is locked. When
+// no stack is deployed it returns an empty object.
+func (s *Server) handleVariableUsage(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, buildVariableUsage(s.loadRunningSpec()))
+}

--- a/internal/api/var_usage_test.go
+++ b/internal/api/var_usage_test.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/state"
+	"github.com/gridctl/gridctl/pkg/vault"
+)
+
+func TestBuildVariableUsage(t *testing.T) {
+	t.Run("nil stack yields empty non-nil map", func(t *testing.T) {
+		got := buildVariableUsage(nil)
+		if got == nil || len(got) != 0 {
+			t.Fatalf("got %v, want empty non-nil map", got)
+		}
+	})
+
+	t.Run("nil references yields empty map", func(t *testing.T) {
+		got := buildVariableUsage(&config.Stack{Name: "s"})
+		if len(got) != 0 {
+			t.Fatalf("got %v, want empty map", got)
+		}
+	})
+
+	t.Run("references are passed through", func(t *testing.T) {
+		spec := &config.Stack{References: config.ReferenceIndex{
+			"TOKEN": {{Kind: config.RefKindMCPServer, Name: "github", Field: "env.TOKEN"}},
+		}}
+		got := buildVariableUsage(spec)
+		if len(got["TOKEN"]) != 1 || got["TOKEN"][0].Name != "github" {
+			t.Fatalf("got %v, want TOKEN used by github", got)
+		}
+	})
+}
+
+// writeStackWithState points the daemon state for stackName at a freshly written
+// stack file under an isolated HOME, so loadRunningSpec resolves to it.
+func writeStackWithState(t *testing.T, stackName, stackYAML string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	stackPath := filepath.Join(home, "stack.yaml")
+	if err := os.WriteFile(stackPath, []byte(stackYAML), 0600); err != nil {
+		t.Fatalf("write stack: %v", err)
+	}
+	if err := state.Save(&state.DaemonState{StackName: stackName, StackFile: stackPath}); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+}
+
+func getUsage(t *testing.T, server *Server) (int, map[string][]config.Consumer) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/var/usage", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	var body map[string][]config.Consumer
+	if w.Body.Len() > 0 {
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode body %q: %v", w.Body.String(), err)
+		}
+	}
+	return w.Code, body
+}
+
+func TestHandleVariableUsage_NoStackLoaded(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // empty state dir → no running spec
+	server := &Server{stackName: "ghost"}
+
+	code, body := getUsage(t, server)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if len(body) != 0 {
+		t.Fatalf("body = %v, want empty object", body)
+	}
+}
+
+const usageStackYAML = `name: test
+mcp-servers:
+  - name: github
+    url: https://api.example.com
+    env:
+      GITHUB_TOKEN: "${var:GITHUB_TOKEN}"
+`
+
+func TestHandleVariableUsage_ReturnsConsumers(t *testing.T) {
+	writeStackWithState(t, "test", usageStackYAML)
+	server := &Server{stackName: "test"}
+
+	code, body := getUsage(t, server)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	consumers := body["GITHUB_TOKEN"]
+	if len(consumers) != 1 {
+		t.Fatalf("GITHUB_TOKEN consumers = %v, want 1", consumers)
+	}
+	c := consumers[0]
+	if c.Kind != config.RefKindMCPServer || c.Name != "github" || c.Field != "env.GITHUB_TOKEN" {
+		t.Errorf("consumer = %+v, want {mcp-server github env.GITHUB_TOKEN}", c)
+	}
+}
+
+// The usage index is derived from the stack file, not the vault, so a locked
+// vault must not turn the endpoint into a 423 or hide the data.
+func TestHandleVariableUsage_SafeWhenVaultLocked(t *testing.T) {
+	writeStackWithState(t, "test", usageStackYAML)
+
+	vaultDir := t.TempDir()
+	writer := vault.NewStore(vaultDir)
+	if err := writer.Load(); err != nil {
+		t.Fatalf("writer Load(): %v", err)
+	}
+	if err := writer.Set("GITHUB_TOKEN", "super-secret"); err != nil {
+		t.Fatalf("writer Set(): %v", err)
+	}
+	if err := writer.Lock("passphrase"); err != nil {
+		t.Fatalf("writer Lock(): %v", err)
+	}
+
+	// A fresh instance over the encrypted dir loads in the locked state (no
+	// passphrase supplied) — this is what the running server would hold.
+	store := vault.NewStore(vaultDir)
+	if err := store.Load(); err != nil {
+		t.Fatalf("store Load(): %v", err)
+	}
+	if !store.IsLocked() {
+		t.Fatal("store should be locked")
+	}
+
+	server := &Server{stackName: "test", vaultStore: store}
+
+	code, body := getUsage(t, server)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 even when vault locked", code)
+	}
+	if len(body["GITHUB_TOKEN"]) != 1 {
+		t.Fatalf("GITHUB_TOKEN consumers = %v, want 1", body["GITHUB_TOKEN"])
+	}
+	// No secret values may appear anywhere in the response.
+	if raw, _ := json.Marshal(body); strings.Contains(string(raw), "super-secret") {
+		t.Fatal("response leaked a secret value")
+	}
+}

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -79,6 +79,19 @@ func warnVaultSyntaxDeprecated() {
 // Returns the expanded string, any unresolved vault references, and env vars
 // that resolved to empty.
 func ExpandString(s string, resolve Resolver) (expanded string, unresolvedVault []string, emptyEnvVars []string) {
+	expanded, _, unresolvedVault, emptyEnvVars = ExpandStringRefs(s, resolve)
+	return expanded, unresolvedVault, emptyEnvVars
+}
+
+// ExpandStringRefs is ExpandString plus storeRefs: the variable-store keys
+// (the KEY in ${var:KEY} / ${vault:KEY}) referenced by s, in first-seen order.
+//
+// storeRefs is captured from the parsed grammar *before* resolution, so it
+// records what s references regardless of whether each key resolves — this is
+// the basis for usage tracing and is why the index can never drift from what
+// expansion actually recognizes. Bare $VAR / ${VAR} env-style references are
+// NOT store references and are deliberately excluded.
+func ExpandStringRefs(s string, resolve Resolver) (expanded string, storeRefs []string, unresolvedVault []string, emptyEnvVars []string) {
 	if resolve == nil {
 		resolve = EnvResolver()
 	}
@@ -110,6 +123,13 @@ func ExpandString(s string, resolve Resolver) (expanded string, unresolvedVault 
 		varName := parts[2]
 		op := parts[3]
 		operand := parts[4]
+
+		// Record the reference up front, independent of resolution outcome,
+		// so usage tracing sees every ${var:KEY} site even when the key is
+		// unresolved or supplied via the environment.
+		if isStoreRef {
+			storeRefs = append(storeRefs, varName)
+		}
 
 		value, exists := resolve(varName)
 
@@ -145,5 +165,5 @@ func ExpandString(s string, resolve Resolver) (expanded string, unresolvedVault 
 		}
 	})
 
-	return expanded, unresolvedVault, emptyEnvVars
+	return expanded, storeRefs, unresolvedVault, emptyEnvVars
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -141,87 +141,120 @@ func injectSetSecrets(s *Stack, vault VaultSetLookup) {
 	}
 }
 
-// expandStackVars expands variable references in all stack string fields using the
-// unified ExpandString function. Returns unresolved vault references and empty env vars.
+// expandStackVars expands variable references in all stack string fields using
+// the unified ExpandString grammar, and as it goes records every variable-store
+// reference into s.References (the usage index). Returns unresolved vault
+// references and empty env vars.
+//
+// Every field expansion flows through the single expandField helper, which both
+// expands and indexes. This is deliberate: a reference can never be expanded
+// without also being indexed, so the usage index cannot drift from what
+// expansion recognizes (see references_test.go's parity test). When adding a
+// newly expandable field, route it through expandField and it is indexed for
+// free.
 func expandStackVars(s *Stack, resolve Resolver) (unresolvedVault []string, emptyEnvVars []string) {
-	expand := func(val string) string {
-		result, unresolved, empty := ExpandString(val, resolve)
+	index := ReferenceIndex{}
+
+	// expandField expands one field's value and records every ${var:KEY}
+	// reference it contains against the consumer site c.
+	expandField := func(c Consumer, val string) string {
+		result, refs, unresolved, empty := ExpandStringRefs(val, resolve)
+		for _, key := range refs {
+			index.add(key, c)
+		}
 		unresolvedVault = append(unresolvedVault, unresolved...)
 		emptyEnvVars = append(emptyEnvVars, empty...)
 		return result
 	}
 
-	s.Name = expand(s.Name)
+	s.Name = expandField(Consumer{Kind: RefKindStack, Field: "name"}, s.Name)
 
 	if s.Gateway != nil {
 		for i := range s.Gateway.AllowedOrigins {
-			s.Gateway.AllowedOrigins[i] = expand(s.Gateway.AllowedOrigins[i])
+			s.Gateway.AllowedOrigins[i] = expandField(
+				Consumer{Kind: RefKindGateway, Field: fmt.Sprintf("allowed_origins[%d]", i)},
+				s.Gateway.AllowedOrigins[i])
 		}
 		if s.Gateway.Auth != nil {
-			s.Gateway.Auth.Token = expand(s.Gateway.Auth.Token)
+			s.Gateway.Auth.Token = expandField(
+				Consumer{Kind: RefKindGateway, Field: "auth.token"}, s.Gateway.Auth.Token)
 		}
 	}
 
-	s.Network.Name = expand(s.Network.Name)
+	s.Network.Name = expandField(Consumer{Kind: RefKindNetwork, Field: "name"}, s.Network.Name)
 
 	for i := range s.Networks {
-		s.Networks[i].Name = expand(s.Networks[i].Name)
+		s.Networks[i].Name = expandField(
+			Consumer{Kind: RefKindNetwork, Name: s.Networks[i].Name, Field: "name"}, s.Networks[i].Name)
 	}
 
 	for i := range s.MCPServers {
-		s.MCPServers[i].Name = expand(s.MCPServers[i].Name)
-		s.MCPServers[i].Image = expand(s.MCPServers[i].Image)
-		s.MCPServers[i].URL = expand(s.MCPServers[i].URL)
-		s.MCPServers[i].Network = expand(s.MCPServers[i].Network)
-
-		for j := range s.MCPServers[i].Command {
-			s.MCPServers[i].Command[j] = expand(s.MCPServers[i].Command[j])
+		srv := &s.MCPServers[i]
+		// site builds a consumer for srv. srv.Name is read at call time, so
+		// every site after the name field below reflects the expanded name.
+		site := func(field string) Consumer {
+			return Consumer{Kind: RefKindMCPServer, Name: srv.Name, Field: field}
 		}
 
-		if s.MCPServers[i].Source != nil {
-			s.MCPServers[i].Source.URL = expand(s.MCPServers[i].Source.URL)
-			s.MCPServers[i].Source.Path = expand(s.MCPServers[i].Source.Path)
-			s.MCPServers[i].Source.Ref = expand(s.MCPServers[i].Source.Ref)
+		srv.Name = expandField(site("name"), srv.Name)
+		srv.Image = expandField(site("image"), srv.Image)
+		srv.URL = expandField(site("url"), srv.URL)
+		srv.Network = expandField(site("network"), srv.Network)
+
+		for j := range srv.Command {
+			srv.Command[j] = expandField(site(fmt.Sprintf("command[%d]", j)), srv.Command[j])
+		}
+
+		if srv.Source != nil {
+			srv.Source.URL = expandField(site("source.url"), srv.Source.URL)
+			srv.Source.Path = expandField(site("source.path"), srv.Source.Path)
+			srv.Source.Ref = expandField(site("source.ref"), srv.Source.Ref)
 			// Source.Auth.CredentialRef intentionally NOT expanded here:
 			// vault references stay literal until clone time so the
 			// orchestrator can resolve them against the live vault.
-			if s.MCPServers[i].Source.Auth != nil {
-				s.MCPServers[i].Source.Auth.SSHKeyPath = expand(s.MCPServers[i].Source.Auth.SSHKeyPath)
-				s.MCPServers[i].Source.Auth.SSHUser = expand(s.MCPServers[i].Source.Auth.SSHUser)
+			if srv.Source.Auth != nil {
+				srv.Source.Auth.SSHKeyPath = expandField(site("source.auth.ssh_key_path"), srv.Source.Auth.SSHKeyPath)
+				srv.Source.Auth.SSHUser = expandField(site("source.auth.ssh_user"), srv.Source.Auth.SSHUser)
 			}
 		}
 
-		for k, v := range s.MCPServers[i].Env {
-			s.MCPServers[i].Env[k] = expand(v)
+		for k, v := range srv.Env {
+			srv.Env[k] = expandField(site("env."+k), v)
 		}
-		for k, v := range s.MCPServers[i].BuildArgs {
-			s.MCPServers[i].BuildArgs[k] = expand(v)
-		}
-
-		if s.MCPServers[i].SSH != nil {
-			s.MCPServers[i].SSH.Host = expand(s.MCPServers[i].SSH.Host)
-			s.MCPServers[i].SSH.User = expand(s.MCPServers[i].SSH.User)
-			s.MCPServers[i].SSH.IdentityFile = expand(s.MCPServers[i].SSH.IdentityFile)
-			s.MCPServers[i].SSH.KnownHostsFile = expand(s.MCPServers[i].SSH.KnownHostsFile)
-			s.MCPServers[i].SSH.JumpHost = expand(s.MCPServers[i].SSH.JumpHost)
+		for k, v := range srv.BuildArgs {
+			srv.BuildArgs[k] = expandField(site("build_args."+k), v)
 		}
 
-		if s.MCPServers[i].OpenAPI != nil {
-			s.MCPServers[i].OpenAPI.Spec = expand(s.MCPServers[i].OpenAPI.Spec)
-			s.MCPServers[i].OpenAPI.BaseURL = expand(s.MCPServers[i].OpenAPI.BaseURL)
+		if srv.SSH != nil {
+			srv.SSH.Host = expandField(site("ssh.host"), srv.SSH.Host)
+			srv.SSH.User = expandField(site("ssh.user"), srv.SSH.User)
+			srv.SSH.IdentityFile = expandField(site("ssh.identityFile"), srv.SSH.IdentityFile)
+			srv.SSH.KnownHostsFile = expandField(site("ssh.knownHostsFile"), srv.SSH.KnownHostsFile)
+			srv.SSH.JumpHost = expandField(site("ssh.jumpHost"), srv.SSH.JumpHost)
+		}
+
+		if srv.OpenAPI != nil {
+			srv.OpenAPI.Spec = expandField(site("openapi.spec"), srv.OpenAPI.Spec)
+			srv.OpenAPI.BaseURL = expandField(site("openapi.baseUrl"), srv.OpenAPI.BaseURL)
 		}
 	}
 
 	for i := range s.Resources {
-		s.Resources[i].Name = expand(s.Resources[i].Name)
-		s.Resources[i].Image = expand(s.Resources[i].Image)
-		s.Resources[i].Network = expand(s.Resources[i].Network)
+		res := &s.Resources[i]
+		site := func(field string) Consumer {
+			return Consumer{Kind: RefKindResource, Name: res.Name, Field: field}
+		}
 
-		for k, v := range s.Resources[i].Env {
-			s.Resources[i].Env[k] = expand(v)
+		res.Name = expandField(site("name"), res.Name)
+		res.Image = expandField(site("image"), res.Image)
+		res.Network = expandField(site("network"), res.Network)
+
+		for k, v := range res.Env {
+			res.Env[k] = expandField(site("env."+k), v)
 		}
 	}
 
+	s.References = index
 	return unresolvedVault, emptyEnvVars
 }
 

--- a/pkg/config/references.go
+++ b/pkg/config/references.go
@@ -1,0 +1,57 @@
+package config
+
+// ReferenceKind identifies what kind of stack element references a variable.
+type ReferenceKind string
+
+const (
+	RefKindMCPServer ReferenceKind = "mcp-server"
+	RefKindResource  ReferenceKind = "resource"
+	RefKindGateway   ReferenceKind = "gateway"
+	RefKindNetwork   ReferenceKind = "network"
+	RefKindStack     ReferenceKind = "stack"
+)
+
+// Consumer is a single site that references a variable: the kind of stack
+// element, its name (server/resource/network name; empty for stack- and
+// gateway-level sites), and the field where the reference appears.
+//
+// Field mirrors the YAML key path the user actually wrote
+// (e.g. "env.GITHUB_TOKEN", "image", "command[2]", "ssh.identityFile",
+// "openapi.baseUrl") so it can be used verbatim to locate the reference in the
+// stack file. Casing therefore tracks the schema's own YAML tags, which mix
+// camelCase (identityFile, baseUrl) and snake_case (build_args, ssh_key_path).
+type Consumer struct {
+	Kind  ReferenceKind `json:"kind"`
+	Name  string        `json:"name,omitempty"`
+	Field string        `json:"field"`
+}
+
+// ReferenceIndex maps a variable-store key to the consumers that reference it.
+//
+// It is built by expandStackVars from the same grammar used for expansion
+// (ExpandStringRefs), so it can never drift from what gridctl actually
+// recognizes as a ${var:KEY}/${vault:KEY} reference. It carries only keys and
+// reference-site metadata — never variable values — so it is safe to expose
+// even while the vault is locked.
+//
+// Scope:
+//   - One-hop only: a variable referenced inside another variable's *value* is
+//     not followed. This is intentional — values live in the vault, outside the
+//     static stack, so resolving transitive references would require reading
+//     secrets at index time. v1 indexes only references written in the stack.
+//   - Known gap: secrets injected via secrets.sets (see injectSetSecrets) are
+//     added to server env *after* expansion without ${var:KEY} syntax, so they
+//     are not recorded here. v1 indexes explicit references only.
+type ReferenceIndex map[string][]Consumer
+
+// add records that the consumer c references key, de-duplicating exact
+// (kind, name, field) repeats so a value like "${var:X}-${var:X}" is counted
+// once per field.
+func (idx ReferenceIndex) add(key string, c Consumer) {
+	for _, existing := range idx[key] {
+		if existing == c {
+			return
+		}
+	}
+	idx[key] = append(idx[key], c)
+}

--- a/pkg/config/references_test.go
+++ b/pkg/config/references_test.go
@@ -1,0 +1,227 @@
+package config
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestExpandStringRefs_StoreRefsCaptured(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"canonical var ref", "${var:TOKEN}", []string{"TOKEN"}},
+		{"deprecated vault ref", "${vault:OLD}", []string{"OLD"}},
+		{"bare braced env is not a store ref", "${PLAIN}", nil},
+		{"bare dollar env is not a store ref", "$PLAIN", nil},
+		{"multiple refs in order", "${var:A}-${var:B}", []string{"A", "B"}},
+		{"ref recorded even with default operator", "${var:KEY:-fallback}", []string{"KEY"}},
+		{"store ref mixed with env ref", "${HOST}:${var:PORT}", []string{"PORT"}},
+		{"no refs", "literal-value", nil},
+	}
+
+	// Empty resolver: nothing resolves, proving refs are captured independent
+	// of resolution.
+	resolve := func(string) (string, bool) { return "", false }
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, refs, _, _ := ExpandStringRefs(tt.input, resolve)
+			if !equalStrings(refs, tt.want) {
+				t.Errorf("storeRefs = %v, want %v", refs, tt.want)
+			}
+		})
+	}
+}
+
+// TestExpandStackVars_ReferenceIndexParity is the lockstep guard: it places the
+// same ${var:PROBE} reference in every expandable field and asserts the index
+// records a consumer for each. If a field is expanded but not indexed (the
+// cardinal under-counting sin), or labeled differently than expected, this
+// fails. Add a newly expandable field to expandStackVars and you must add it
+// here too.
+func TestExpandStackVars_ReferenceIndexParity(t *testing.T) {
+	const probe = "${var:PROBE}"
+	stack := &Stack{
+		Name: probe,
+		Gateway: &GatewayConfig{
+			AllowedOrigins: []string{probe},
+			Auth:           &AuthConfig{Token: probe},
+		},
+		Network:  Network{Name: probe},
+		Networks: []Network{{Name: probe}},
+		MCPServers: []MCPServer{{
+			Name:    probe,
+			Image:   probe,
+			URL:     probe,
+			Network: probe,
+			Command: []string{probe},
+			Source: &Source{
+				URL:  probe,
+				Path: probe,
+				Ref:  probe,
+				Auth: &SourceAuth{
+					CredentialRef: "${var:PROBE_CRED}", // intentionally NOT expanded/indexed
+					SSHKeyPath:    probe,
+					SSHUser:       probe,
+				},
+			},
+			Env:       map[string]string{"E1": probe},
+			BuildArgs: map[string]string{"B1": probe},
+			SSH: &SSHConfig{
+				Host:           probe,
+				User:           probe,
+				IdentityFile:   probe,
+				KnownHostsFile: probe,
+				JumpHost:       probe,
+			},
+			OpenAPI: &OpenAPIConfig{Spec: probe, BaseURL: probe},
+		}},
+		Resources: []Resource{{
+			Name:    probe,
+			Image:   probe,
+			Network: probe,
+			Env:     map[string]string{"RE1": probe},
+		}},
+	}
+
+	// Resolve PROBE so expanded names stay clean; refs are still captured.
+	expandStackVars(stack, VaultResolver(&mockVault{secrets: map[string]string{"PROBE": "x"}}))
+
+	want := []string{
+		"stack|name",
+		"gateway|allowed_origins[0]",
+		"gateway|auth.token",
+		"network|name",
+		"mcp-server|name",
+		"mcp-server|image",
+		"mcp-server|url",
+		"mcp-server|network",
+		"mcp-server|command[0]",
+		"mcp-server|source.url",
+		"mcp-server|source.path",
+		"mcp-server|source.ref",
+		"mcp-server|source.auth.ssh_key_path",
+		"mcp-server|source.auth.ssh_user",
+		"mcp-server|env.E1",
+		"mcp-server|build_args.B1",
+		"mcp-server|ssh.host",
+		"mcp-server|ssh.user",
+		"mcp-server|ssh.identityFile",
+		"mcp-server|ssh.knownHostsFile",
+		"mcp-server|ssh.jumpHost",
+		"mcp-server|openapi.spec",
+		"mcp-server|openapi.baseUrl",
+		"resource|name",
+		"resource|image",
+		"resource|network",
+		"resource|env.RE1",
+	}
+
+	got := map[string]bool{}
+	for _, c := range stack.References["PROBE"] {
+		got[string(c.Kind)+"|"+c.Field] = true
+	}
+
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("missing indexed reference site: %s (under-counting)", w)
+		}
+		delete(got, w)
+	}
+	for extra := range got {
+		t.Errorf("unexpected indexed reference site: %s", extra)
+	}
+
+	// CredentialRef is deliberately left literal for clone-time resolution and
+	// must not be indexed.
+	if _, ok := stack.References["PROBE_CRED"]; ok {
+		t.Error("source.auth.credential_ref must not be indexed")
+	}
+}
+
+func TestExpandStackVars_OneHop(t *testing.T) {
+	// X's value itself references Y. One-hop means we index X (it appears in the
+	// stack) but never follow into X's value to index Y.
+	stack := &Stack{
+		MCPServers: []MCPServer{{
+			Name: "api",
+			Env:  map[string]string{"TOKEN": "${var:X}"},
+		}},
+	}
+	expandStackVars(stack, VaultResolver(&mockVault{secrets: map[string]string{
+		"X": "${var:Y}",
+		"Y": "deep",
+	}}))
+
+	if _, ok := stack.References["X"]; !ok {
+		t.Error("expected X to be indexed (direct stack reference)")
+	}
+	if _, ok := stack.References["Y"]; ok {
+		t.Error("Y must NOT be indexed: it lives inside X's value, not the stack (one-hop)")
+	}
+}
+
+func TestExpandStackVars_DedupesPerField(t *testing.T) {
+	stack := &Stack{
+		MCPServers: []MCPServer{{
+			Name: "api",
+			Env:  map[string]string{"E": "${var:DUP}-${var:DUP}"},
+		}},
+	}
+	expandStackVars(stack, EnvResolver())
+
+	if got := len(stack.References["DUP"]); got != 1 {
+		t.Errorf("DUP consumers = %d, want 1 (same field counted once)", got)
+	}
+}
+
+func TestExpandStackVars_BareEnvNotIndexed(t *testing.T) {
+	stack := &Stack{
+		MCPServers: []MCPServer{{
+			Name: "api",
+			Env: map[string]string{
+				"A": "${PLAIN}",
+				"B": "$BARE",
+			},
+		}},
+	}
+	expandStackVars(stack, EnvResolver())
+
+	if len(stack.References) != 0 {
+		t.Errorf("env-style references must not be indexed, got %v", stack.References)
+	}
+}
+
+func TestExpandStackVars_TwoServersDistinctConsumers(t *testing.T) {
+	stack := &Stack{
+		MCPServers: []MCPServer{
+			{Name: "github", Env: map[string]string{"TOKEN": "${var:SHARED}"}},
+			{Name: "gitlab", Env: map[string]string{"TOKEN": "${var:SHARED}"}},
+		},
+	}
+	expandStackVars(stack, EnvResolver())
+
+	consumers := stack.References["SHARED"]
+	if len(consumers) != 2 {
+		t.Fatalf("SHARED consumers = %d, want 2", len(consumers))
+	}
+	names := []string{consumers[0].Name, consumers[1].Name}
+	sort.Strings(names)
+	if names[0] != "github" || names[1] != "gitlab" {
+		t.Errorf("consumer names = %v, want [github gitlab]", names)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -18,6 +18,12 @@ type Stack struct {
 	Networks   []Network        `yaml:"networks,omitempty"`  // Multiple networks (advanced mode)
 	MCPServers []MCPServer      `yaml:"mcp-servers"`
 	Resources  []Resource       `yaml:"resources,omitempty"`
+
+	// References is the variable-usage index, derived during expandStackVars:
+	// which consumers reference each ${var:KEY}/${vault:KEY} key. It is computed
+	// from the stack, not persisted with it — the yaml/json "-" tags keep it out
+	// of every existing serialization path. Nil until a stack is loaded/expanded.
+	References ReferenceIndex `yaml:"-" json:"-"`
 }
 
 // LoggingConfig configures log file output with automatic rotation.


### PR DESCRIPTION
## Description

Backend phase (1 of 2) of variable usage tracing. Builds a reference index during stack expansion that maps each `${var:KEY}`/`${vault:KEY}` to the consumers referencing it, and exposes it via a new read-only `GET /api/var/usage`. This lays the groundwork for the UI to show the "blast radius" of changing a variable. Frontend (badge + drill-down) is phase 2.

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

- `ExpandStringRefs` reports the variable-store keys a value references; `ExpandString` now delegates to it (no behavior change for existing callers).
- `expandStackVars` builds `Stack.References` as it expands, routing every field through a single helper so the index can never drift from what expansion recognizes (verified by a parity test).
- New `GET /api/var/usage` returns `key → [{kind, name, field}]` for the active stack.

## Notes / scope

- Derived from the loaded stack file, **not** the vault: exposes no secret values and is safe while the vault is locked.
- One-hop only (a variable referenced inside another variable's value is not followed).
- Known gap: secrets injected via `secrets.sets` are added to env after expansion without `${var:KEY}` syntax, so they are not indexed in v1.
- `vault.Variable` and the `variableEntry` wire type are unchanged.

## Testing

- `go test -race ./...` passes.
- `golangci-lint run` clean.
- New tests: reference-index parity (every expandable field is indexed), one-hop, dedup, bare-`$VAR` exclusion, two-server attribution; endpoint tests for no-stack-loaded (empty `{}`), returns-consumers, and safe-when-vault-locked (no secret leakage).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #695