### PR TITLE
feat: add Audit Mode to the Tools workspace

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -205,6 +205,35 @@ Returns all aggregated tools from registered MCP servers.
 curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/tools
 ```
 
+#### `GET /api/tools/usage`
+
+Returns per-(server, tool) usage observed by the gateway: cumulative call count and the last-called timestamp. Powers the Tools workspace **Audit Mode**, which separates actively-used, configured-but-unused, and disabled tools.
+
+Usage is recorded for both direct tool calls and tools invoked through code mode's `execute` (both flow through the same observer). For servers with metrics persistence enabled, the data is restored from disk on startup so it survives gateway restarts; otherwise it reflects activity since the last gateway start.
+
+`observedSince` is when this gateway process began recording. With persistence enabled, restored counts and timestamps may predate it — clients should treat tools absent from `servers` (or with no `lastCalledAt`) as "no recorded calls" rather than asserting a longer disuse history than `observedSince` supports.
+
+**Auth:** Yes
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/tools/usage
+```
+
+**Response:**
+```json
+{
+  "observedSince": "2026-05-20T10:00:00Z",
+  "servers": {
+    "github": {
+      "create_issue": { "calls": 42, "lastCalledAt": "2026-05-24T09:13:00Z" },
+      "list_repos": { "calls": 3, "lastCalledAt": "2026-05-21T08:00:00Z" }
+    }
+  }
+}
+```
+
+`servers` is an object keyed by server name; each value maps unprefixed tool names to their stats. Tools that have never been called are omitted. Returns `503` when no metrics accumulator is configured.
+
 #### `GET /api/logs`
 
 Returns structured log entries from the gateway log buffer.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -224,6 +224,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("PUT /api/mcp-servers/{name}/tools", s.handleSetServerTools)
 	mux.HandleFunc("/api/mcp-servers", s.handleMCPServers)
 	mux.HandleFunc("/api/tools", s.handleTools)
+	mux.HandleFunc("GET /api/tools/usage", s.handleToolsUsage)
 	mux.HandleFunc("/api/logs", s.handleGatewayLogs)
 	mux.HandleFunc("/api/metrics/tokens", s.handleMetricsTokens)
 	mux.HandleFunc("/api/metrics/cost", s.handleMetricsCost)

--- a/internal/api/tools_usage.go
+++ b/internal/api/tools_usage.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"net/http"
+	"time"
+)
+
+// toolUsageStat is the wire shape for one tool's usage in
+// GET /api/tools/usage. LastCalledAt is a pointer so a tool that has a
+// recorded call count but a zero timestamp (or never-called tools the UI
+// cross-references from the status list) renders as null rather than the
+// Go zero time.
+type toolUsageStat struct {
+	Calls        int64      `json:"calls"`
+	LastCalledAt *time.Time `json:"lastCalledAt,omitempty"`
+}
+
+// toolUsageResponse is the GET /api/tools/usage envelope. Servers maps each
+// MCP server name to its per-tool usage. ObservedSince is when this gateway
+// process began recording calls; with metrics persistence enabled the
+// restored counts may predate it. The Audit Mode UI uses ObservedSince to
+// stay honest: a tool with no recorded calls may simply predate the tracking
+// horizon rather than being genuinely unused.
+type toolUsageResponse struct {
+	ObservedSince *time.Time                          `json:"observedSince,omitempty"`
+	Servers       map[string]map[string]toolUsageStat `json:"servers"`
+}
+
+// handleToolsUsage serves GET /api/tools/usage: per-(server, tool) cumulative
+// call counts and last-called timestamps from the metrics accumulator. The
+// data is seeded from disk on startup (telemetry.MetricsFlusher.SeedFromFile)
+// so it survives gateway restarts for servers with metrics persistence
+// enabled. Returns 503 when no accumulator is wired (no observation data
+// yet), mirroring GET /api/optimize.
+//
+// Servers is always a non-nil object so the JSON body is "{}" rather than
+// null when nothing has been called.
+func (s *Server) handleToolsUsage(w http.ResponseWriter, _ *http.Request) {
+	if s.metricsAccumulator == nil {
+		writeJSONError(w, "metrics accumulator not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	resp := toolUsageResponse{Servers: map[string]map[string]toolUsageStat{}}
+	if started := s.metricsAccumulator.StartedAt(); !started.IsZero() {
+		t := started.UTC()
+		resp.ObservedSince = &t
+	}
+	for serverName, tools := range s.metricsAccumulator.ToolUsageSnapshot() {
+		inner := make(map[string]toolUsageStat, len(tools))
+		for toolName, stat := range tools {
+			entry := toolUsageStat{Calls: stat.Calls}
+			if !stat.LastCalledAt.IsZero() {
+				t := stat.LastCalledAt.UTC()
+				entry.LastCalledAt = &t
+			}
+			inner[toolName] = entry
+		}
+		resp.Servers[serverName] = inner
+	}
+	writeJSON(w, resp)
+}

--- a/internal/api/tools_usage_test.go
+++ b/internal/api/tools_usage_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/metrics"
+)
+
+// decodeToolUsage runs GET /api/tools/usage against srv and returns the
+// decoded response plus the HTTP status.
+func decodeToolUsage(t *testing.T, srv *Server) (toolUsageResponse, int) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/tools/usage", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	var resp toolUsageResponse
+	if rec.Body.Len() > 0 {
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v (body=%s)", err, rec.Body.String())
+		}
+	}
+	return resp, rec.Code
+}
+
+func TestHandleToolsUsage_ReportsPerToolCounts(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	// The observer records both direct and code-mode calls through
+	// RecordToolCall with the real downstream (server, tool); record a few
+	// here to stand in for that path.
+	srv.metricsAccumulator.RecordToolCall("github", "create_issue")
+	srv.metricsAccumulator.RecordToolCall("github", "create_issue")
+	srv.metricsAccumulator.RecordToolCall("github", "list_repos")
+
+	resp, code := decodeToolUsage(t, srv)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+
+	gh, ok := resp.Servers["github"]
+	if !ok {
+		t.Fatalf("github missing from response: %+v", resp.Servers)
+	}
+	if gh["create_issue"].Calls != 2 {
+		t.Errorf("create_issue calls = %d, want 2", gh["create_issue"].Calls)
+	}
+	if gh["list_repos"].Calls != 1 {
+		t.Errorf("list_repos calls = %d, want 1", gh["list_repos"].Calls)
+	}
+	if gh["create_issue"].LastCalledAt == nil || gh["create_issue"].LastCalledAt.IsZero() {
+		t.Error("create_issue lastCalledAt should be set")
+	}
+	if resp.ObservedSince == nil || resp.ObservedSince.IsZero() {
+		t.Error("observedSince should be set when an accumulator is wired")
+	}
+}
+
+func TestHandleToolsUsage_EmptyIsObjectNotNull(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	resp, code := decodeToolUsage(t, srv)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if resp.Servers == nil {
+		t.Error("servers should be a non-nil object when nothing has been called")
+	}
+	if len(resp.Servers) != 0 {
+		t.Errorf("servers = %+v, want empty", resp.Servers)
+	}
+}
+
+func TestHandleToolsUsage_NoAccumulatorReturns503(t *testing.T) {
+	srv := newTestServer(t) // no metrics accumulator wired
+	req := httptest.NewRequest(http.MethodGet, "/api/tools/usage", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+// TestHandleToolsUsage_SurvivesRestoreSeed asserts the endpoint surfaces
+// usage that was restored from disk (the persistence path), not just usage
+// recorded live this process — i.e. Audit Mode reflects pre-restart history.
+func TestHandleToolsUsage_SurvivesRestoreSeed(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	last := time.Now().Add(-3 * time.Hour).Truncate(time.Second)
+	srv.metricsAccumulator.RestoreToolUsage(map[string]map[string]metrics.ToolStat{
+		"atlassian": {"get_page": {Calls: 7, LastCalledAt: last}},
+	})
+
+	resp, code := decodeToolUsage(t, srv)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	got := resp.Servers["atlassian"]["get_page"]
+	if got.Calls != 7 {
+		t.Errorf("restored get_page calls = %d, want 7", got.Calls)
+	}
+	if got.LastCalledAt == nil || !got.LastCalledAt.Equal(last.UTC()) {
+		t.Errorf("restored lastCalledAt = %v, want %v", got.LastCalledAt, last.UTC())
+	}
+}

--- a/pkg/mcp/gateway_test.go
+++ b/pkg/mcp/gateway_test.go
@@ -1074,6 +1074,60 @@ func TestGateway_CallTool(t *testing.T) {
 	}
 }
 
+// recordingObserver captures every ToolCallObservation the gateway emits.
+// It implements both ToolCallObserver (so SetToolCallObserver accepts it) and
+// ClientObserver (so it takes the synchronous, tool-name-bearing path).
+type recordingObserver struct {
+	mu    sync.Mutex
+	calls []ToolCallObservation
+}
+
+func (r *recordingObserver) ObserveToolCall(string, int, map[string]any, *ToolCallResult) {}
+
+func (r *recordingObserver) ObserveToolCallWithClient(_ context.Context, obs ToolCallObservation) ToolCallSummary {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, obs)
+	return ToolCallSummary{}
+}
+
+// TestGateway_CallTool_ObserverAttribution verifies the convergence point that
+// Audit Mode depends on: a call routed through Gateway.CallTool with a
+// prefixed "server__tool" name notifies the observer with the *real
+// downstream* server and tool. This is the exact path code mode's execute
+// takes (its sandbox tool caller is the gateway), so usage recorded for
+// code-mode calls is attributed identically to direct calls.
+func TestGateway_CallTool_ObserverAttribution(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+	ctx := context.Background()
+
+	client := setupMockAgentClient(ctrl, "agent1", []Tool{{Name: "echo", Description: "Echo tool"}})
+	client.EXPECT().CallTool(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, string, map[string]any) (*ToolCallResult, error) {
+			return &ToolCallResult{Content: []Content{NewTextContent("ok")}}, nil
+		},
+	).AnyTimes()
+	g.Router().AddClient(client)
+	g.Router().RefreshTools()
+
+	obs := &recordingObserver{}
+	g.SetToolCallObserver(obs)
+
+	if _, err := g.CallTool(ctx, "agent1__echo", map[string]any{}); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	obs.mu.Lock()
+	defer obs.mu.Unlock()
+	if len(obs.calls) != 1 {
+		t.Fatalf("observer saw %d calls, want 1", len(obs.calls))
+	}
+	if got := obs.calls[0]; got.ServerName != "agent1" || got.ToolName != "echo" {
+		t.Errorf("attribution = (%q, %q), want (agent1, echo)", got.ServerName, got.ToolName)
+	}
+}
+
 // promptProviderClient wraps a MockAgentClient to also implement PromptProvider.
 type promptProviderClient struct {
 	AgentClient
@@ -3405,5 +3459,3 @@ func TestGateway_HandleInitialize_NormalizesClientID(t *testing.T) {
 		t.Errorf("Session.ClientID = %q, want claude-code", sess.ClientID)
 	}
 }
-
-

--- a/pkg/metrics/accumulator.go
+++ b/pkg/metrics/accumulator.go
@@ -525,6 +525,57 @@ func (a *Accumulator) ToolUsageSnapshot() map[string]map[string]ToolStat {
 	return out
 }
 
+// RestoreToolUsage seeds per-(server, tool) call counters from a persisted
+// snapshot so Audit Mode's usage history survives a gateway restart. Called
+// on startup by telemetry.MetricsFlusher.SeedFromFile before the gateway
+// serves traffic, so the counters it re-creates are the same *toolUsage
+// buckets RecordToolCall increments afterward — live calls continue from the
+// restored count rather than starting at zero.
+//
+// Tool-call attribution flows through the same observer for direct and
+// code-mode calls (Gateway.CallTool → HandleToolsCall → Observer →
+// RecordToolCall), so a restored snapshot reflects both equally.
+//
+// Restore is max-wins per counter: an existing in-memory value is kept when
+// it already exceeds the restored one (defensive against a seed racing late
+// initialization). Entries with no recorded calls are skipped so the snapshot
+// stays sparse. An empty map is a no-op.
+func (a *Accumulator) RestoreToolUsage(perServer map[string]map[string]ToolStat) {
+	if len(perServer) == 0 {
+		return
+	}
+	a.toolUsageMu.Lock()
+	defer a.toolUsageMu.Unlock()
+	for serverName, tools := range perServer {
+		if serverName == "" {
+			continue
+		}
+		for toolName, stat := range tools {
+			if toolName == "" || stat.Calls <= 0 {
+				continue
+			}
+			m, ok := a.toolUsage[serverName]
+			if !ok {
+				m = make(map[string]*toolUsage)
+				a.toolUsage[serverName] = m
+			}
+			tu, ok := m[toolName]
+			if !ok {
+				tu = &toolUsage{}
+				m[toolName] = tu
+			}
+			if stat.Calls > tu.calls.Load() {
+				tu.calls.Store(stat.Calls)
+			}
+			if !stat.LastCalledAt.IsZero() {
+				if nanos := stat.LastCalledAt.UnixNano(); nanos > tu.lastCalledNanos.Load() {
+					tu.lastCalledNanos.Store(nanos)
+				}
+			}
+		}
+	}
+}
+
 // RecordFormatSavings records token counts before and after format conversion.
 // Normal token usage tracking is handled separately by the ToolCallObserver;
 // this method only tracks the format savings delta.

--- a/pkg/metrics/accumulator_test.go
+++ b/pkg/metrics/accumulator_test.go
@@ -764,6 +764,64 @@ func TestAccumulator_StartedAt_StableAcrossClear(t *testing.T) {
 	}
 }
 
+func TestAccumulator_RestoreToolUsage(t *testing.T) {
+	t.Run("seeds counts and continues incrementing", func(t *testing.T) {
+		acc := NewAccumulator(100)
+		last := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+		acc.RestoreToolUsage(map[string]map[string]ToolStat{
+			"github": {
+				"create_issue": {Calls: 5, LastCalledAt: last},
+			},
+		})
+
+		snap := acc.ToolUsageSnapshot()
+		if got := snap["github"]["create_issue"].Calls; got != 5 {
+			t.Fatalf("restored calls = %d, want 5", got)
+		}
+		if got := snap["github"]["create_issue"].LastCalledAt; !got.Equal(last) {
+			t.Errorf("restored LastCalledAt = %v, want %v", got, last)
+		}
+
+		// A live call must increment the *restored* bucket, not start fresh.
+		acc.RecordToolCall("github", "create_issue")
+		if got := acc.ToolUsageSnapshot()["github"]["create_issue"].Calls; got != 6 {
+			t.Errorf("calls after restore+record = %d, want 6", got)
+		}
+	})
+
+	t.Run("max-wins keeps a larger in-memory count", func(t *testing.T) {
+		acc := NewAccumulator(100)
+		acc.RecordToolCall("github", "create_issue")
+		acc.RecordToolCall("github", "create_issue")
+		acc.RecordToolCall("github", "create_issue") // 3 live calls
+		acc.RestoreToolUsage(map[string]map[string]ToolStat{
+			"github": {"create_issue": {Calls: 1, LastCalledAt: time.Now()}},
+		})
+		if got := acc.ToolUsageSnapshot()["github"]["create_issue"].Calls; got != 3 {
+			t.Errorf("calls = %d, want 3 (live count must win over smaller restore)", got)
+		}
+	})
+
+	t.Run("zero-call and empty entries are skipped", func(t *testing.T) {
+		acc := NewAccumulator(100)
+		acc.RestoreToolUsage(map[string]map[string]ToolStat{
+			"github": {"never": {Calls: 0}},
+			"":       {"x": {Calls: 9}},
+		})
+		if snap := acc.ToolUsageSnapshot(); snap != nil {
+			t.Errorf("expected no usage restored; got %v", snap)
+		}
+	})
+
+	t.Run("empty map is a no-op", func(t *testing.T) {
+		acc := NewAccumulator(100)
+		acc.RestoreToolUsage(nil)
+		if snap := acc.ToolUsageSnapshot(); snap != nil {
+			t.Errorf("nil restore should be no-op; got %v", snap)
+		}
+	})
+}
+
 func TestAccumulator_Clear_ResetsPerClient(t *testing.T) {
 	acc := NewAccumulator(100)
 	acc.RecordReplicaWithClient("s", -1, "client-a", 10, 5)

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -37,6 +37,13 @@ type MetricsSnapshotLine struct {
 	Total     metrics.TokenCounts         `json:"total"`
 	CostDiff  *metrics.CostMicroUSDCounts `json:"cost_diff,omitempty"`
 	CostTotal *metrics.CostMicroUSDCounts `json:"cost_total,omitempty"`
+	// ToolUsage carries the server's *cumulative* per-tool call counters
+	// (toolName -> calls + last-called) at flush time — the analogue of
+	// Total for tools, not a per-minute diff. omitempty keeps token-only
+	// minutes and legacy pre-tool-usage files byte-identical; SeedFromFile
+	// takes the most recent non-nil ToolUsage per server (resetting on a
+	// token Reset) to rehydrate Audit Mode's usage history across restarts.
+	ToolUsage map[string]metrics.ToolStat `json:"tool_usage,omitempty"`
 }
 
 // MetricsFlusher periodically serializes per-server token counters from a
@@ -49,10 +56,11 @@ type MetricsFlusher struct {
 	interval time.Duration
 	logger   *slog.Logger
 
-	mu       sync.Mutex
-	writers  map[string]*lumberjack.Logger         // serverName -> writer
-	prev     map[string]metrics.TokenCounts        // serverName -> last token snapshot
-	prevCost map[string]metrics.CostMicroUSDCounts // serverName -> last cost snapshot (parallel to prev)
+	mu        sync.Mutex
+	writers   map[string]*lumberjack.Logger          // serverName -> writer
+	prev      map[string]metrics.TokenCounts         // serverName -> last token snapshot
+	prevCost  map[string]metrics.CostMicroUSDCounts  // serverName -> last cost snapshot (parallel to prev)
+	prevTools map[string]map[string]metrics.ToolStat // serverName -> last per-tool snapshot (parallel to prev)
 
 	stop     chan struct{}
 	done     chan struct{}
@@ -67,13 +75,14 @@ func NewMetricsFlusher(acc *metrics.Accumulator, interval time.Duration) *Metric
 		interval = DefaultMetricsFlushInterval
 	}
 	return &MetricsFlusher{
-		acc:      acc,
-		interval: interval,
-		writers:  make(map[string]*lumberjack.Logger),
-		prev:     make(map[string]metrics.TokenCounts),
-		prevCost: make(map[string]metrics.CostMicroUSDCounts),
-		stop:     make(chan struct{}),
-		done:     make(chan struct{}),
+		acc:       acc,
+		interval:  interval,
+		writers:   make(map[string]*lumberjack.Logger),
+		prev:      make(map[string]metrics.TokenCounts),
+		prevCost:  make(map[string]metrics.CostMicroUSDCounts),
+		prevTools: make(map[string]map[string]metrics.ToolStat),
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
 	}
 }
 
@@ -138,6 +147,7 @@ func (f *MetricsFlusher) RemoveServer(name string) {
 	}
 	delete(f.prev, name)
 	delete(f.prevCost, name)
+	delete(f.prevTools, name)
 }
 
 // ConfiguredServers returns the names currently persisting metrics.
@@ -221,6 +231,7 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 	}
 	snap := f.acc.Snapshot()
 	costSnap := f.acc.CostMicroSnapshot()
+	toolSnap := f.acc.ToolUsageSnapshot()
 
 	type planned struct {
 		writer *lumberjack.Logger
@@ -238,8 +249,15 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 		// priced call has hit the server yet — treat a missing entry as
 		// the zero CostMicroUSDCounts so the diff math stays uniform.
 		currentCost := costSnap[name]
+		currentTools := toolSnap[name]
 		prev, hadPrev := f.prev[name]
 		prevCost, hadPrevCost := f.prevCost[name]
+		// Per-tool usage has no diff/reset machinery — it persists as a
+		// cumulative snapshot. toolChanged forces a line when call counts
+		// advanced even if tokens and cost did not (a tool call need not
+		// attribute tokens), mirroring how cost forces a line independently
+		// of the token diff.
+		toolChanged := toolUsageChanged(f.prevTools[name], currentTools)
 		line := MetricsSnapshotLine{
 			Time:   now.UTC(),
 			Server: name,
@@ -295,7 +313,7 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 		// emits because it carries the post-reset boundary signal even
 		// when the post-reset state is zero.
 		tokenDiffZero := tokenDiff.InputTokens == 0 && tokenDiff.OutputTokens == 0 && tokenDiff.TotalTokens == 0
-		if !line.Reset && !line.CostReset && tokenDiffZero && costDiff.IsZero() {
+		if !line.Reset && !line.CostReset && tokenDiffZero && costDiff.IsZero() && !toolChanged {
 			continue
 		}
 
@@ -307,6 +325,13 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 			ct := currentCost
 			line.CostTotal = &ct
 		}
+		// Always carry the freshest cumulative tool usage on every emitted
+		// line (not only when toolChanged) so the most recent line per
+		// server — whatever dimension triggered it — holds the latest
+		// snapshot for SeedFromFile to restore.
+		if len(currentTools) > 0 {
+			line.ToolUsage = currentTools
+		}
 
 		plan = append(plan, planned{writer: writer, line: line})
 		// Update prev / prevCost under the lock — even if the write fails
@@ -316,6 +341,7 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 		// failure cannot leave them out of sync for the next tick's diff.
 		f.prev[name] = current
 		f.prevCost[name] = currentCost
+		f.prevTools[name] = currentTools
 	}
 	f.mu.Unlock()
 
@@ -371,11 +397,32 @@ func isCostCounterReset(prev, current metrics.CostMicroUSDCounts) bool {
 		current.CacheWriteMicroUSD < prev.CacheWriteMicroUSD
 }
 
+// toolUsageChanged reports whether the cumulative per-tool call counts for a
+// server differ between two snapshots. Comparing call counts alone suffices:
+// RecordToolCall bumps the count on every call, so a changed LastCalledAt
+// always coincides with a changed count. A new tool key (len differs) or any
+// per-tool count delta returns true. A token Reset clears tool usage, which
+// surfaces here as a shrink (len differs) — but reset lines already force a
+// flush, so this only needs to catch the steady-state tool-only delta.
+func toolUsageChanged(prev, current map[string]metrics.ToolStat) bool {
+	if len(prev) != len(current) {
+		return true
+	}
+	for tool, cur := range current {
+		if p, ok := prev[tool]; !ok || p.Calls != cur.Calls {
+			return true
+		}
+	}
+	return false
+}
+
 // SeedFromFile reads up to the last n NDJSON entries from path and seeds
-// four surfaces atomically: cumulative per-server token totals (via
-// Restore), cumulative per-server cost totals (via RestoreCost), per-minute
-// time-series ring buckets — both tokens and cost — (via ReplaySnapshot),
-// and this flusher's previous-snapshot maps (prev + prevCost). The Token
+// these surfaces atomically: cumulative per-server token totals (via
+// Restore), cumulative per-server cost totals (via RestoreCost), cumulative
+// per-(server, tool) call counts for Audit Mode (via RestoreToolUsage),
+// per-minute time-series ring buckets — both tokens and cost — (via
+// ReplaySnapshot), and this flusher's previous-snapshot maps (prev +
+// prevCost + prevTools). The Token
 // Usage Over Time and Cost Over Time charts are backed by the time-series
 // ring; without the bucket replay each would show only a single post-restart
 // point. The Cost KPI card is backed by the cumulative atomics; without
@@ -443,6 +490,7 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 	// shape they had during live operation.
 	latest := make(map[string]metrics.TokenCounts)
 	latestCost := make(map[string]metrics.CostMicroUSDCounts)
+	latestTools := make(map[string]map[string]metrics.ToolStat)
 	series := make([]seriesPoint, 0, len(lines))
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -459,6 +507,17 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 		latest[rec.Server] = rec.Total
 		if rec.CostTotal != nil {
 			latestCost[rec.Server] = *rec.CostTotal
+		}
+		// Tool usage is a cumulative snapshot, not a diff. A token Reset
+		// means the accumulator cleared (server restart / Clear), wiping
+		// tool usage too — drop the carried-over snapshot so a post-reset
+		// run with no tool calls restores nothing rather than stale counts.
+		// Any ToolUsage on this same line (post-reset activity) then wins.
+		if rec.Reset {
+			delete(latestTools, rec.Server)
+		}
+		if rec.ToolUsage != nil {
+			latestTools[rec.Server] = rec.ToolUsage
 		}
 		// Reset and CostReset are independent: a token-reset line skips
 		// token replay (Diff is the full carryover, replaying would spike
@@ -502,12 +561,16 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 	}
 	f.acc.Restore(latest)
 	f.acc.RestoreCost(latestCost)
+	f.acc.RestoreToolUsage(latestTools)
 	f.mu.Lock()
 	for name, counts := range latest {
 		f.prev[name] = counts
 	}
 	for name, counts := range latestCost {
 		f.prevCost[name] = counts
+	}
+	for name, tools := range latestTools {
+		f.prevTools[name] = tools
 	}
 	f.mu.Unlock()
 	return nil

--- a/pkg/telemetry/metrics_test.go
+++ b/pkg/telemetry/metrics_test.go
@@ -543,6 +543,141 @@ func TestMetricsSnapshotLine_IncludesCostFieldsWhenPresent(t *testing.T) {
 	}
 }
 
+// TestMetricsSnapshotLine_OmitsToolUsageWhenEmpty pins the wire-format
+// guarantee for the tool_usage extension: a line with no per-tool activity
+// (and legacy files predating Audit Mode) serializes without the field, so
+// the addition is backward-compatible exactly like the cost fields.
+func TestMetricsSnapshotLine_OmitsToolUsageWhenEmpty(t *testing.T) {
+	line := MetricsSnapshotLine{
+		Time:   time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC),
+		Server: "github",
+		Diff:   metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+		Total:  metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+	}
+	data, err := json.Marshal(line)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "tool_usage") {
+		t.Errorf("tool-usage-free line carried tool_usage field: %s", data)
+	}
+}
+
+// TestMetricsFlusher_ToolUsagePersistence covers Audit Mode's per-tool usage
+// surviving a gateway restart: a flush writes the cumulative per-tool counts,
+// a fresh accumulator restores them via SeedFromFile, a tool-only delta still
+// reaches disk, and a token reset drops carried-over usage so a wiped
+// accumulator does not resurrect stale counts.
+func TestMetricsFlusher_ToolUsagePersistence(t *testing.T) {
+	t.Run("flush persists cumulative tool usage and seed restores it", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		acc := metrics.NewAccumulator(100)
+		acc.Record("github", 100, 50)
+		acc.RecordToolCall("github", "create_issue")
+		acc.RecordToolCall("github", "create_issue")
+		acc.RecordToolCall("github", "list_repos")
+
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.AddServer("github", path, LogOpts{}); err != nil {
+			t.Fatalf("AddServer: %v", err)
+		}
+		f.flushOnce(time.Now())
+
+		// The latest payload line carries the cumulative per-tool snapshot.
+		var persisted map[string]metrics.ToolStat
+		for _, l := range readMetricsLines(t, path) {
+			var rec MetricsSnapshotLine
+			if err := json.Unmarshal([]byte(l), &rec); err == nil && rec.ToolUsage != nil {
+				persisted = rec.ToolUsage
+			}
+		}
+		if persisted == nil {
+			t.Fatal("no flushed line carried tool_usage")
+		}
+		if got := persisted["create_issue"].Calls; got != 2 {
+			t.Errorf("persisted create_issue calls = %d, want 2", got)
+		}
+
+		// Simulate a restart: a fresh accumulator seeded from the same file.
+		acc2 := metrics.NewAccumulator(100)
+		f2 := NewMetricsFlusher(acc2, time.Hour)
+		if err := f2.SeedFromFile(path, 100); err != nil {
+			t.Fatalf("SeedFromFile: %v", err)
+		}
+		snap := acc2.ToolUsageSnapshot()
+		if got := snap["github"]["create_issue"].Calls; got != 2 {
+			t.Errorf("restored create_issue calls = %d, want 2", got)
+		}
+		if got := snap["github"]["list_repos"].Calls; got != 1 {
+			t.Errorf("restored list_repos calls = %d, want 1", got)
+		}
+	})
+
+	t.Run("tool-only delta forces a line without a token change", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		acc := metrics.NewAccumulator(100)
+		acc.Record("github", 100, 50)
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.AddServer("github", path, LogOpts{}); err != nil {
+			t.Fatalf("AddServer: %v", err)
+		}
+		f.flushOnce(time.Now()) // token baseline
+		before := len(readMetricsLines(t, path))
+
+		// A tool call with no token delta must still produce a flush line so
+		// the usage reaches disk (mirrors cost's independent delta path).
+		acc.RecordToolCall("github", "create_issue")
+		f.flushOnce(time.Now())
+
+		lines := readMetricsLines(t, path)
+		if len(lines) <= before {
+			t.Fatalf("tool-only delta produced no new line: before=%d after=%d", before, len(lines))
+		}
+		var last MetricsSnapshotLine
+		if err := json.Unmarshal([]byte(lines[len(lines)-1]), &last); err != nil {
+			t.Fatalf("unmarshal last line: %v", err)
+		}
+		if got := last.ToolUsage["create_issue"].Calls; got != 1 {
+			t.Errorf("forced line tool usage = %+v, want create_issue calls 1", last.ToolUsage)
+		}
+	})
+
+	t.Run("token reset drops carried-over tool usage on seed", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		// Pre-reset history with tool usage.
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:      time.Now().Add(-time.Hour).UTC(),
+			Server:    "github",
+			Total:     metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+			ToolUsage: map[string]metrics.ToolStat{"create_issue": {Calls: 9, LastCalledAt: time.Now().Add(-time.Hour)}},
+		})
+		// Reset sentinel + post-reset full line with no tool usage (Clear
+		// wiped it): the seed must not resurrect the pre-reset counts.
+		writeRawLine(t, path, `{"reset":true,"ts":"2026-05-06T00:00:00Z","server":"github"}`)
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:   time.Now().UTC(),
+			Server: "github",
+			Reset:  true,
+			Total:  metrics.TokenCounts{},
+		})
+
+		acc := metrics.NewAccumulator(100)
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.SeedFromFile(path, 100); err != nil {
+			t.Fatalf("SeedFromFile: %v", err)
+		}
+		if snap := acc.ToolUsageSnapshot(); snap != nil {
+			t.Errorf("post-reset seed should restore no tool usage; got %v", snap)
+		}
+	})
+}
+
 // writeMetricsLine appends one MetricsSnapshotLine as NDJSON to path.
 func writeMetricsLine(t *testing.T, path string, line MetricsSnapshotLine) {
 	t.Helper()

--- a/web/src/__tests__/ToolsWorkspace.test.tsx
+++ b/web/src/__tests__/ToolsWorkspace.test.tsx
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import { ToolsWorkspace } from '../components/workspaces/ToolsWorkspace';
 import { useStackStore } from '../stores/useStackStore';
 import { TOOL_NAME_DELIMITER } from '../lib/constants';
+import * as api from '../lib/api';
 import type { MCPServerStatus, Tool } from '../types';
 
 vi.mock('../components/ui/Toast', () => ({ showToast: vi.fn() }));
@@ -123,5 +124,84 @@ describe('ToolsWorkspace', () => {
     fireEvent.click(screen.getByRole('button', { name: /show create_issue schema/i }));
     // The CodeViewer renders the JSON schema content.
     expect(screen.getByLabelText('create_issue input schema')).toBeInTheDocument();
+  });
+});
+
+describe('ToolsWorkspace — Audit Mode', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const recent = () => new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1h ago
+  const observedSince = () => new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  it('toggling Audit Mode fetches usage and annotates rows by state', async () => {
+    vi.spyOn(api, 'fetchToolUsage').mockResolvedValue({
+      observedSince: observedSince(),
+      servers: { github: { create_issue: { calls: 5, lastCalledAt: recent() } } },
+    });
+
+    renderAt('/tools?server=github');
+    fireEvent.click(screen.getByRole('button', { name: /toggle audit mode/i }));
+
+    // create_issue is exposed + recently used → "used".
+    expect(await screen.findByText('used')).toBeInTheDocument();
+    // list_repos is advertised but not whitelisted → "disabled".
+    expect(screen.getByText('disabled')).toBeInTheDocument();
+  });
+
+  it('shows an unused-count rail badge for servers with idle exposed tools', async () => {
+    // github's only exposed tool (create_issue) is recently used → 0 unused;
+    // atlassian exposes get_page with no calls → 1 unused. Only atlassian
+    // should carry the badge.
+    vi.spyOn(api, 'fetchToolUsage').mockResolvedValue({
+      observedSince: observedSince(),
+      servers: { github: { create_issue: { calls: 5, lastCalledAt: recent() } } },
+    });
+
+    renderAt('/tools');
+    fireEvent.click(screen.getByRole('button', { name: /toggle audit mode/i }));
+
+    expect(await screen.findByText('1 unused')).toBeInTheDocument();
+  });
+
+  it('remediation disables idle exposed tools through a single-server save', async () => {
+    // gitlab exposes a + b (whitelist), advertises a third disabled tool c.
+    useStackStore.setState({
+      isLoading: false,
+      mcpServers: [server('gitlab', ['a', 'b', 'c'], ['a', 'b'])],
+      tools: [
+        tool(`gitlab${TOOL_NAME_DELIMITER}a`),
+        tool(`gitlab${TOOL_NAME_DELIMITER}b`),
+        tool(`gitlab${TOOL_NAME_DELIMITER}c`),
+      ],
+    });
+    vi.spyOn(api, 'fetchToolUsage').mockResolvedValue({
+      observedSince: observedSince(),
+      // a used recently; b exposed but idle → the remediation target.
+      servers: { gitlab: { a: { calls: 9, lastCalledAt: recent() } } },
+    });
+    const saveSpy = vi
+      .spyOn(api, 'setServerTools')
+      .mockResolvedValue({ server: 'gitlab', tools: ['a'], reloaded: true });
+    vi.spyOn(api, 'fetchStatus').mockResolvedValue({
+      gateway: { name: 'x', version: '1' },
+      'mcp-servers': [],
+    });
+    vi.spyOn(api, 'fetchTools').mockResolvedValue({ tools: [] });
+
+    renderAt('/tools?server=gitlab');
+    fireEvent.click(screen.getByRole('button', { name: /toggle audit mode/i }));
+
+    // The remediation affordance appears once usage loads.
+    const disableBtn = await screen.findByRole('button', { name: /disable 1 unused tools/i });
+    fireEvent.click(disableBtn);
+
+    // Consequence-stating confirmation, then commit.
+    const confirm = await screen.findByRole('button', { name: /disable & reload/i });
+    fireEvent.click(confirm);
+
+    // The idle tool (b) is dropped; the used tool (a) persists as the whitelist.
+    await waitFor(() => expect(saveSpy).toHaveBeenCalledWith('gitlab', ['a']));
   });
 });

--- a/web/src/__tests__/fetchToolUsage.test.ts
+++ b/web/src/__tests__/fetchToolUsage.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchToolUsage } from '../lib/api';
+import type { ToolUsageResponse } from '../types';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchToolUsage', () => {
+  it('GETs /api/tools/usage and returns the parsed response', async () => {
+    const payload: ToolUsageResponse = {
+      observedSince: '2026-05-20T10:00:00Z',
+      servers: {
+        github: { create_issue: { calls: 2, lastCalledAt: '2026-05-24T09:00:00Z' } },
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchToolUsage();
+
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith('/api/tools/usage', expect.anything());
+  });
+
+  it('throws on a non-ok response so callers can surface the failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        json: async () => ({}),
+      }),
+    );
+
+    await expect(fetchToolUsage()).rejects.toThrow(/503/);
+  });
+});

--- a/web/src/__tests__/toolAudit.test.ts
+++ b/web/src/__tests__/toolAudit.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  auditWindowMs,
+  classifyTool,
+  effectiveEnabledTools,
+  formatLastUsed,
+  unusedEnabledTools,
+} from '../lib/toolAudit';
+import type { MCPServerStatus } from '../types';
+
+const NOW = Date.parse('2026-05-24T12:00:00Z');
+const W7D = auditWindowMs('7d');
+
+function srv(tools: string[], toolWhitelist?: string[]): MCPServerStatus {
+  return { name: 's', tools, toolWhitelist } as unknown as MCPServerStatus;
+}
+
+describe('classifyTool', () => {
+  it('is disabled when not enabled, regardless of usage', () => {
+    expect(classifyTool(false, '2026-05-24T11:00:00Z', W7D, NOW)).toBe('disabled');
+  });
+
+  it('is used when last call falls within the window', () => {
+    // 1 day ago, window 7d.
+    expect(classifyTool(true, '2026-05-23T12:00:00Z', W7D, NOW)).toBe('used');
+  });
+
+  it('is unused when the last call is older than the window', () => {
+    // 14 days ago, window 7d.
+    expect(classifyTool(true, '2026-05-10T12:00:00Z', W7D, NOW)).toBe('unused');
+  });
+
+  it('is unused when there is no recorded call', () => {
+    expect(classifyTool(true, undefined, W7D, NOW)).toBe('unused');
+  });
+
+  it('is unused on an unparseable timestamp (honest fallback)', () => {
+    expect(classifyTool(true, 'not-a-date', W7D, NOW)).toBe('unused');
+  });
+});
+
+describe('effectiveEnabledTools', () => {
+  it('returns the whitelist when it is non-empty', () => {
+    expect([...effectiveEnabledTools(srv(['a', 'b', 'c'], ['a', 'b']))].sort()).toEqual(['a', 'b']);
+  });
+
+  it('returns every advertised tool when the whitelist is empty (expose-all)', () => {
+    expect([...effectiveEnabledTools(srv(['a', 'b'], []))].sort()).toEqual(['a', 'b']);
+  });
+
+  it('returns every advertised tool when the whitelist is absent', () => {
+    expect([...effectiveEnabledTools(srv(['a', 'b']))].sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('unusedEnabledTools', () => {
+  it('counts only exposed tools with no recent activity', () => {
+    // a used (recent), b exposed but idle, c not exposed (disabled).
+    const usage = { a: { calls: 3, lastCalledAt: '2026-05-24T11:00:00Z' } };
+    expect(unusedEnabledTools(srv(['a', 'b', 'c'], ['a', 'b']), usage, W7D, NOW)).toEqual(['b']);
+  });
+
+  it('treats every exposed tool as unused when usage is undefined', () => {
+    expect(unusedEnabledTools(srv(['a', 'b'], []), undefined, W7D, NOW).sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('formatLastUsed', () => {
+  it('returns a placeholder when never recorded', () => {
+    expect(formatLastUsed(undefined)).toBe('no recorded calls');
+    expect(formatLastUsed('not-a-date')).toBe('no recorded calls');
+  });
+
+  it('renders days for multi-day gaps', () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    expect(formatLastUsed(threeDaysAgo)).toBe('3d ago');
+  });
+
+  it('renders weeks for multi-week gaps', () => {
+    const twoWeeksAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+    expect(formatLastUsed(twoWeeksAgo)).toBe('2w ago');
+  });
+});

--- a/web/src/__tests__/useToolsEditor.test.ts
+++ b/web/src/__tests__/useToolsEditor.test.ts
@@ -149,6 +149,46 @@ describe('useToolsEditor', () => {
     expect(setSpy).toHaveBeenCalledWith(SERVER, []);
   });
 
+  it('disableTools deselects the named tools and saves the remainder', async () => {
+    const setSpy = vi
+      .spyOn(apiModule, 'setServerTools')
+      .mockResolvedValue({ server: SERVER, tools: ['query'], reloaded: true, reloadedAt: 'now' });
+    vi.spyOn(apiModule, 'fetchStatus').mockResolvedValue({
+      gateway: { name: 'x', version: '1' },
+      'mcp-servers': [],
+    });
+    vi.spyOn(apiModule, 'fetchTools').mockResolvedValue({ tools: [] });
+
+    // Saved whitelist exposes query + insert (2 of 3 tools); disable insert.
+    const { result } = renderHook(() => useToolsEditor(SERVER, ['query', 'insert']));
+
+    await act(async () => {
+      await result.current.disableTools(['insert']);
+    });
+
+    // Remaining selection is the curated whitelist, persisted as-is (not []).
+    expect(setSpy).toHaveBeenCalledWith(SERVER, ['query']);
+    expect(result.current.selected.has('insert')).toBe(false);
+    expect(result.current.selected.has('query')).toBe(true);
+  });
+
+  it('disableTools refuses to disable every exposed tool (would re-expose all)', async () => {
+    const setSpy = vi.spyOn(apiModule, 'setServerTools');
+
+    // Curated whitelist exposes exactly query + insert; disabling both would
+    // empty the whitelist, which means "expose all" — the opposite intent.
+    const { result } = renderHook(() => useToolsEditor(SERVER, ['query', 'insert']));
+
+    await act(async () => {
+      await result.current.disableTools(['query', 'insert']);
+    });
+
+    // No save attempted; the live selection is untouched.
+    expect(setSpy).not.toHaveBeenCalled();
+    expect(result.current.selected.has('query')).toBe(true);
+    expect(result.current.selected.has('insert')).toBe(true);
+  });
+
   it('surfaces a 409 stack_modified error as a conflict instead of throwing', async () => {
     vi.spyOn(apiModule, 'setServerTools').mockRejectedValue(
       new SetServerToolsError('stack_modified', 'File changed', 'Reload the file.', 409),

--- a/web/src/components/workspaces/ToolsWorkspace.tsx
+++ b/web/src/components/workspaces/ToolsWorkspace.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Command } from 'cmdk';
 import {
+  Activity,
   AlertCircle,
   Check,
   ChevronRight,
@@ -16,13 +17,33 @@ import { cn } from '../../lib/cn';
 import { useStackStore } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
 import { useToolsEditor } from '../../hooks/useToolsEditor';
+import { useToolUsage } from '../../hooks/useToolUsage';
 import { useFuzzySearch } from '../../hooks/useFuzzySearch';
 import { TOOL_NAME_DELIMITER } from '../../lib/constants';
+import { formatRelativeTime } from '../../lib/time';
+import {
+  AUDIT_WINDOWS,
+  DEFAULT_AUDIT_WINDOW,
+  auditWindowMs,
+  classifyTool,
+  formatLastUsed,
+  unusedEnabledTools,
+  type AuditState,
+  type AuditWindow,
+} from '../../lib/toolAudit';
 import { WorkspaceShell } from '../layout/WorkspaceShell';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { StatusDot } from '../ui/StatusDot';
 import { CodeViewer } from '../ui/CodeViewer';
-import type { MCPServerStatus, NodeStatus, Tool } from '../../types';
+import type { MCPServerStatus, NodeStatus, Tool, ToolUsageStat } from '../../types';
+
+// Per-state styling for Audit Mode dots/labels, keyed to the shared status
+// color tokens: used→running (green), unused→pending (amber), disabled→muted.
+const AUDIT_STYLES: Record<AuditState, { dot: string; text: string; label: string }> = {
+  used: { dot: 'bg-status-running', text: 'text-status-running', label: 'used' },
+  unused: { dot: 'bg-status-pending', text: 'text-status-pending', label: 'unused' },
+  disabled: { dot: 'bg-text-muted/50', text: 'text-text-muted', label: 'disabled' },
+};
 
 // ToolsWorkspace is the fleet-wide tool-management surface, sibling to
 // Topology, Library, and Variables. The left rail lists every MCP server with
@@ -103,6 +124,28 @@ export function ToolsWorkspace() {
     activeServer?.tools ?? [],
   );
 
+  // ---- Audit Mode ---------------------------------------------------------
+  // An overlay that classifies each tool as used / configured-but-unused /
+  // disabled against a lookback window. Usage is fetched only while the mode
+  // is on (the hook idles otherwise) so the editor pays nothing when it's off.
+  const [auditMode, setAuditMode] = useState(false);
+  const [auditWindow, setAuditWindow] = useState<AuditWindow>(DEFAULT_AUDIT_WINDOW);
+  const { usage, fetchedAt } = useToolUsage(auditMode);
+  const windowMs = auditWindowMs(auditWindow);
+  const usageByServer = usage?.servers;
+
+  // Per-server count of exposed-but-unused tools, for the rail badge. "now" is
+  // the fetch time from the hook (not a render-time clock read) so the memo
+  // stays pure and only recomputes when usage/window changes.
+  const unusedByServer = useMemo(() => {
+    const out: Record<string, number> = {};
+    if (!auditMode || !usageByServer || fetchedAt == null) return out;
+    for (const s of servers) {
+      out[s.name] = unusedEnabledTools(s, usageByServer[s.name], windowMs, fetchedAt).length;
+    }
+    return out;
+  }, [auditMode, usageByServer, servers, windowMs, fetchedAt]);
+
   // ---- Server-switch guard ------------------------------------------------
   // A pending target set while the active editor has unsaved edits. The switch
   // commits (URL change) only after the user discards.
@@ -153,6 +196,8 @@ export function ToolsWorkspace() {
       servers={servers}
       activeServerName={activeServerName}
       onSelectServer={(name) => requestServer(name)}
+      auditMode={auditMode}
+      unusedByServer={unusedByServer}
     />
   );
 
@@ -171,6 +216,11 @@ export function ToolsWorkspace() {
             serverCount={servers.length}
             query={globalQuery}
             onQueryChange={setGlobalQuery}
+            auditMode={auditMode}
+            onToggleAudit={() => setAuditMode((v) => !v)}
+            auditWindow={auditWindow}
+            onWindowChange={setAuditWindow}
+            observedSince={usage?.observedSince}
           />
 
           <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark">
@@ -191,6 +241,10 @@ export function ToolsWorkspace() {
                 allTools={tools}
                 expanded={expandedTool}
                 onToggleExpand={toggleExpanded}
+                auditMode={auditMode}
+                usage={usageByServer?.[activeServer.name]}
+                windowMs={windowMs}
+                now={fetchedAt}
               />
             ) : null}
           </div>
@@ -227,10 +281,26 @@ interface ToolsHeaderProps {
   serverCount: number;
   query: string;
   onQueryChange: (q: string) => void;
+  auditMode: boolean;
+  onToggleAudit: () => void;
+  auditWindow: AuditWindow;
+  onWindowChange: (w: AuditWindow) => void;
+  observedSince?: string;
 }
 
-function ToolsHeader({ compact, serverCount, query, onQueryChange }: ToolsHeaderProps) {
+function ToolsHeader({
+  compact,
+  serverCount,
+  query,
+  onQueryChange,
+  auditMode,
+  onToggleAudit,
+  auditWindow,
+  onWindowChange,
+  observedSince,
+}: ToolsHeaderProps) {
   const searching = query.trim().length > 0;
+  const windowLabel = AUDIT_WINDOWS.find((w) => w.id === auditWindow)?.label ?? '7 days';
   return (
     <header
       className={cn(
@@ -245,7 +315,54 @@ function ToolsHeader({ compact, serverCount, query, onQueryChange }: ToolsHeader
         <div className="font-mono text-[10px] text-text-muted">
           {serverCount} {serverCount === 1 ? 'server' : 'servers'}
         </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onToggleAudit}
+            aria-pressed={auditMode}
+            aria-label="Toggle audit mode"
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[10px] font-medium border transition-colors',
+              auditMode
+                ? 'bg-primary/15 text-primary border-primary/40'
+                : 'bg-background/40 text-text-muted border-border/40 hover:text-text-secondary hover:border-border',
+            )}
+          >
+            <Activity size={11} aria-hidden="true" />
+            Audit
+          </button>
+          {auditMode && (
+            <label className="inline-flex items-center gap-1.5 text-[10px] text-text-muted">
+              <span className="sr-only">Audit lookback window</span>
+              <select
+                value={auditWindow}
+                onChange={(e) => onWindowChange(e.target.value as AuditWindow)}
+                aria-label="Audit lookback window"
+                className="bg-background/60 border border-border/40 rounded-md px-1.5 py-1 text-[10px] text-text-secondary focus:outline-none focus:border-primary/50"
+              >
+                {AUDIT_WINDOWS.map((w) => (
+                  <option key={w.id} value={w.id}>
+                    {w.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+        </div>
       </div>
+
+      {auditMode && (
+        <p className="text-[10px] text-text-muted/80 leading-relaxed" role="status">
+          <span className="text-status-running">●</span> used ·{' '}
+          <span className="text-status-pending">●</span> unused ·{' '}
+          <span className="text-text-muted">●</span> disabled — &ldquo;unused&rdquo; means no
+          recorded calls in the last {windowLabel}.
+          {observedSince
+            ? ` Tracking since ${formatRelativeTime(new Date(observedSince))}; tools with no recorded calls may predate it.`
+            : ' Counts cover activity since the last gateway restart.'}
+        </p>
+      )}
 
       <div className="relative">
         <Search
@@ -286,9 +403,18 @@ interface ServerRailProps {
   servers: MCPServerStatus[];
   activeServerName: string;
   onSelectServer: (name: string) => void;
+  auditMode: boolean;
+  unusedByServer: Record<string, number>;
 }
 
-function ServerRail({ compact, servers, activeServerName, onSelectServer }: ServerRailProps) {
+function ServerRail({
+  compact,
+  servers,
+  activeServerName,
+  onSelectServer,
+  auditMode,
+  unusedByServer,
+}: ServerRailProps) {
   return (
     <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-r border-border-subtle">
       <div
@@ -309,6 +435,8 @@ function ServerRail({ compact, servers, activeServerName, onSelectServer }: Serv
             server={server}
             active={server.name === activeServerName}
             onClick={() => onSelectServer(server.name)}
+            auditMode={auditMode}
+            unusedCount={unusedByServer[server.name] ?? 0}
           />
         ))}
         {servers.length === 0 && (
@@ -325,11 +453,14 @@ interface ServerPillProps {
   server: MCPServerStatus;
   active: boolean;
   onClick: () => void;
+  auditMode: boolean;
+  unusedCount: number;
 }
 
-function ServerPill({ server, active, onClick }: ServerPillProps) {
+function ServerPill({ server, active, onClick, auditMode, unusedCount }: ServerPillProps) {
   const { enabled, total } = toolCounts(server);
   const status = serverStatus(server);
+  const showUnused = auditMode && unusedCount > 0;
   return (
     <button
       onClick={onClick}
@@ -345,6 +476,14 @@ function ServerPill({ server, active, onClick }: ServerPillProps) {
       <span className={cn('flex-1 min-w-0 text-xs font-mono truncate', active && 'text-primary')}>
         {server.name}
       </span>
+      {showUnused && (
+        <span
+          className="flex-shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded tabular-nums bg-status-pending/15 text-status-pending"
+          title={`${unusedCount} exposed ${unusedCount === 1 ? 'tool' : 'tools'} unused in the lookback window`}
+        >
+          {unusedCount} unused
+        </span>
+      )}
       <span
         className={cn(
           'flex-shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded tabular-nums',
@@ -370,9 +509,26 @@ interface ServerDetailProps {
   // global-search reveal can target it). null = none expanded.
   expanded: string | null;
   onToggleExpand: (tool: string) => void;
+  auditMode: boolean;
+  // This server's per-tool usage map (from GET /api/tools/usage), or undefined
+  // when usage hasn't loaded / Audit Mode is off.
+  usage: Record<string, ToolUsageStat> | undefined;
+  windowMs: number;
+  // Fetch time used as "now" for audit classification (null until loaded).
+  now: number | null;
 }
 
-function ServerDetail({ server, editor, allTools, expanded, onToggleExpand }: ServerDetailProps) {
+function ServerDetail({
+  server,
+  editor,
+  allTools,
+  expanded,
+  onToggleExpand,
+  auditMode,
+  usage,
+  windowMs,
+  now,
+}: ServerDetailProps) {
   const {
     allTools: rows,
     visible,
@@ -387,8 +543,35 @@ function ServerDetail({ server, editor, allTools, expanded, onToggleExpand }: Se
     isSaving,
     conflict,
     handleSave,
+    disableTools,
     handleReloadFromDisk,
   } = editor;
+
+  // Audit state per tool row, computed once per usage/selection/window change.
+  // Captures `now` inside the memo so the row render stays pure (no clock read
+  // during render). Empty when Audit Mode is off.
+  const auditByTool = useMemo(() => {
+    const map = new Map<string, AuditState>();
+    if (!auditMode || now == null) return map;
+    for (const row of rows) {
+      map.set(row.name, classifyTool(selected.has(row.name), usage?.[row.name]?.lastCalledAt, windowMs, now));
+    }
+    return map;
+  }, [auditMode, rows, selected, usage, windowMs, now]);
+
+  // Tools currently exposed (selected) but with no activity in the window —
+  // the "disable unused" remediation target. Derived from auditByTool so the
+  // banner and the per-row dots never disagree.
+  const unusedSelected = useMemo(() => {
+    const out: string[] = [];
+    for (const [name, state] of auditByTool) {
+      if (state === 'unused') out.push(name);
+    }
+    return out;
+  }, [auditByTool]);
+
+  // Confirm gate for the remediation bulk action (consequence-stating).
+  const [remediateOpen, setRemediateOpen] = useState(false);
 
   // Input schemas for this server's tools, keyed by unprefixed tool name.
   const schemaByTool = useMemo(() => {
@@ -446,6 +629,26 @@ function ServerDetail({ server, editor, allTools, expanded, onToggleExpand }: Se
         </div>
       </div>
 
+      {auditMode && unusedSelected.length > 0 && (
+        <div className="flex items-center gap-2 rounded-md border border-status-pending/30 bg-status-pending/[0.06] px-3 py-2">
+          <Activity size={12} className="text-status-pending flex-shrink-0" aria-hidden="true" />
+          <p className="flex-1 text-[11px] text-text-secondary">
+            <span className="font-medium text-status-pending">{unusedSelected.length}</span> exposed{' '}
+            {unusedSelected.length === 1 ? 'tool has' : 'tools have'} no recorded calls in the
+            lookback window.
+          </p>
+          <button
+            type="button"
+            onClick={() => setRemediateOpen(true)}
+            disabled={isSaving}
+            aria-label={`Disable ${unusedSelected.length} unused tools`}
+            className="flex-shrink-0 inline-flex items-center gap-1 rounded-md border border-status-pending/40 bg-status-pending/10 px-2 py-1 text-[10px] font-medium text-status-pending hover:bg-status-pending/20 transition-colors disabled:opacity-50"
+          >
+            Disable {unusedSelected.length} unused
+          </button>
+        </div>
+      )}
+
       <div className="rounded-lg border border-border/40 bg-background/60 overflow-hidden">
         <Command shouldFilter={false} label={`Tools for ${server.name}`} className="flex flex-col">
           <div className="flex items-center gap-2 px-3 py-2 border-b border-border/30">
@@ -471,6 +674,7 @@ function ServerDetail({ server, editor, allTools, expanded, onToggleExpand }: Se
               const isSelected = selected.has(opt.name);
               const schema = schemaByTool.get(opt.name);
               const isExpanded = expanded === opt.name;
+              const auditState = auditByTool.get(opt.name) ?? null;
               return (
                 <div
                   key={opt.name}
@@ -516,6 +720,28 @@ function ServerDetail({ server, editor, allTools, expanded, onToggleExpand }: Se
                       </div>
                       {opt.description && (
                         <div className="text-[10px] text-text-muted truncate">{opt.description}</div>
+                      )}
+                      {auditState && (
+                        <div
+                          className={cn(
+                            'flex items-center gap-1 text-[10px] mt-0.5',
+                            AUDIT_STYLES[auditState].text,
+                          )}
+                        >
+                          <span
+                            className={cn(
+                              'inline-block w-1.5 h-1.5 rounded-full flex-shrink-0',
+                              AUDIT_STYLES[auditState].dot,
+                            )}
+                            aria-hidden="true"
+                          />
+                          <span>{AUDIT_STYLES[auditState].label}</span>
+                          {auditState !== 'disabled' && (
+                            <span className="text-text-muted/70 truncate">
+                              · {formatLastUsed(usage?.[opt.name]?.lastCalledAt)}
+                            </span>
+                          )}
+                        </div>
                       )}
                     </div>
                     {schema && (
@@ -602,6 +828,26 @@ function ServerDetail({ server, editor, allTools, expanded, onToggleExpand }: Se
           </>
         )}
       </button>
+
+      <ConfirmDialog
+        isOpen={remediateOpen}
+        onClose={() => setRemediateOpen(false)}
+        onConfirm={() => {
+          setRemediateOpen(false);
+          void disableTools(unusedSelected);
+        }}
+        title="Disable unused tools"
+        message={
+          <p>
+            Disable <span className="font-mono text-primary">{unusedSelected.length}</span> unused{' '}
+            {unusedSelected.length === 1 ? 'tool' : 'tools'} on{' '}
+            <span className="font-mono text-primary">{server.name}</span>? This updates the
+            whitelist and reloads the server.
+          </p>
+        }
+        confirmLabel="Disable & reload"
+        variant="danger"
+      />
     </div>
   );
 }

--- a/web/src/hooks/useToolUsage.ts
+++ b/web/src/hooks/useToolUsage.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { fetchToolUsage } from '../lib/api';
+import type { ToolUsageResponse } from '../types';
+
+// Poll cadence for Audit Mode usage. Slower than status polling — usage shifts
+// over hours/days, so a tight loop buys nothing and the Fuse/classification
+// memos are keyed on this data, not rebuilt per render.
+const USAGE_POLL_MS = 15000;
+
+export interface ToolUsageState {
+  usage: ToolUsageResponse | null;
+  error: string | null;
+  // Epoch ms when `usage` was fetched. Audit classification uses this as
+  // "now" so the clock read stays out of render (React purity) and matches
+  // the snapshot it compares against. null until the first successful load.
+  fetchedAt: number | null;
+}
+
+// useToolUsage fetches GET /api/tools/usage and refreshes it on an interval
+// while `enabled` is true (Audit Mode on). When disabled it stops polling and
+// retains the last snapshot so toggling back is instant; the next enable
+// triggers an immediate refetch. The 401 path surfaces as an error string
+// rather than throwing — the workspace renders usage as best-effort overlay
+// data and must not crash the editor if it's unavailable.
+export function useToolUsage(enabled: boolean): ToolUsageState {
+  const [usage, setUsage] = useState<ToolUsageResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [fetchedAt, setFetchedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let active = true;
+
+    // State writes happen only inside this async loader (after an await
+    // tick), never synchronously in the effect body, so a refetch can't
+    // cascade an extra synchronous render. Date.now() is read here (not in
+    // render) so audit classification stays pure.
+    const load = async () => {
+      try {
+        const data = await fetchToolUsage();
+        if (!active) return;
+        setUsage(data);
+        setFetchedAt(Date.now());
+        setError(null);
+      } catch (err) {
+        if (!active) return;
+        setError(err instanceof Error ? err.message : 'Failed to load tool usage');
+      }
+    };
+
+    void load();
+    const id = setInterval(load, USAGE_POLL_MS);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, [enabled]);
+
+  return { usage, error, fetchedAt };
+}

--- a/web/src/hooks/useToolsEditor.ts
+++ b/web/src/hooks/useToolsEditor.ts
@@ -52,6 +52,11 @@ export interface UseToolsEditor {
   // dirty editor and must confirm before the edit is discarded.
   discardPrompt: string | null;
   handleSave: () => Promise<void>;
+  // Deselect the named tools and save the result through the same save+reload
+  // path as handleSave. Used by Audit Mode's "disable unused" remediation.
+  // Respects expose-all semantics: persists the remaining tools as a concrete
+  // whitelist (or [] if the remaining set is every tool).
+  disableTools: (names: string[]) => Promise<void>;
   handleReloadFromDisk: () => Promise<void>;
   handleDiscard: () => void;
   handleKeepEditing: () => void;
@@ -187,16 +192,18 @@ export function useToolsEditor(
   const selectAll = () => setSelection(allTools.map((t) => t.name));
   const clearAll = () => setSelection([]);
 
-  const handleSave = async () => {
+  // saveSelection persists a canonical selection through the atomic
+  // save+reload path and refreshes the global caches. Shared by handleSave
+  // (current selection) and disableTools (selection minus the unused tools)
+  // so both honor the same expose-all semantics and structured-error handling.
+  const saveSelection = async (targetSelection: string[]) => {
     setIsSaving(true);
     setConflict(null);
     // Empty whitelist means "expose all tools" in stack YAML semantics. We
-    // send an empty array when the user has selected every known tool so
+    // send an empty array when the selection covers every known tool so
     // the stack file stays clean of a redundant full-list whitelist.
     const wire =
-      canonicalSelection.length === allTools.length && allTools.length > 0
-        ? []
-        : canonicalSelection;
+      targetSelection.length === allTools.length && allTools.length > 0 ? [] : targetSelection;
     try {
       const resp = await setServerTools(serverName, wire);
       showToast('success', `Tools saved for ${serverName}`);
@@ -255,6 +262,29 @@ export function useToolsEditor(
     }
   };
 
+  const handleSave = () => saveSelection(canonicalSelection);
+
+  const disableTools = (names: string[]) => {
+    const drop = new Set(names);
+    const remaining = canonicalSelection.filter((name) => !drop.has(name));
+    // The whitelist model can't express "expose nothing" — an empty whitelist
+    // means "expose all". Disabling every exposed tool would therefore
+    // paradoxically re-expose them (and any previously-disabled tools). Refuse
+    // that case rather than silently inverting the user's intent.
+    if (remaining.length === 0) {
+      showToast(
+        'error',
+        `Can't disable every exposed tool on ${serverName} — at least one must stay enabled.`,
+      );
+      return Promise.resolve();
+    }
+    // Reflect the change in the view, then persist it. saveSelection reads the
+    // computed `remaining` directly (not React state) so the save is correct
+    // even though setSelection has not flushed yet.
+    setSelection(remaining);
+    return saveSelection(remaining);
+  };
+
   // handleReloadFromDisk refreshes the saved state after a 409. We refetch
   // gateway status (which carries the running whitelist) and let the consumer
   // re-render with the new savedTools; the user's in-flight selection is kept
@@ -304,6 +334,7 @@ export function useToolsEditor(
     conflict,
     discardPrompt,
     handleSave,
+    disableTools,
     handleReloadFromDisk,
     handleDiscard,
     handleKeepEditing,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, RegistryStatus, AgentSkill, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
+import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, RegistryStatus, AgentSkill, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
 
 // Base URL for API calls - empty for same origin
 const API_BASE = '';
@@ -119,6 +119,16 @@ export async function fetchMCPServers(): Promise<MCPServerStatus[]> {
  */
 export async function fetchTools(): Promise<ToolsListResult> {
   return fetchJSON<ToolsListResult>('/api/tools');
+}
+
+/**
+ * Fetch per-(server, tool) usage: cumulative call counts + last-called
+ * timestamps observed by the gateway. Powers Tools workspace Audit Mode.
+ * Survives gateway restarts for servers with metrics persistence enabled.
+ * GET /api/tools/usage
+ */
+export async function fetchToolUsage(): Promise<ToolUsageResponse> {
+  return fetchJSON<ToolUsageResponse>('/api/tools/usage');
 }
 
 /**

--- a/web/src/lib/toolAudit.ts
+++ b/web/src/lib/toolAudit.ts
@@ -1,0 +1,104 @@
+import type { MCPServerStatus, ToolUsageStat } from '../types';
+
+// Audit Mode classifies each tool into one of three states relative to a
+// lookback window of recorded usage. The logic is pure (no React, no clock
+// reads beyond an injected `now`) so it can be unit-tested directly and
+// memoized in the workspace without rebuilding on every poll.
+
+export type AuditWindow = '24h' | '7d' | '30d';
+
+export type AuditState = 'used' | 'unused' | 'disabled';
+
+export interface AuditWindowOption {
+  id: AuditWindow;
+  label: string;
+  ms: number;
+}
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+// Selectable lookback windows. Default is 7d — it matches the gateway's
+// `unused_tool` optimize heuristic (defaultFreshnessWindow = 7 * 24h) so the
+// two surfaces agree on what "unused" means.
+export const AUDIT_WINDOWS: AuditWindowOption[] = [
+  { id: '24h', label: '24 hours', ms: 24 * HOUR },
+  { id: '7d', label: '7 days', ms: 7 * DAY },
+  { id: '30d', label: '30 days', ms: 30 * DAY },
+];
+
+export const DEFAULT_AUDIT_WINDOW: AuditWindow = '7d';
+
+export function auditWindowMs(window: AuditWindow): number {
+  return AUDIT_WINDOWS.find((w) => w.id === window)?.ms ?? 7 * DAY;
+}
+
+// effectiveEnabledTools returns the set of tool names a server actually
+// exposes. An empty (or absent) whitelist means "expose all", so every
+// advertised tool is enabled — matching the gateway's whitelist semantics
+// and the enabled/total badge math.
+export function effectiveEnabledTools(server: MCPServerStatus): Set<string> {
+  const wl = server.toolWhitelist;
+  if (wl && wl.length > 0) return new Set(wl);
+  return new Set(server.tools);
+}
+
+// classifyTool decides a tool's audit state.
+//   - disabled: not currently exposed (precedence over usage — a disabled
+//     tool's past activity is irrelevant to whether it's exposed now).
+//   - used:     exposed and called within the window.
+//   - unused:   exposed but no call within the window (includes "never
+//     called", which the UI labels distinctly so it never implies a longer
+//     disuse history than the data supports).
+export function classifyTool(
+  enabled: boolean,
+  lastCalledAt: string | undefined,
+  windowMs: number,
+  now: number,
+): AuditState {
+  if (!enabled) return 'disabled';
+  if (lastCalledAt) {
+    const t = Date.parse(lastCalledAt);
+    if (!Number.isNaN(t) && now - t <= windowMs) return 'used';
+  }
+  return 'unused';
+}
+
+// unusedEnabledTools returns the names of a server's exposed tools that have
+// no activity within the window — the remediation target for "disable unused".
+// `usage` is the per-tool map for this server from GET /api/tools/usage.
+export function unusedEnabledTools(
+  server: MCPServerStatus,
+  usage: Record<string, ToolUsageStat> | undefined,
+  windowMs: number,
+  now: number,
+): string[] {
+  const enabled = effectiveEnabledTools(server);
+  const out: string[] = [];
+  for (const name of enabled) {
+    const last = usage?.[name]?.lastCalledAt;
+    if (classifyTool(true, last, windowMs, now) === 'unused') out.push(name);
+  }
+  return out;
+}
+
+// formatLastUsed renders a tool's last-call time for the audit row. Extends
+// the shared formatRelativeTime vocabulary to days/weeks since audit windows
+// span up to 30 days (where "720h ago" would read poorly). Undefined input
+// (never recorded) yields a caller-supplied placeholder.
+export function formatLastUsed(lastCalledAt: string | undefined): string {
+  if (!lastCalledAt) return 'no recorded calls';
+  const t = Date.parse(lastCalledAt);
+  if (Number.isNaN(t)) return 'no recorded calls';
+  const seconds = Math.floor((Date.now() - t) / 1000);
+  if (seconds < 10) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  return `${weeks}w ago`;
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -225,6 +225,24 @@ export interface ToolsListResult {
   nextCursor?: string;
 }
 
+// One tool's observed usage from GET /api/tools/usage.
+export interface ToolUsageStat {
+  calls: number;
+  // RFC3339; absent when the tool has a count but no recorded timestamp,
+  // or (cross-referenced from the status list) has never been called.
+  lastCalledAt?: string;
+}
+
+// GET /api/tools/usage — per-(server, tool) call counts + last-called times,
+// keyed by server name then unprefixed tool name. Powers Tools Audit Mode.
+// observedSince is when this gateway process began recording; with metrics
+// persistence enabled, restored counts may predate it, so tools missing from
+// `servers` mean "no recorded calls" — not a guaranteed longer disuse window.
+export interface ToolUsageResponse {
+  observedSince?: string;
+  servers: Record<string, Record<string, ToolUsageStat>>;
+}
+
 // Node status for UI display
 export type NodeStatus = 'running' | 'stopped' | 'error' | 'initializing' | 'idle';
 


### PR DESCRIPTION
## Description

Adds **Audit Mode** to the `/tools` workspace: a per-tool usage overlay that separates actively-used, configured-but-unused, and disabled tools so multi-server stacks can prune tool exposure with evidence. Usage is persisted to disk so it survives gateway restarts.

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

**Per-tool usage persistence (backend)**
- `MetricsSnapshotLine.ToolUsage` carries cumulative per-(server, tool) counts; the flusher emits a line on a tool-only delta and `SeedFromFile` rehydrates usage on startup (`RestoreToolUsage`). `omitempty` keeps token-only and legacy files byte-identical.
- Persistence rides the existing per-server NDJSON flusher + seed path — no new files or wiring.

**Usage endpoint**
- `GET /api/tools/usage` returns per-(server, tool) call counts + last-called timestamps and an `observedSince` horizon; `503` when no accumulator is wired. Documented in `docs/api-reference.md`.

**Audit Mode UI**
- Toggle + configurable lookback window (24h / 7d / 30d, default 7d) in the Tools workspace header, with an honest legend tied to `observedSince`.
- Rail badges show an exposed-but-unused count; detail rows are annotated used / unused / disabled with "last used".
- Remediation: "Disable N unused" routes through the existing single-server save (refuses to empty a whitelist, since `[]` means expose-all). The fleet batch action is deferred to a later phase.

## Testing

- Go: `go test -race ./pkg/metrics/... ./pkg/telemetry/... ./pkg/mcp/... ./internal/api/...` — persistence round-trip, restart survival, reset handling, endpoint, and code-mode → observer attribution.
- Web: `npm test` (734 passing) — audit classification, `fetchToolUsage`, Audit Mode UI, and remediation incl. the expose-all guard.
- `golangci-lint` (changed packages), `tsc`, targeted `eslint`, and `npm run build` all clean.

Part of #712

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed