### PR TITLE
feat: drag-and-drop import on the Variables workspace

### DIFF
--- a/web/src/__tests__/VaultWorkspace.test.tsx
+++ b/web/src/__tests__/VaultWorkspace.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import { VaultWorkspace } from '../components/workspaces/VaultWorkspace';
+import { ToastContainer } from '../components/ui/Toast';
 import { useVaultStore } from '../stores/useVaultStore';
 import * as api from '../lib/api';
 
@@ -38,6 +39,32 @@ function renderWorkspace() {
     </MemoryRouter>,
   );
 }
+
+// Renders the workspace alongside a ToastContainer so drop-validation toasts
+// (normally mounted by AppShell) are assertable in isolation.
+function renderWithToasts() {
+  return render(
+    <MemoryRouter initialEntries={['/vault']}>
+      <VaultWorkspace />
+      <ToastContainer />
+    </MemoryRouter>,
+  );
+}
+
+// Duck-typed File — the drop path only reads name/type/text().
+function fakeFile(name: string, content: string, type = ''): File {
+  return { name, type, text: () => Promise.resolve(content) } as unknown as File;
+}
+
+function dispatchDrag(type: string, files: unknown[] = []) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, { dataTransfer: { types: ['Files'], files } });
+  act(() => {
+    window.dispatchEvent(event);
+  });
+}
+
+const OVERLAY_COPY = /drop a \.env or \.json file to import/i;
 
 describe('VaultWorkspace — empty state', () => {
   beforeEach(() => {
@@ -272,5 +299,132 @@ describe('VaultWorkspace — recently edited indicator', () => {
     renderWorkspace();
     await screen.findByRole('button', { name: /all variables/i });
     expect(screen.queryByTitle('Recently edited')).not.toBeInTheDocument();
+  });
+});
+
+describe('VaultWorkspace — drag-and-drop import', () => {
+  beforeEach(() => {
+    // Reset fetch mocks so a prior block's variables don't leak in and create
+    // duplicate-key matches between the list and the modal preview.
+    vi.mocked(api.fetchVariables).mockResolvedValue([]);
+    vi.mocked(api.fetchVariableSets).mockResolvedValue([]);
+    vi.mocked(api.fetchVariableUsage).mockResolvedValue({});
+    vi.mocked(api.fetchVariableStoreStatus).mockResolvedValue({
+      locked: false,
+      encrypted: false,
+    });
+    useVaultStore.setState({
+      variables: [],
+      sets: [],
+      usage: {},
+      recentlyEdited: {},
+      loading: false,
+      error: null,
+      locked: false,
+      encrypted: false,
+    });
+  });
+
+  it('shows the dropzone overlay while a file is dragged over the page', async () => {
+    renderWithToasts();
+    await screen.findByText('variables');
+    dispatchDrag('dragenter');
+    expect(await screen.findByText(OVERLAY_COPY)).toBeInTheDocument();
+  });
+
+  it('opens the import modal pre-populated when a .env file is dropped', async () => {
+    renderWithToasts();
+    await screen.findByText('variables');
+    dispatchDrag('drop', [fakeFile('app.env', 'FOO=bar')]);
+    expect(
+      await screen.findByRole('dialog', { name: /import variables/i }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('FOO')).toBeInTheDocument();
+  });
+
+  it('parses a dropped .json file into the preview', async () => {
+    renderWithToasts();
+    await screen.findByText('variables');
+    dispatchDrag('drop', [
+      fakeFile('vars.json', '{"variables":[{"key":"API_KEY","value":"sk"}]}'),
+    ]);
+    expect(
+      await screen.findByRole('dialog', { name: /import variables/i }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('API_KEY')).toBeInTheDocument();
+  });
+
+  it('rejects an unsupported file type with a toast and no modal', async () => {
+    renderWithToasts();
+    await screen.findByText('variables');
+    dispatchDrag('drop', [fakeFile('photo.png', 'binary', 'image/png')]);
+    expect(
+      await screen.findByText(/only \.env and \.json files/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('dialog', { name: /import variables/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('warns and skips an empty file', async () => {
+    renderWithToasts();
+    await screen.findByText('variables');
+    dispatchDrag('drop', [fakeFile('empty.env', '   ')]);
+    expect(await screen.findByText(/file looks empty/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('dialog', { name: /import variables/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('imports the first of multiple dropped files and warns', async () => {
+    renderWithToasts();
+    await screen.findByText('variables');
+    dispatchDrag('drop', [
+      fakeFile('a.env', 'FOO=bar'),
+      fakeFile('b.env', 'BAZ=qux'),
+    ]);
+    expect(await screen.findByText(/multiple files/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole('dialog', { name: /import variables/i }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('FOO')).toBeInTheDocument();
+    expect(screen.queryByText('BAZ')).not.toBeInTheDocument();
+  });
+
+  it('suppresses the overlay while the import modal is already open', async () => {
+    renderWithToasts();
+    const cta = await screen.findByRole('button', { name: /^import \.env$/i });
+    fireEvent.click(cta);
+    await screen.findByRole('dialog', { name: /import variables/i });
+    dispatchDrag('dragenter');
+    expect(screen.queryByText(OVERLAY_COPY)).not.toBeInTheDocument();
+  });
+});
+
+describe('VaultWorkspace — drag-and-drop while locked', () => {
+  beforeEach(() => {
+    vi.mocked(api.fetchVariableStoreStatus).mockResolvedValue({
+      locked: true,
+      encrypted: true,
+    });
+    useVaultStore.setState({
+      variables: null,
+      sets: null,
+      loading: false,
+      error: null,
+      locked: true,
+      encrypted: true,
+    });
+  });
+
+  it('does not show the overlay or open the modal when locked', async () => {
+    renderWithToasts();
+    await screen.findByText('Vault Locked');
+    dispatchDrag('dragenter');
+    expect(screen.queryByText(OVERLAY_COPY)).not.toBeInTheDocument();
+    dispatchDrag('drop', [fakeFile('a.env', 'FOO=bar')]);
+    expect(
+      screen.queryByRole('dialog', { name: /import variables/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/__tests__/parseFile.test.ts
+++ b/web/src/__tests__/parseFile.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseImport,
+  parseVariablesJson,
+  isImportableFile,
+} from '../lib/parseFile';
+
+describe('parseVariablesJson — legacy map', () => {
+  it('imports every pair as a string secret', () => {
+    const { entries, ignored } = parseVariablesJson('{"FOO":"bar","BAZ":"qux"}');
+    expect(ignored).toHaveLength(0);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      key: 'FOO',
+      value: 'bar',
+      type: 'string',
+      isSecret: true,
+    });
+    expect(entries[0].set).toBeUndefined();
+  });
+
+  it('coerces non-string values to strings', () => {
+    const { entries } = parseVariablesJson('{"PORT":5432,"DEBUG":true}');
+    expect(entries[0]).toMatchObject({ key: 'PORT', value: '5432' });
+    expect(entries[1]).toMatchObject({ key: 'DEBUG', value: 'true' });
+  });
+
+  it('ignores invalid keys without aborting the rest', () => {
+    const { entries, ignored } = parseVariablesJson('{"foo-bar":"x","OK":"y"}');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].key).toBe('OK');
+    expect(ignored).toHaveLength(1);
+    expect(ignored[0].reason).toMatch(/invalid key/i);
+  });
+});
+
+describe('parseVariablesJson — v2 shape', () => {
+  it('honors explicit type, is_secret, and set', () => {
+    const input = JSON.stringify({
+      variables: [
+        { key: 'API_KEY', value: 'sk_live', type: 'string', is_secret: true, set: 'prod' },
+        { key: 'PORT', value: '8080', type: 'number', is_secret: false },
+      ],
+    });
+    const { entries, ignored } = parseVariablesJson(input);
+    expect(ignored).toHaveLength(0);
+    expect(entries[0]).toMatchObject({
+      key: 'API_KEY',
+      value: 'sk_live',
+      type: 'string',
+      isSecret: true,
+      set: 'prod',
+    });
+    expect(entries[1]).toMatchObject({
+      key: 'PORT',
+      type: 'number',
+      isSecret: false,
+    });
+  });
+
+  it('defaults to secret when is_secret is absent', () => {
+    const { entries } = parseVariablesJson('{"variables":[{"key":"TOK","value":"x"}]}');
+    expect(entries[0]).toMatchObject({ isSecret: true, type: 'string' });
+  });
+
+  it('tolerates camelCase isSecret', () => {
+    const { entries } = parseVariablesJson(
+      '{"variables":[{"key":"PUB","value":"x","isSecret":false}]}',
+    );
+    expect(entries[0].isSecret).toBe(false);
+  });
+
+  it('falls back to string for an invalid type', () => {
+    const { entries } = parseVariablesJson(
+      '{"variables":[{"key":"X","value":"y","type":"bogus"}]}',
+    );
+    expect(entries[0].type).toBe('string');
+  });
+
+  it('ignores entries with invalid keys', () => {
+    const { entries, ignored } = parseVariablesJson(
+      '{"variables":[{"key":"bad key","value":"y"},{"key":"GOOD","value":"z"}]}',
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0].key).toBe('GOOD');
+    expect(ignored).toHaveLength(1);
+  });
+});
+
+describe('parseVariablesJson — malformed input', () => {
+  it('reports invalid JSON as a single ignored line', () => {
+    const { entries, ignored } = parseVariablesJson('{not valid');
+    expect(entries).toHaveLength(0);
+    expect(ignored).toHaveLength(1);
+    expect(ignored[0].reason).toMatch(/invalid json/i);
+  });
+
+  it('rejects a non-object document', () => {
+    const { entries, ignored } = parseVariablesJson('[1,2,3]');
+    expect(entries).toHaveLength(0);
+    expect(ignored[0].reason).toMatch(/expected a json object/i);
+  });
+
+  it('returns nothing for empty input', () => {
+    expect(parseVariablesJson('   ')).toEqual({ entries: [], ignored: [] });
+  });
+});
+
+describe('parseImport — content dispatch', () => {
+  it('routes KEY=value content to the env parser', () => {
+    const { entries } = parseImport('FOO=bar\nBAZ=qux');
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ key: 'FOO', value: 'bar' });
+  });
+
+  it('routes brace-leading content to the JSON parser', () => {
+    const { entries } = parseImport('{"FOO":"bar"}');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ key: 'FOO', value: 'bar', isSecret: true });
+  });
+
+  it('detects JSON despite leading whitespace', () => {
+    const { entries } = parseImport('  \n {"variables":[{"key":"A","value":"b"}]}');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].key).toBe('A');
+  });
+});
+
+describe('isImportableFile', () => {
+  const file = (name: string, type = '') =>
+    new File(['x'], name, { type });
+
+  it('accepts .env, .json, .txt and dotted env files', () => {
+    expect(isImportableFile(file('config.env'))).toBe(true);
+    expect(isImportableFile(file('config.json', 'application/json'))).toBe(true);
+    expect(isImportableFile(file('notes.txt', 'text/plain'))).toBe(true);
+    expect(isImportableFile(file('.env'))).toBe(true);
+    expect(isImportableFile(file('.env.local'))).toBe(true);
+  });
+
+  it('accepts files with an empty or text MIME type', () => {
+    expect(isImportableFile(file('secrets', ''))).toBe(true);
+    expect(isImportableFile(file('data', 'text/plain'))).toBe(true);
+  });
+
+  it('rejects clearly binary files', () => {
+    expect(isImportableFile(file('photo.png', 'image/png'))).toBe(false);
+    expect(isImportableFile(file('archive.zip', 'application/zip'))).toBe(false);
+  });
+});

--- a/web/src/__tests__/usePageFileDrop.test.ts
+++ b/web/src/__tests__/usePageFileDrop.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePageFileDrop } from '../hooks/usePageFileDrop';
+
+// jsdom doesn't construct real DragEvents with a DataTransfer, so synthesize a
+// plain Event and attach a duck-typed dataTransfer.
+function dragEvent(
+  type: string,
+  {
+    types = ['Files'],
+    files = [] as unknown[],
+    relatedTarget = document.body as EventTarget | null,
+  } = {},
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, { dataTransfer: { types, files }, relatedTarget });
+  return event;
+}
+
+function dispatch(event: Event) {
+  act(() => {
+    window.dispatchEvent(event);
+  });
+}
+
+describe('usePageFileDrop', () => {
+  it('does not activate while disabled', () => {
+    const { result } = renderHook(() =>
+      usePageFileDrop({ enabled: false, onFiles: vi.fn() }),
+    );
+    dispatch(dragEvent('dragenter'));
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('activates on a file dragenter and deactivates on the matching dragleave', () => {
+    const { result } = renderHook(() =>
+      usePageFileDrop({ enabled: true, onFiles: vi.fn() }),
+    );
+    dispatch(dragEvent('dragenter'));
+    expect(result.current.isDragging).toBe(true);
+    dispatch(dragEvent('dragleave'));
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('stays inactive across nested dragenter/leave (depth counter)', () => {
+    const { result } = renderHook(() =>
+      usePageFileDrop({ enabled: true, onFiles: vi.fn() }),
+    );
+    dispatch(dragEvent('dragenter')); // depth 1
+    dispatch(dragEvent('dragenter')); // depth 2 (crossed into a child)
+    dispatch(dragEvent('dragleave')); // depth 1 — still dragging
+    expect(result.current.isDragging).toBe(true);
+    dispatch(dragEvent('dragleave')); // depth 0
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('ignores drags that carry no files', () => {
+    const { result } = renderHook(() =>
+      usePageFileDrop({ enabled: true, onFiles: vi.fn() }),
+    );
+    dispatch(dragEvent('dragenter', { types: ['text/plain'] }));
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('calls onFiles with the dropped files and resets dragging', () => {
+    const onFiles = vi.fn();
+    const { result } = renderHook(() =>
+      usePageFileDrop({ enabled: true, onFiles }),
+    );
+    const files = [{ name: 'a.env' }];
+    dispatch(dragEvent('dragenter'));
+    dispatch(dragEvent('drop', { files }));
+    expect(onFiles).toHaveBeenCalledTimes(1);
+    expect(onFiles.mock.calls[0][0]).toBe(files);
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('does not fire onFiles for a fileless drop', () => {
+    const onFiles = vi.fn();
+    renderHook(() => usePageFileDrop({ enabled: true, onFiles }));
+    dispatch(dragEvent('drop', { types: ['text/plain'] }));
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+
+  it('resets when the drag is cancelled (dragend)', () => {
+    const { result } = renderHook(() =>
+      usePageFileDrop({ enabled: true, onFiles: vi.fn() }),
+    );
+    dispatch(dragEvent('dragenter'));
+    expect(result.current.isDragging).toBe(true);
+    dispatch(new Event('dragend'));
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('resets when the cursor leaves the window (null relatedTarget)', () => {
+    const { result } = renderHook(() =>
+      usePageFileDrop({ enabled: true, onFiles: vi.fn() }),
+    );
+    dispatch(dragEvent('dragenter')); // depth 1
+    dispatch(dragEvent('dragenter')); // depth 2
+    dispatch(dragEvent('dragleave', { relatedTarget: null }));
+    expect(result.current.isDragging).toBe(false);
+  });
+});

--- a/web/src/components/vault/EnvImportModal.tsx
+++ b/web/src/components/vault/EnvImportModal.tsx
@@ -19,7 +19,7 @@ import { cn } from '../../lib/cn';
 import { Button } from '../ui/Button';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { VariableTypeSelector } from './VariableTypeSelector';
-import { parseEnv } from '../../lib/envParser';
+import { parseImport } from '../../lib/parseFile';
 import type { ParsedEnvEntry } from '../../lib/envParser';
 import type {
   ImportVariableInput,
@@ -36,6 +36,10 @@ export interface EnvImportModalProps {
   // Optional initial set assignment for every parsed row. Used when the user
   // opens the modal while a set filter is active in the workspace.
   defaultSet?: string;
+  // Optional content to pre-seed the input with — used when the modal is
+  // opened by dropping a file onto the workspace. `.env` or JSON is auto-
+  // detected by parseImport, so this is just the raw file text.
+  initialText?: string;
 }
 
 interface RowOverride {
@@ -69,10 +73,12 @@ function rowFromParsed(
     key: entry.key,
     value: entry.value,
     type: override?.type ?? entry.type,
-    set: override?.set ?? defaultSet,
+    // Precedence: a per-row user tweak, then a value the source carried
+    // explicitly (JSON v2), then the workspace/secure default.
+    set: override?.set ?? entry.set ?? defaultSet,
     // Default new imports to "secret" per Article XII secure default — the
     // user can toggle to plaintext per row if needed.
-    isSecret: override?.isSecret ?? true,
+    isSecret: override?.isSecret ?? entry.isSecret ?? true,
     skipped: override?.skipped ?? false,
     revealed: override?.revealed ?? false,
   };
@@ -86,6 +92,7 @@ export function EnvImportModal({
   existingVariables,
   sets,
   defaultSet = '',
+  initialText = '',
 }: EnvImportModalProps) {
   const titleId = useId();
   const closeRef = useRef<HTMLButtonElement | null>(null);
@@ -95,7 +102,10 @@ export function EnvImportModal({
     initialFocusRef: textareaRef,
   });
 
-  const [text, setText] = useState('');
+  // Seeded once from initialText; the modal is mounted fresh on each open
+  // (see the unmount-resets-state note above), so a plain initializer is
+  // enough — no open/close effect needed.
+  const [text, setText] = useState(initialText);
   // Per-key user overrides — survive re-parses so small textarea edits don't
   // wipe per-row tweaks. Keyed by variable key, not by parser line, since
   // line numbers shift as the user types.
@@ -105,7 +115,7 @@ export function EnvImportModal({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState(false);
 
-  const parsed = useMemo(() => parseEnv(text), [text]);
+  const parsed = useMemo(() => parseImport(text), [text]);
 
   const rows = useMemo<RowState[]>(
     () =>
@@ -245,7 +255,7 @@ export function EnvImportModal({
                 Import variables
               </h2>
               <p className="text-[10px] text-text-muted uppercase tracking-[0.18em]">
-                paste · drop · pick a .env file
+                paste · drop · pick a .env or .json file
               </p>
             </div>
           </div>
@@ -300,7 +310,7 @@ export function EnvImportModal({
                 Pick a file
                 <input
                   type="file"
-                  accept=".env,text/plain"
+                  accept=".env,.json,text/plain,application/json"
                   onChange={onFilePicked}
                   className="hidden"
                 />

--- a/web/src/components/workspaces/VaultWorkspace.tsx
+++ b/web/src/components/workspaces/VaultWorkspace.tsx
@@ -16,6 +16,7 @@ import {
   RefreshCw,
   Search,
   Trash2,
+  Upload,
   X,
 } from 'lucide-react';
 import { cn } from '../../lib/cn';
@@ -33,6 +34,8 @@ import { useUIStore } from '../../stores/useUIStore';
 import { useStackStore } from '../../stores/useStackStore';
 import { useVaultManager } from '../../hooks/useVaultManager';
 import { useRevealedValues } from '../../hooks/useRevealedValues';
+import { usePageFileDrop } from '../../hooks/usePageFileDrop';
+import { isImportableFile } from '../../lib/parseFile';
 import { validateVariableInput } from '../vault/variableTypeHelpers';
 import type { Consumer, Variable, VariableType } from '../../lib/api';
 
@@ -140,6 +143,8 @@ export function VaultWorkspace() {
 
   const [encryptOpen, setEncryptOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
+  // Content seeded into the import modal when it's opened by a file drop.
+  const [droppedText, setDroppedText] = useState('');
   const [addOneOpen, setAddOneOpen] = useState(false);
   const [newSetOpen, setNewSetOpen] = useState(false);
   const [newSetName, setNewSetName] = useState('');
@@ -338,6 +343,46 @@ export function VaultWorkspace() {
     },
     [importVars],
   );
+
+  // Page-level file drop: dragging a .env/.json file anywhere over the
+  // workspace opens the import modal pre-seeded with the file's contents.
+  // Validation happens here, before the modal opens, so failures surface as a
+  // toast rather than an empty modal.
+  const handleDroppedFiles = useCallback(async (files: FileList) => {
+    if (files.length > 1) {
+      showToast('warning', 'Dropped multiple files — importing the first only');
+    }
+    const file = files[0];
+    if (!isImportableFile(file)) {
+      showToast('error', 'Only .env and .json files can be imported');
+      return;
+    }
+    let content: string;
+    try {
+      content = await file.text();
+    } catch {
+      showToast('error', 'Could not read that file');
+      return;
+    }
+    if (!content.trim()) {
+      showToast('warning', 'That file looks empty');
+      return;
+    }
+    setDroppedText(content);
+    setImportOpen(true);
+  }, []);
+
+  // Overlay is suppressed while the modal is open (its textarea has its own
+  // dropzone for mid-edit drops) and while the vault is locked.
+  const { isDragging } = usePageFileDrop({
+    enabled: !importOpen && !locked,
+    onFiles: handleDroppedFiles,
+  });
+
+  const closeImport = useCallback(() => {
+    setImportOpen(false);
+    setDroppedText('');
+  }, []);
 
   // Selecting a consumer highlights its topology node (ids are mcp-<name> /
   // resource-<name>). We stay on the Variables route — a toast points the user
@@ -595,12 +640,37 @@ export function VaultWorkspace() {
 
       {importOpen && (
         <EnvImportModal
-          onClose={() => setImportOpen(false)}
+          onClose={closeImport}
           onImport={handleImport}
           existingVariables={allVariables}
           sets={allSets}
           defaultSet={activeSet === ALL_SETS_KEY ? '' : activeSet}
+          initialText={droppedText}
         />
+      )}
+
+      {/* Drag-activated dropzone overlay. Decorative — the window-level
+          listeners (usePageFileDrop) own the drop; the existing modal file
+          picker remains the keyboard/screen-reader path. */}
+      {isDragging && (
+        <div
+          aria-hidden="true"
+          className={cn(
+            'absolute inset-0 z-[55] pointer-events-none p-6',
+            'flex items-center justify-center',
+            'bg-background/80 backdrop-blur-sm animate-fade-in-scale',
+          )}
+        >
+          <div className="flex flex-col items-center justify-center gap-3 w-full max-w-2xl px-10 py-16 rounded-2xl border-2 border-dashed border-primary/50 bg-primary/5 text-primary">
+            <Upload size={28} />
+            <p className="text-sm font-medium">
+              Drop a .env or .json file to import
+            </p>
+            <p className="text-[11px] text-text-muted">
+              You'll review the parsed variables before anything is saved
+            </p>
+          </div>
+        </div>
       )}
     </div>
   );
@@ -1033,6 +1103,12 @@ function VaultEmptyState({ onImport, onAddOne }: VaultEmptyStateProps) {
           </button>
         </div>
         <p className="text-[10px] text-text-muted/70 pt-2">
+          Tip: drop a{' '}
+          <code className="font-mono text-text-secondary">.env</code> or{' '}
+          <code className="font-mono text-text-secondary">.json</code> file
+          anywhere on this page.
+        </p>
+        <p className="text-[10px] text-text-muted/70">
           Or use the CLI:
           <code className="ml-1 font-mono text-text-secondary">
             gridctl var import .env

--- a/web/src/hooks/usePageFileDrop.ts
+++ b/web/src/hooks/usePageFileDrop.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface UsePageFileDropOptions {
+  // When false the listeners are torn down entirely — used to suppress the
+  // page dropzone while a modal is open or the surface is otherwise busy.
+  enabled: boolean;
+  // Called once per drop with the dropped FileList (when it contains files).
+  onFiles: (files: FileList) => void;
+}
+
+// usePageFileDrop wires window-level drag listeners so a file dragged anywhere
+// over the page reveals a dropzone. It only reacts to drags carrying files
+// (so internal pointer drags — panel resizers, canvas nodes — are ignored) and
+// uses a depth counter to avoid the classic dragenter/dragleave flicker as the
+// cursor crosses child elements. Native, no dependency.
+export function usePageFileDrop({ enabled, onFiles }: UsePageFileDropOptions) {
+  const [isDragging, setIsDragging] = useState(false);
+  const depth = useRef(0);
+  // Hold the latest callback in a ref so changing it doesn't re-subscribe.
+  const onFilesRef = useRef(onFiles);
+  useEffect(() => {
+    onFilesRef.current = onFiles;
+  }, [onFiles]);
+
+  useEffect(() => {
+    if (!enabled) {
+      depth.current = 0;
+      return;
+    }
+
+    const hasFiles = (e: DragEvent) =>
+      !!e.dataTransfer && Array.from(e.dataTransfer.types).includes('Files');
+
+    const onDragEnter = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      depth.current += 1;
+      setIsDragging(true);
+    };
+
+    const onDragOver = (e: DragEvent) => {
+      // preventDefault is required on dragover or the drop never fires and the
+      // browser navigates away to open the file.
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+    };
+
+    const reset = () => {
+      depth.current = 0;
+      setIsDragging(false);
+    };
+
+    const onDragLeave = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      // A null relatedTarget means the cursor left the window entirely — hard
+      // reset rather than decrementing, since the matching enters won't come.
+      if (e.relatedTarget === null) {
+        reset();
+        return;
+      }
+      depth.current = Math.max(0, depth.current - 1);
+      if (depth.current === 0) setIsDragging(false);
+    };
+
+    const onDrop = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      reset();
+      const files = e.dataTransfer?.files;
+      if (files && files.length > 0) onFilesRef.current(files);
+    };
+
+    window.addEventListener('dragenter', onDragEnter);
+    window.addEventListener('dragover', onDragOver);
+    window.addEventListener('dragleave', onDragLeave);
+    window.addEventListener('drop', onDrop);
+    // A cancelled drag (Escape, or dropping outside the window) fires neither a
+    // drop nor a balancing dragleave, so without this the overlay would stick.
+    window.addEventListener('dragend', reset);
+    return () => {
+      window.removeEventListener('dragenter', onDragEnter);
+      window.removeEventListener('dragover', onDragOver);
+      window.removeEventListener('dragleave', onDragLeave);
+      window.removeEventListener('drop', onDrop);
+      window.removeEventListener('dragend', reset);
+      depth.current = 0;
+    };
+  }, [enabled]);
+
+  // Mask any residual dragging state while disabled so callers never see a
+  // stale overlay when the surface is suppressed.
+  return { isDragging: enabled && isDragging };
+}

--- a/web/src/lib/envParser.ts
+++ b/web/src/lib/envParser.ts
@@ -10,6 +10,11 @@ export interface ParsedEnvEntry {
   // True when the source value was wrapped in single or double quotes. The UI
   // uses this to render the literal value rather than stripping quotes.
   quoted: boolean;
+  // Populated only by structured (JSON) imports that carry these explicitly.
+  // `.env` parsing leaves them undefined so the modal falls back to its
+  // secure defaults (secret, unassigned).
+  isSecret?: boolean;
+  set?: string;
 }
 
 export interface IgnoredEnvLine {
@@ -24,6 +29,12 @@ export interface ParseEnvResult {
 }
 
 const KEY_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// isValidKey reports whether a string is an acceptable variable key. Shared
+// with the JSON importer so both formats enforce the same key rules.
+export function isValidKey(key: string): boolean {
+  return KEY_REGEX.test(key);
+}
 
 // parseEnv parses a textual `.env`-style block into a list of key/value
 // entries plus any lines we couldn't make sense of. Behaviour is intentionally

--- a/web/src/lib/parseFile.ts
+++ b/web/src/lib/parseFile.ts
@@ -1,0 +1,158 @@
+import type { VariableType } from './api';
+import {
+  parseEnv,
+  isValidKey,
+  type ParseEnvResult,
+  type ParsedEnvEntry,
+  type IgnoredEnvLine,
+} from './envParser';
+
+// parseFile turns dropped/pasted/picked import content into the same
+// {entries, ignored} shape the import preview already consumes, regardless of
+// whether the source is a `.env` block or a JSON document. Detection is by
+// content, not filename, so pasted JSON works the same as a dropped `.json`.
+
+const VALID_TYPES = new Set<VariableType>([
+  'string',
+  'json',
+  'list',
+  'number',
+  'bool',
+]);
+
+// looksLikeJson is intentionally narrow: both supported JSON shapes are
+// objects, and a `.env` block never begins with `{`, so a leading brace is an
+// unambiguous signal.
+function looksLikeJson(input: string): boolean {
+  return input.trimStart().startsWith('{');
+}
+
+// parseImport dispatches to the JSON or env parser based on content.
+export function parseImport(input: string): ParseEnvResult {
+  return looksLikeJson(input) ? parseVariablesJson(input) : parseEnv(input);
+}
+
+// parseVariablesJson follows the CLI's parseVariablesJSON (cmd/gridctl/var.go):
+// it accepts either the v2 `{ "variables": [...] }` shape (carrying explicit
+// type / is_secret / set) or the legacy `{ "KEY": "value" }` map (everything
+// string + secret). It differs deliberately in one place — an absent is_secret
+// defaults to secret here (Article XII) rather than the CLI's zero-value false.
+// Unparseable input returns a single ignored entry so the modal surfaces it the
+// same way it surfaces bad `.env` lines.
+export function parseVariablesJson(input: string): ParseEnvResult {
+  const trimmed = input.trim();
+  if (trimmed === '') return { entries: [], ignored: [] };
+
+  let data: unknown;
+  try {
+    data = JSON.parse(trimmed);
+  } catch {
+    return { entries: [], ignored: [ignored('invalid JSON', trimmed)] };
+  }
+
+  if (!isRecord(data)) {
+    return { entries: [], ignored: [ignored('expected a JSON object', trimmed)] };
+  }
+
+  // v2 shape wins when a `variables` array is present, matching the CLI.
+  if (Array.isArray((data as Record<string, unknown>).variables)) {
+    return fromV2((data as Record<string, unknown>).variables as unknown[]);
+  }
+
+  return fromLegacyMap(data as Record<string, unknown>);
+}
+
+function fromV2(items: unknown[]): ParseEnvResult {
+  const entries: ParsedEnvEntry[] = [];
+  const ignoredLines: IgnoredEnvLine[] = [];
+
+  items.forEach((item, idx) => {
+    const line = idx + 1;
+    if (!isRecord(item)) {
+      ignoredLines.push({ line, raw: snippet(String(item)), reason: 'not an object' });
+      return;
+    }
+    const key = typeof item.key === 'string' ? item.key : '';
+    if (!isValidKey(key)) {
+      ignoredLines.push({ line, raw: snippet(key || JSON.stringify(item)), reason: `invalid key "${key}"` });
+      return;
+    }
+    const type =
+      typeof item.type === 'string' && VALID_TYPES.has(item.type as VariableType)
+        ? (item.type as VariableType)
+        : 'string';
+    // Honor an explicit secret flag (snake_case is the canonical export field;
+    // accept camelCase too), defaulting to secret per Article XII.
+    const secretRaw = item.is_secret ?? item.isSecret;
+    const isSecret = typeof secretRaw === 'boolean' ? secretRaw : true;
+    entries.push({
+      line,
+      key,
+      value: coerceValue(item.value),
+      type,
+      quoted: false,
+      isSecret,
+      set: typeof item.set === 'string' && item.set ? item.set : undefined,
+    });
+  });
+
+  return { entries, ignored: ignoredLines };
+}
+
+function fromLegacyMap(map: Record<string, unknown>): ParseEnvResult {
+  const entries: ParsedEnvEntry[] = [];
+  const ignoredLines: IgnoredEnvLine[] = [];
+
+  Object.entries(map).forEach(([key, value], idx) => {
+    const line = idx + 1;
+    if (!isValidKey(key)) {
+      ignoredLines.push({ line, raw: snippet(key), reason: `invalid key "${key}"` });
+      return;
+    }
+    // Legacy maps carry no metadata — everything imports as a string secret,
+    // exactly like the CLI's legacy branch.
+    entries.push({
+      line,
+      key,
+      value: coerceValue(value),
+      type: 'string',
+      quoted: false,
+      isSecret: true,
+    });
+  });
+
+  return { entries, ignored: ignoredLines };
+}
+
+// isImportableFile gates which dropped files we try to read. `accept` does not
+// apply to drops, so the type check happens here in JS.
+export function isImportableFile(file: File): boolean {
+  const name = file.name.toLowerCase();
+  // Named env/json/text files, including dotfiles like `.env.local`.
+  if (/\.(env|json|txt)$/.test(name) || name.startsWith('.env.')) {
+    return true;
+  }
+  // Otherwise fall back to MIME: text and JSON, plus the empty type browsers
+  // report for many extensionless config files.
+  const type = file.type;
+  return type === '' || type === 'application/json' || type.startsWith('text/');
+}
+
+function coerceValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function snippet(raw: string): string {
+  return raw.length > 60 ? `${raw.slice(0, 60)}…` : raw;
+}
+
+function ignored(reason: string, raw: string): IgnoredEnvLine {
+  return { line: 1, raw: snippet(raw), reason };
+}


### PR DESCRIPTION
## Description

Adds drag-and-drop file import to the Variables workspace: dragging a `.env`/`.json` file anywhere over the page reveals a dropzone overlay, and dropping it opens the existing import modal pre-populated with the parsed variables for review before saving. Also adds web-side `.json` import, closing a CLI/UI parity gap.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- New `usePageFileDrop` hook: native window-level drag listeners, drag-depth counter to avoid flicker, files-only gate, and resets on cancelled/out-of-window drags
- New `parseFile` module: content-based dispatcher (`parseImport`) plus a JSON parser handling both the legacy map and v2 `{ variables: [...] }` shapes, defaulting to secret per Article XII
- `EnvImportModal` gains an `initialText` prop and parses via `parseImport`, so it can open pre-seeded and accept JSON (pasting JSON works too)
- `VaultWorkspace` validates dropped files (type/emptiness, toasts), opens the modal pre-populated, and shows a decorative dropzone overlay — gated off while the modal is open or the vault is locked
- Empty-state discovery hint; no new dependency

## Testing

- `npm run test` — 650 pass (added parser, hook, and workspace drop coverage: `.env`/`.json` drops, unsupported/empty/multiple files, locked + modal-open suppression)
- `npm run build` — passes (tsc + vite)
- New/changed files lint clean

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #706