### PR TITLE
feat: secret generator for the Variables workspace

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- Secret generator in the Variables workspace: a wand button beside the
+  value input (quick-add form, wizard create-new form, and inline edit)
+  opens an inline panel to generate a cryptographically secure random
+  string with configurable length and character classes and a live
+  entropy readout. Generation is fully client-side via the Web Crypto
+  CSPRNG with rejection sampling (no modulo bias); shown only for
+  `string` variables.
 - Type badge (string / json / list / number / bool) and visibility icon
   (lock for secret, eye for plaintext) on every variable row in the
   Variables panel, detached page, and wizard popover.

--- a/web/src/__tests__/SecretGenerator.test.tsx
+++ b/web/src/__tests__/SecretGenerator.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SecretGenerator } from '../components/vault/SecretGenerator';
+
+vi.mock('../components/ui/Toast', () => ({ showToast: vi.fn() }));
+import { showToast } from '../components/ui/Toast';
+
+function open() {
+  fireEvent.click(screen.getByRole('button', { name: 'Generate value' }));
+}
+
+describe('SecretGenerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a collapsed trigger by default', () => {
+    render(<SecretGenerator onGenerate={vi.fn()} />);
+    const trigger = screen.getByRole('button', { name: 'Generate value' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('button', { name: 'Generate' })).toBeNull();
+  });
+
+  it('expands the panel on trigger click', () => {
+    render(<SecretGenerator onGenerate={vi.fn()} />);
+    open();
+    expect(
+      screen.getByRole('button', { name: 'Generate value' }),
+    ).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('slider', { name: 'Length' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Character classes' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeInTheDocument();
+  });
+
+  it('updates the live entropy readout as classes change', () => {
+    render(<SecretGenerator onGenerate={vi.fn()} />);
+    open();
+    // Default: length 24 over the full 74-char alphabet → ~149 bits.
+    expect(screen.getByText('~149 bits')).toBeInTheDocument();
+    // Drop symbols (12 chars) → 62-char alphabet → ~143 bits.
+    fireEvent.click(screen.getByRole('button', { name: '!@#' }));
+    expect(screen.getByText('~143 bits')).toBeInTheDocument();
+  });
+
+  it('updates entropy as the length slider moves', () => {
+    render(<SecretGenerator onGenerate={vi.fn()} />);
+    open();
+    fireEvent.change(screen.getByRole('slider', { name: 'Length' }), {
+      target: { value: '8' },
+    });
+    // 8 × log2(74) ≈ 50 bits.
+    expect(screen.getByText('~50 bits')).toBeInTheDocument();
+  });
+
+  it('never lets the last character class be disabled', () => {
+    render(<SecretGenerator onGenerate={vi.fn()} />);
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'A-Z' }));
+    fireEvent.click(screen.getByRole('button', { name: 'a-z' }));
+    fireEvent.click(screen.getByRole('button', { name: '0-9' }));
+    // Only symbols remain — its chip is now locked.
+    expect(screen.getByRole('button', { name: '!@#' })).toBeDisabled();
+  });
+
+  it('fills the value and reveals it on Generate', () => {
+    const onGenerate = vi.fn();
+    const onReveal = vi.fn();
+    render(<SecretGenerator onGenerate={onGenerate} onReveal={onReveal} />);
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+    expect(onGenerate.mock.calls[0][0]).toHaveLength(24);
+    expect(onReveal).toHaveBeenCalledTimes(1);
+    // Button relabels and a copy affordance appears.
+    expect(screen.getByRole('button', { name: 'Regenerate' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /copy generated value/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('produces a new value on regenerate', () => {
+    const onGenerate = vi.fn();
+    render(<SecretGenerator onGenerate={onGenerate} />);
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Regenerate' }));
+    expect(onGenerate).toHaveBeenCalledTimes(2);
+    expect(onGenerate.mock.calls[0][0]).not.toBe(onGenerate.mock.calls[1][0]);
+  });
+
+  it('copies the generated value to the clipboard without leaking it to the toast', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const onGenerate = vi.fn();
+    render(<SecretGenerator onGenerate={onGenerate} />);
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+    const value = onGenerate.mock.calls[0][0];
+
+    fireEvent.click(screen.getByRole('button', { name: /copy generated value/i }));
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledWith(value);
+    expect(showToast).toHaveBeenCalledWith('success', 'Copied');
+    // The toast message must never contain the secret characters.
+    expect(vi.mocked(showToast).mock.calls[0][1]).not.toContain(value);
+  });
+
+  it('announces only metadata — never the secret characters', () => {
+    const onGenerate = vi.fn();
+    render(<SecretGenerator onGenerate={onGenerate} />);
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+    const value = onGenerate.mock.calls[0][0];
+
+    const live = screen.getByText(/Generated a 24-character value/);
+    expect(live).toHaveTextContent('~149 bits of entropy');
+    expect(live).not.toHaveTextContent(value);
+  });
+
+  it('collapses on Escape', () => {
+    render(<SecretGenerator onGenerate={vi.fn()} />);
+    open();
+    fireEvent.keyDown(screen.getByRole('slider', { name: 'Length' }), {
+      key: 'Escape',
+    });
+    expect(
+      screen.getByRole('button', { name: 'Generate value' }),
+    ).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('slider', { name: 'Length' })).toBeNull();
+  });
+});

--- a/web/src/__tests__/SecretItem.test.tsx
+++ b/web/src/__tests__/SecretItem.test.tsx
@@ -106,3 +106,39 @@ describe('SecretItem — usage badge', () => {
     expect(screen.queryByText(/github · env\.GITHUB_TOKEN/)).toBeNull();
   });
 });
+
+describe('SecretItem — secret generator (edit mode)', () => {
+  it('offers the generator while editing a string variable', () => {
+    renderItem({ isEditing: true });
+    expect(
+      screen.getByRole('button', { name: 'Generate value' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the generator for non-string variables', () => {
+    renderItem({
+      isEditing: true,
+      secret: { key: 'PORT', type: 'number', is_secret: false },
+    });
+    expect(screen.queryByRole('button', { name: 'Generate value' })).toBeNull();
+  });
+
+  it('writes a generated value and reveals it via the toggle', () => {
+    const onEditValueChange = vi.fn();
+    const onEditToggleShow = vi.fn();
+    renderItem({
+      isEditing: true,
+      showEditValue: false,
+      onEditValueChange,
+      onEditToggleShow,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate value' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(onEditValueChange).toHaveBeenCalledTimes(1);
+    expect(onEditValueChange.mock.calls[0][0]).toHaveLength(24);
+    // Value was masked, so the reveal toggle is fired exactly once.
+    expect(onEditToggleShow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/__tests__/VariableQuickAddForm.test.tsx
+++ b/web/src/__tests__/VariableQuickAddForm.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { VariableQuickAddForm } from '../components/vault/VariableQuickAddForm';
+
+vi.mock('../components/ui/Toast', () => ({ showToast: vi.fn() }));
+
+function renderForm() {
+  return render(<VariableQuickAddForm setNames={[]} onSubmit={vi.fn()} />);
+}
+
+describe('VariableQuickAddForm — secret generator', () => {
+  it('offers the generator for string variables (the default)', () => {
+    renderForm();
+    expect(
+      screen.getByRole('button', { name: 'Generate value' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the generator for non-string types', () => {
+    renderForm();
+    fireEvent.click(screen.getByRole('button', { name: 'json' }));
+    expect(screen.queryByRole('button', { name: 'Generate value' })).toBeNull();
+  });
+
+  it('fills and reveals the value input when Generate is clicked', () => {
+    renderForm();
+    const valueInput = screen.getByPlaceholderText('secret value') as HTMLInputElement;
+    // Secret value starts masked.
+    expect(valueInput).toHaveAttribute('type', 'password');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate value' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(valueInput.value).toHaveLength(24);
+    // Auto-revealed after generation.
+    expect(valueInput).toHaveAttribute('type', 'text');
+  });
+});

--- a/web/src/__tests__/VariablesPopover.test.tsx
+++ b/web/src/__tests__/VariablesPopover.test.tsx
@@ -202,4 +202,35 @@ describe('VariablesPopover', () => {
       expect(screen.queryByPlaceholderText('Filter variables...')).not.toBeInTheDocument();
     });
   });
+
+  describe('secret generator', () => {
+    const openCreateForm = async () => {
+      render(<VariablesPopover onSelect={onSelect} />);
+      fireEvent.click(screen.getByTitle('Insert variable'));
+      await waitFor(() => {
+        fireEvent.click(screen.getByText('Create New Variable'));
+      });
+    };
+
+    it('offers the generator in the create-new form for string variables', async () => {
+      await openCreateForm();
+      expect(
+        screen.getByRole('button', { name: 'Generate value' }),
+      ).toBeInTheDocument();
+    });
+
+    it('generates into the value input without closing the popover', async () => {
+      await openCreateForm();
+      const valueInput = screen.getByPlaceholderText('secret value') as HTMLInputElement;
+
+      fireEvent.click(screen.getByRole('button', { name: 'Generate value' }));
+      // Interacting inside the inline panel must not close the host popover.
+      fireEvent.mouseDown(screen.getByRole('slider', { name: 'Length' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+
+      expect(valueInput.value).toHaveLength(24);
+      // The create form (and popover) are still open.
+      expect(screen.getByPlaceholderText('VARIABLE_KEY')).toBeInTheDocument();
+    });
+  });
 });

--- a/web/src/__tests__/generateSecret.test.ts
+++ b/web/src/__tests__/generateSecret.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAlphabet,
+  entropyBits,
+  generateSecret,
+  type SecretOptions,
+} from '../lib/generateSecret';
+
+const ALL: SecretOptions = {
+  length: 24,
+  upper: true,
+  lower: true,
+  digits: true,
+  symbols: true,
+};
+
+describe('buildAlphabet', () => {
+  it('includes only the enabled classes', () => {
+    expect(buildAlphabet({ ...ALL, lower: false, digits: false, symbols: false })).toBe(
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    );
+    expect(buildAlphabet({ ...ALL, upper: false, lower: false, symbols: false })).toBe(
+      '0123456789',
+    );
+  });
+
+  it('is empty when no class is enabled', () => {
+    expect(
+      buildAlphabet({ length: 8, upper: false, lower: false, digits: false, symbols: false }),
+    ).toBe('');
+  });
+});
+
+describe('entropyBits', () => {
+  it('is length × log2(alphabetSize)', () => {
+    // 64-char alphabet → 6 bits/char.
+    expect(entropyBits(20, 64)).toBeCloseTo(120, 5);
+  });
+
+  it('is zero for degenerate inputs', () => {
+    expect(entropyBits(0, 64)).toBe(0);
+    expect(entropyBits(20, 1)).toBe(0);
+    expect(entropyBits(20, 0)).toBe(0);
+  });
+});
+
+describe('generateSecret', () => {
+  it('honors the requested length', () => {
+    for (const length of [8, 24, 64]) {
+      expect(generateSecret({ ...ALL, length })).toHaveLength(length);
+    }
+  });
+
+  it('returns an empty string for non-positive length', () => {
+    expect(generateSecret({ ...ALL, length: 0 })).toBe('');
+  });
+
+  it('throws when no character class is enabled', () => {
+    expect(() =>
+      generateSecret({ length: 16, upper: false, lower: false, digits: false, symbols: false }),
+    ).toThrow(/at least one character class/);
+  });
+
+  it('only emits characters from the selected alphabet', () => {
+    const opts: SecretOptions = { length: 200, upper: true, lower: false, digits: true, symbols: false };
+    const alphabet = new Set(buildAlphabet(opts));
+    for (const ch of generateSecret(opts)) {
+      expect(alphabet.has(ch)).toBe(true);
+    }
+  });
+
+  it('produces a different value on each call (overwhelmingly likely)', () => {
+    const a = generateSecret(ALL);
+    const b = generateSecret(ALL);
+    expect(a).not.toBe(b);
+  });
+
+  it('distributes characters roughly uniformly (no modulo bias)', () => {
+    // 62-char alphabet does not divide 256, so a naive `% len` would bias the
+    // first 8 characters. Rejection sampling must keep the distribution flat.
+    const opts: SecretOptions = { length: 1, upper: true, lower: true, digits: true, symbols: false };
+    const alphabet = buildAlphabet(opts);
+    expect(alphabet).toHaveLength(62);
+
+    const counts = new Map<string, number>();
+    const samples = 62 * 2000; // ~2000 expected hits per character
+    for (let i = 0; i < samples; i++) {
+      const ch = generateSecret(opts);
+      counts.set(ch, (counts.get(ch) ?? 0) + 1);
+    }
+
+    const expected = samples / alphabet.length;
+    // Every character should appear, within ±25% of the expected frequency.
+    for (const ch of alphabet) {
+      const c = counts.get(ch) ?? 0;
+      expect(c).toBeGreaterThan(expected * 0.75);
+      expect(c).toBeLessThan(expected * 1.25);
+    }
+  });
+});

--- a/web/src/components/vault/SecretGenerator.tsx
+++ b/web/src/components/vault/SecretGenerator.tsx
@@ -1,0 +1,248 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react';
+import { Wand2, Copy } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { Button } from '../ui/Button';
+import { showToast } from '../ui/Toast';
+import {
+  buildAlphabet,
+  entropyBits,
+  generateSecret,
+  type SecretOptions,
+} from '../../lib/generateSecret';
+
+const MIN_LENGTH = 8;
+const MAX_LENGTH = 64;
+const DEFAULT_LENGTH = 24;
+
+interface SecretGeneratorProps {
+  // onGenerate receives the freshly generated value; wire it to the host's
+  // value setter (e.g. setNewValue / onEditValueChange).
+  onGenerate: (value: string) => void;
+  // onReveal asks the host to reveal the (now non-empty) value input.
+  onReveal?: () => void;
+  iconSize?: number;
+  // Applied to the trigger button (e.g. `mr-auto` to push neighbors right).
+  className?: string;
+}
+
+type ClassKey = 'upper' | 'lower' | 'digits' | 'symbols';
+
+const CLASS_CHIPS: { key: ClassKey; label: string }[] = [
+  { key: 'upper', label: 'A-Z' },
+  { key: 'lower', label: 'a-z' },
+  { key: 'digits', label: '0-9' },
+  { key: 'symbols', label: '!@#' },
+];
+
+// SecretGenerator is a disclosure-style control: a wand trigger that expands an
+// inline panel (length, character classes, live entropy) and fills the host's
+// value input with a CSPRNG-generated string. Rendered inline (no portal) so it
+// is safe inside the wizard's portal popover — clicks inside the panel still
+// count as "inside" that popover.
+export function SecretGenerator({
+  onGenerate,
+  onReveal,
+  iconSize = 12,
+  className,
+}: SecretGeneratorProps) {
+  const [open, setOpen] = useState(false);
+  const [length, setLength] = useState(DEFAULT_LENGTH);
+  const [classes, setClasses] = useState({
+    upper: true,
+    lower: true,
+    digits: true,
+    symbols: true,
+  });
+  // Held only while the panel is open, to enable copy + the Regenerate label.
+  // Cleared on close so the value isn't retained in long-lived state.
+  const [generated, setGenerated] = useState('');
+  const [announcement, setAnnouncement] = useState('');
+
+  const panelId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const lengthRef = useRef<HTMLInputElement>(null);
+
+  const opts: SecretOptions = { length, ...classes };
+  const alphabetSize = buildAlphabet(opts).length;
+  const bits = Math.round(entropyBits(length, alphabetSize));
+  const activeCount = CLASS_CHIPS.filter((c) => classes[c.key]).length;
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setGenerated('');
+    setAnnouncement('');
+  }, []);
+
+  // Collapse on clicks outside the trigger and panel. Clicks inside the panel
+  // keep any host popover open too, since the panel lives in its DOM subtree.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (!triggerRef.current?.contains(t) && !panelRef.current?.contains(t)) {
+        close();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open, close]);
+
+  // Move focus into the panel when it opens.
+  useEffect(() => {
+    if (open) lengthRef.current?.focus();
+  }, [open]);
+
+  const toggleClass = (key: ClassKey) => {
+    setClasses((prev) => {
+      // Never disable the last enabled class — the alphabet must stay non-empty.
+      if (prev[key] && CLASS_CHIPS.filter((c) => prev[c.key]).length === 1) {
+        return prev;
+      }
+      return { ...prev, [key]: !prev[key] };
+    });
+  };
+
+  const handleGenerate = () => {
+    const value = generateSecret({ length, ...classes });
+    setGenerated(value);
+    onGenerate(value);
+    onReveal?.();
+    // Announce metadata only — never the characters.
+    setAnnouncement(
+      `Generated a ${length}-character value, ~${bits} bits of entropy`,
+    );
+  };
+
+  const handleCopy = async () => {
+    if (!generated) return;
+    try {
+      await navigator.clipboard.writeText(generated);
+      showToast('success', 'Copied');
+    } catch {
+      // Fail quietly — never surface the secret value in an error.
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      // Stop the host (wizard popover / inline edit) from also reacting.
+      e.stopPropagation();
+      close();
+      triggerRef.current?.focus();
+    }
+  };
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => (open ? close() : setOpen(true))}
+        aria-label="Generate value"
+        aria-expanded={open}
+        aria-controls={panelId}
+        title="Generate a secure value"
+        className={cn(
+          'inline-flex items-center justify-center p-1 rounded text-text-muted transition-colors',
+          'hover:text-primary',
+          open && 'text-primary',
+          className,
+        )}
+      >
+        <Wand2 size={iconSize} />
+      </button>
+
+      {open && (
+        <div
+          ref={panelRef}
+          id={panelId}
+          onKeyDown={handleKeyDown}
+          className="w-full basis-full mt-1 rounded-lg border border-border/60 bg-surface-elevated/60 p-2.5 space-y-2"
+        >
+          {/* Length */}
+          <div className="flex items-center gap-2">
+            <span className="w-12 shrink-0 text-[10px] text-text-muted">Length</span>
+            <input
+              ref={lengthRef}
+              type="range"
+              min={MIN_LENGTH}
+              max={MAX_LENGTH}
+              value={length}
+              onChange={(e) => setLength(Number(e.target.value))}
+              aria-label="Length"
+              aria-valuetext={`${length} characters`}
+              className="flex-1 accent-primary"
+            />
+            <span className="w-6 text-right text-[10px] font-mono tabular-nums text-text-primary">
+              {length}
+            </span>
+          </div>
+
+          {/* Character classes */}
+          <div
+            role="group"
+            aria-label="Character classes"
+            className="flex flex-wrap gap-1"
+          >
+            {CLASS_CHIPS.map(({ key, label }) => {
+              const enabled = classes[key];
+              const locked = enabled && activeCount === 1;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  aria-pressed={enabled}
+                  disabled={locked}
+                  onClick={() => toggleClass(key)}
+                  title={locked ? 'At least one class is required' : label}
+                  className={cn(
+                    'rounded px-2 py-1 text-[10px] font-mono font-medium transition-colors',
+                    enabled
+                      ? 'bg-primary/20 text-primary'
+                      : 'text-text-muted hover:bg-white/[0.04] hover:text-text-primary',
+                    locked && 'cursor-not-allowed',
+                  )}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Entropy + actions */}
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-[10px] font-mono text-text-muted">~{bits} bits</span>
+            <div className="flex items-center gap-1.5">
+              {generated && (
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  title="Copy to clipboard"
+                  aria-label="Copy generated value to clipboard"
+                  className="p-1 rounded text-text-muted hover:text-text-primary transition-colors"
+                >
+                  <Copy size={12} />
+                </button>
+              )}
+              <Button type="button" variant="primary" size="sm" onClick={handleGenerate}>
+                {generated ? 'Regenerate' : 'Generate'}
+              </Button>
+            </div>
+          </div>
+
+          <div aria-live="polite" className="sr-only">
+            {announcement}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/components/vault/SecretItem.tsx
+++ b/web/src/components/vault/SecretItem.tsx
@@ -13,6 +13,7 @@ import { cn } from '../../lib/cn';
 import { Button } from '../ui/Button';
 import { VariableTypeBadge } from './VariableTypeBadge';
 import { VariableVisibilityIcon } from './VariableVisibilityIcon';
+import { SecretGenerator } from './SecretGenerator';
 import type { Consumer, Variable } from '../../lib/api';
 
 // How many consumers to show before collapsing behind a "see all" toggle.
@@ -125,6 +126,14 @@ export function SecretItem({
             {showEditValue ? <EyeOff size={10} /> : <Eye size={10} />}
           </button>
         </div>
+        {secret.type === 'string' && (
+          <SecretGenerator
+            onGenerate={onEditValueChange}
+            onReveal={() => {
+              if (!showEditValue) onEditToggleShow();
+            }}
+          />
+        )}
         <div className="flex justify-end gap-1.5">
           <button
             onClick={onEditCancel}

--- a/web/src/components/vault/VariableQuickAddForm.tsx
+++ b/web/src/components/vault/VariableQuickAddForm.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../lib/cn';
 import { Button } from '../ui/Button';
 import { VariableTypeSelector } from './VariableTypeSelector';
 import { VariableSecretToggle } from './VariableSecretToggle';
+import { SecretGenerator } from './SecretGenerator';
 import {
   validateVariableInput,
   getValuePlaceholder,
@@ -125,6 +126,12 @@ export function VariableQuickAddForm({
         <div className="flex flex-wrap items-center gap-2">
           <VariableTypeSelector value={type} onChange={setType} />
           <VariableSecretToggle isSecret={isSecret} onChange={setIsSecret} />
+          {type === 'string' && (
+            <SecretGenerator
+              onGenerate={setNewValue}
+              onReveal={() => setShowValue(true)}
+            />
+          )}
         </div>
         <div className="flex gap-2">
           <select

--- a/web/src/components/wizard/VariablesPopover.tsx
+++ b/web/src/components/wizard/VariablesPopover.tsx
@@ -9,6 +9,7 @@ import { VariableVisibilityIcon } from '../vault/VariableVisibilityIcon';
 import { VariableTypeBadge } from '../vault/VariableTypeBadge';
 import { VariableTypeSelector } from '../vault/VariableTypeSelector';
 import { VariableSecretToggle } from '../vault/VariableSecretToggle';
+import { SecretGenerator } from '../vault/SecretGenerator';
 import { validateVariableInput, getValuePlaceholder } from '../vault/variableTypeHelpers';
 
 interface VariablesPopoverProps {
@@ -257,8 +258,14 @@ export function VariablesPopover({ onSelect, className }: VariablesPopoverProps)
           <div className="flex flex-wrap gap-1">
             <VariableTypeSelector value={newType} onChange={setNewType} />
           </div>
-          <div className="flex flex-wrap gap-1">
+          <div className="flex flex-wrap items-center gap-1">
             <VariableSecretToggle isSecret={newIsSecret} onChange={setNewIsSecret} />
+            {newType === 'string' && (
+              <SecretGenerator
+                onGenerate={setNewValue}
+                onReveal={() => setShowValue(true)}
+              />
+            )}
           </div>
           {error && (
             <p className="text-[10px] text-status-error">{error}</p>

--- a/web/src/lib/generateSecret.ts
+++ b/web/src/lib/generateSecret.ts
@@ -1,0 +1,60 @@
+// Cryptographically secure random-string generation for the secret generator.
+// Uses the Web Crypto CSPRNG (crypto.getRandomValues) with rejection sampling
+// to avoid modulo bias — never Math.random. See CONSTITUTION Article XII.
+
+export interface SecretOptions {
+  length: number;
+  upper: boolean;
+  lower: boolean;
+  digits: boolean;
+  symbols: boolean;
+}
+
+const UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const LOWER = 'abcdefghijklmnopqrstuvwxyz';
+const DIGITS = '0123456789';
+const SYMBOLS = '!@#$%^&*-_=+';
+
+// buildAlphabet assembles the character pool from the enabled classes.
+export function buildAlphabet(opts: SecretOptions): string {
+  return (
+    (opts.upper ? UPPER : '') +
+    (opts.lower ? LOWER : '') +
+    (opts.digits ? DIGITS : '') +
+    (opts.symbols ? SYMBOLS : '')
+  );
+}
+
+// entropyBits returns the Shannon entropy (length × log2(alphabetSize)) of a
+// string drawn uniformly from the alphabet. Zero for a degenerate alphabet.
+export function entropyBits(length: number, alphabetSize: number): number {
+  if (length <= 0 || alphabetSize <= 1) return 0;
+  return length * Math.log2(alphabetSize);
+}
+
+// generateSecret returns a random string of opts.length characters drawn
+// uniformly from the enabled alphabet. Bytes come from the CSPRNG and are
+// mapped with rejection sampling: any byte at or above the largest multiple of
+// the alphabet size that fits in a byte is discarded, so every character is
+// equally likely (no modulo bias).
+export function generateSecret(opts: SecretOptions): string {
+  const alphabet = buildAlphabet(opts);
+  if (alphabet.length === 0) {
+    throw new Error('at least one character class must be enabled');
+  }
+  if (opts.length <= 0) return '';
+
+  const setLen = alphabet.length;
+  const max = 256 - (256 % setLen); // largest multiple of setLen within a byte
+  const out: string[] = [];
+  // Over-allocate so rejections rarely force a second getRandomValues call.
+  const buf = new Uint8Array(opts.length * 2);
+  while (out.length < opts.length) {
+    crypto.getRandomValues(buf);
+    for (let i = 0; i < buf.length && out.length < opts.length; i++) {
+      const b = buf[i];
+      if (b < max) out.push(alphabet[b % setLen]);
+    }
+  }
+  return out.join('');
+}


### PR DESCRIPTION
## Description

Adds a built-in, fully client-side secret generator to the Variables workspace. A wand button beside the value input opens an inline panel (length, character classes, live entropy) and fills the field with a cryptographically secure random string — removing the need to leave the app to generate strong secrets.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- New `generateSecret` util — Web Crypto CSPRNG (`crypto.getRandomValues`) with rejection sampling to avoid modulo bias; `buildAlphabet` / `entropyBits` helpers.
- New shared `SecretGenerator` component — wand trigger + inline disclosure panel (length slider, A-Z/a-z/0-9/symbols toggles with a ≥1-class guard, live `~N bits` entropy, generate/regenerate, copy).
- Wired into all three variable value-entry sites: the quick-add form, the wizard's create-new form, and the inline edit row. Shown only for `string` variables.
- Inline (not portal) so it is safe inside the wizard popover; auto-reveals the generated value; `aria-live` announces metadata only (never the characters).
- No new dependencies; no backend changes.

## Testing

`npm run build` and `npm test` (678/678 pass). New suites cover the CSPRNG util (incl. a modulo-bias distribution check), the component, and the three host wirings (including that interacting with the panel does not close the wizard popover).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #708