### PR TITLE
refactor: extract useToolsEditor hook for reuse

### DIFF
--- a/web/src/__tests__/useToolsEditor.test.ts
+++ b/web/src/__tests__/useToolsEditor.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useToolsEditor } from '../hooks/useToolsEditor';
+import { TOOL_NAME_DELIMITER } from '../lib/constants';
+import type { Tool } from '../types';
+import * as apiModule from '../lib/api';
+import { SetServerToolsError } from '../lib/api';
+
+vi.mock('../components/ui/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+const mockStoreState: {
+  tools: Tool[];
+  setGatewayStatus: ReturnType<typeof vi.fn>;
+  setTools: ReturnType<typeof vi.fn>;
+  selectNode: ReturnType<typeof vi.fn>;
+} = {
+  tools: [],
+  setGatewayStatus: vi.fn(),
+  setTools: vi.fn(),
+  selectNode: vi.fn(),
+};
+
+vi.mock('../stores/useStackStore', () => ({
+  useStackStore: Object.assign(
+    vi.fn((selector: (s: { tools: Tool[] }) => unknown) => selector(mockStoreState)),
+    {
+      getState: () => mockStoreState,
+    },
+  ),
+}));
+
+const SERVER = 'db';
+
+function tool(name: string, description?: string): Tool {
+  return {
+    name: `${SERVER}${TOOL_NAME_DELIMITER}${name}`,
+    description,
+    inputSchema: {},
+  };
+}
+
+beforeEach(() => {
+  mockStoreState.tools = [
+    tool('query', 'Run a SQL query'),
+    tool('insert', 'Insert a row'),
+    tool('delete_row', 'Delete a row'),
+  ];
+  mockStoreState.setGatewayStatus.mockReset();
+  mockStoreState.setTools.mockReset();
+  mockStoreState.selectNode.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe('useToolsEditor', () => {
+  it('derives every advertised tool, prefix-stripped', () => {
+    const { result } = renderHook(() => useToolsEditor(SERVER, []));
+    expect(result.current.allTools.map((t) => t.name).sort()).toEqual([
+      'delete_row',
+      'insert',
+      'query',
+    ]);
+  });
+
+  it('seeds selection from the saved whitelist', () => {
+    const { result } = renderHook(() => useToolsEditor(SERVER, ['query']));
+    expect(result.current.selected.has('query')).toBe(true);
+    expect(result.current.selected.has('insert')).toBe(false);
+    expect(result.current.dirty).toBe(false);
+  });
+
+  it('seeds every tool as selected when the saved whitelist is empty (expose-all)', () => {
+    const { result } = renderHook(() => useToolsEditor(SERVER, []));
+    expect(result.current.selected.size).toBe(3);
+    expect(result.current.dirty).toBe(false);
+  });
+
+  it('toggles a tool and tracks dirty + diff count', () => {
+    const { result } = renderHook(() => useToolsEditor(SERVER, ['query']));
+
+    act(() => result.current.toggle('insert'));
+    expect(result.current.selected.has('insert')).toBe(true);
+    expect(result.current.dirty).toBe(true);
+    expect(result.current.diffCount).toBe(1);
+
+    // Toggling back to the saved state clears the dirty flag.
+    act(() => result.current.toggle('insert'));
+    expect(result.current.dirty).toBe(false);
+    expect(result.current.diffCount).toBe(0);
+  });
+
+  it('selectAll selects every tool; clearAll empties the selection', () => {
+    const { result } = renderHook(() => useToolsEditor(SERVER, ['query']));
+
+    act(() => result.current.selectAll());
+    expect(result.current.selected.size).toBe(3);
+
+    act(() => result.current.clearAll());
+    expect(result.current.selected.size).toBe(0);
+    expect(result.current.dirty).toBe(true);
+  });
+
+  it('saves the curated selection (canonical, sorted) and refreshes store caches', async () => {
+    const setSpy = vi
+      .spyOn(apiModule, 'setServerTools')
+      .mockResolvedValue({ server: SERVER, tools: ['insert', 'query'], reloaded: true, reloadedAt: 'now' });
+    const fetchStatusSpy = vi
+      .spyOn(apiModule, 'fetchStatus')
+      .mockResolvedValue({ gateway: { name: 'x', version: '1' }, 'mcp-servers': [] });
+    const fetchToolsSpy = vi.spyOn(apiModule, 'fetchTools').mockResolvedValue({ tools: [] });
+
+    const { result } = renderHook(() => useToolsEditor(SERVER, ['query']));
+    act(() => result.current.toggle('insert'));
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy).toHaveBeenCalledWith(SERVER, ['insert', 'query']);
+    await waitFor(() => expect(fetchStatusSpy).toHaveBeenCalled());
+    expect(fetchToolsSpy).toHaveBeenCalled();
+    expect(mockStoreState.setGatewayStatus).toHaveBeenCalled();
+    expect(mockStoreState.setTools).toHaveBeenCalled();
+  });
+
+  it('sends an empty whitelist when every tool is selected (expose-all wire semantics)', async () => {
+    const setSpy = vi
+      .spyOn(apiModule, 'setServerTools')
+      .mockResolvedValue({ server: SERVER, tools: [], reloaded: true, reloadedAt: 'now' });
+    vi.spyOn(apiModule, 'fetchStatus').mockResolvedValue({
+      gateway: { name: 'x', version: '1' },
+      'mcp-servers': [],
+    });
+    vi.spyOn(apiModule, 'fetchTools').mockResolvedValue({ tools: [] });
+
+    // Start curated on "query"; selecting the remaining two brings the
+    // selection to the full set, which must normalize to [].
+    const { result } = renderHook(() => useToolsEditor(SERVER, ['query']));
+    act(() => result.current.toggle('insert'));
+    act(() => result.current.toggle('delete_row'));
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy).toHaveBeenCalledWith(SERVER, []);
+  });
+
+  it('surfaces a 409 stack_modified error as a conflict instead of throwing', async () => {
+    vi.spyOn(apiModule, 'setServerTools').mockRejectedValue(
+      new SetServerToolsError('stack_modified', 'File changed', 'Reload the file.', 409),
+    );
+
+    const { result } = renderHook(() => useToolsEditor(SERVER, ['query']));
+    act(() => result.current.toggle('insert'));
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(result.current.conflict).toBe('Reload the file.');
+  });
+
+  it('lists every tool from the server-advertised list when the global store is empty (code mode)', () => {
+    mockStoreState.tools = [];
+    const { result } = renderHook(() =>
+      useToolsEditor(SERVER, [], ['query', 'insert', 'delete_row']),
+    );
+    expect(result.current.allTools.map((t) => t.name).sort()).toEqual([
+      'delete_row',
+      'insert',
+      'query',
+    ]);
+    // Empty whitelist → all rows selected.
+    expect(result.current.selected.size).toBe(3);
+  });
+
+  it('prompts to discard when the server switches with unsaved edits', () => {
+    const { result, rerender } = renderHook(
+      ({ server, saved }: { server: string; saved: string[] }) =>
+        useToolsEditor(server, saved),
+      { initialProps: { server: 'db', saved: ['query'] } },
+    );
+
+    act(() => result.current.toggle('insert'));
+    expect(result.current.dirty).toBe(true);
+
+    // A different server is selected out from under the dirty editor.
+    mockStoreState.tools = [tool('foo')];
+    rerender({ server: 'other', saved: [] });
+
+    expect(result.current.discardPrompt).toBe('db');
+
+    // "Keep editing" re-selects the original server node in the store.
+    act(() => result.current.handleKeepEditing());
+    expect(mockStoreState.selectNode).toHaveBeenCalledWith('mcp-db');
+    expect(result.current.discardPrompt).toBeNull();
+  });
+});

--- a/web/src/components/sidebar/ToolsEditor.tsx
+++ b/web/src/components/sidebar/ToolsEditor.tsx
@@ -1,18 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
 import { Command } from 'cmdk';
-import Fuse from 'fuse.js';
 import { AlertCircle, Check, Loader2, RefreshCw, Save, Search } from 'lucide-react';
 import { cn } from '../../lib/cn';
-import { useStackStore } from '../../stores/useStackStore';
-import { TOOL_NAME_DELIMITER } from '../../lib/constants';
-import { showToast } from '../ui/Toast';
-import {
-  AuthError,
-  fetchStatus,
-  fetchTools,
-  setServerTools,
-  SetServerToolsError,
-} from '../../lib/api';
+import { useToolsEditor } from '../../hooks/useToolsEditor';
 
 interface ToolsEditorProps {
   serverName: string;
@@ -31,238 +20,30 @@ interface ToolsEditorProps {
   serverTools?: string[];
 }
 
-interface ToolRow {
-  name: string;
-  description?: string;
-}
-
-// canonicalWhitelist normalizes a selection into the wire form: a sorted,
-// deduplicated array. Dirty comparison uses it on both sides so selection
-// order never triggers a spurious "unsaved changes" state.
-function canonicalWhitelist(names: string[]): string[] {
-  return Array.from(new Set(names)).sort();
-}
-
-function arraysEqual(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
-  return true;
-}
-
+// ToolsEditor is the sidebar's per-server whitelist editor. All of its state
+// and the save-and-reload flow live in useToolsEditor; this component is the
+// presentational shell. The fleet Tools workspace reuses the same hook so the
+// two surfaces stay in lock-step.
 export function ToolsEditor({ serverName, savedTools, serverTools }: ToolsEditorProps) {
-  const tools = useStackStore((s) => s.tools);
-
-  // Every tool the editor should render. The server's own advertised list
-  // (from /api/status) is the authoritative source — it holds every tool
-  // regardless of code mode. The global tools store provides descriptions
-  // when available. A saved whitelist entry missing from both still renders
-  // so the user sees what's actually persisted in the YAML.
-  const allTools: ToolRow[] = useMemo(() => {
-    const prefix = `${serverName}${TOOL_NAME_DELIMITER}`;
-    const descriptions = new Map<string, string | undefined>();
-    for (const t of tools ?? []) {
-      if (t.name.startsWith(prefix)) {
-        descriptions.set(t.name.slice(prefix.length), t.description);
-      }
-    }
-    const rows = new Map<string, ToolRow>();
-    for (const name of serverTools ?? []) {
-      rows.set(name, { name, description: descriptions.get(name) });
-    }
-    for (const [name, description] of descriptions) {
-      if (!rows.has(name)) rows.set(name, { name, description });
-    }
-    for (const name of savedTools) {
-      if (!rows.has(name)) rows.set(name, { name });
-    }
-    return [...rows.values()];
-  }, [tools, serverName, savedTools, serverTools]);
-
-  // Saved selection in canonical form. When savedTools is empty, the YAML
-  // has no whitelist, so the server is exposing every tool — we reflect that
-  // by checking every row.
-  const savedSelection = useMemo(() => {
-    if (savedTools.length === 0) {
-      return canonicalWhitelist(allTools.map((t) => t.name));
-    }
-    return canonicalWhitelist(savedTools);
-  }, [savedTools, allTools]);
-
-  const [selection, setSelection] = useState<string[]>(savedSelection);
-  const [query, setQuery] = useState('');
-  const [isSaving, setIsSaving] = useState(false);
-  const [conflict, setConflict] = useState<string | null>(null);
-  // When the user tries to switch nodes with unsaved edits, we stash the name
-  // of the server we were editing so the "Keep editing" affordance can re-
-  // select it in the graph store.
-  const [discardPrompt, setDiscardPrompt] = useState<string | null>(null);
-
-  // Reset local selection when the server switches or when the saved state
-  // changes and the user has no pending edits. The ref captures the
-  // most-recent committed serverName so polling-driven re-renders don't
-  // clobber the user's in-progress edits.
-  const committedServer = useRef(serverName);
-  const savedRef = useRef(savedSelection);
-  const selectionRef = useRef(selection);
-  selectionRef.current = selection;
-
-  useEffect(() => {
-    const prevServer = committedServer.current;
-    const prevSaved = savedRef.current;
-    const currentCanonical = canonicalWhitelist(selectionRef.current);
-    const isDirty = !arraysEqual(currentCanonical, prevSaved);
-
-    if (prevServer !== serverName && isDirty) {
-      // Node switched out from under a dirty editor. Freeze the incoming
-      // render and surface a confirm dialog — until the user decides we keep
-      // the previous selection in view.
-      setDiscardPrompt(prevServer);
-      return;
-    }
-
-    committedServer.current = serverName;
-    savedRef.current = savedSelection;
-    if (!isDirty || prevServer !== serverName) {
-      setSelection(savedSelection);
-    }
-    // Intentionally depend on the tuple of (serverName, canonicalized
-    // savedSelection) — polling that reshuffles the underlying tools array
-    // without changing membership must not reset state.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [serverName, savedSelection.join('\u0000')]);
-
-  const fuse = useMemo(
-    () => new Fuse(allTools, { keys: ['name', 'description'], threshold: 0.4 }),
-    [allTools],
-  );
-
-  const visible = useMemo(() => {
-    if (!query.trim()) return allTools;
-    return fuse.search(query).map((r) => r.item);
-  }, [fuse, query, allTools]);
-
-  const selected = useMemo(() => new Set(selection), [selection]);
-  const canonicalSelection = useMemo(() => canonicalWhitelist(selection), [selection]);
-  const dirty = !arraysEqual(canonicalSelection, savedSelection);
-  const diffCount = useMemo(() => {
-    const saved = new Set(savedSelection);
-    let count = 0;
-    for (const name of canonicalSelection) if (!saved.has(name)) count++;
-    for (const name of savedSelection) if (!selected.has(name)) count++;
-    return count;
-  }, [canonicalSelection, savedSelection, selected]);
-
-  const toggle = (name: string) => {
-    const next = new Set(selected);
-    if (next.has(name)) next.delete(name);
-    else next.add(name);
-    setSelection([...next]);
-  };
-
-  const selectAll = () => setSelection(allTools.map((t) => t.name));
-  const clearAll = () => setSelection([]);
-
-  const handleSave = async () => {
-    setIsSaving(true);
-    setConflict(null);
-    // Empty whitelist means "expose all tools" in stack YAML semantics. We
-    // send an empty array when the user has selected every known tool so
-    // the stack file stays clean of a redundant full-list whitelist.
-    const wire =
-      canonicalSelection.length === allTools.length && allTools.length > 0
-        ? []
-        : canonicalSelection;
-    try {
-      const resp = await setServerTools(serverName, wire);
-      showToast('success', `Tools saved for ${serverName}`);
-      if (resp.reloaded === false) {
-        showToast(
-          'warning',
-          'Stack updated. Run "gridctl reload" or restart with --watch to apply.',
-        );
-      }
-      // Refresh the global caches so the sidebar reflects the now-filtered
-      // tool set. Best-effort; we've already persisted the write.
-      try {
-        const [status, toolsList] = await Promise.all([fetchStatus(), fetchTools()]);
-        useStackStore.getState().setGatewayStatus(status);
-        useStackStore.getState().setTools(toolsList.tools);
-      } catch {
-        /* ignore refresh failures — the page will re-poll shortly */
-      }
-    } catch (err) {
-      if (err instanceof AuthError) {
-        throw err;
-      }
-      if (err instanceof SetServerToolsError) {
-        switch (err.code) {
-          case 'stack_modified':
-            setConflict(err.hint || err.message);
-            return;
-          case 'reload_failed':
-            showToast(
-              'error',
-              `Tools saved for ${serverName}, but reload failed: ${err.message}. Check gridctl logs.`,
-            );
-            // The save persisted. Refetch so the editor shows the new
-            // on-disk state as the clean baseline; the hot reload can be
-            // re-attempted via the Reload button elsewhere in the UI.
-            try {
-              const [status, toolsList] = await Promise.all([fetchStatus(), fetchTools()]);
-              useStackStore.getState().setGatewayStatus(status);
-              useStackStore.getState().setTools(toolsList.tools);
-            } catch {
-              /* ignore refresh failures */
-            }
-            return;
-          case 'unknown_tool':
-            showToast('error', err.message);
-            return;
-          default:
-            showToast('error', err.message);
-            return;
-        }
-      }
-      const msg = err instanceof Error ? err.message : 'Save failed';
-      showToast('error', msg);
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  // handleReloadFromDisk refreshes the saved state after a 409. We refetch
-  // gateway status (which carries the running whitelist) and let the parent
-  // re-render the editor with the new savedTools prop; the user's in-flight
-  // selection is kept on top of the refreshed state.
-  const handleReloadFromDisk = async () => {
-    setConflict(null);
-    try {
-      const [status, toolsList] = await Promise.all([fetchStatus(), fetchTools()]);
-      useStackStore.getState().setGatewayStatus(status);
-      useStackStore.getState().setTools(toolsList.tools);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Refresh failed';
-      showToast('error', msg);
-    }
-  };
-
-  const handleDiscard = () => {
-    // User accepted the node switch. Adopt the incoming prop shape by
-    // re-initialising selection to the new savedSelection.
-    committedServer.current = serverName;
-    savedRef.current = savedSelection;
-    setSelection(savedSelection);
-    setDiscardPrompt(null);
-  };
-
-  const handleKeepEditing = () => {
-    if (!discardPrompt) return;
-    // Revert the graph's node selection back to the server we were editing.
-    // The sidebar re-renders with the previous node's data and our local
-    // selection is still the in-flight edit.
-    useStackStore.getState().selectNode(`mcp-${discardPrompt}`);
-    setDiscardPrompt(null);
-  };
+  const {
+    allTools,
+    visible,
+    query,
+    setQuery,
+    selected,
+    toggle,
+    selectAll,
+    clearAll,
+    dirty,
+    diffCount,
+    isSaving,
+    conflict,
+    discardPrompt,
+    handleSave,
+    handleReloadFromDisk,
+    handleDiscard,
+    handleKeepEditing,
+  } = useToolsEditor(serverName, savedTools, serverTools);
 
   const saveLabel = dirty
     ? `Save ${diffCount} change${diffCount === 1 ? '' : 's'} & Reload`

--- a/web/src/components/wizard/steps/ToolsPicker.tsx
+++ b/web/src/components/wizard/steps/ToolsPicker.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from 'react';
 import { Command } from 'cmdk';
-import Fuse from 'fuse.js';
 import { AlertCircle, ArrowLeft, Check, Edit3, Loader2, Plus, Radar, Search, X } from 'lucide-react';
 import { cn } from '../../../lib/cn';
 import { useStackStore } from '../../../stores/useStackStore';
 import { TOOL_NAME_DELIMITER } from '../../../lib/constants';
 import { showToast } from '../../ui/Toast';
+import { useFuzzySearch } from '../../../hooks/useFuzzySearch';
 import { useProbeServer } from '../../../hooks/useProbeServer';
 import { ProbeError, type ProbeServerConfig } from '../../../lib/api';
 
@@ -81,15 +81,11 @@ export function ToolsPicker({ value, onChange, serverName, probeConfig }: ToolsP
   const inManualMode = modeOverride ?? autoManual;
   const inEmptyState = !hasTools && !inManualMode;
 
-  const fuse = useMemo(
-    () => new Fuse(displayTools, { keys: ['name', 'description'], threshold: 0.4 }),
-    [displayTools],
-  );
-
-  const visible = useMemo(() => {
-    if (!query.trim()) return displayTools;
-    return fuse.search(query).map((r) => r.item);
-  }, [fuse, query, displayTools]);
+  // Shared fuzzy search over the merged tool list. ToolsPicker stays a
+  // controlled input (selection lives in the parent via value/onChange), so it
+  // only borrows the search primitive from useToolsEditor's world — not the
+  // stateful save/dirty controller, which would be a poor fit here.
+  const visible = useFuzzySearch(displayTools, query);
 
   const selected = useMemo(() => new Set(value), [value]);
 

--- a/web/src/hooks/useFuzzySearch.ts
+++ b/web/src/hooks/useFuzzySearch.ts
@@ -1,17 +1,25 @@
 import { useMemo } from 'react';
-import Fuse, { type IFuseOptions } from 'fuse.js';
-import type { AgentSkill } from '../types';
+import Fuse from 'fuse.js';
 
-const FUSE_OPTIONS: IFuseOptions<AgentSkill> = {
-  keys: ['name', 'description'],
-  threshold: 0.4,
-};
+// Anything searchable by name + optional description. AgentSkill, the tool rows
+// in ToolsEditor/ToolsPicker, and similar name/description records all satisfy
+// this — the hook is generic so each call site keeps its own item type.
+export interface FuzzySearchable {
+  name: string;
+  description?: string;
+}
 
-export function useFuzzySearch(skills: AgentSkill[], query: string): AgentSkill[] {
-  const fuse = useMemo(() => new Fuse(skills, FUSE_OPTIONS), [skills]);
+// Fuzzy-filter a list of name/description records by query, returning the full
+// list unchanged when the query is blank. Memoized on the source list and the
+// query so re-renders that change neither are free.
+export function useFuzzySearch<T extends FuzzySearchable>(items: T[], query: string): T[] {
+  const fuse = useMemo(
+    () => new Fuse(items, { keys: ['name', 'description'], threshold: 0.4 }),
+    [items],
+  );
 
   return useMemo(() => {
-    if (!query.trim()) return skills;
+    if (!query.trim()) return items;
     return fuse.search(query).map((r) => r.item);
-  }, [fuse, query, skills]);
+  }, [fuse, query, items]);
 }

--- a/web/src/hooks/useToolsEditor.ts
+++ b/web/src/hooks/useToolsEditor.ts
@@ -1,0 +1,311 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useStackStore } from '../stores/useStackStore';
+import { TOOL_NAME_DELIMITER } from '../lib/constants';
+import { showToast } from '../components/ui/Toast';
+import {
+  AuthError,
+  fetchStatus,
+  fetchTools,
+  setServerTools,
+  SetServerToolsError,
+} from '../lib/api';
+import { useFuzzySearch } from './useFuzzySearch';
+
+export interface ToolRow {
+  name: string;
+  description?: string;
+}
+
+// canonicalWhitelist normalizes a selection into the wire form: a sorted,
+// deduplicated array. Dirty comparison uses it on both sides so selection
+// order never triggers a spurious "unsaved changes" state.
+function canonicalWhitelist(names: string[]): string[] {
+  return Array.from(new Set(names)).sort();
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+export interface UseToolsEditor {
+  // Every tool the editor should render (server-advertised + saved + described).
+  allTools: ToolRow[];
+  // allTools narrowed by the current search query.
+  visible: ToolRow[];
+  query: string;
+  setQuery: (q: string) => void;
+  // Current selection as a Set for cheap membership/size lookups in the view.
+  selected: Set<string>;
+  toggle: (name: string) => void;
+  selectAll: () => void;
+  clearAll: () => void;
+  // True when the selection differs from what's persisted in the stack YAML.
+  dirty: boolean;
+  // Count of added + removed tools relative to the saved whitelist.
+  diffCount: number;
+  isSaving: boolean;
+  // Non-null when a 409 (stack file changed on disk) needs a reload affordance.
+  conflict: string | null;
+  // Non-null (the previous server name) when the user switched servers with a
+  // dirty editor and must confirm before the edit is discarded.
+  discardPrompt: string | null;
+  handleSave: () => Promise<void>;
+  handleReloadFromDisk: () => Promise<void>;
+  handleDiscard: () => void;
+  handleKeepEditing: () => void;
+}
+
+// useToolsEditor owns the per-server tool whitelist editing controller: the
+// tool list derivation, selection + dirty tracking, the polling/server-switch
+// guard, and the save-and-reload flow with its structured error handling. The
+// sidebar ToolsEditor and the fleet Tools workspace both drive their UI from
+// this hook so the two never diverge.
+//
+// `savedTools` is the whitelist applied to the server in the live stack — an
+// empty array means "no whitelist" (every tool the gateway knows is exposed).
+// `serverTools` is the unprefixed list of tools this specific server advertises
+// (from /api/status); it is authoritative because code mode hides downstream
+// tools behind meta-tools in the global aggregated list.
+export function useToolsEditor(
+  serverName: string,
+  savedTools: string[],
+  serverTools?: string[],
+): UseToolsEditor {
+  const tools = useStackStore((s) => s.tools);
+
+  // Every tool the editor should render. The server's own advertised list
+  // (from /api/status) is the authoritative source — it holds every tool
+  // regardless of code mode. The global tools store provides descriptions
+  // when available. A saved whitelist entry missing from both still renders
+  // so the user sees what's actually persisted in the YAML.
+  const allTools: ToolRow[] = useMemo(() => {
+    const prefix = `${serverName}${TOOL_NAME_DELIMITER}`;
+    const descriptions = new Map<string, string | undefined>();
+    for (const t of tools ?? []) {
+      if (t.name.startsWith(prefix)) {
+        descriptions.set(t.name.slice(prefix.length), t.description);
+      }
+    }
+    const rows = new Map<string, ToolRow>();
+    for (const name of serverTools ?? []) {
+      rows.set(name, { name, description: descriptions.get(name) });
+    }
+    for (const [name, description] of descriptions) {
+      if (!rows.has(name)) rows.set(name, { name, description });
+    }
+    for (const name of savedTools) {
+      if (!rows.has(name)) rows.set(name, { name });
+    }
+    return [...rows.values()];
+  }, [tools, serverName, savedTools, serverTools]);
+
+  // Saved selection in canonical form. When savedTools is empty, the YAML
+  // has no whitelist, so the server is exposing every tool — we reflect that
+  // by checking every row.
+  const savedSelection = useMemo(() => {
+    if (savedTools.length === 0) {
+      return canonicalWhitelist(allTools.map((t) => t.name));
+    }
+    return canonicalWhitelist(savedTools);
+  }, [savedTools, allTools]);
+
+  const [selection, setSelection] = useState<string[]>(savedSelection);
+  const [query, setQuery] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [conflict, setConflict] = useState<string | null>(null);
+  // When the user tries to switch servers with unsaved edits, we stash the name
+  // of the server we were editing so the "Keep editing" affordance can re-
+  // select it in the graph store.
+  const [discardPrompt, setDiscardPrompt] = useState<string | null>(null);
+
+  // Reset local selection when the server switches or when the saved state
+  // changes and the user has no pending edits. The ref captures the
+  // most-recent committed serverName so polling-driven re-renders don't
+  // clobber the user's in-progress edits.
+  const committedServer = useRef(serverName);
+  const savedRef = useRef(savedSelection);
+  const selectionRef = useRef(selection);
+  // Mirror the latest selection into a ref so the server-switch guard can read
+  // it without depending on `selection` (which would re-run the guard on every
+  // toggle). Done in an effect to keep ref writes out of render.
+  useEffect(() => {
+    selectionRef.current = selection;
+  }, [selection]);
+
+  // Tool names are constrained to [a-zA-Z0-9_-] (Claude Desktop tool-name
+  // rules), so a NUL byte can never appear inside one — it is a collision-free
+  // join delimiter for the membership signature this effect depends on.
+  const savedSignature = savedSelection.join(String.fromCharCode(0));
+
+  useEffect(() => {
+    const prevServer = committedServer.current;
+    const prevSaved = savedRef.current;
+    const currentCanonical = canonicalWhitelist(selectionRef.current);
+    const isDirty = !arraysEqual(currentCanonical, prevSaved);
+
+    if (prevServer !== serverName && isDirty) {
+      // Server switched out from under a dirty editor. Freeze the incoming
+      // render and surface a confirm dialog — until the user decides we keep
+      // the previous selection in view.
+      setDiscardPrompt(prevServer);
+      return;
+    }
+
+    committedServer.current = serverName;
+    savedRef.current = savedSelection;
+    if (!isDirty || prevServer !== serverName) {
+      setSelection(savedSelection);
+    }
+    // Intentionally depend on the tuple of (serverName, canonicalized
+    // savedSelection signature) — polling that reshuffles the underlying tools
+    // array without changing membership must not reset state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serverName, savedSignature]);
+
+  const visible = useFuzzySearch(allTools, query);
+
+  const selected = useMemo(() => new Set(selection), [selection]);
+  const canonicalSelection = useMemo(() => canonicalWhitelist(selection), [selection]);
+  const dirty = !arraysEqual(canonicalSelection, savedSelection);
+  const diffCount = useMemo(() => {
+    const saved = new Set(savedSelection);
+    let count = 0;
+    for (const name of canonicalSelection) if (!saved.has(name)) count++;
+    for (const name of savedSelection) if (!selected.has(name)) count++;
+    return count;
+  }, [canonicalSelection, savedSelection, selected]);
+
+  const toggle = (name: string) => {
+    const next = new Set(selected);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    setSelection([...next]);
+  };
+
+  const selectAll = () => setSelection(allTools.map((t) => t.name));
+  const clearAll = () => setSelection([]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setConflict(null);
+    // Empty whitelist means "expose all tools" in stack YAML semantics. We
+    // send an empty array when the user has selected every known tool so
+    // the stack file stays clean of a redundant full-list whitelist.
+    const wire =
+      canonicalSelection.length === allTools.length && allTools.length > 0
+        ? []
+        : canonicalSelection;
+    try {
+      const resp = await setServerTools(serverName, wire);
+      showToast('success', `Tools saved for ${serverName}`);
+      if (resp.reloaded === false) {
+        showToast(
+          'warning',
+          'Stack updated. Run "gridctl reload" or restart with --watch to apply.',
+        );
+      }
+      // Refresh the global caches so the sidebar reflects the now-filtered
+      // tool set. Best-effort; we've already persisted the write.
+      try {
+        const [status, toolsList] = await Promise.all([fetchStatus(), fetchTools()]);
+        useStackStore.getState().setGatewayStatus(status);
+        useStackStore.getState().setTools(toolsList.tools);
+      } catch {
+        /* ignore refresh failures — the page will re-poll shortly */
+      }
+    } catch (err) {
+      if (err instanceof AuthError) {
+        throw err;
+      }
+      if (err instanceof SetServerToolsError) {
+        switch (err.code) {
+          case 'stack_modified':
+            setConflict(err.hint || err.message);
+            return;
+          case 'reload_failed':
+            showToast(
+              'error',
+              `Tools saved for ${serverName}, but reload failed: ${err.message}. Check gridctl logs.`,
+            );
+            // The save persisted. Refetch so the editor shows the new
+            // on-disk state as the clean baseline; the hot reload can be
+            // re-attempted via the Reload button elsewhere in the UI.
+            try {
+              const [status, toolsList] = await Promise.all([fetchStatus(), fetchTools()]);
+              useStackStore.getState().setGatewayStatus(status);
+              useStackStore.getState().setTools(toolsList.tools);
+            } catch {
+              /* ignore refresh failures */
+            }
+            return;
+          case 'unknown_tool':
+            showToast('error', err.message);
+            return;
+          default:
+            showToast('error', err.message);
+            return;
+        }
+      }
+      const msg = err instanceof Error ? err.message : 'Save failed';
+      showToast('error', msg);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  // handleReloadFromDisk refreshes the saved state after a 409. We refetch
+  // gateway status (which carries the running whitelist) and let the consumer
+  // re-render with the new savedTools; the user's in-flight selection is kept
+  // on top of the refreshed state.
+  const handleReloadFromDisk = async () => {
+    setConflict(null);
+    try {
+      const [status, toolsList] = await Promise.all([fetchStatus(), fetchTools()]);
+      useStackStore.getState().setGatewayStatus(status);
+      useStackStore.getState().setTools(toolsList.tools);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Refresh failed';
+      showToast('error', msg);
+    }
+  };
+
+  const handleDiscard = () => {
+    // User accepted the server switch. Adopt the incoming shape by
+    // re-initialising selection to the new savedSelection.
+    committedServer.current = serverName;
+    savedRef.current = savedSelection;
+    setSelection(savedSelection);
+    setDiscardPrompt(null);
+  };
+
+  const handleKeepEditing = () => {
+    if (!discardPrompt) return;
+    // Revert the graph's node selection back to the server we were editing.
+    // The consumer re-renders with the previous server's data and our local
+    // selection is still the in-flight edit.
+    useStackStore.getState().selectNode(`mcp-${discardPrompt}`);
+    setDiscardPrompt(null);
+  };
+
+  return {
+    allTools,
+    visible,
+    query,
+    setQuery,
+    selected,
+    toggle,
+    selectAll,
+    clearAll,
+    dirty,
+    diffCount,
+    isSaving,
+    conflict,
+    discardPrompt,
+    handleSave,
+    handleReloadFromDisk,
+    handleDiscard,
+    handleKeepEditing,
+  };
+}


### PR DESCRIPTION
## Description

Extracts the per-server tool whitelist editing controller out of `ToolsEditor` into a reusable `useToolsEditor` hook, and generalizes `useFuzzySearch` so both the sidebar editor and the wizard's tool picker share one fuzzy-search primitive. This is a behavior-preserving refactor that lays the groundwork for a fleet-wide Tools workspace to reuse the same controller.

## Type of Change

- [x] Refactor (no functional change)

## Changes Made

- Add `useToolsEditor` hook: tool-list derivation, selection + dirty/diff tracking, the polling/server-switch guard, and the save-and-reload flow with structured `stack_modified` / `reload_failed` / `unknown_tool` handling.
- Generalize `useFuzzySearch` to `useFuzzySearch<T extends FuzzySearchable>` (existing skill consumers infer their type unchanged).
- Refactor `ToolsEditor` into a thin presentational consumer of the hook.
- Refactor `ToolsPicker` to share `useFuzzySearch`. It stays a controlled input (selection lives in the parent, probe discovery + manual entry intact) — only the search primitive is shared, not the stateful controller.
- Add `useToolsEditor` unit tests (seeding, toggle, dirty/diff, expose-all wire semantics, 409 conflict, code-mode, server-switch discard guard).

## Testing

- `npx vitest run` — 707/707 pass (existing `ToolsEditor` / `ToolsPicker` contracts unchanged; 11 new hook tests).
- `npx tsc -b` — clean.
- `npm run build` — succeeds.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #712