### PR TITLE
feat: variable set recently-edited indicator

### DIFF
--- a/web/src/__tests__/SetGroup.test.tsx
+++ b/web/src/__tests__/SetGroup.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SetGroup, type SetGroupRowHandlers } from '../components/vault/SetGroup';
+
+const handlers: SetGroupRowHandlers = {
+  revealed: {},
+  editingKey: null,
+  editValue: '',
+  showEditValue: false,
+  setNames: [],
+  onReveal: () => {},
+  onEdit: () => {},
+  onDeleteSecret: () => {},
+  onEditValueChange: () => {},
+  onEditToggleShow: () => {},
+  onEditSave: () => {},
+  onEditCancel: () => {},
+  onAssignSet: () => {},
+};
+
+function renderGroup(recentlyEdited?: boolean) {
+  return render(
+    <SetGroup
+      set={{ name: 'dev', count: 2 }}
+      variables={[]}
+      expanded={false}
+      onToggleExpand={() => {}}
+      recentlyEdited={recentlyEdited}
+      handlers={handlers}
+    />,
+  );
+}
+
+describe('SetGroup — recently edited dot', () => {
+  it('renders the dot with title and aria-label when recentlyEdited is true', () => {
+    renderGroup(true);
+    const dot = screen.getByTitle('Recently edited');
+    expect(dot).toBeInTheDocument();
+    // Meaning must not be conveyed by color alone.
+    expect(dot).toHaveAttribute('aria-label', 'Recently edited');
+  });
+
+  it('renders no dot when recentlyEdited is false', () => {
+    renderGroup(false);
+    expect(screen.queryByTitle('Recently edited')).not.toBeInTheDocument();
+  });
+
+  it('renders no dot when recentlyEdited is omitted', () => {
+    render(
+      <SetGroup
+        set={{ name: 'dev', count: 2 }}
+        variables={[]}
+        expanded={false}
+        onToggleExpand={() => {}}
+        handlers={handlers}
+      />,
+    );
+    expect(screen.queryByTitle('Recently edited')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/VaultWorkspace.test.tsx
+++ b/web/src/__tests__/VaultWorkspace.test.tsx
@@ -219,3 +219,58 @@ describe('VaultWorkspace — locked state', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe('VaultWorkspace — recently edited indicator', () => {
+  const variables = [
+    { key: 'API_KEY', type: 'string' as const, is_secret: true, set: 'dev' },
+    { key: 'DB_URL', type: 'string' as const, is_secret: true, set: 'prod' },
+  ];
+  const sets = [
+    { name: 'dev', count: 1 },
+    { name: 'prod', count: 1 },
+  ];
+
+  beforeEach(() => {
+    vi.mocked(api.fetchVariableStoreStatus).mockResolvedValue({
+      locked: false,
+      encrypted: false,
+    });
+    vi.mocked(api.fetchVariables).mockResolvedValue(variables);
+    vi.mocked(api.fetchVariableSets).mockResolvedValue(sets);
+    vi.mocked(api.fetchVariableUsage).mockResolvedValue({});
+  });
+
+  it('marks only the set whose member was edited this session', async () => {
+    useVaultStore.setState({
+      variables,
+      sets,
+      usage: {},
+      recentlyEdited: { API_KEY: Date.now() },
+      loading: false,
+      error: null,
+      locked: false,
+      encrypted: false,
+    });
+    renderWorkspace();
+    // API_KEY belongs to "dev", so exactly one set pill carries the dot.
+    const dots = await screen.findAllByTitle('Recently edited');
+    expect(dots).toHaveLength(1);
+    expect(dots[0]).toHaveAttribute('aria-label', 'Recently edited');
+  });
+
+  it('shows no indicator when nothing was edited this session', async () => {
+    useVaultStore.setState({
+      variables,
+      sets,
+      usage: {},
+      recentlyEdited: {},
+      loading: false,
+      error: null,
+      locked: false,
+      encrypted: false,
+    });
+    renderWorkspace();
+    await screen.findByRole('button', { name: /all variables/i });
+    expect(screen.queryByTitle('Recently edited')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/useVaultStore.test.ts
+++ b/web/src/__tests__/useVaultStore.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useVaultStore } from '../stores/useVaultStore';
+
+// Covers the session-scoped "recently edited" state that powers the per-set
+// indicator dot: marking keys, merge semantics, and clear-on-lock.
+describe('useVaultStore — recentlyEdited', () => {
+  beforeEach(() => {
+    useVaultStore.setState({
+      variables: [],
+      sets: [],
+      usage: {},
+      recentlyEdited: {},
+      locked: false,
+    });
+  });
+
+  it('markRecentlyEdited records each key with a timestamp', () => {
+    const before = Date.now();
+    useVaultStore.getState().markRecentlyEdited(['API_KEY', 'DB_URL']);
+    const { recentlyEdited } = useVaultStore.getState();
+    expect(Object.keys(recentlyEdited).sort()).toEqual(['API_KEY', 'DB_URL']);
+    expect(recentlyEdited.API_KEY).toBeGreaterThanOrEqual(before);
+    expect(recentlyEdited.DB_URL).toBeGreaterThanOrEqual(before);
+  });
+
+  it('merges new keys without dropping previously marked ones', () => {
+    useVaultStore.getState().markRecentlyEdited(['A']);
+    useVaultStore.getState().markRecentlyEdited(['B']);
+    expect(Object.keys(useVaultStore.getState().recentlyEdited).sort()).toEqual([
+      'A',
+      'B',
+    ]);
+  });
+
+  it('treats an empty key list as a no-op (preserves the reference)', () => {
+    useVaultStore.getState().markRecentlyEdited(['A']);
+    const ref = useVaultStore.getState().recentlyEdited;
+    useVaultStore.getState().markRecentlyEdited([]);
+    expect(useVaultStore.getState().recentlyEdited).toBe(ref);
+  });
+
+  it('clearRecentlyEdited empties the map', () => {
+    useVaultStore.getState().markRecentlyEdited(['A']);
+    useVaultStore.getState().clearRecentlyEdited();
+    expect(useVaultStore.getState().recentlyEdited).toEqual({});
+  });
+
+  it('locking the vault clears recentlyEdited', () => {
+    useVaultStore.getState().markRecentlyEdited(['A']);
+    useVaultStore.getState().setLocked(true);
+    expect(useVaultStore.getState().recentlyEdited).toEqual({});
+  });
+
+  it('unlocking the vault leaves recentlyEdited untouched', () => {
+    useVaultStore.setState({ locked: true, recentlyEdited: {} });
+    useVaultStore.getState().markRecentlyEdited(['A']);
+    useVaultStore.getState().setLocked(false);
+    expect(Object.keys(useVaultStore.getState().recentlyEdited)).toEqual(['A']);
+  });
+});

--- a/web/src/components/vault/SetGroup.tsx
+++ b/web/src/components/vault/SetGroup.tsx
@@ -32,6 +32,9 @@ export interface SetGroupProps {
   // When omitted, the per-set delete (trash) affordance is not rendered.
   // The sidebar (quick-lookup) hides it; the workspace shows it.
   onDeleteSet?: () => void;
+  // When true, a small dot marks the set as containing a variable edited this
+  // session. Absence is the signal — nothing renders when false/omitted.
+  recentlyEdited?: boolean;
   handlers: SetGroupRowHandlers;
   // Use `.log-text` on key/value text for detached-page zoom scaling.
   enableZoom?: boolean;
@@ -51,6 +54,7 @@ export function SetGroup({
   expanded,
   onToggleExpand,
   onDeleteSet,
+  recentlyEdited,
   handlers,
   enableZoom,
   innerClassName,
@@ -72,6 +76,13 @@ export function SetGroup({
           <span className={cn('text-xs font-mono text-text-primary', nameClassName)}>
             {set.name}
           </span>
+          {recentlyEdited && (
+            <span
+              className="h-1.5 w-1.5 rounded-full bg-secondary/70 flex-shrink-0"
+              title="Recently edited"
+              aria-label="Recently edited"
+            />
+          )}
           <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-secondary/10 text-secondary">
             {set.count}
           </span>

--- a/web/src/components/vault/VaultPanel.tsx
+++ b/web/src/components/vault/VaultPanel.tsx
@@ -37,6 +37,7 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
   const {
     variables: secrets,
     sets,
+    recentlyEdited,
     loading,
     error,
     locked,
@@ -211,6 +212,17 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
   const unassigned = filteredSecrets.filter((s) => !s.set);
   const setNames = (sets ?? []).map((s) => s.name);
   const isEmpty = allSecrets.length === 0 && (sets ?? []).length === 0;
+
+  // Set names with a member edited this session — drives the per-set
+  // "recently edited" dot. Derived from the full (unfiltered) list so the
+  // search query doesn't suppress the hint.
+  const recentlyEditedSets = useMemo(() => {
+    const names = new Set<string>();
+    for (const v of allSecrets) {
+      if (v.set && v.key in recentlyEdited) names.add(v.set);
+    }
+    return names;
+  }, [allSecrets, recentlyEdited]);
 
   const rowHandlers = {
     revealed: revealedState.revealed,
@@ -412,6 +424,7 @@ export function VaultPanel({ onClose }: VaultPanelProps) {
                         )}
                         expanded={expandedSets[set.name] ?? false}
                         onToggleExpand={() => toggleSetExpand(set.name)}
+                        recentlyEdited={recentlyEditedSets.has(set.name)}
                         handlers={rowHandlers}
                       />
                     ))}

--- a/web/src/components/workspaces/VaultWorkspace.tsx
+++ b/web/src/components/workspaces/VaultWorkspace.tsx
@@ -53,6 +53,7 @@ export function VaultWorkspace() {
     variables: vaultVariables,
     sets: vaultSets,
     usage,
+    recentlyEdited,
     loading,
     error,
     locked,
@@ -150,6 +151,15 @@ export function VaultWorkspace() {
   );
   const allSets = useMemo(() => vaultSets ?? [], [vaultSets]);
   const setNames = useMemo(() => allSets.map((s) => s.name), [allSets]);
+  // Set names whose members include a variable edited this session — drives the
+  // left-rail "recently edited" dot.
+  const recentlyEditedSets = useMemo(() => {
+    const names = new Set<string>();
+    for (const v of allVariables) {
+      if (v.set && v.key in recentlyEdited) names.add(v.set);
+    }
+    return names;
+  }, [allVariables, recentlyEdited]);
   const isEmpty = allVariables.length === 0 && allSets.length === 0;
 
   // Exact consumption filter: keep variables actually referenced by the named
@@ -356,6 +366,7 @@ export function VaultWorkspace() {
       onSelectSet={setActiveSet}
       totalCount={allVariables.length}
       unassignedCount={allVariables.filter((v) => !v.set).length}
+      recentlyEditedSets={recentlyEditedSets}
       newSetOpen={newSetOpen}
       onNewSetOpen={setNewSetOpen}
       newSetName={newSetName}
@@ -705,6 +716,7 @@ interface VaultLeftRailProps {
   onSelectSet: (name: string) => void;
   totalCount: number;
   unassignedCount: number;
+  recentlyEditedSets: Set<string>;
   newSetOpen: boolean;
   onNewSetOpen: (open: boolean) => void;
   newSetName: string;
@@ -721,6 +733,7 @@ function VaultLeftRail({
   onSelectSet,
   totalCount,
   unassignedCount,
+  recentlyEditedSets,
   newSetOpen,
   onNewSetOpen,
   newSetName,
@@ -761,6 +774,7 @@ function VaultLeftRail({
             count={set.count}
             mono
             active={activeSet === set.name}
+            recentlyEdited={recentlyEditedSets.has(set.name)}
             onClick={() => onSelectSet(set.name)}
             onDelete={locked ? undefined : () => onDeleteSet(set.name)}
           />
@@ -806,6 +820,9 @@ interface SetPillProps {
   onClick: () => void;
   mono?: boolean;
   onDelete?: () => void;
+  // When true, a dot marks the set as containing a variable edited this
+  // session. Absence is the signal — nothing renders when false/omitted.
+  recentlyEdited?: boolean;
 }
 
 function SetPill({
@@ -815,6 +832,7 @@ function SetPill({
   onClick,
   mono,
   onDelete,
+  recentlyEdited,
 }: SetPillProps) {
   return (
     <div
@@ -838,15 +856,24 @@ function SetPill({
         >
           {label}
         </span>
-        <span
-          className={cn(
-            'flex-shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded',
-            active
-              ? 'bg-primary/15 text-primary'
-              : 'bg-surface-elevated text-text-muted',
+        <span className="flex-shrink-0 flex items-center gap-1.5">
+          {recentlyEdited && (
+            <span
+              className="h-1.5 w-1.5 rounded-full bg-secondary/70 flex-shrink-0"
+              title="Recently edited"
+              aria-label="Recently edited"
+            />
           )}
-        >
-          {count}
+          <span
+            className={cn(
+              'text-[10px] font-mono px-1.5 py-0.5 rounded',
+              active
+                ? 'bg-primary/15 text-primary'
+                : 'bg-surface-elevated text-text-muted',
+            )}
+          >
+            {count}
+          </span>
         </span>
       </button>
       {onDelete && (

--- a/web/src/hooks/useVaultManager.ts
+++ b/web/src/hooks/useVaultManager.ts
@@ -37,6 +37,9 @@ export interface UseVaultManagerResult {
   variables: Variable[] | null;
   sets: VariableSet[] | null;
   usage: Record<string, Consumer[]>;
+  // recentlyEdited maps variable key → epoch-ms of its last session mutation;
+  // consumers derive the per-set "recently edited" dot from it.
+  recentlyEdited: Record<string, number>;
   loading: boolean;
   error: string | null;
   locked: boolean;
@@ -49,6 +52,7 @@ export interface UseVaultManagerResult {
   createVar: (input: CreateVariableInput) => Promise<void>;
   updateVar: (key: string, input: UpdateVariableInput) => Promise<void>;
   deleteVar: (key: string) => Promise<void>;
+  markRecentlyEdited: (keys: string[]) => void;
   getVar: (key: string) => Promise<{ value: string }>;
   createSet: (name: string) => Promise<void>;
   deleteSet: (name: string) => Promise<void>;
@@ -67,6 +71,8 @@ export function useVaultManager(
   const variables = useVaultStore((s) => s.variables);
   const sets = useVaultStore((s) => s.sets);
   const usage = useVaultStore((s) => s.usage);
+  const recentlyEdited = useVaultStore((s) => s.recentlyEdited);
+  const markRecentlyEdited = useVaultStore((s) => s.markRecentlyEdited);
   const loading = useVaultStore((s) => s.loading);
   const error = useVaultStore((s) => s.error);
   const locked = useVaultStore((s) => s.locked);
@@ -147,6 +153,7 @@ export function useVaultManager(
     async (input: CreateVariableInput) => {
       await createVariable(input);
       await refresh();
+      useVaultStore.getState().markRecentlyEdited([input.key]);
     },
     [refresh],
   );
@@ -155,6 +162,7 @@ export function useVaultManager(
     async (key: string, input: UpdateVariableInput) => {
       await updateVariable(key, input);
       await refresh();
+      useVaultStore.getState().markRecentlyEdited([key]);
     },
     [refresh],
   );
@@ -191,6 +199,9 @@ export function useVaultManager(
     async (key: string, set: string) => {
       await assignVariableToSet(key, set);
       await refresh();
+      // After refresh the variable's `.set` is the destination, so the dot
+      // surfaces on the set it moved into (not the one it left).
+      useVaultStore.getState().markRecentlyEdited([key]);
     },
     [refresh],
   );
@@ -199,6 +210,7 @@ export function useVaultManager(
     async (vars: ImportVariableInput[]) => {
       const result = await importVariables(vars);
       await refresh();
+      useVaultStore.getState().markRecentlyEdited(vars.map((v) => v.key));
       return result;
     },
     [refresh],
@@ -208,6 +220,7 @@ export function useVaultManager(
     variables,
     sets,
     usage,
+    recentlyEdited,
     loading,
     error,
     locked,
@@ -218,6 +231,7 @@ export function useVaultManager(
     createVar,
     updateVar,
     deleteVar,
+    markRecentlyEdited,
     getVar,
     createSet,
     deleteSet,

--- a/web/src/pages/DetachedVaultPage.tsx
+++ b/web/src/pages/DetachedVaultPage.tsx
@@ -35,6 +35,7 @@ function DetachedVaultContent() {
   const {
     variables: secrets,
     sets,
+    recentlyEdited,
     loading,
     error,
     locked,
@@ -214,6 +215,16 @@ function DetachedVaultContent() {
   const unassigned = filteredSecrets.filter((s) => !s.set);
   const setNames = (sets ?? []).map((s) => s.name);
   const isEmpty = allSecrets.length === 0 && (sets ?? []).length === 0;
+
+  // Set names with a member edited this session (this window's own store) —
+  // drives the per-set "recently edited" dot, independent of the search query.
+  const recentlyEditedSets = useMemo(() => {
+    const names = new Set<string>();
+    for (const v of allSecrets) {
+      if (v.set && v.key in recentlyEdited) names.add(v.set);
+    }
+    return names;
+  }, [allSecrets, recentlyEdited]);
 
   const rowHandlers = {
     revealed: revealedState.revealed,
@@ -468,6 +479,7 @@ function DetachedVaultContent() {
                       expanded={expandedSets[set.name] ?? false}
                       onToggleExpand={() => toggleSetExpand(set.name)}
                       onDeleteSet={() => handleDeleteSet(set.name)}
+                      recentlyEdited={recentlyEditedSets.has(set.name)}
                       handlers={rowHandlers}
                       enableZoom
                       nameClassName="log-text"

--- a/web/src/stores/useVaultStore.ts
+++ b/web/src/stores/useVaultStore.ts
@@ -12,6 +12,11 @@ interface VaultState {
   // active stack (the "used by" index). Best-effort: stays {} when no stack is
   // loaded or the usage fetch fails, so the variable list never depends on it.
   usage: Record<string, Consumer[]>;
+  // recentlyEdited maps a variable key to the epoch-ms it was last mutated in
+  // this session (create/update/import/reassign). It powers the per-set
+  // "recently edited" dot and is in-memory only — never persisted and cleared
+  // on lock, so it's a "since you last looked" hint, not durable metadata.
+  recentlyEdited: Record<string, number>;
   loading: boolean;
   error: string | null;
   locked: boolean;
@@ -20,6 +25,8 @@ interface VaultState {
   setVariables: (variables: Variable[]) => void;
   setSets: (sets: VariableSet[]) => void;
   setUsage: (usage: Record<string, Consumer[]>) => void;
+  markRecentlyEdited: (keys: string[]) => void;
+  clearRecentlyEdited: () => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
   setLocked: (locked: boolean) => void;
@@ -30,6 +37,7 @@ export const useVaultStore = create<VaultState>()((set) => ({
   variables: null,
   sets: null,
   usage: {},
+  recentlyEdited: {},
   loading: false,
   error: null,
   locked: false,
@@ -38,9 +46,22 @@ export const useVaultStore = create<VaultState>()((set) => ({
   setVariables: (variables) => set({ variables: variables ?? [] }),
   setSets: (sets) => set({ sets: sets ?? [] }),
   setUsage: (usage) => set({ usage: usage ?? {} }),
+  markRecentlyEdited: (keys) =>
+    set((state) => {
+      if (keys.length === 0) return state;
+      const now = Date.now();
+      const next = { ...state.recentlyEdited };
+      for (const key of keys) next[key] = now;
+      return { recentlyEdited: next };
+    }),
+  clearRecentlyEdited: () => set({ recentlyEdited: {} }),
   setLoading: (loading) => set({ loading }),
   setError: (error) => set({ error }),
   setLocked: (locked) =>
-    set(locked ? { locked, variables: null, sets: null, usage: {} } : { locked }),
+    set(
+      locked
+        ? { locked, variables: null, sets: null, usage: {}, recentlyEdited: {} }
+        : { locked },
+    ),
   setEncrypted: (encrypted) => set({ encrypted }),
 }));


### PR DESCRIPTION
## Description

Adds a small, session-scoped "recently edited" dot to each variable Set row (sidebar `SetGroup`, workspace `SetPill`, and the detached `/var` page). The dot appears on a set when any of its members is created, updated, imported, or reassigned during the current session, giving at-a-glance feedback about where a change landed. It is purely client-side and ephemeral — it clears on vault lock and page reload.

This is the scoped-down outcome of evaluating a broader "set metadata" idea: the per-set variable count already ships, and a real per-set "Last Updated" timestamp was deferred (it would require timestamps in the encrypted vault schema for a signal that is misleading as a container aggregate and not actionable for stable secrets). This indicator captures the one genuinely useful recency moment with zero backend changes.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- Add ephemeral `recentlyEdited` map + `markRecentlyEdited`/`clearRecentlyEdited` to the vault store; clear it on lock
- Mark edited keys at the `useVaultManager` mutation chokepoints (create/update/import/assign) after a successful refresh
- Render a `secondary`-colored dot beside the count pill in `SetGroup` and the workspace set pill, with `title`/`aria-label` (never color alone)
- Derive per-set recency in the sidebar, workspace, and detached containers
- Tests for the store actions + clear-on-lock and the dot's conditional render + a11y

## Testing

- `npm run build` — passes
- Full web suite: 617 tests pass (11 new), covering store actions, clear-on-lock, and the indicator render/accessibility

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #704