### PR TITLE
feat: surface variable usage in the Variables workspace

### DIFF
--- a/web/src/__tests__/SecretItem.test.tsx
+++ b/web/src/__tests__/SecretItem.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SecretItem, type SecretItemProps } from '../components/vault/SecretItem';
+import type { Consumer, Variable } from '../lib/api';
+
+const baseVariable: Variable = {
+  key: 'GITHUB_TOKEN',
+  type: 'string',
+  is_secret: true,
+};
+
+function renderItem(overrides: Partial<SecretItemProps> = {}) {
+  const props: SecretItemProps = {
+    secret: baseVariable,
+    isEditing: false,
+    editValue: '',
+    showEditValue: false,
+    onReveal: vi.fn(),
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onEditValueChange: vi.fn(),
+    onEditToggleShow: vi.fn(),
+    onEditSave: vi.fn(),
+    onEditCancel: vi.fn(),
+    sets: [],
+    onAssignSet: vi.fn(),
+    ...overrides,
+  };
+  return render(<SecretItem {...props} />);
+}
+
+describe('SecretItem — usage badge', () => {
+  it('renders no badge when there are no consumers', () => {
+    renderItem({ consumers: [] });
+    expect(screen.queryByRole('button', { name: /used by/i })).toBeNull();
+  });
+
+  it('renders a "Used by N" badge with the consumer count', () => {
+    const consumers: Consumer[] = [
+      { kind: 'mcp-server', name: 'github', field: 'env.GITHUB_TOKEN' },
+      { kind: 'resource', name: 'postgres', field: 'env.GITHUB_TOKEN' },
+    ];
+    renderItem({ consumers });
+    expect(
+      screen.getByRole('button', { name: /used by 2 consumers/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('reveals the consumer list when the badge is clicked, without expanding the row', () => {
+    const consumers: Consumer[] = [
+      { kind: 'mcp-server', name: 'github', field: 'env.GITHUB_TOKEN' },
+    ];
+    renderItem({ consumers });
+
+    // Consumer detail and the row's expanded "Value" section are both hidden initially.
+    expect(screen.queryByText(/github · env\.GITHUB_TOKEN/)).toBeNull();
+    expect(screen.queryByText('Value')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /used by 1 consumer/i }));
+
+    // The drill-down appears...
+    expect(
+      screen.getByText(/github · env\.GITHUB_TOKEN/),
+    ).toBeInTheDocument();
+    // ...but the row's expand-only "Value" section did NOT open.
+    expect(screen.queryByText('Value')).toBeNull();
+  });
+
+  it('navigates when a server/resource consumer is clicked', () => {
+    const onConsumerClick = vi.fn();
+    const consumers: Consumer[] = [
+      { kind: 'mcp-server', name: 'github', field: 'env.GITHUB_TOKEN' },
+    ];
+    renderItem({ consumers, onConsumerClick });
+
+    fireEvent.click(screen.getByRole('button', { name: /used by 1 consumer/i }));
+    fireEvent.click(screen.getByRole('button', { name: /go to github/i }));
+
+    expect(onConsumerClick).toHaveBeenCalledWith(consumers[0]);
+  });
+
+  it('renders non-navigable consumers (gateway/network) as plain text, not links', () => {
+    const onConsumerClick = vi.fn();
+    const consumers: Consumer[] = [
+      { kind: 'gateway', field: 'auth.token' },
+    ];
+    renderItem({ consumers, onConsumerClick });
+
+    fireEvent.click(screen.getByRole('button', { name: /used by 1 consumer/i }));
+
+    expect(screen.getByText(/gateway · auth\.token/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /go to/i })).toBeNull();
+  });
+
+  it('collapses the consumer list on a second badge click', () => {
+    const consumers: Consumer[] = [
+      { kind: 'mcp-server', name: 'github', field: 'env.GITHUB_TOKEN' },
+    ];
+    renderItem({ consumers });
+    const badge = screen.getByRole('button', { name: /used by 1 consumer/i });
+
+    fireEvent.click(badge);
+    expect(screen.getByText(/github · env\.GITHUB_TOKEN/)).toBeInTheDocument();
+    fireEvent.click(badge);
+    expect(screen.queryByText(/github · env\.GITHUB_TOKEN/)).toBeNull();
+  });
+});

--- a/web/src/__tests__/VaultWorkspace.test.tsx
+++ b/web/src/__tests__/VaultWorkspace.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../lib/api', async () => {
     ...actual,
     fetchVariables: vi.fn().mockResolvedValue([]),
     fetchVariableSets: vi.fn().mockResolvedValue([]),
+    fetchVariableUsage: vi.fn().mockResolvedValue({}),
     createVariable: vi.fn().mockResolvedValue(undefined),
     getVariable: vi.fn().mockResolvedValue({ value: '' }),
     updateVariable: vi.fn().mockResolvedValue(undefined),
@@ -96,15 +97,32 @@ describe('VaultWorkspace — server filter', () => {
     { key: 'REDIS_URL', type: 'string' as const, is_secret: false },
   ];
 
+  // Exact usage index: which server/resource references each variable. The
+  // filter now matches this (not a key substring), so POSTGRES_PASSWORD counts
+  // for `postgres` even though its key shares no substring with another server.
+  const testUsage = {
+    POSTGRES_URL: [
+      { kind: 'mcp-server' as const, name: 'postgres', field: 'env.POSTGRES_URL' },
+    ],
+    POSTGRES_PASSWORD: [
+      { kind: 'resource' as const, name: 'postgres', field: 'env.POSTGRES_PASSWORD' },
+    ],
+    REDIS_URL: [
+      { kind: 'mcp-server' as const, name: 'redis', field: 'env.REDIS_URL' },
+    ],
+  };
+
   beforeEach(() => {
     vi.mocked(api.fetchVariableStoreStatus).mockResolvedValue({
       locked: false,
       encrypted: false,
     });
     vi.mocked(api.fetchVariables).mockResolvedValue(testVariables);
+    vi.mocked(api.fetchVariableUsage).mockResolvedValue(testUsage);
     useVaultStore.setState({
       variables: testVariables,
       sets: [],
+      usage: testUsage,
       loading: false,
       error: null,
       locked: false,
@@ -112,7 +130,7 @@ describe('VaultWorkspace — server filter', () => {
     });
   });
 
-  it('applies ?filter=server:<name> on mount and shows the inline banner', async () => {
+  it('filters to the exact consumers of the deep-linked server', async () => {
     render(
       <MemoryRouter initialEntries={['/vault?filter=server:postgres']}>
         <VaultWorkspace />
@@ -121,8 +139,22 @@ describe('VaultWorkspace — server filter', () => {
     expect(await screen.findByText('POSTGRES_URL')).toBeInTheDocument();
     expect(screen.getByText('POSTGRES_PASSWORD')).toBeInTheDocument();
     expect(screen.queryByText('REDIS_URL')).not.toBeInTheDocument();
-    expect(screen.getByText(/filtering for server/i)).toBeInTheDocument();
+    // Exact-match banner — no "approximate" disclaimer.
+    expect(screen.getByText(/variables used by/i)).toBeInTheDocument();
     expect(screen.getByText('postgres')).toBeInTheDocument();
+    expect(screen.queryByText(/approximate/i)).not.toBeInTheDocument();
+  });
+
+  it('excludes a variable whose key contains the server name but is not referenced by it', async () => {
+    // REDIS_URL's key has no "postgres" substring, and POSTGRES_* are only kept
+    // because the usage index — not the key text — links them to postgres.
+    render(
+      <MemoryRouter initialEntries={['/vault?filter=server:redis']}>
+        <VaultWorkspace />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText('REDIS_URL')).toBeInTheDocument();
+    expect(screen.queryByText('POSTGRES_URL')).not.toBeInTheDocument();
   });
 
   it('clears the banner and removes the filter when Clear is clicked', async () => {
@@ -136,7 +168,22 @@ describe('VaultWorkspace — server filter', () => {
     });
     fireEvent.click(clearBtn);
     expect(await screen.findByText('REDIS_URL')).toBeInTheDocument();
-    expect(screen.queryByText(/filtering for server/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/variables used by/i)).not.toBeInTheDocument();
+  });
+
+  it('warns about consumers in the delete confirmation', async () => {
+    render(
+      <MemoryRouter initialEntries={['/vault']}>
+        <VaultWorkspace />
+      </MemoryRouter>,
+    );
+    // Expand the POSTGRES_URL row, then trigger its Delete action.
+    const row = await screen.findByRole('button', { name: /POSTGRES_URL/i });
+    fireEvent.click(row);
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    expect(await screen.findByText(/used by 1 consumer/i)).toBeInTheDocument();
+    expect(screen.getByText(/may break it/i)).toBeInTheDocument();
   });
 });
 

--- a/web/src/components/vault/SecretItem.tsx
+++ b/web/src/components/vault/SecretItem.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import {
+  ArrowUpRight,
   ChevronDown,
   ChevronRight,
   Eye,
   EyeOff,
+  Link2,
   Pencil,
   Trash2,
 } from 'lucide-react';
@@ -11,7 +13,16 @@ import { cn } from '../../lib/cn';
 import { Button } from '../ui/Button';
 import { VariableTypeBadge } from './VariableTypeBadge';
 import { VariableVisibilityIcon } from './VariableVisibilityIcon';
-import type { Variable } from '../../lib/api';
+import type { Consumer, Variable } from '../../lib/api';
+
+// How many consumers to show before collapsing behind a "see all" toggle.
+const CONSUMER_PREVIEW_LIMIT = 3;
+
+// A consumer is navigable to a topology node only when it is a server or a
+// resource (those are the kinds the graph renders as nodes).
+function isNavigable(c: Consumer): boolean {
+  return c.kind === 'mcp-server' || c.kind === 'resource';
+}
 
 export interface SecretItemProps {
   secret: Variable;
@@ -28,6 +39,13 @@ export interface SecretItemProps {
   onEditCancel: () => void;
   sets: string[];
   onAssignSet: (set: string) => void;
+  // consumers are the stack sites referencing this variable (the "used by"
+  // index). Empty (the default) renders no badge — absence is the signal.
+  consumers?: Consumer[];
+  // onConsumerClick is invoked when a navigable consumer row is clicked;
+  // VaultWorkspace wires this to topology node selection. Omit to render
+  // consumer rows as non-interactive.
+  onConsumerClick?: (consumer: Consumer) => void;
   compact?: boolean;
   // When true, the key + value text uses the `.log-text` class so its size
   // is driven by the parent's `--log-font-size` CSS variable (used by the
@@ -52,10 +70,14 @@ export function SecretItem({
   onEditCancel,
   sets,
   onAssignSet,
+  consumers = [],
+  onConsumerClick,
   compact,
   enableZoom,
 }: SecretItemProps) {
   const [expanded, setExpanded] = useState(false);
+  const [showConsumers, setShowConsumers] = useState(false);
+  const [showAllConsumers, setShowAllConsumers] = useState(false);
 
   const keyTextClass = cn(
     'text-xs font-mono font-medium text-text-primary flex-1 text-left truncate',
@@ -135,22 +157,63 @@ export function SecretItem({
 
   return (
     <div className="rounded-lg bg-surface-elevated/50 border border-border-subtle overflow-hidden">
-      {/* Header row */}
-      <button
-        onClick={() => setExpanded(!expanded)}
+      {/* Header row. The expand toggle and the usage badge are sibling buttons
+          (never nested) so each stays independently clickable. */}
+      <div
         className={cn(
-          'w-full flex items-center gap-2 hover:bg-surface-highlight/50 transition-colors',
+          'flex items-center gap-2 hover:bg-surface-highlight/50 transition-colors',
           compact ? 'px-2 py-1.5' : 'p-3',
         )}
       >
-        <div className="p-0.5 text-text-muted">
-          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-        </div>
-        <VariableVisibilityIcon isSecret={secret.is_secret} />
-        <span className={keyTextClass}>{secret.key}</span>
-        <VariableTypeBadge type={secret.type} />
-        <span className={valuePreviewClass}>{displayValue}</span>
-      </button>
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="flex flex-1 min-w-0 items-center gap-2 text-left"
+          aria-expanded={expanded}
+        >
+          <div className="p-0.5 text-text-muted">
+            {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          </div>
+          <VariableVisibilityIcon isSecret={secret.is_secret} />
+          <span className={keyTextClass}>{secret.key}</span>
+          <VariableTypeBadge type={secret.type} />
+          <span className={valuePreviewClass}>{displayValue}</span>
+        </button>
+        {consumers.length > 0 && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowConsumers((v) => !v);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') setShowConsumers(false);
+            }}
+            aria-expanded={showConsumers}
+            aria-label={`Used by ${consumers.length} ${consumers.length === 1 ? 'consumer' : 'consumers'}`}
+            title={`Used by ${consumers.length} ${consumers.length === 1 ? 'consumer' : 'consumers'}`}
+            className={cn(
+              'flex-shrink-0 inline-flex items-center gap-1 rounded-md px-1.5 py-px text-[10px] font-mono transition-colors',
+              showConsumers
+                ? 'bg-primary/10 text-primary'
+                : 'bg-surface-elevated text-text-muted hover:bg-surface-highlight hover:text-text-primary',
+            )}
+          >
+            <Link2 size={9} />
+            {consumers.length}
+          </button>
+        )}
+      </div>
+
+      {/* Consumer drill-down — toggled by the usage badge, independent of the
+          row's expand state. */}
+      {showConsumers && consumers.length > 0 && (
+        <ConsumerList
+          consumers={consumers}
+          showAll={showAllConsumers}
+          onToggleShowAll={() => setShowAllConsumers((v) => !v)}
+          onConsumerClick={onConsumerClick}
+        />
+      )}
 
       {/* Expanded content */}
       {expanded && (
@@ -225,6 +288,80 @@ export function SecretItem({
             </button>
           </div>
         </div>
+      )}
+    </div>
+  );
+}
+
+interface ConsumerListProps {
+  consumers: Consumer[];
+  showAll: boolean;
+  onToggleShowAll: () => void;
+  onConsumerClick?: (consumer: Consumer) => void;
+}
+
+// ConsumerList renders the variable's reference sites. Server/resource sites
+// are clickable (they navigate to a topology node); other kinds render as
+// plain rows. Long lists collapse behind a "see all" toggle.
+function ConsumerList({
+  consumers,
+  showAll,
+  onToggleShowAll,
+  onConsumerClick,
+}: ConsumerListProps) {
+  const visible = showAll
+    ? consumers
+    : consumers.slice(0, CONSUMER_PREVIEW_LIMIT);
+  const hiddenCount = consumers.length - visible.length;
+
+  return (
+    <div
+      role="group"
+      aria-label="Variables consuming this value"
+      className="px-3 pb-2 pt-1 border-t border-border-subtle/60 space-y-0.5"
+    >
+      {visible.map((c, i) => {
+        const label = `${c.name || c.kind} · ${c.field}`;
+        if (isNavigable(c) && onConsumerClick) {
+          return (
+            <button
+              key={`${c.kind}-${c.name}-${c.field}-${i}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onConsumerClick(c);
+              }}
+              aria-label={`Go to ${c.name} (${c.field})`}
+              className="w-full flex items-center gap-1.5 px-2 py-1 rounded text-[10px] font-mono text-text-secondary hover:text-primary hover:bg-surface-highlight/50 transition-colors text-left"
+            >
+              <ArrowUpRight
+                size={10}
+                className="flex-shrink-0 text-text-muted"
+              />
+              <span className="truncate">{label}</span>
+            </button>
+          );
+        }
+        return (
+          <div
+            key={`${c.kind}-${c.name}-${c.field}-${i}`}
+            className="flex items-center gap-1.5 px-2 py-1 text-[10px] font-mono text-text-muted"
+          >
+            <span className="w-2.5 flex-shrink-0 text-center">·</span>
+            <span className="truncate">{label}</span>
+          </div>
+        );
+      })}
+      {(hiddenCount > 0 || showAll) && consumers.length > CONSUMER_PREVIEW_LIMIT && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleShowAll();
+          }}
+          className="px-2 py-0.5 text-[10px] text-primary hover:text-primary/80 transition-colors"
+        >
+          {showAll ? 'Show less' : `See all ${consumers.length}`}
+        </button>
       )}
     </div>
   );

--- a/web/src/components/workspaces/VaultWorkspace.tsx
+++ b/web/src/components/workspaces/VaultWorkspace.tsx
@@ -30,10 +30,11 @@ import { VaultEncryptForm } from '../vault/VaultEncryptForm';
 import { VaultLockPrompt } from '../vault/VaultLockPrompt';
 import { EnvImportModal } from '../vault/EnvImportModal';
 import { useUIStore } from '../../stores/useUIStore';
+import { useStackStore } from '../../stores/useStackStore';
 import { useVaultManager } from '../../hooks/useVaultManager';
 import { useRevealedValues } from '../../hooks/useRevealedValues';
 import { validateVariableInput } from '../vault/variableTypeHelpers';
-import type { Variable, VariableType } from '../../lib/api';
+import type { Consumer, Variable, VariableType } from '../../lib/api';
 
 const ALL_SETS_KEY = '__all__';
 
@@ -45,11 +46,13 @@ export function VaultWorkspace() {
   const [searchParams, setSearchParams] = useSearchParams();
   const compact = useUIStore((s) => s.compactMode.vault);
 
+  const selectNode = useStackStore((s) => s.selectNode);
   const revealedState = useRevealedValues();
   const vault = useVaultManager({ onPlaintextLoaded: revealedState.bulkSet });
   const {
     variables: vaultVariables,
     sets: vaultSets,
+    usage,
     loading,
     error,
     locked,
@@ -149,15 +152,19 @@ export function VaultWorkspace() {
   const setNames = useMemo(() => allSets.map((s) => s.name), [allSets]);
   const isEmpty = allVariables.length === 0 && allSets.length === 0;
 
-  // Approximate consumption filter: matches variable keys that contain the
-  // server name (case-insensitive). The backend doesn't yet track which
-  // server consumes which variable, so this is the best the client can do.
-  // Surfaced inline via ServerFilterBanner so users understand the limitation.
+  // Exact consumption filter: keep variables actually referenced by the named
+  // server/resource, using the backend usage index (GET /api/var/usage). This
+  // replaces the former approximate key-substring heuristic.
   const filteredByServer = useMemo(() => {
     if (!serverFilter) return allVariables;
-    const lower = serverFilter.toLowerCase();
-    return allVariables.filter((v) => v.key.toLowerCase().includes(lower));
-  }, [allVariables, serverFilter]);
+    return allVariables.filter((v) =>
+      (usage[v.key] ?? []).some(
+        (c) =>
+          (c.kind === 'mcp-server' || c.kind === 'resource') &&
+          c.name === serverFilter,
+      ),
+    );
+  }, [allVariables, serverFilter, usage]);
 
   const filteredBySet = useMemo(() => {
     if (activeSet === ALL_SETS_KEY) return filteredByServer;
@@ -322,6 +329,24 @@ export function VaultWorkspace() {
     [importVars],
   );
 
+  // Selecting a consumer highlights its topology node (ids are mcp-<name> /
+  // resource-<name>). We stay on the Variables route — a toast points the user
+  // to Topology rather than yanking them out of their current view.
+  const handleConsumerClick = useCallback(
+    (consumer: Consumer) => {
+      const nodeId =
+        consumer.kind === 'mcp-server'
+          ? `mcp-${consumer.name}`
+          : consumer.kind === 'resource'
+            ? `resource-${consumer.name}`
+            : null;
+      if (!nodeId) return;
+      selectNode(nodeId);
+      showToast('success', `Selected ${consumer.name} — open Topology to inspect`);
+    },
+    [selectNode],
+  );
+
   // ---- Rendering ----------------------------------------------------------
   const leftRail = (
     <VaultLeftRail
@@ -482,6 +507,7 @@ export function VaultWorkspace() {
                   <VariableList
                     variables={filteredBySearch}
                     revealed={revealedState.revealed}
+                    usage={usage}
                     editingKey={editingKey}
                     editValue={editValue}
                     showEditValue={showEditValue}
@@ -494,6 +520,7 @@ export function VaultWorkspace() {
                     onEditSave={handleEditSave}
                     onEditCancel={handleEditCancel}
                     onAssignSet={handleAssignSet}
+                    onConsumerClick={handleConsumerClick}
                   />
                 )}
               </div>
@@ -512,6 +539,14 @@ export function VaultWorkspace() {
             <p>
               Delete <span className="font-mono text-primary">{confirmDelete}</span>?
             </p>
+            {confirmDelete && (usage[confirmDelete]?.length ?? 0) > 0 && (
+              <p className="mt-2 px-2.5 py-2 rounded-md bg-status-error/10 border border-status-error/20 text-[11px] text-status-error">
+                Used by {usage[confirmDelete].length}{' '}
+                {usage[confirmDelete].length === 1 ? 'consumer' : 'consumers'} in
+                the active stack. Deleting it may break{' '}
+                {usage[confirmDelete].length === 1 ? 'it' : 'them'}.
+              </p>
+            )}
             <p>This action cannot be undone.</p>
           </>
         }
@@ -835,6 +870,7 @@ function SetPill({
 interface VariableListProps {
   variables: Variable[];
   revealed: Record<string, string>;
+  usage: Record<string, Consumer[]>;
   editingKey: string | null;
   editValue: string;
   showEditValue: boolean;
@@ -847,11 +883,13 @@ interface VariableListProps {
   onEditSave: () => void;
   onEditCancel: () => void;
   onAssignSet: (key: string, set: string) => void;
+  onConsumerClick: (consumer: Consumer) => void;
 }
 
 function VariableList({
   variables,
   revealed,
+  usage,
   editingKey,
   editValue,
   showEditValue,
@@ -864,6 +902,7 @@ function VariableList({
   onEditSave,
   onEditCancel,
   onAssignSet,
+  onConsumerClick,
 }: VariableListProps) {
   return (
     <div className="px-6 py-4 space-y-2 max-w-3xl">
@@ -872,6 +911,8 @@ function VariableList({
           key={variable.key}
           secret={variable}
           revealed={revealed[variable.key]}
+          consumers={usage[variable.key]}
+          onConsumerClick={onConsumerClick}
           isEditing={editingKey === variable.key}
           editValue={editValue}
           showEditValue={showEditValue}
@@ -897,9 +938,8 @@ interface ServerFilterBannerProps {
 }
 
 // Inline banner shown when the workspace is deep-linked from a Topology
-// server node. Documents the approximate-match limitation: variable
-// consumption tracking isn't wired server-side yet, so the filter is a
-// substring match against variable keys.
+// server node. Backed by the exact usage index (GET /api/var/usage): the filter
+// shows the variables that server actually references.
 function ServerFilterBanner({
   serverName,
   matchCount,
@@ -909,11 +949,10 @@ function ServerFilterBanner({
     <div className="flex-shrink-0 px-6 py-2 border-b border-border-subtle bg-primary/[0.04] flex items-center gap-2">
       <Filter size={12} className="text-primary/70 flex-shrink-0" />
       <div className="flex-1 min-w-0 text-[11px] text-text-secondary">
-        Filtering for server{' '}
+        Variables used by{' '}
         <span className="font-mono text-primary">{serverName}</span>
         <span className="text-text-muted/70 ml-2">
-          · {matchCount} {matchCount === 1 ? 'match' : 'matches'} · approximate
-          (matches keys containing the server name)
+          · {matchCount} {matchCount === 1 ? 'variable' : 'variables'}
         </span>
       </div>
       <button

--- a/web/src/hooks/useVaultManager.ts
+++ b/web/src/hooks/useVaultManager.ts
@@ -3,6 +3,7 @@ import { useVaultStore } from '../stores/useVaultStore';
 import {
   fetchVariables,
   fetchVariableSets,
+  fetchVariableUsage,
   createVariable,
   getVariable,
   updateVariable,
@@ -16,6 +17,7 @@ import {
   importVariables,
 } from '../lib/api';
 import type {
+  Consumer,
   CreateVariableInput,
   ImportVariableInput,
   UpdateVariableInput,
@@ -34,6 +36,7 @@ export interface UseVaultManagerResult {
   // Store state — re-rendered when useVaultStore changes
   variables: Variable[] | null;
   sets: VariableSet[] | null;
+  usage: Record<string, Consumer[]>;
   loading: boolean;
   error: string | null;
   locked: boolean;
@@ -63,6 +66,7 @@ export function useVaultManager(
 ): UseVaultManagerResult {
   const variables = useVaultStore((s) => s.variables);
   const sets = useVaultStore((s) => s.sets);
+  const usage = useVaultStore((s) => s.usage);
   const loading = useVaultStore((s) => s.loading);
   const error = useVaultStore((s) => s.error);
   const locked = useVaultStore((s) => s.locked);
@@ -79,12 +83,16 @@ export function useVaultManager(
       useVaultStore.getState().setEncrypted(status.encrypted);
 
       if (!status.locked) {
-        const [variablesData, setsData] = await Promise.all([
+        // Usage is best-effort and parallel: a failure must not break the
+        // variable list, so it resolves to {} rather than rejecting.
+        const [variablesData, setsData, usageData] = await Promise.all([
           fetchVariables(),
           fetchVariableSets(),
+          fetchVariableUsage().catch(() => ({}) as Record<string, Consumer[]>),
         ]);
         useVaultStore.getState().setVariables(variablesData);
         useVaultStore.getState().setSets(setsData);
+        useVaultStore.getState().setUsage(usageData);
 
         // Plaintext variables display their value inline by default
         // (no Reveal click needed). Eager-fetch them so the rows render
@@ -199,6 +207,7 @@ export function useVaultManager(
   return {
     variables,
     sets,
+    usage,
     loading,
     error,
     locked,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -555,6 +555,32 @@ export async function fetchVariables(): Promise<Variable[]> {
   return fetchJSON<Variable[]>('/api/var');
 }
 
+// ConsumerKind mirrors the backend config.ReferenceKind: where in the active
+// stack a ${var:KEY} reference appears. Only 'mcp-server' and 'resource' map to
+// topology nodes; the rest are stack/gateway/network-level sites.
+export type ConsumerKind =
+  | 'mcp-server'
+  | 'resource'
+  | 'gateway'
+  | 'network'
+  | 'stack';
+
+// Consumer is a single site that references a variable. `field` is the YAML key
+// path the user wrote (e.g. "env.GITHUB_TOKEN", "image", "openapi.baseUrl").
+export interface Consumer {
+  kind: ConsumerKind;
+  name?: string;
+  field: string;
+}
+
+// fetchVariableUsage returns the usage index for the active stack: each variable
+// key mapped to the consumers that reference it. Returns {} when no stack is
+// loaded. Derived from the stack file (never the vault), so it carries no values
+// and is safe to call while the vault is locked.
+export async function fetchVariableUsage(): Promise<Record<string, Consumer[]>> {
+  return fetchJSON<Record<string, Consumer[]>>('/api/var/usage');
+}
+
 export interface CreateVariableInput {
   key: string;
   value: string;

--- a/web/src/stores/useVaultStore.ts
+++ b/web/src/stores/useVaultStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Variable, VariableSet } from '../lib/api';
+import type { Consumer, Variable, VariableSet } from '../lib/api';
 
 // useVaultStore is kept as the in-memory cache for the unified variable
 // store (secrets + plaintext config). The hook name retains "Vault" for
@@ -8,6 +8,10 @@ import type { Variable, VariableSet } from '../lib/api';
 interface VaultState {
   variables: Variable[] | null;
   sets: VariableSet[] | null;
+  // usage maps each variable key to the consumers that reference it in the
+  // active stack (the "used by" index). Best-effort: stays {} when no stack is
+  // loaded or the usage fetch fails, so the variable list never depends on it.
+  usage: Record<string, Consumer[]>;
   loading: boolean;
   error: string | null;
   locked: boolean;
@@ -15,6 +19,7 @@ interface VaultState {
 
   setVariables: (variables: Variable[]) => void;
   setSets: (sets: VariableSet[]) => void;
+  setUsage: (usage: Record<string, Consumer[]>) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
   setLocked: (locked: boolean) => void;
@@ -24,6 +29,7 @@ interface VaultState {
 export const useVaultStore = create<VaultState>()((set) => ({
   variables: null,
   sets: null,
+  usage: {},
   loading: false,
   error: null,
   locked: false,
@@ -31,8 +37,10 @@ export const useVaultStore = create<VaultState>()((set) => ({
 
   setVariables: (variables) => set({ variables: variables ?? [] }),
   setSets: (sets) => set({ sets: sets ?? [] }),
+  setUsage: (usage) => set({ usage: usage ?? {} }),
   setLoading: (loading) => set({ loading }),
   setError: (error) => set({ error }),
-  setLocked: (locked) => set(locked ? { locked, variables: null, sets: null } : { locked }),
+  setLocked: (locked) =>
+    set(locked ? { locked, variables: null, sets: null, usage: {} } : { locked }),
   setEncrypted: (encrypted) => set({ encrypted }),
 }));


### PR DESCRIPTION
## Description

Frontend phase (2 of 2) of variable usage tracing. Consumes the `GET /api/var/usage` endpoint to show, for each variable, which servers/resources reference it — turning the "blast radius" of a change from guesswork into something visible before you edit, rotate, or delete.

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

- "Used by N" badge on each variable card (rendered only when N > 0), with an inline drill-down listing consumers as `name · field`.
- Clicking a server/resource consumer selects its topology node and toasts "open Topology to inspect" (stays on the Variables route).
- Delete confirmation now warns "used by N consumer(s) … may break them" when the variable is referenced.
- Replaces the former **approximate** `ServerFilterBanner` key-substring filter with an **exact** match against the usage index; banner copy updated to drop the "approximate" disclaimer.

## Notes

- Usage is fetched in parallel and is best-effort: a failure degrades to no badges (never blocks or errors the variable list).
- The badge is a real button (Escape collapses, aria-labelled); non-navigable consumer kinds (gateway/network/stack) render as plain rows.
- No backend or topology-canvas changes (the backend landed in the prior phase).

## Testing

- `npm run build` and `npm run test` pass (606 tests).
- New tests: badge presence/absence, drill-down reveal without toggling row expansion, navigable vs non-navigable consumers, exact server filter, and the delete-confirmation warning.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #695