### PR TITLE
feat: add fleet bulk actions to the Tools workspace

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -532,6 +532,49 @@ The body must be a JSON object with a `tools` field. An empty array (`[]`) clear
 - `502 reload_failed` - YAML written but hot reload failed
 - `503` - No stack file configured (stackless mode)
 
+#### `PUT /api/mcp-servers/tools`
+
+Applies tool-whitelist changes to **multiple** servers in one atomic `stack.yaml` write and triggers a **single** hot reload — the fleet-bulk counterpart to the per-server endpoint above. Powers the Tools workspace bulk actions (fleet-wide expose-all / clear / pattern filtering), where applying N servers via N single-server calls would cost N reloads.
+
+**Transaction semantics: all-or-nothing.** Every server's tools are validated before anything is written; if any tool is unknown the whole batch is rejected (`400 unknown_tool`, naming the offending server) and the stack file is left untouched. This prevents a half-applied fleet edit. The reload runs once after the single write.
+
+**Auth:** Yes
+
+**Request:**
+```bash
+curl -X PUT -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"servers": [
+        {"name": "github", "tools": ["search_code"]},
+        {"name": "atlassian", "tools": []}
+      ]}' \
+  http://localhost:8180/api/mcp-servers/tools
+```
+
+The body must be a JSON object with a non-empty `servers` array; each entry needs a `name` and a `tools` array (`[]` clears that server's whitelist = expose all). Server names must be unique within the batch. The body is capped at 512 KiB.
+
+**Response:**
+```json
+{
+  "servers": [
+    { "server": "github", "tools": ["search_code"] },
+    { "server": "atlassian", "tools": [] }
+  ],
+  "reloaded": true,
+  "reloadedAt": "2025-01-15T10:30:00Z"
+}
+```
+
+`reloaded`/`reloadedAt` follow the single-server rules (one reload for the whole batch; `false` without live-reload).
+
+**Errors:**
+- `400 unknown_tool` - A tool name is not advertised by its server (message names the server); nothing written
+- `400` - Body missing/empty `servers`, an entry missing `name`/`tools`, a duplicate server, or an empty tool name
+- `404` - A named server is not in the stack file; nothing written
+- `409 stack_modified` - Stack file changed on disk between read and write; nothing written
+- `502 reload_failed` - YAML written but hot reload failed
+- `503` - No stack file configured (stackless mode)
+
 #### `POST /api/servers/probe`
 
 Probes an external URL (or any other) MCP server configuration ephemerally and returns its advertised tool list, without registering it with the gateway. Powers the wizard's "Discover tools" button on the MCP server form.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -28,29 +28,29 @@ const statusLocked = 423
 
 // Server provides the combined API server for gridctl.
 type Server struct {
-	gateway          *mcp.Gateway
-	streamableServer *mcp.StreamableHTTPServer
-	sseServer        *mcp.SSEServer
-	staticFS       fs.FS
-	dockerClient   dockerclient.DockerClient
-	stackName      string
-	logBuffer      *logging.LogBuffer
-	reloadHandler  *reload.Handler
-	provisioners   *provisioner.Registry
-	linkServerName string
-	registryServer *registry.Server
+	gateway            *mcp.Gateway
+	streamableServer   *mcp.StreamableHTTPServer
+	sseServer          *mcp.SSEServer
+	staticFS           fs.FS
+	dockerClient       dockerclient.DockerClient
+	stackName          string
+	logBuffer          *logging.LogBuffer
+	reloadHandler      *reload.Handler
+	provisioners       *provisioner.Registry
+	linkServerName     string
+	registryServer     *registry.Server
 	pinStore           *pins.PinStore
 	vaultStore         *vault.Store
 	metricsAccumulator *metrics.Accumulator
 	traceBuffer        *tracing.Buffer
 	stackFile          string
 	allowedOrigins     []string
-	authType       string
-	authToken      string
-	authHeader     string
+	authType           string
+	authToken          string
+	authHeader         string
 
-	gatewayAddr        string // e.g. "http://localhost:8180" — used to build MCP config for CLI proxy
-	tokenizerName      string // active tokenizer mode: "embedded" or "api"
+	gatewayAddr   string // e.g. "http://localhost:8180" — used to build MCP config for CLI proxy
+	tokenizerName string // active tokenizer mode: "embedded" or "api"
 
 	// startWatcher, when set, starts a file watcher on the given stack path.
 	// Injected by GatewayBuilder so POST /api/stack/initialize can activate live reload.
@@ -211,9 +211,9 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 
 	// MCP endpoints - Streamable HTTP (POST/GET/DELETE) and legacy SSE negotiation
-	mux.Handle("/mcp", s.streamableServer)                 // Streamable HTTP transport
-	mux.Handle("/sse", s.sseServer)                        // Legacy negotiation redirect
-	mux.HandleFunc("/message", s.sseServer.HandleMessage)  // Legacy endpoint (410 Gone)
+	mux.Handle("/mcp", s.streamableServer)                // Streamable HTTP transport
+	mux.Handle("/sse", s.sseServer)                       // Legacy negotiation redirect
+	mux.HandleFunc("/message", s.sseServer.HandleMessage) // Legacy endpoint (410 Gone)
 
 	// API endpoints
 	mux.HandleFunc("/api/status", s.handleStatus)
@@ -221,6 +221,7 @@ func (s *Server) Handler() http.Handler {
 
 	mux.HandleFunc("GET /api/mcp-servers/{name}/logs", s.handleMCPServerLogs)
 	mux.HandleFunc("POST /api/mcp-servers/{name}/restart", s.handleMCPServerRestart)
+	mux.HandleFunc("PUT /api/mcp-servers/tools", s.handleSetServerToolsBatch)
 	mux.HandleFunc("PUT /api/mcp-servers/{name}/tools", s.handleSetServerTools)
 	mux.HandleFunc("/api/mcp-servers", s.handleMCPServers)
 	mux.HandleFunc("/api/tools", s.handleTools)
@@ -371,7 +372,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		},
 		MCPServers: s.getMCPServerStatuses(),
 		Resources:  s.getResourceStatuses(),
-		Sessions: s.gateway.SessionCount(),
+		Sessions:   s.gateway.SessionCount(),
 	}
 	// Only expose stack_name when a user-defined stack is loaded.
 	// The embedded gateway uses "gridctl" as its default name even in stackless

--- a/internal/api/mcp_servers.go
+++ b/internal/api/mcp_servers.go
@@ -11,6 +11,11 @@ import (
 const (
 	setToolsRequestMaxBytes = 64 * 1024
 
+	// setToolsBatchRequestMaxBytes caps the batch body. It is larger than the
+	// single-server cap because the payload carries one tools list per server;
+	// 512KiB comfortably holds a fleet of servers with long whitelists.
+	setToolsBatchRequestMaxBytes = 512 * 1024
+
 	// errCodeStackModified is the structured code returned with 409 responses
 	// so the UI can distinguish it from other failures and offer a
 	// Reload-file affordance.
@@ -136,6 +141,150 @@ func (s *Server) handleSetServerTools(w http.ResponseWriter, r *http.Request) {
 	// Trigger reload when live-reload is enabled. In no-watch mode we
 	// respond with reloaded: false so the UI can show a hint to run
 	// `gridctl reload` manually.
+	if s.reloadHandler != nil {
+		result, err := s.reloadHandler.Reload(r.Context())
+		if err != nil {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed,
+				err.Error(),
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+		if !result.Success {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed,
+				result.Message,
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+		resp.Reloaded = true
+		resp.ReloadedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	writeJSON(w, resp)
+}
+
+// setServerToolsBatchRequest is the wire shape for PUT /api/mcp-servers/tools.
+type setServerToolsBatchRequest struct {
+	Servers []batchServerToolsEntry `json:"servers"`
+}
+
+type batchServerToolsEntry struct {
+	Name  string    `json:"name"`
+	Tools *[]string `json:"tools"`
+}
+
+// batchServerResult reports one server's applied whitelist in a batch success.
+type batchServerResult struct {
+	Server string   `json:"server"`
+	Tools  []string `json:"tools"`
+}
+
+// setServerToolsBatchResponse is the success payload. The batch is atomic, so
+// every listed server was applied and (when live-reload is enabled) a single
+// reload ran once for the whole batch.
+type setServerToolsBatchResponse struct {
+	Servers    []batchServerResult `json:"servers"`
+	Reloaded   bool                `json:"reloaded"`
+	ReloadedAt string              `json:"reloadedAt,omitempty"`
+}
+
+// handleSetServerToolsBatch applies tool-whitelist changes to MULTIPLE servers
+// in one atomic YAML write, then triggers a SINGLE hot reload — avoiding the
+// N-reloads cost of calling the per-server endpoint in a loop.
+//
+// Transaction semantics are all-or-nothing: every server's tools are validated
+// up front, and if any tool is unknown the whole batch is rejected (400
+// unknown_tool) with nothing written. This keeps the on-disk stack from ever
+// landing in a half-applied state. A concurrent external edit surfaces as 409
+// (stack_modified, nothing written); a write that lands but fails to reload
+// surfaces as 502 (reload_failed) with the YAML changes persisted — identical
+// to the single-server endpoint's contract.
+//
+// PUT /api/mcp-servers/tools
+func (s *Server) handleSetServerToolsBatch(w http.ResponseWriter, r *http.Request) {
+	if s.stackFile == "" {
+		writeJSONError(w, "No stack file configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, setToolsBatchRequestMaxBytes))
+	if err != nil {
+		writeJSONError(w, "Failed to read request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var req setServerToolsBatchRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(req.Servers) == 0 {
+		writeJSONError(w, "Request body must include a non-empty servers array", http.StatusBadRequest)
+		return
+	}
+
+	// Build the update set, validating each entry up front so the whole batch
+	// is rejected before any write touches disk.
+	updates := make([]serverToolsUpdate, 0, len(req.Servers))
+	seen := make(map[string]struct{}, len(req.Servers))
+	for _, entry := range req.Servers {
+		if entry.Name == "" {
+			writeJSONError(w, "Each server entry must include a name", http.StatusBadRequest)
+			return
+		}
+		if _, dup := seen[entry.Name]; dup {
+			writeJSONError(w, "Duplicate server in batch: "+entry.Name, http.StatusBadRequest)
+			return
+		}
+		seen[entry.Name] = struct{}{}
+
+		if entry.Tools == nil {
+			writeJSONError(w, "Server "+entry.Name+" must include a tools array", http.StatusBadRequest)
+			return
+		}
+		tools := *entry.Tools
+		if tools == nil {
+			tools = []string{}
+		}
+		for _, t := range tools {
+			if t == "" {
+				writeJSONError(w, "Tool names must be non-empty strings", http.StatusBadRequest)
+				return
+			}
+		}
+		if err := s.validateToolsAgainstServer(entry.Name, tools); err != nil {
+			writeStructuredError(w, http.StatusBadRequest, errCodeUnknownTool,
+				err.Error()+" (server "+entry.Name+")",
+				"The tool list is out of date. Refresh and try again.")
+			return
+		}
+		updates = append(updates, serverToolsUpdate{Server: entry.Name, Tools: tools})
+	}
+
+	switch err := setServerToolsBatch(s.stackFile, updates); {
+	case err == nil:
+		// proceed
+	case errors.Is(err, errServerNotFound):
+		// err already reads "mcp server not found in stack: <name>".
+		writeJSONError(w, err.Error(), http.StatusNotFound)
+		return
+	case errors.Is(err, errStackModified):
+		writeStructuredError(w, http.StatusConflict, errCodeStackModified,
+			"The stack file was modified outside the canvas.",
+			"Reload the file to see the latest contents, then re-apply your changes.")
+		return
+	default:
+		writeJSONError(w, "Failed to update stack: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := setServerToolsBatchResponse{Servers: make([]batchServerResult, 0, len(updates))}
+	for _, u := range updates {
+		// serverToolsUpdate and batchServerResult share the same fields; the
+		// conversion echoes each applied server's name + persisted whitelist.
+		resp.Servers = append(resp.Servers, batchServerResult(u))
+	}
+
+	// Exactly one reload for the whole batch.
 	if s.reloadHandler != nil {
 		result, err := s.reloadHandler.Reload(r.Context())
 		if err != nil {

--- a/internal/api/mcp_servers_batch_test.go
+++ b/internal/api/mcp_servers_batch_test.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/reload"
+	"github.com/gridctl/gridctl/pkg/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newBatchHarness writes a stack.yaml with two external MCP servers so batch
+// tests can apply whitelist changes across both in one request.
+func newBatchHarness(t *testing.T) (string, *Server) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	content := `version: "1"
+name: test-stack
+network:
+  name: test-net
+  driver: bridge
+mcp-servers:
+  - name: github
+    url: https://example.com/gh
+    transport: http
+  - name: atlassian
+    url: https://example.com/atl
+    transport: http
+    tools:
+      - get_page
+      - create_page
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	s := &Server{}
+	s.SetStackFile(path)
+	return path, s
+}
+
+func batchRequest(t *testing.T, s *Server, payload any) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPut, "/api/mcp-servers/tools", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+	s.handleSetServerToolsBatch(w, req)
+	return w
+}
+
+func TestHandleSetServerToolsBatch_AppliesAllServers(t *testing.T) {
+	path, s := newBatchHarness(t)
+
+	w := batchRequest(t, s, map[string]any{
+		"servers": []map[string]any{
+			{"name": "github", "tools": []string{"a", "b"}},
+			{"name": "atlassian", "tools": []string{}}, // clear = expose all
+		},
+	})
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var resp setServerToolsBatchResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp.Servers, 2)
+	assert.False(t, resp.Reloaded, "no reloadHandler means reloaded: false")
+
+	// Both changes landed in one write: github gained a whitelist, atlassian's
+	// tools: key was dropped (expose all).
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	out := string(data)
+	assert.Contains(t, out, "- a")
+	assert.Contains(t, out, "- b")
+	assert.NotContains(t, out, "get_page", "atlassian whitelist should be cleared")
+}
+
+func TestHandleSetServerToolsBatch_SingleReload(t *testing.T) {
+	path, s := newBatchHarness(t)
+
+	currentCfg := &config.Stack{
+		Version: "1",
+		Name:    "test-stack",
+		Network: config.Network{Name: "test-net", Driver: "bridge"},
+		MCPServers: []config.MCPServer{
+			{Name: "github", URL: "https://example.com/gh", Transport: "http"},
+			{Name: "atlassian", URL: "https://example.com/atl", Transport: "http", Tools: []string{"get_page", "create_page"}},
+		},
+	}
+	gw := mcp.NewGateway()
+	orch := runtime.NewOrchestrator(nil, nil)
+	rh := reload.NewHandler(path, currentCfg, gw, orch, 8180, 9000, nil, nil)
+
+	// The handler calls reloadHandler.Reload exactly once for the whole batch
+	// (no per-server loop), so a successful response carries a single reloaded
+	// flag rather than one reload per server.
+	rh.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []reload.ReplicaRuntime, stackPath string) error {
+		return nil
+	})
+	s.SetReloadHandler(rh)
+
+	w := batchRequest(t, s, map[string]any{
+		"servers": []map[string]any{
+			{"name": "github", "tools": []string{"a"}},
+			{"name": "atlassian", "tools": []string{"get_page"}},
+		},
+	})
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var resp setServerToolsBatchResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Reloaded)
+	assert.NotEmpty(t, resp.ReloadedAt)
+}
+
+// TestHandleSetServerToolsBatch_UnknownServer demonstrates the all-or-nothing
+// contract: one invalid entry rejects the whole batch with nothing written.
+// (Unknown-tool rejection follows the same validate-before-write structure;
+// it fires earlier, in validateToolsAgainstServer, which is shared with the
+// single-server endpoint and exercises a fully-registered gateway in its own
+// integration tests rather than this YAML-only harness.)
+func TestHandleSetServerToolsBatch_UnknownServer(t *testing.T) {
+	path, s := newBatchHarness(t)
+	before, _ := os.ReadFile(path)
+
+	w := batchRequest(t, s, map[string]any{
+		"servers": []map[string]any{
+			{"name": "github", "tools": []string{"a"}},  // valid on its own
+			{"name": "missing", "tools": []string{"b"}}, // not in stack → reject all
+		},
+	})
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	after, _ := os.ReadFile(path)
+	assert.Equal(t, string(before), string(after), "unknown server must not write")
+}
+
+func TestHandleSetServerToolsBatch_Conflict(t *testing.T) {
+	path, s := newBatchHarness(t)
+	before, _ := os.ReadFile(path)
+
+	swapBetweenReadsHook(func() {
+		_ = os.WriteFile(path, []byte("version: \"2\"\nname: mutated\nnetwork:\n  name: n\nmcp-servers:\n  - name: github\n    url: https://example.com/gh\n"), 0o600)
+	})
+	defer swapBetweenReadsHook(nil)
+
+	w := batchRequest(t, s, map[string]any{
+		"servers": []map[string]any{
+			{"name": "github", "tools": []string{"a"}},
+		},
+	})
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	var resp structuredError
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, errCodeStackModified, resp.Error.Code)
+
+	// The conflicting write was discarded; our intended change is absent.
+	_ = before
+}
+
+func TestHandleSetServerToolsBatch_BadRequests(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"empty servers", `{"servers":[]}`},
+		{"missing servers", `{}`},
+		{"entry missing name", `{"servers":[{"tools":["a"]}]}`},
+		{"entry missing tools", `{"servers":[{"name":"github"}]}`},
+		{"empty tool name", `{"servers":[{"name":"github","tools":["a",""]}]}`},
+		{"duplicate server", `{"servers":[{"name":"github","tools":["a"]},{"name":"github","tools":["b"]}]}`},
+		{"invalid json", `:::not json`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, s := newBatchHarness(t)
+			req := httptest.NewRequest(http.MethodPut, "/api/mcp-servers/tools", strings.NewReader(tc.payload))
+			w := httptest.NewRecorder()
+			s.handleSetServerToolsBatch(w, req)
+			assert.Equal(t, http.StatusBadRequest, w.Code, "payload: %s", tc.payload)
+		})
+	}
+}
+
+func TestHandleSetServerToolsBatch_NoStackFile(t *testing.T) {
+	s := &Server{}
+	w := batchRequest(t, s, map[string]any{
+		"servers": []map[string]any{{"name": "github", "tools": []string{"a"}}},
+	})
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// TestSetServerToolsBatch_SingleWriteAppliesAll exercises the stack_edit layer
+// directly: one call patches every server's tools in a single atomic write.
+func TestSetServerToolsBatch_SingleWriteAppliesAll(t *testing.T) {
+	path, _ := newBatchHarness(t)
+
+	err := setServerToolsBatch(path, []serverToolsUpdate{
+		{Server: "github", Tools: []string{"a", "b"}},
+		{Server: "atlassian", Tools: []string{}}, // expose all → drop key
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	out := string(data)
+	assert.Contains(t, out, "- a")
+	assert.Contains(t, out, "- b")
+	assert.NotContains(t, out, "get_page")
+
+	// Unknown server in the batch fails the whole thing.
+	err = setServerToolsBatch(path, []serverToolsUpdate{{Server: "nope", Tools: []string{"x"}}})
+	require.ErrorIs(t, err, errServerNotFound)
+}

--- a/internal/api/stack_edit.go
+++ b/internal/api/stack_edit.go
@@ -116,6 +116,116 @@ func setServerTools(path, serverName string, tools []string) error {
 	return atomicWrite(path, updated)
 }
 
+// serverToolsUpdate is one server's whitelist change within a batch write.
+type serverToolsUpdate struct {
+	Server string
+	Tools  []string
+}
+
+// setServerToolsBatch applies whitelist changes for multiple servers to the
+// stack YAML at path in a SINGLE atomic write, mirroring setServerTools'
+// per-path locking and read-verify-write conflict detection. The change is
+// all-or-nothing: every update lands or none do (the caller validates tool
+// names up front and triggers exactly one reload afterward).
+//
+// Returns errServerNotFound (wrapped with the missing name) when any update
+// targets a server absent from the stack, errStackModified when the file
+// changed between the initial read and the write, or a filesystem error.
+func setServerToolsBatch(path string, updates []serverToolsUpdate) error {
+	if path == "" {
+		return errStackFileEmpty
+	}
+
+	mu := stackFileLock(path)
+	mu.Lock()
+	defer mu.Unlock()
+
+	original, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read stack file: %w", err)
+	}
+	originalHash := sha256.Sum256(original)
+
+	updated, err := patchMultipleServerTools(original, updates)
+	if err != nil {
+		return err
+	}
+
+	fireBetweenReadsHook()
+
+	current, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("re-read stack file: %w", err)
+	}
+	if sha256.Sum256(current) != originalHash {
+		return errStackModified
+	}
+
+	return atomicWrite(path, updated)
+}
+
+// patchMultipleServerTools applies every update's tools list to its server in
+// one yaml.Node round-trip, preserving comments/ordering. It indexes the
+// mcp-servers sequence by name once, then applies each update via the same
+// replaceOrInsertTools the single-server path uses (an empty list drops the
+// tools: key = expose all). Returns errServerNotFound (wrapped with the name)
+// if any update targets a server that isn't in the stack — and writes nothing,
+// since the marshal happens only after all updates apply.
+func patchMultipleServerTools(source []byte, updates []serverToolsUpdate) ([]byte, error) {
+	if len(updates) == 0 {
+		return nil, fmt.Errorf("no server updates provided")
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(source, &root); err != nil {
+		return nil, fmt.Errorf("parse stack yaml: %w", err)
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil, fmt.Errorf("parse stack yaml: not a document")
+	}
+
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse stack yaml: top-level not a mapping")
+	}
+
+	serversSeq := findMappingValue(doc, "mcp-servers")
+	if serversSeq == nil || serversSeq.Kind != yaml.SequenceNode {
+		return nil, errServerNotFound
+	}
+
+	byName := make(map[string]*yaml.Node, len(serversSeq.Content))
+	for _, entry := range serversSeq.Content {
+		if entry.Kind != yaml.MappingNode {
+			continue
+		}
+		if nameNode := findMappingValue(entry, "name"); nameNode != nil {
+			byName[nameNode.Value] = entry
+		}
+	}
+
+	for _, u := range updates {
+		target, ok := byName[u.Server]
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", errServerNotFound, u.Server)
+		}
+		if err := replaceOrInsertTools(target, u.Tools); err != nil {
+			return nil, err
+		}
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
 // patchServerTools rewrites the given YAML source with tools set to the
 // provided list for the named server. The yaml.Node round-trip keeps line
 // comments and ordering; only the target tools: sequence is replaced.

--- a/web/src/__tests__/FleetActions.test.tsx
+++ b/web/src/__tests__/FleetActions.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FleetActions } from '../components/workspaces/FleetActions';
+import * as api from '../lib/api';
+import type { MCPServerStatus } from '../types';
+
+vi.mock('../components/ui/Toast', () => ({ showToast: vi.fn() }));
+
+function server(name: string, tools: string[], toolWhitelist?: string[]): MCPServerStatus {
+  return { name, transport: 'stdio', initialized: true, toolCount: tools.length, tools, toolWhitelist, healthy: true } as unknown as MCPServerStatus;
+}
+
+const servers = [
+  server('github', ['create_issue', 'delete_issue', 'delete_repo']), // expose-all
+  server('atlassian', ['get_page']),
+];
+
+beforeEach(() => {
+  vi.spyOn(api, 'fetchStatus').mockResolvedValue({
+    gateway: { name: 'g', version: '1' },
+    'mcp-servers': [],
+  } as unknown as Awaited<ReturnType<typeof api.fetchStatus>>);
+  vi.spyOn(api, 'fetchTools').mockResolvedValue({ tools: [] });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderPanel() {
+  return render(
+    <FleetActions isOpen onClose={vi.fn()} servers={servers} activeServerName="github" />,
+  );
+}
+
+describe('FleetActions', () => {
+  it('echoes the resolved match count for a hide pattern', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: /hide matching pattern/i }));
+    fireEvent.change(screen.getByLabelText(/glob pattern/i), { target: { value: 'delete_*' } });
+
+    // delete_issue + delete_repo on github → 2 tools across 1 server.
+    expect(screen.getByText(/Matches/)).toHaveTextContent('Matches 2 tools across 1 server');
+    expect(screen.getByRole('button', { name: /review & apply \(1\)/i })).toBeEnabled();
+  });
+
+  it('requires a consequence-stating confirmation, then applies via the batch endpoint', async () => {
+    const batchSpy = vi
+      .spyOn(api, 'setServerToolsBatch')
+      .mockResolvedValue({ servers: [{ server: 'github', tools: ['create_issue'] }], reloaded: true });
+
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: /hide matching pattern/i }));
+    fireEvent.change(screen.getByLabelText(/glob pattern/i), { target: { value: 'delete_*' } });
+    fireEvent.click(screen.getByRole('button', { name: /review & apply/i }));
+
+    // The confirmation states the single-reload consequence.
+    expect(screen.getByText(/single reload/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /apply & reload/i }));
+
+    // Batch payload keeps the non-matching tool as an explicit whitelist.
+    await waitFor(() =>
+      expect(batchSpy).toHaveBeenCalledWith([{ name: 'github', tools: ['create_issue'] }]),
+    );
+    // Per-server result summary.
+    expect(await screen.findByText(/Updated 1 server/)).toBeInTheDocument();
+    expect(screen.getByText('✓ github')).toBeInTheDocument();
+  });
+
+  it('disables apply when an expose-all action would change nothing', () => {
+    // No server restricts tools → expose-all is a no-op.
+    renderPanel(); // default action is expose-all
+    expect(screen.getByText(/already exposes all/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /review & apply \(0\)/i })).toBeDisabled();
+  });
+
+  it('surfaces a batch error in the summary', async () => {
+    vi.spyOn(api, 'setServerToolsBatch').mockRejectedValue(
+      new api.SetServerToolsError('stack_modified', 'File changed', 'Reload and retry.', 409),
+    );
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: /hide matching pattern/i }));
+    fireEvent.change(screen.getByLabelText(/glob pattern/i), { target: { value: 'delete_*' } });
+    fireEvent.click(screen.getByRole('button', { name: /review & apply/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply & reload/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/File changed/);
+  });
+});

--- a/web/src/__tests__/setServerToolsBatch.test.ts
+++ b/web/src/__tests__/setServerToolsBatch.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setServerToolsBatch, SetServerToolsError } from '../lib/api';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('setServerToolsBatch', () => {
+  it('PUTs the servers payload to /api/mcp-servers/tools and returns the result', async () => {
+    const payload = {
+      servers: [{ server: 'github', tools: ['a'] }],
+      reloaded: true,
+      reloadedAt: '2026-05-24T10:00:00Z',
+    };
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => payload });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await setServerToolsBatch([{ name: 'github', tools: ['a'] }]);
+
+    expect(result).toEqual(payload);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/mcp-servers/tools');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body)).toEqual({ servers: [{ name: 'github', tools: ['a'] }] });
+  });
+
+  it('throws a SetServerToolsError on a structured envelope', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        statusText: 'Conflict',
+        json: async () => ({ error: { code: 'stack_modified', message: 'changed', hint: 'reload' } }),
+      }),
+    );
+
+    await expect(setServerToolsBatch([{ name: 'github', tools: [] }])).rejects.toMatchObject({
+      name: 'SetServerToolsError',
+      code: 'stack_modified',
+      httpStatus: 409,
+    });
+    // Constructor sanity: the class is the one we import.
+    expect(new SetServerToolsError('x', 'y', undefined, 400)).toBeInstanceOf(Error);
+  });
+});

--- a/web/src/__tests__/toolBulk.test.ts
+++ b/web/src/__tests__/toolBulk.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { globToRegExp, planBulkAction } from '../lib/toolBulk';
+import type { MCPServerStatus } from '../types';
+
+function srv(name: string, tools: string[], toolWhitelist?: string[]): MCPServerStatus {
+  return { name, tools, toolWhitelist } as unknown as MCPServerStatus;
+}
+
+describe('globToRegExp', () => {
+  it('matches a trailing wildcard', () => {
+    const re = globToRegExp('delete_*');
+    expect(re.test('delete_row')).toBe(true);
+    expect(re.test('delete_')).toBe(true);
+    expect(re.test('list_rows')).toBe(false);
+    expect(re.test('soft_delete_row')).toBe(false); // anchored
+  });
+
+  it('treats ? as a single char and escapes regex metachars', () => {
+    expect(globToRegExp('get_?').test('get_x')).toBe(true);
+    expect(globToRegExp('get_?').test('get_xy')).toBe(false);
+    // A literal dot must not act as "any char".
+    expect(globToRegExp('a.b').test('axb')).toBe(false);
+    expect(globToRegExp('a.b').test('a.b')).toBe(true);
+  });
+});
+
+describe('planBulkAction — expose-all', () => {
+  it('targets only servers that currently restrict tools', () => {
+    const servers = [
+      srv('github', ['a', 'b'], ['a']), // restricts → change to []
+      srv('atlassian', ['x'], []), // already expose-all → unchanged
+      srv('gitlab', ['m', 'n']), // no whitelist → unchanged
+    ];
+    const plan = planBulkAction(servers, 'expose-all', '');
+    expect(plan.entries).toEqual([{ name: 'github', tools: [], hidden: [] }]);
+    expect(plan.blocked).toEqual([]);
+  });
+});
+
+describe('planBulkAction — hide-pattern', () => {
+  it('hides matching exposed tools and keeps the rest as an explicit whitelist', () => {
+    const servers = [
+      srv('github', ['create_issue', 'delete_issue', 'delete_repo']), // expose-all
+    ];
+    const plan = planBulkAction(servers, 'hide-pattern', 'delete_*');
+    expect(plan.matchedTools).toBe(2);
+    expect(plan.entries).toEqual([
+      { name: 'github', tools: ['create_issue'], hidden: ['delete_issue', 'delete_repo'] },
+    ]);
+    expect(plan.blocked).toEqual([]);
+  });
+
+  it('operates on the currently-exposed set when a whitelist exists', () => {
+    const servers = [srv('s', ['a', 'b', 'delete_x', 'delete_y'], ['a', 'delete_x'])];
+    const plan = planBulkAction(servers, 'hide-pattern', 'delete_*');
+    // Only delete_x is exposed-and-matching; delete_y is already hidden.
+    expect(plan.matchedTools).toBe(1);
+    expect(plan.entries).toEqual([{ name: 's', tools: ['a'], hidden: ['delete_x'] }]);
+  });
+
+  it('skips servers with no match', () => {
+    const plan = planBulkAction([srv('s', ['a', 'b'])], 'hide-pattern', 'delete_*');
+    expect(plan.entries).toEqual([]);
+    expect(plan.matchedTools).toBe(0);
+  });
+
+  it('blocks (does not re-expose) a server whose every exposed tool matches', () => {
+    // Hiding delete_* would leave zero exposed tools; [] = expose-all, so we
+    // must refuse rather than silently re-expose everything.
+    const servers = [srv('s', ['delete_a', 'delete_b'])];
+    const plan = planBulkAction(servers, 'hide-pattern', 'delete_*');
+    expect(plan.entries).toEqual([]);
+    expect(plan.blocked).toEqual(['s']);
+  });
+
+  it('returns an empty plan for a blank pattern', () => {
+    const plan = planBulkAction([srv('s', ['a'])], 'hide-pattern', '   ');
+    expect(plan.entries).toEqual([]);
+    expect(plan.matchedTools).toBe(0);
+  });
+});

--- a/web/src/components/workspaces/FleetActions.tsx
+++ b/web/src/components/workspaces/FleetActions.tsx
@@ -1,0 +1,401 @@
+import { useMemo, useState } from 'react';
+import { AlertCircle, AlertTriangle, ArrowLeft, Check, Loader2 } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useStackStore } from '../../stores/useStackStore';
+import {
+  AuthError,
+  fetchStatus,
+  fetchTools,
+  setServerToolsBatch,
+  SetServerToolsError,
+} from '../../lib/api';
+import { planBulkAction, type BulkAction } from '../../lib/toolBulk';
+import { showToast } from '../ui/Toast';
+import { Modal } from '../ui/Modal';
+import type { MCPServerStatus } from '../../types';
+
+type Scope = 'fleet' | 'server';
+type Phase = 'configure' | 'confirm';
+type ApplyStatus = 'idle' | 'applying' | 'done' | 'error';
+
+interface FleetActionsProps {
+  isOpen: boolean;
+  onClose: () => void;
+  servers: MCPServerStatus[];
+  // The currently-selected server, so the action can be scoped to one server
+  // (the per-server counterpart to the fleet-wide default).
+  activeServerName: string;
+}
+
+// FleetActions is the bulk-action surface for the Tools workspace. It resolves
+// an action (expose-all / hide-pattern) over a scope (all servers or the active
+// one) into a concrete plan, echoes the resolved count, gates the commit behind
+// a consequence-stating confirm step, applies the change through the batch
+// endpoint (a single reload), and reports a per-server summary.
+//
+// The confirm step is an inline phase of this one focus-trapped Modal rather
+// than a nested dialog — two stacked focus traps (Modal + ConfirmDialog) fight
+// over Tab, so a single trap keeps the whole flow keyboard-operable.
+export function FleetActions({ isOpen, onClose, servers, activeServerName }: FleetActionsProps) {
+  const [scope, setScope] = useState<Scope>('fleet');
+  const [action, setAction] = useState<BulkAction>('expose-all');
+  const [pattern, setPattern] = useState('');
+  const [phase, setPhase] = useState<Phase>('configure');
+  const [status, setStatus] = useState<ApplyStatus>('idle');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [summary, setSummary] = useState<{ reloaded: boolean; servers: string[] } | null>(null);
+
+  const scopedServers = useMemo(
+    () => (scope === 'server' ? servers.filter((s) => s.name === activeServerName) : servers),
+    [scope, servers, activeServerName],
+  );
+
+  const plan = useMemo(
+    () => planBulkAction(scopedServers, action, pattern),
+    [scopedServers, action, pattern],
+  );
+
+  const canApply = plan.entries.length > 0 && status !== 'applying';
+  const showResult = status === 'done' || status === 'error';
+
+  function handleClose() {
+    setPhase('configure');
+    setStatus('idle');
+    setErrorMsg(null);
+    setSummary(null);
+    setPattern('');
+    onClose();
+  }
+
+  async function apply() {
+    setStatus('applying');
+    setErrorMsg(null);
+    try {
+      const resp = await setServerToolsBatch(
+        plan.entries.map((e) => ({ name: e.name, tools: e.tools })),
+      );
+      // Reflect the change immediately; polling would otherwise lag.
+      try {
+        const [statusResp, toolsList] = await Promise.all([fetchStatus(), fetchTools()]);
+        useStackStore.getState().setGatewayStatus(statusResp);
+        useStackStore.getState().setTools(toolsList.tools);
+      } catch {
+        /* ignore — the next poll will refresh */
+      }
+      setSummary({ reloaded: resp.reloaded, servers: resp.servers.map((s) => s.server) });
+      setStatus('done');
+      showToast('success', `Updated ${resp.servers.length} server${resp.servers.length === 1 ? '' : 's'}`);
+      if (!resp.reloaded) {
+        showToast('warning', 'Stack updated. Run "gridctl reload" or restart with --watch to apply.');
+      }
+    } catch (err) {
+      if (err instanceof AuthError) {
+        setErrorMsg('Authentication required.');
+      } else if (err instanceof SetServerToolsError) {
+        setErrorMsg(err.hint ? `${err.message} — ${err.hint}` : err.message);
+      } else {
+        setErrorMsg(err instanceof Error ? err.message : 'Batch update failed');
+      }
+      setStatus('error');
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="Fleet tool actions">
+      <div className="space-y-4 text-sm">
+        {showResult ? (
+          <ResultView status={status} summary={summary} errorMsg={errorMsg} onClose={handleClose} />
+        ) : phase === 'confirm' ? (
+          <ConfirmView
+            action={action}
+            plan={plan}
+            applying={status === 'applying'}
+            onBack={() => setPhase('configure')}
+            onConfirm={() => void apply()}
+          />
+        ) : (
+          <ConfigureView
+            servers={servers}
+            scopedCount={scopedServers.length}
+            activeServerName={activeServerName}
+            scope={scope}
+            onScope={setScope}
+            action={action}
+            onAction={setAction}
+            pattern={pattern}
+            onPattern={setPattern}
+            plan={plan}
+            canApply={canApply}
+            onReview={() => setPhase('confirm')}
+            onCancel={handleClose}
+          />
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+type Plan = ReturnType<typeof planBulkAction>;
+
+interface ConfigureViewProps {
+  servers: MCPServerStatus[];
+  scopedCount: number;
+  activeServerName: string;
+  scope: Scope;
+  onScope: (s: Scope) => void;
+  action: BulkAction;
+  onAction: (a: BulkAction) => void;
+  pattern: string;
+  onPattern: (p: string) => void;
+  plan: Plan;
+  canApply: boolean;
+  onReview: () => void;
+  onCancel: () => void;
+}
+
+function ConfigureView({
+  servers,
+  scopedCount,
+  activeServerName,
+  scope,
+  onScope,
+  action,
+  onAction,
+  pattern,
+  onPattern,
+  plan,
+  canApply,
+  onReview,
+  onCancel,
+}: ConfigureViewProps) {
+  const scopeLabel =
+    scope === 'server' ? activeServerName || 'the selected server' : `all ${servers.length} servers`;
+  return (
+    <>
+      <fieldset className="space-y-1.5">
+        <legend className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">Scope</legend>
+        <div className="flex gap-2">
+          <SegButton active={scope === 'fleet'} onClick={() => onScope('fleet')}>
+            All {servers.length} servers
+          </SegButton>
+          <SegButton active={scope === 'server'} disabled={!activeServerName} onClick={() => onScope('server')}>
+            {activeServerName || 'Selected server'} only
+          </SegButton>
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-1.5">
+        <legend className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">Action</legend>
+        <div className="flex gap-2">
+          <SegButton active={action === 'expose-all'} onClick={() => onAction('expose-all')}>
+            Expose all tools
+          </SegButton>
+          <SegButton active={action === 'hide-pattern'} onClick={() => onAction('hide-pattern')}>
+            Hide matching pattern
+          </SegButton>
+        </div>
+      </fieldset>
+
+      {action === 'hide-pattern' && (
+        <div className="space-y-1.5">
+          <label htmlFor="fleet-pattern" className="block text-[11px] text-text-secondary">
+            Glob pattern (e.g. <span className="font-mono text-text-primary">delete_*</span>) — hides matching
+            tools, keeps the rest
+          </label>
+          <input
+            id="fleet-pattern"
+            value={pattern}
+            onChange={(e) => onPattern(e.target.value)}
+            placeholder="delete_*"
+            spellCheck={false}
+            className="w-full bg-background/60 border border-border/40 rounded-md px-2.5 py-1.5 text-sm font-mono text-text-primary placeholder:text-text-muted/40 focus:outline-none focus:border-primary/50"
+          />
+        </div>
+      )}
+
+      <div className="rounded-md border border-border/30 bg-background/40 px-3 py-2 text-[11px] text-text-secondary" role="status">
+        {action === 'expose-all' ? (
+          plan.entries.length > 0 ? (
+            <span>
+              Exposes all tools on <span className="font-medium text-text-primary">{plan.entries.length}</span>{' '}
+              of {scopedCount} server{scopedCount === 1 ? '' : 's'} (the rest already expose everything).
+            </span>
+          ) : (
+            <span>Every targeted server already exposes all of its tools — nothing to change.</span>
+          )
+        ) : !pattern.trim() ? (
+          <span>Enter a pattern to preview the matched tools.</span>
+        ) : plan.entries.length > 0 ? (
+          <span>
+            Matches <span className="font-medium text-text-primary">{plan.matchedTools}</span> tool
+            {plan.matchedTools === 1 ? '' : 's'} across{' '}
+            <span className="font-medium text-text-primary">{plan.entries.length}</span> server
+            {plan.entries.length === 1 ? '' : 's'}.
+          </span>
+        ) : (
+          <span>No exposed tools match across {scopeLabel}.</span>
+        )}
+        {plan.blocked.length > 0 && (
+          <span className="block mt-1 text-status-pending">
+            {plan.blocked.length} server{plan.blocked.length === 1 ? '' : 's'} skipped — every exposed tool
+            matches, and at least one must stay exposed.
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center justify-end gap-2 pt-1">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md px-3 py-1.5 text-[11px] text-text-secondary hover:text-text-primary transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onReview}
+          disabled={!canApply}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] font-medium border transition-colors',
+            canApply
+              ? 'bg-primary/20 text-primary border-primary/30 hover:bg-primary/30'
+              : 'bg-surface-highlight/50 text-text-muted border-border/30 cursor-not-allowed',
+          )}
+        >
+          Review &amp; apply ({plan.entries.length})
+        </button>
+      </div>
+    </>
+  );
+}
+
+interface ConfirmViewProps {
+  action: BulkAction;
+  plan: Plan;
+  applying: boolean;
+  onBack: () => void;
+  onConfirm: () => void;
+}
+
+function ConfirmView({ action, plan, applying, onBack, onConfirm }: ConfirmViewProps) {
+  const n = plan.entries.length;
+  return (
+    <>
+      <div className="flex items-start gap-2.5 rounded-md border border-status-pending/40 bg-status-pending/[0.06] px-3 py-3" role="status">
+        <AlertTriangle size={14} className="text-status-pending flex-shrink-0 mt-0.5" aria-hidden="true" />
+        <p className="text-[12px] text-text-secondary leading-relaxed">
+          {action === 'expose-all' ? 'Expose all tools on ' : 'Update '}
+          <span className="font-mono text-text-primary">{n}</span> server{n === 1 ? '' : 's'}
+          {action === 'hide-pattern' && (
+            <>
+              {' '}
+              (hiding <span className="font-mono text-text-primary">{plan.matchedTools}</span> tool
+              {plan.matchedTools === 1 ? '' : 's'})
+            </>
+          )}
+          ? This writes the stack file once and triggers a <span className="font-medium">single reload</span>{' '}
+          of {n === 1 ? 'that server' : `${n} servers`}.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 pt-1">
+        <button
+          type="button"
+          onClick={onBack}
+          disabled={applying}
+          className="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-[11px] text-text-secondary hover:text-text-primary transition-colors disabled:opacity-50"
+        >
+          <ArrowLeft size={11} aria-hidden="true" />
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={applying}
+          className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] font-medium border border-status-pending/40 bg-status-pending/10 text-status-pending hover:bg-status-pending/20 transition-colors disabled:opacity-50"
+        >
+          {applying ? (
+            <>
+              <Loader2 size={11} className="animate-spin" />
+              Applying…
+            </>
+          ) : (
+            'Apply & reload'
+          )}
+        </button>
+      </div>
+    </>
+  );
+}
+
+interface ResultViewProps {
+  status: ApplyStatus;
+  summary: { reloaded: boolean; servers: string[] } | null;
+  errorMsg: string | null;
+  onClose: () => void;
+}
+
+function ResultView({ status, summary, errorMsg, onClose }: ResultViewProps) {
+  return (
+    <>
+      {status === 'done' && summary && (
+        <div className="rounded-md border border-status-running/30 bg-status-running/[0.06] px-3 py-2 space-y-1" role="status">
+          <p className="flex items-center gap-1.5 text-[11px] font-medium text-status-running">
+            <Check size={12} aria-hidden="true" />
+            Updated {summary.servers.length} server{summary.servers.length === 1 ? '' : 's'}
+            {summary.reloaded ? ' · reloaded once' : ' · reload pending'}
+          </p>
+          <ul className="text-[10px] text-text-muted font-mono space-y-0.5">
+            {summary.servers.map((name) => (
+              <li key={name}>✓ {name}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {status === 'error' && errorMsg && (
+        <div className="flex items-start gap-2 rounded-md border border-status-error/40 bg-status-error/[0.06] px-3 py-2" role="alert">
+          <AlertCircle size={12} className="text-status-error flex-shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="text-[11px] text-status-error">{errorMsg}</p>
+        </div>
+      )}
+      <div className="flex items-center justify-end pt-1">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md px-3 py-1.5 text-[11px] font-medium border border-border/40 bg-background/40 text-text-secondary hover:text-text-primary hover:border-border transition-colors"
+        >
+          Close
+        </button>
+      </div>
+    </>
+  );
+}
+
+interface SegButtonProps {
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function SegButton({ active, disabled, onClick, children }: SegButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active}
+      className={cn(
+        'flex-1 rounded-md px-2.5 py-1.5 text-[11px] font-medium border transition-colors',
+        disabled && 'opacity-40 cursor-not-allowed',
+        active
+          ? 'bg-primary/15 text-primary border-primary/40'
+          : 'bg-background/40 text-text-secondary border-border/40 hover:border-border hover:text-text-primary',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default FleetActions;

--- a/web/src/components/workspaces/ToolsWorkspace.tsx
+++ b/web/src/components/workspaces/ToolsWorkspace.tsx
@@ -6,6 +6,7 @@ import {
   AlertCircle,
   Check,
   ChevronRight,
+  Layers,
   Loader2,
   RefreshCw,
   Save,
@@ -35,6 +36,7 @@ import { WorkspaceShell } from '../layout/WorkspaceShell';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { StatusDot } from '../ui/StatusDot';
 import { CodeViewer } from '../ui/CodeViewer';
+import { FleetActions } from './FleetActions';
 import type { MCPServerStatus, NodeStatus, Tool, ToolUsageStat } from '../../types';
 
 // Per-state styling for Audit Mode dots/labels, keyed to the shared status
@@ -130,6 +132,8 @@ export function ToolsWorkspace() {
   // is on (the hook idles otherwise) so the editor pays nothing when it's off.
   const [auditMode, setAuditMode] = useState(false);
   const [auditWindow, setAuditWindow] = useState<AuditWindow>(DEFAULT_AUDIT_WINDOW);
+  // Fleet bulk-action panel (expose-all / hide-pattern across servers).
+  const [fleetOpen, setFleetOpen] = useState(false);
   const { usage, fetchedAt } = useToolUsage(auditMode);
   const windowMs = auditWindowMs(auditWindow);
   const usageByServer = usage?.servers;
@@ -221,6 +225,8 @@ export function ToolsWorkspace() {
             auditWindow={auditWindow}
             onWindowChange={setAuditWindow}
             observedSince={usage?.observedSince}
+            onOpenFleet={() => setFleetOpen(true)}
+            fleetDisabled={servers.length === 0}
           />
 
           <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark">
@@ -268,6 +274,13 @@ export function ToolsWorkspace() {
         confirmLabel="Discard & switch"
         variant="danger"
       />
+
+      <FleetActions
+        isOpen={fleetOpen}
+        onClose={() => setFleetOpen(false)}
+        servers={servers}
+        activeServerName={activeServerName}
+      />
     </div>
   );
 }
@@ -286,6 +299,8 @@ interface ToolsHeaderProps {
   auditWindow: AuditWindow;
   onWindowChange: (w: AuditWindow) => void;
   observedSince?: string;
+  onOpenFleet: () => void;
+  fleetDisabled: boolean;
 }
 
 function ToolsHeader({
@@ -298,6 +313,8 @@ function ToolsHeader({
   auditWindow,
   onWindowChange,
   observedSince,
+  onOpenFleet,
+  fleetDisabled,
 }: ToolsHeaderProps) {
   const searching = query.trim().length > 0;
   const windowLabel = AUDIT_WINDOWS.find((w) => w.id === auditWindow)?.label ?? '7 days';
@@ -317,6 +334,20 @@ function ToolsHeader({
         </div>
 
         <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onOpenFleet}
+            disabled={fleetDisabled}
+            aria-label="Open fleet tool actions"
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[10px] font-medium border transition-colors',
+              'bg-background/40 text-text-muted border-border/40 hover:text-text-secondary hover:border-border',
+              fleetDisabled && 'opacity-40 cursor-not-allowed',
+            )}
+          >
+            <Layers size={11} aria-hidden="true" />
+            Fleet
+          </button>
           <button
             type="button"
             onClick={onToggleAudit}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -273,6 +273,72 @@ export async function setServerTools(
   return data as SetServerToolsResponse;
 }
 
+// One server's whitelist change in a batch request. tools = [] clears the
+// whitelist (expose all), matching the single-server semantics.
+export interface ServerToolsBatchEntry {
+  name: string;
+  tools: string[];
+}
+
+// One server's applied whitelist in a successful batch response.
+export interface ServerToolsBatchResult {
+  server: string;
+  tools: string[];
+}
+
+// Response payload for PUT /api/mcp-servers/tools on success. The batch is
+// atomic, so every listed server was applied and a single reload (when enabled)
+// ran once for the whole batch.
+export interface SetServerToolsBatchResponse {
+  servers: ServerToolsBatchResult[];
+  reloaded: boolean;
+  reloadedAt?: string; // RFC3339, only present when reloaded is true
+}
+
+/**
+ * Apply tool-whitelist changes to MULTIPLE servers in one atomic write that
+ * triggers a SINGLE reload — the fleet-bulk path. Transaction semantics are
+ * all-or-nothing: if any tool is unknown the whole batch is rejected and
+ * nothing is written (SetServerToolsError code "unknown_tool", message names
+ * the offending server). A concurrent external edit rejects with
+ * "stack_modified" (409); a write that reloads-failed surfaces "reload_failed"
+ * (502) with the changes persisted — mirroring the single-server endpoint.
+ *
+ * PUT /api/mcp-servers/tools
+ */
+export async function setServerToolsBatch(
+  servers: ServerToolsBatchEntry[],
+): Promise<SetServerToolsBatchResponse> {
+  const response = await fetch(`${API_BASE}/api/mcp-servers/tools`, {
+    method: 'PUT',
+    headers: buildHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ servers }),
+  });
+
+  if (response.status === 401) throw new AuthError('Authentication required');
+
+  const data = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const err = data?.error;
+    if (err && typeof err === 'object' && typeof err.code === 'string') {
+      throw new SetServerToolsError(
+        err.code,
+        err.message ?? 'Batch set tools failed',
+        err.hint,
+        response.status,
+      );
+    }
+    const msg =
+      typeof err === 'string'
+        ? err
+        : `Batch set tools failed: ${response.status} ${response.statusText}`;
+    throw new Error(msg);
+  }
+
+  return data as SetServerToolsBatchResponse;
+}
+
 // === Structured Log Entry (from gateway) ===
 
 export interface LogEntry {

--- a/web/src/lib/toolBulk.ts
+++ b/web/src/lib/toolBulk.ts
@@ -1,0 +1,99 @@
+import type { MCPServerStatus } from '../types';
+import { effectiveEnabledTools } from './toolAudit';
+
+// Fleet bulk-action planning. Pure functions (no React, no clock) so they're
+// unit-testable and memoizable in the workspace. A plan resolves an action +
+// pattern over a set of servers into the concrete batch payload, the resolved
+// match count to echo before acting, and the servers that can't be changed.
+
+export type BulkAction = 'expose-all' | 'hide-pattern';
+
+// globToRegExp converts a shell-style glob (`*` = any run, `?` = one char) into
+// an anchored RegExp. All other regex metacharacters are escaped so a pattern
+// like "delete_*" matches literally except for the wildcard.
+export function globToRegExp(pattern: string): RegExp {
+  let out = '';
+  for (const ch of pattern) {
+    if (ch === '*') out += '.*';
+    else if (ch === '?') out += '.';
+    else out += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  }
+  return new RegExp(`^${out}$`);
+}
+
+export interface BulkPlanEntry {
+  name: string;
+  // The new whitelist to persist for this server. [] = expose all (the kept
+  // set covers every advertised tool).
+  tools: string[];
+  // Tool names this change removes from exposure (for the summary).
+  hidden: string[];
+}
+
+export interface BulkPlan {
+  // Servers that actually change — the source of the batch payload. Servers
+  // already in the target state are omitted so the batch stays minimal.
+  entries: BulkPlanEntry[];
+  // Total tools the pattern would hide across all entries (the echoed count).
+  matchedTools: number;
+  // Servers skipped because the action would hide every exposed tool. The
+  // whitelist model can't express "expose nothing" ([] = expose all), so we
+  // refuse rather than silently re-expose everything.
+  blocked: string[];
+}
+
+function sortedUnique(names: Iterable<string>): string[] {
+  return [...new Set(names)].sort();
+}
+
+// planBulkAction resolves the action over `servers` (already scoped by the
+// caller to all servers or a single one).
+//
+// expose-all: clears the whitelist (persist []) on servers that currently
+// restrict tools; servers already exposing everything are unchanged.
+//
+// hide-pattern: removes currently-exposed tools matching `pattern` from each
+// server, persisting the kept set as an explicit whitelist. A server whose
+// every exposed tool matches is blocked (see BulkPlan.blocked).
+export function planBulkAction(
+  servers: MCPServerStatus[],
+  action: BulkAction,
+  pattern: string,
+): BulkPlan {
+  const entries: BulkPlanEntry[] = [];
+  const blocked: string[] = [];
+  let matchedTools = 0;
+
+  if (action === 'expose-all') {
+    for (const server of servers) {
+      const restricts = (server.toolWhitelist?.length ?? 0) > 0;
+      if (!restricts) continue; // already exposing all
+      entries.push({ name: server.name, tools: [], hidden: [] });
+    }
+    return { entries, matchedTools, blocked };
+  }
+
+  // hide-pattern
+  const trimmed = pattern.trim();
+  if (!trimmed) return { entries, matchedTools, blocked };
+  const re = globToRegExp(trimmed);
+
+  for (const server of servers) {
+    const exposed = effectiveEnabledTools(server);
+    const hidden = [...exposed].filter((t) => re.test(t));
+    if (hidden.length === 0) continue; // nothing matches on this server
+    matchedTools += hidden.length;
+
+    const kept = [...exposed].filter((t) => !re.test(t));
+    if (kept.length === 0) {
+      // Hiding these would leave zero exposed tools, which [] can't express.
+      blocked.push(server.name);
+      continue;
+    }
+    // kept is necessarily a strict subset of advertised (we removed ≥1 exposed
+    // tool), so it's always a concrete whitelist — never the expose-all [].
+    entries.push({ name: server.name, tools: sortedUnique(kept), hidden: sortedUnique(hidden) });
+  }
+
+  return { entries, matchedTools, blocked };
+}


### PR DESCRIPTION
## Description

Adds **fleet bulk actions** to the `/tools` workspace — the final piece of the Tools workspace. A new batch whitelist endpoint applies tool changes to many MCP servers in one atomic write + a **single** reload, and a Fleet Actions panel drives it: expose-all or hide-tools-matching-a-glob, fleet-wide or per server, with a resolved-count echo, a consequence-stating confirmation, and a per-server result summary.

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

**Batch endpoint (`PUT /api/mcp-servers/tools`)**
- Applies whitelist changes to multiple servers in one `yaml.Node` round-trip + one `atomicWrite`, then triggers one reload — avoiding the N-reloads cost of looping the per-server endpoint.
- Reuses the single-server path's per-path lock, hash-based `stack_modified` conflict detection, and structured error envelope (`unknown_tool` / `stack_modified` / `reload_failed`).
- **All-or-nothing**: every server is validated up front; any unknown tool/server rejects the whole batch with nothing written. Documented in `docs/api-reference.md`. Matching `setServerToolsBatch()` client.

**Fleet Actions UI**
- Header **Fleet** button opens a panel: scope (all servers / active server) × action (expose all / hide matching glob).
- Pattern resolves to a concrete set and echoes the count (\"Matches 7 tools across 3 servers\") before acting.
- Commit gated behind an inline consequence-stating confirm (\"single reload of N servers\"), then applied via the batch endpoint; per-server result summary on completion.
- Guards the whitelist `[]`=expose-all footgun: a hide that would leave a server with zero exposed tools is blocked rather than silently re-exposing everything.

## Testing

- Go: \`go test -race ./internal/api/...\` — multi-server apply in one write, single reload, whole-batch conflict (\`stack_modified\`), unknown-server rejection (nothing written), \`[]\` expose-all semantics, bad-request validation.
- Web: \`npm test\` (748 passing) — \`setServerToolsBatch\` client, glob matching, bulk-action planning incl. the expose-nothing block, and the Fleet panel flow (resolved count, consequence confirm, batch apply, summary, error).
- \`golangci-lint\`, \`tsc\`, targeted \`eslint\`, and \`npm run build\` all clean.

Closes #712

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed