### PR TITLE
feat: add tool detail panel to the Tools workspace

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -225,6 +225,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("PUT /api/mcp-servers/{name}/tools", s.handleSetServerTools)
 	mux.HandleFunc("/api/mcp-servers", s.handleMCPServers)
 	mux.HandleFunc("/api/tools", s.handleTools)
+	mux.HandleFunc("GET /api/tools/catalog", s.handleToolsCatalog)
 	mux.HandleFunc("GET /api/tools/usage", s.handleToolsUsage)
 	mux.HandleFunc("/api/logs", s.handleGatewayLogs)
 	mux.HandleFunc("/api/metrics/tokens", s.handleMetricsTokens)
@@ -440,6 +441,20 @@ func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result, _ := s.gateway.HandleToolsList()
+	writeJSON(w, result)
+}
+
+// handleToolsCatalog returns the full downstream tool inventory (each tool's
+// raw description + input schema) for the web console, regardless of code
+// mode. Read-only and informational: it does not change what MCP clients see
+// from tools/list.
+func (s *Server) handleToolsCatalog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	result, _ := s.gateway.HandleToolsCatalog()
 	writeJSON(w, result)
 }
 

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -1233,6 +1233,15 @@ func (g *Gateway) HandleToolsList() (*ToolsListResult, error) {
 	return &ToolsListResult{Tools: tools}, nil
 }
 
+// HandleToolsCatalog returns the full downstream tool inventory with each
+// tool's raw description and input schema, regardless of code mode. It is
+// informational only (served to the web console for tool detail); it never
+// affects what tools/list exposes to MCP clients — code mode still hides
+// downstream tools behind the meta-tools there.
+func (g *Gateway) HandleToolsCatalog() (*ToolsListResult, error) {
+	return &ToolsListResult{Tools: g.router.CatalogTools()}, nil
+}
+
 // HandleToolsCall routes a tool call to the appropriate MCP server.
 // When code mode is active and the tool is a meta-tool, delegates to code mode.
 func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*ToolCallResult, error) {

--- a/pkg/mcp/gateway_test.go
+++ b/pkg/mcp/gateway_test.go
@@ -1644,6 +1644,48 @@ func TestGateway_HandleToolsList_CodeMode(t *testing.T) {
 	}
 }
 
+func TestGateway_HandleToolsCatalog_CodeMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+	client := setupMockAgentClient(ctrl, "server1", []Tool{
+		{Name: "tool1", Description: "raw tool description", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	})
+	g.Router().AddClient(client)
+	g.Router().RefreshTools()
+	g.SetCodeMode(30 * time.Second)
+
+	// tools/list still hides downstream tools behind the meta-tools.
+	list, err := g.HandleToolsList()
+	if err != nil {
+		t.Fatalf("HandleToolsList: %v", err)
+	}
+	for _, tool := range list.Tools {
+		if tool.Name == "server1__tool1" {
+			t.Fatal("code mode tools/list must not expose downstream tools")
+		}
+	}
+
+	// The catalog returns the full inventory with the tool's raw description,
+	// regardless of code mode.
+	cat, err := g.HandleToolsCatalog()
+	if err != nil {
+		t.Fatalf("HandleToolsCatalog: %v", err)
+	}
+	var found *Tool
+	for i := range cat.Tools {
+		if cat.Tools[i].Name == "server1__tool1" {
+			found = &cat.Tools[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected server1__tool1 in catalog, got %v", cat.Tools)
+	}
+	if found.Description != "raw tool description" {
+		t.Errorf("expected unwrapped description, got %q", found.Description)
+	}
+}
+
 func TestGateway_RefreshAllTools(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	g := NewGateway()

--- a/pkg/mcp/router.go
+++ b/pkg/mcp/router.go
@@ -176,6 +176,35 @@ func (r *Router) AggregatedTools() []Tool {
 	return tools
 }
 
+// CatalogTools returns the full downstream tool inventory for informational
+// (web console) use: prefixed names with each tool's own raw description and
+// input schema. Unlike AggregatedTools it does not wrap descriptions with
+// call-routing instructions, so consumers get the tool's documentation
+// verbatim. Callers use this to surface tool detail regardless of code mode.
+func (r *Router) CatalogTools() []Tool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	names := make([]string, 0, len(r.sets))
+	for name := range r.sets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var tools []Tool
+	for _, name := range names {
+		for _, tool := range toolsOf(r.sets[name]) {
+			tools = append(tools, Tool{
+				Name:        PrefixTool(name, tool.Name),
+				Title:       tool.Title,
+				Description: tool.Description,
+				InputSchema: tool.InputSchema,
+			})
+		}
+	}
+	return tools
+}
+
 // RouteToolCall routes a tool call to the appropriate server. The concrete
 // replica is chosen by the set's dispatch policy.
 func (r *Router) RouteToolCall(prefixedName string) (AgentClient, string, error) {

--- a/web/src/__tests__/ToolsEditor.test.tsx
+++ b/web/src/__tests__/ToolsEditor.test.tsx
@@ -13,19 +13,25 @@ vi.mock('../components/ui/Toast', () => ({
 
 const mockStoreState: {
   tools: Tool[];
+  toolCatalog: Tool[];
   setGatewayStatus: ReturnType<typeof vi.fn>;
   setTools: ReturnType<typeof vi.fn>;
+  setToolCatalog: ReturnType<typeof vi.fn>;
   selectNode: ReturnType<typeof vi.fn>;
 } = {
   tools: [],
+  toolCatalog: [],
   setGatewayStatus: vi.fn(),
   setTools: vi.fn(),
+  setToolCatalog: vi.fn(),
   selectNode: vi.fn(),
 };
 
 vi.mock('../stores/useStackStore', () => ({
   useStackStore: Object.assign(
-    vi.fn((selector: (s: { tools: Tool[] }) => unknown) => selector(mockStoreState)),
+    vi.fn((selector: (s: { tools: Tool[]; toolCatalog: Tool[] }) => unknown) =>
+      selector(mockStoreState),
+    ),
     {
       getState: () => mockStoreState,
     },
@@ -43,13 +49,17 @@ function tool(name: string, description?: string): Tool {
 }
 
 beforeEach(() => {
-  mockStoreState.tools = [
+  const catalog = [
     tool('query', 'Run a SQL query'),
     tool('insert', 'Insert a row'),
     tool('delete_row', 'Delete a row'),
   ];
+  // The editor derives rows + descriptions from the catalog, not `tools`.
+  mockStoreState.tools = catalog;
+  mockStoreState.toolCatalog = catalog;
   mockStoreState.setGatewayStatus.mockReset();
   mockStoreState.setTools.mockReset();
+  mockStoreState.setToolCatalog.mockReset();
   mockStoreState.selectNode.mockReset();
   vi.restoreAllMocks();
 });
@@ -92,6 +102,7 @@ describe('ToolsEditor', () => {
       .spyOn(apiModule, 'fetchStatus')
       .mockResolvedValue({ gateway: { name: 'x', version: '1' }, 'mcp-servers': [] });
     const fetchToolsSpy = vi.spyOn(apiModule, 'fetchTools').mockResolvedValue({ tools: [] });
+    vi.spyOn(apiModule, 'fetchToolCatalog').mockResolvedValue({ tools: [] });
 
     render(<ToolsEditor serverName={SERVER} savedTools={[]} />);
     fireEvent.click(screen.getByRole('option', { name: 'insert' }));
@@ -114,6 +125,7 @@ describe('ToolsEditor', () => {
       'mcp-servers': [],
     });
     vi.spyOn(apiModule, 'fetchTools').mockResolvedValue({ tools: [] });
+    vi.spyOn(apiModule, 'fetchToolCatalog').mockResolvedValue({ tools: [] });
 
     // Start curated: only "query" is saved. User selects the remaining two,
     // bringing selection up to the full set of 3. The handler should
@@ -137,6 +149,7 @@ describe('ToolsEditor', () => {
     // the editor with the new server name; the editor must intercept and
     // prompt before discarding the in-flight edit.
     mockStoreState.tools = [tool('foo')];
+    mockStoreState.toolCatalog = [tool('foo')];
     rerender(<ToolsEditor serverName="other" savedTools={[]} />);
 
     const dialog = screen.getByRole('alertdialog');
@@ -148,10 +161,11 @@ describe('ToolsEditor', () => {
   });
 
   it('renders every server tool when the global store is empty (code mode)', () => {
-    // Simulates code mode: /api/tools returns only the meta-tools, so the
-    // global store has nothing prefixed for this server. The editor must
-    // still list every tool using the per-server `tools` field from status.
+    // Simulates the catalog being empty (e.g. it failed to load), so the
+    // store has nothing prefixed for this server. The editor must still list
+    // every tool using the per-server `tools` field from status.
     mockStoreState.tools = [];
+    mockStoreState.toolCatalog = [];
     render(
       <ToolsEditor
         serverName={SERVER}

--- a/web/src/__tests__/ToolsWorkspace.test.tsx
+++ b/web/src/__tests__/ToolsWorkspace.test.tsx
@@ -34,6 +34,16 @@ const GITHUB = 'github';
 const ATLAS = 'atlassian';
 
 beforeEach(() => {
+  // The workspace sources per-tool detail (descriptions, schemas, global
+  // search) from the catalog, so seed it; `tools` is the MCP-facing list.
+  const catalog = [
+    tool(`${GITHUB}${TOOL_NAME_DELIMITER}create_issue`, 'Create a GitHub issue', {
+      type: 'object',
+      properties: { title: { type: 'string' } },
+    }),
+    tool(`${GITHUB}${TOOL_NAME_DELIMITER}list_repos`, 'List repositories'),
+    tool(`${ATLAS}${TOOL_NAME_DELIMITER}get_page`, 'Get a Confluence page'),
+  ];
   useStackStore.setState({
     isLoading: false,
     mcpServers: [
@@ -42,14 +52,8 @@ beforeEach(() => {
       // atlassian: empty whitelist = all exposed (1/1)
       server(ATLAS, ['get_page'], []),
     ],
-    tools: [
-      tool(`${GITHUB}${TOOL_NAME_DELIMITER}create_issue`, 'Create a GitHub issue', {
-        type: 'object',
-        properties: { title: { type: 'string' } },
-      }),
-      tool(`${GITHUB}${TOOL_NAME_DELIMITER}list_repos`, 'List repositories'),
-      tool(`${ATLAS}${TOOL_NAME_DELIMITER}get_page`, 'Get a Confluence page'),
-    ],
+    tools: catalog,
+    toolCatalog: catalog,
   });
 });
 
@@ -71,14 +75,15 @@ describe('ToolsWorkspace', () => {
     expect(screen.getByRole('button', { name: /atlassian/i })).toBeInTheDocument();
   });
 
-  it('deep-links to ?server= and shows that server\'s tools, seeded from its whitelist', () => {
+  it('deep-links to ?server= and seeds the per-tool checkbox from its whitelist', () => {
     renderAt('/tools?server=github');
+    // The enable/disable state lives on the per-row checkbox, not the row.
     // github advertises create_issue + list_repos; whitelist is [create_issue].
-    expect(screen.getByRole('option', { name: 'create_issue' })).toHaveAttribute(
+    expect(screen.getByRole('checkbox', { name: /create_issue/i })).toHaveAttribute(
       'aria-checked',
       'true',
     );
-    expect(screen.getByRole('option', { name: 'list_repos' })).toHaveAttribute(
+    expect(screen.getByRole('checkbox', { name: /list_repos/i })).toHaveAttribute(
       'aria-checked',
       'false',
     );
@@ -87,14 +92,14 @@ describe('ToolsWorkspace', () => {
   it('defaults to the first server (alphabetical) when no ?server= is given', () => {
     renderAt('/tools');
     // atlassian sorts before github → its tool is shown by default.
-    expect(screen.getByRole('option', { name: 'get_page' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /get_page/i })).toBeInTheDocument();
   });
 
   it('selecting a server in the rail switches the detail pane', () => {
     renderAt('/tools');
     fireEvent.click(screen.getByRole('button', { name: /github/i }));
-    expect(screen.getByRole('option', { name: 'create_issue' })).toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: 'get_page' })).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /create_issue/i })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /get_page/i })).not.toBeInTheDocument();
   });
 
   it('global search returns cross-server matches, each labeled with its parent server', () => {
@@ -115,15 +120,33 @@ describe('ToolsWorkspace', () => {
     const result = screen.getByText('create_issue').closest('button')!;
     fireEvent.click(result);
     // Search clears and the github detail pane is shown with its tools.
-    expect(screen.getByRole('option', { name: 'create_issue' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'list_repos' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /create_issue/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /list_repos/i })).toBeInTheDocument();
   });
 
-  it('previews a tool input schema on expand', () => {
+  it('clicking the checkbox toggles exposure without selecting the row', () => {
     renderAt('/tools?server=github');
-    fireEvent.click(screen.getByRole('button', { name: /show create_issue schema/i }));
-    // The CodeViewer renders the JSON schema content.
+    // The panel starts empty (nothing selected).
+    expect(screen.getByText(/select a tool to view/i)).toBeInTheDocument();
+    // Toggling list_repos on flips its checkbox but does not open the panel.
+    const checkbox = screen.getByRole('checkbox', { name: /list_repos/i });
+    fireEvent.click(checkbox);
+    expect(screen.getByRole('checkbox', { name: /list_repos/i })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByText(/select a tool to view/i)).toBeInTheDocument();
+  });
+
+  it('selecting a tool row shows its schema in the detail panel', () => {
+    renderAt('/tools?server=github');
+    // Before selection the right rail prompts the user.
+    expect(screen.getByText(/select a tool to view/i)).toBeInTheDocument();
+    // Clicking the row body (the cmdk option) selects it for the panel.
+    fireEvent.click(screen.getByRole('option', { name: /create_issue details/i }));
+    // The panel renders the JSON schema via CodeViewer; the prompt is gone.
     expect(screen.getByLabelText('create_issue input schema')).toBeInTheDocument();
+    expect(screen.queryByText(/select a tool to view/i)).not.toBeInTheDocument();
   });
 });
 
@@ -167,14 +190,16 @@ describe('ToolsWorkspace — Audit Mode', () => {
 
   it('remediation disables idle exposed tools through a single-server save', async () => {
     // gitlab exposes a + b (whitelist), advertises a third disabled tool c.
+    const gitlabCatalog = [
+      tool(`gitlab${TOOL_NAME_DELIMITER}a`),
+      tool(`gitlab${TOOL_NAME_DELIMITER}b`),
+      tool(`gitlab${TOOL_NAME_DELIMITER}c`),
+    ];
     useStackStore.setState({
       isLoading: false,
       mcpServers: [server('gitlab', ['a', 'b', 'c'], ['a', 'b'])],
-      tools: [
-        tool(`gitlab${TOOL_NAME_DELIMITER}a`),
-        tool(`gitlab${TOOL_NAME_DELIMITER}b`),
-        tool(`gitlab${TOOL_NAME_DELIMITER}c`),
-      ],
+      tools: gitlabCatalog,
+      toolCatalog: gitlabCatalog,
     });
     vi.spyOn(api, 'fetchToolUsage').mockResolvedValue({
       observedSince: observedSince(),
@@ -189,6 +214,7 @@ describe('ToolsWorkspace — Audit Mode', () => {
       'mcp-servers': [],
     });
     vi.spyOn(api, 'fetchTools').mockResolvedValue({ tools: [] });
+    vi.spyOn(api, 'fetchToolCatalog').mockResolvedValue({ tools: [] });
 
     renderAt('/tools?server=gitlab');
     fireEvent.click(screen.getByRole('button', { name: /toggle audit mode/i }));

--- a/web/src/__tests__/useToolsEditor.test.ts
+++ b/web/src/__tests__/useToolsEditor.test.ts
@@ -12,19 +12,25 @@ vi.mock('../components/ui/Toast', () => ({
 
 const mockStoreState: {
   tools: Tool[];
+  toolCatalog: Tool[];
   setGatewayStatus: ReturnType<typeof vi.fn>;
   setTools: ReturnType<typeof vi.fn>;
+  setToolCatalog: ReturnType<typeof vi.fn>;
   selectNode: ReturnType<typeof vi.fn>;
 } = {
   tools: [],
+  toolCatalog: [],
   setGatewayStatus: vi.fn(),
   setTools: vi.fn(),
+  setToolCatalog: vi.fn(),
   selectNode: vi.fn(),
 };
 
 vi.mock('../stores/useStackStore', () => ({
   useStackStore: Object.assign(
-    vi.fn((selector: (s: { tools: Tool[] }) => unknown) => selector(mockStoreState)),
+    vi.fn((selector: (s: { tools: Tool[]; toolCatalog: Tool[] }) => unknown) =>
+      selector(mockStoreState),
+    ),
     {
       getState: () => mockStoreState,
     },
@@ -42,13 +48,17 @@ function tool(name: string, description?: string): Tool {
 }
 
 beforeEach(() => {
-  mockStoreState.tools = [
+  const catalog = [
     tool('query', 'Run a SQL query'),
     tool('insert', 'Insert a row'),
     tool('delete_row', 'Delete a row'),
   ];
+  // The editor derives rows + descriptions from the catalog, not `tools`.
+  mockStoreState.tools = catalog;
+  mockStoreState.toolCatalog = catalog;
   mockStoreState.setGatewayStatus.mockReset();
   mockStoreState.setTools.mockReset();
+  mockStoreState.setToolCatalog.mockReset();
   mockStoreState.selectNode.mockReset();
   vi.restoreAllMocks();
 });
@@ -109,6 +119,7 @@ describe('useToolsEditor', () => {
       .spyOn(apiModule, 'fetchStatus')
       .mockResolvedValue({ gateway: { name: 'x', version: '1' }, 'mcp-servers': [] });
     const fetchToolsSpy = vi.spyOn(apiModule, 'fetchTools').mockResolvedValue({ tools: [] });
+    vi.spyOn(apiModule, 'fetchToolCatalog').mockResolvedValue({ tools: [] });
 
     const { result } = renderHook(() => useToolsEditor(SERVER, ['query']));
     act(() => result.current.toggle('insert'));
@@ -134,6 +145,7 @@ describe('useToolsEditor', () => {
       'mcp-servers': [],
     });
     vi.spyOn(apiModule, 'fetchTools').mockResolvedValue({ tools: [] });
+    vi.spyOn(apiModule, 'fetchToolCatalog').mockResolvedValue({ tools: [] });
 
     // Start curated on "query"; selecting the remaining two brings the
     // selection to the full set, which must normalize to [].
@@ -158,6 +170,7 @@ describe('useToolsEditor', () => {
       'mcp-servers': [],
     });
     vi.spyOn(apiModule, 'fetchTools').mockResolvedValue({ tools: [] });
+    vi.spyOn(apiModule, 'fetchToolCatalog').mockResolvedValue({ tools: [] });
 
     // Saved whitelist exposes query + insert (2 of 3 tools); disable insert.
     const { result } = renderHook(() => useToolsEditor(SERVER, ['query', 'insert']));

--- a/web/src/components/workspaces/FleetActions.tsx
+++ b/web/src/components/workspaces/FleetActions.tsx
@@ -6,6 +6,7 @@ import {
   AuthError,
   fetchStatus,
   fetchTools,
+  fetchToolCatalog,
   setServerToolsBatch,
   SetServerToolsError,
 } from '../../lib/api';
@@ -76,9 +77,14 @@ export function FleetActions({ isOpen, onClose, servers, activeServerName }: Fle
       );
       // Reflect the change immediately; polling would otherwise lag.
       try {
-        const [statusResp, toolsList] = await Promise.all([fetchStatus(), fetchTools()]);
+        const [statusResp, toolsList, catalogList] = await Promise.all([
+          fetchStatus(),
+          fetchTools(),
+          fetchToolCatalog(),
+        ]);
         useStackStore.getState().setGatewayStatus(statusResp);
         useStackStore.getState().setTools(toolsList.tools);
+        useStackStore.getState().setToolCatalog(catalogList.tools);
       } catch {
         /* ignore — the next poll will refresh */
       }

--- a/web/src/components/workspaces/ToolDetailPanel.tsx
+++ b/web/src/components/workspaces/ToolDetailPanel.tsx
@@ -1,0 +1,144 @@
+import type { ReactNode } from 'react';
+import { Wrench } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { CodeViewer } from '../ui/CodeViewer';
+import { InspectorHeader } from '../inspector';
+import { formatLastUsed, type AuditState } from '../../lib/toolAudit';
+import type { ToolRow } from '../../hooks/useToolsEditor';
+
+// Per-state styling for the audit row, mirroring the list's AUDIT_STYLES.
+const AUDIT_LABEL: Record<AuditState, { text: string; dot: string; label: string }> = {
+  used: { text: 'text-status-running', dot: 'bg-status-running', label: 'used' },
+  unused: { text: 'text-status-pending', dot: 'bg-status-pending', label: 'unused' },
+  disabled: { text: 'text-text-muted', dot: 'bg-text-muted/50', label: 'disabled' },
+};
+
+interface ToolDetailPanelProps {
+  serverName: string;
+  // The selected tool (name + description), or null when nothing is selected.
+  tool: ToolRow | null;
+  // The tool's input schema (JSON Schema), or undefined when unavailable.
+  schema?: Record<string, unknown>;
+  // Whether the tool is in the server's exposed whitelist.
+  enabled: boolean;
+  auditMode: boolean;
+  auditState: AuditState | null;
+  lastCalledAt?: string;
+  onClose: () => void;
+}
+
+// ToolDetailPanel fills the Tools workspace right rail with the selected tool's
+// description, input schema, and metadata. Schema is rendered with the shared
+// CodeViewer so it matches the Spec tab's tokenized treatment. When no tool is
+// selected it shows an explicit prompt rather than a blank gap.
+export function ToolDetailPanel({
+  serverName,
+  tool,
+  schema,
+  enabled,
+  auditMode,
+  auditState,
+  lastCalledAt,
+  onClose,
+}: ToolDetailPanelProps) {
+  return (
+    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle">
+      {tool ? (
+        <>
+          <InspectorHeader
+            title={tool.name}
+            icon={Wrench}
+            accent="primary"
+            onClose={onClose}
+            subtitle={
+              <div className="flex items-center gap-1.5 flex-wrap mt-0.5">
+                <span className="text-[10px] font-mono text-primary/80 truncate">{serverName}</span>
+                <span
+                  className={cn(
+                    'text-[10px] font-mono px-1.5 py-0.5 rounded',
+                    enabled
+                      ? 'bg-primary/15 text-primary'
+                      : 'bg-surface-elevated text-text-muted',
+                  )}
+                >
+                  {enabled ? 'enabled' : 'disabled'}
+                </span>
+              </div>
+            }
+          />
+
+          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark px-4 py-4 space-y-5">
+            <Section title="Description">
+              {tool.description ? (
+                <p className="text-xs text-text-secondary leading-relaxed whitespace-pre-wrap break-words">
+                  {tool.description}
+                </p>
+              ) : (
+                <p className="text-[11px] text-text-muted/70 italic">No description available.</p>
+              )}
+            </Section>
+
+            <Section title="Input schema">
+              {schema ? (
+                <CodeViewer
+                  language="json"
+                  content={JSON.stringify(schema, null, 2)}
+                  ariaLabel={`${tool.name} input schema`}
+                  className="rounded-md border border-border/30 bg-background/80 max-h-[45vh]"
+                />
+              ) : (
+                <p className="text-[11px] text-text-muted/70 italic">No input schema available.</p>
+              )}
+            </Section>
+
+            {auditMode && auditState && (
+              <Section title="Usage">
+                <div
+                  className={cn(
+                    'flex items-center gap-1.5 text-[11px]',
+                    AUDIT_LABEL[auditState].text,
+                  )}
+                >
+                  <span
+                    className={cn('inline-block w-1.5 h-1.5 rounded-full', AUDIT_LABEL[auditState].dot)}
+                    aria-hidden="true"
+                  />
+                  <span>{AUDIT_LABEL[auditState].label}</span>
+                  {auditState !== 'disabled' && (
+                    <span className="text-text-muted/70">· {formatLastUsed(lastCalledAt)}</span>
+                  )}
+                </div>
+              </Section>
+            )}
+          </div>
+        </>
+      ) : (
+        <ToolDetailEmpty />
+      )}
+    </aside>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function ToolDetailEmpty() {
+  return (
+    <div className="h-full flex items-center justify-center px-6 text-center">
+      <div className="space-y-3">
+        <div className="mx-auto w-12 h-12 rounded-2xl bg-surface-highlight/40 border border-border/40 flex items-center justify-center">
+          <Wrench size={20} className="text-text-muted/60" aria-hidden="true" />
+        </div>
+        <p className="text-xs text-text-muted leading-relaxed max-w-[220px]">
+          Select a tool to view its description and input schema.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/workspaces/ToolsWorkspace.tsx
+++ b/web/src/components/workspaces/ToolsWorkspace.tsx
@@ -35,8 +35,8 @@ import {
 import { WorkspaceShell } from '../layout/WorkspaceShell';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { StatusDot } from '../ui/StatusDot';
-import { CodeViewer } from '../ui/CodeViewer';
 import { FleetActions } from './FleetActions';
+import { ToolDetailPanel } from './ToolDetailPanel';
 import type { MCPServerStatus, NodeStatus, Tool, ToolUsageStat } from '../../types';
 
 // Per-state styling for Audit Mode dots/labels, keyed to the shared status
@@ -61,7 +61,10 @@ export function ToolsWorkspace() {
   const compact = useUIStore((s) => s.compactMode.tools);
 
   const mcpServers = useStackStore((s) => s.mcpServers);
-  const tools = useStackStore((s) => s.tools);
+  // The Tools workspace sources per-tool detail from the catalog (raw
+  // descriptions + schemas, populated even in code mode), not the MCP-facing
+  // `tools` list which is just the meta-tools when code mode is on.
+  const toolCatalog = useStackStore((s) => s.toolCatalog);
   const isLoading = useStackStore((s) => s.isLoading);
 
   // Servers sorted by name for a stable rail order.
@@ -154,9 +157,10 @@ export function ToolsWorkspace() {
   // A pending target set while the active editor has unsaved edits. The switch
   // commits (URL change) only after the user discards.
   const [pendingServer, setPendingServer] = useState<string | null>(null);
-  // The tool whose input schema is expanded in the detail pane. Picking a
+  // The tool whose detail is shown in the right rail. Distinct from the
+  // whitelist selection (the checkboxes) — this is the "active" tool. Picking a
   // global-search result sets it so that tool is revealed on arrival.
-  const [expandedTool, setExpandedTool] = useState<string | null>(null);
+  const [selectedTool, setSelectedTool] = useState<string | null>(null);
 
   // Switch to a server (or reveal a tool on the active one). Unsaved edits on
   // the current server route through a confirm dialog before the switch
@@ -164,13 +168,13 @@ export function ToolsWorkspace() {
   function requestServer(name: string, tool?: string) {
     if (name !== activeServerName && editor.dirty) {
       setPendingServer(name);
-      setExpandedTool(tool ?? null);
+      setSelectedTool(tool ?? null);
       return;
     }
     if (name !== activeServerName) applyServer(name);
-    // Clear any active filter so a revealed tool is visible, then expand it.
+    // Clear any active filter so a revealed tool is visible, then select it.
     editor.setQuery('');
-    setExpandedTool(tool ?? null);
+    setSelectedTool(tool ?? null);
   }
 
   function confirmSwitch() {
@@ -183,16 +187,35 @@ export function ToolsWorkspace() {
     setPendingServer(null);
   }
 
-  const toggleExpanded = (tool: string) =>
-    setExpandedTool((prev) => (prev === tool ? null : tool));
-
   // ---- Global search ------------------------------------------------------
   const searchActive = globalQuery.trim().length > 0;
-  const globalMatches = useFuzzySearch(tools, globalQuery);
+  const globalMatches = useFuzzySearch(toolCatalog, globalQuery);
   const globalResults = useMemo(
     () => globalMatches.map(splitTool).filter((r): r is GlobalResult => r !== null),
     [globalMatches],
   );
+
+  // ---- Selected-tool detail (right rail) ----------------------------------
+  // The active tool's row (name + description), schema, whitelist state, and
+  // audit classification — all derived here so the panel can live in the shell
+  // right rail (a sibling of the center pane).
+  const selectedRow = useMemo(
+    () => (selectedTool ? editor.allTools.find((t) => t.name === selectedTool) ?? null : null),
+    [selectedTool, editor.allTools],
+  );
+  const selectedSchema = useMemo(() => {
+    if (!selectedTool || !activeServerName) return undefined;
+    const prefixed = `${activeServerName}${TOOL_NAME_DELIMITER}${selectedTool}`;
+    return toolCatalog.find((t) => t.name === prefixed)?.inputSchema;
+  }, [selectedTool, activeServerName, toolCatalog]);
+  const selectedEnabled = selectedTool ? editor.selected.has(selectedTool) : false;
+  const selectedLastCalled = selectedTool
+    ? usageByServer?.[activeServerName]?.[selectedTool]?.lastCalledAt
+    : undefined;
+  const selectedAuditState = useMemo(() => {
+    if (!auditMode || !selectedTool || fetchedAt == null) return null;
+    return classifyTool(selectedEnabled, selectedLastCalled, windowMs, fetchedAt);
+  }, [auditMode, selectedTool, selectedEnabled, selectedLastCalled, windowMs, fetchedAt]);
 
   const leftRail = (
     <ServerRail
@@ -205,14 +228,29 @@ export function ToolsWorkspace() {
     />
   );
 
+  const rightRail = (
+    <ToolDetailPanel
+      serverName={activeServerName}
+      tool={selectedRow}
+      schema={selectedSchema}
+      enabled={selectedEnabled}
+      auditMode={auditMode}
+      auditState={selectedAuditState}
+      lastCalledAt={selectedLastCalled}
+      onClose={() => setSelectedTool(null)}
+    />
+  );
+
   return (
     <div className="absolute inset-0 flex flex-col bg-background text-text-primary overflow-hidden">
       <WorkspaceShell
         workspace="tools"
-        defaultLeftPct={22}
-        defaultRightPct={0}
+        defaultLeftPct={20}
+        defaultRightPct={30}
         left={leftRail}
+        right={rightRail}
         minLeftPx={220}
+        minRightPx={300}
       >
         <main className="flex flex-col h-full overflow-hidden">
           <ToolsHeader
@@ -244,9 +282,8 @@ export function ToolsWorkspace() {
                 key={activeServer.name}
                 server={activeServer}
                 editor={editor}
-                allTools={tools}
-                expanded={expandedTool}
-                onToggleExpand={toggleExpanded}
+                selectedTool={selectedTool}
+                onSelect={setSelectedTool}
                 auditMode={auditMode}
                 usage={usageByServer?.[activeServer.name]}
                 windowMs={windowMs}
@@ -535,11 +572,11 @@ function ServerPill({ server, active, onClick, auditMode, unusedCount }: ServerP
 interface ServerDetailProps {
   server: MCPServerStatus;
   editor: ReturnType<typeof useToolsEditor>;
-  allTools: Tool[];
-  // The tool whose schema is expanded (controlled by the workspace so a
-  // global-search reveal can target it). null = none expanded.
-  expanded: string | null;
-  onToggleExpand: (tool: string) => void;
+  // The active tool whose detail shows in the right rail (controlled by the
+  // workspace so a global-search reveal can target it). null = none selected.
+  // Distinct from the editor's whitelist selection (the checkboxes).
+  selectedTool: string | null;
+  onSelect: (tool: string) => void;
   auditMode: boolean;
   // This server's per-tool usage map (from GET /api/tools/usage), or undefined
   // when usage hasn't loaded / Audit Mode is off.
@@ -552,9 +589,8 @@ interface ServerDetailProps {
 function ServerDetail({
   server,
   editor,
-  allTools,
-  expanded,
-  onToggleExpand,
+  selectedTool,
+  onSelect,
   auditMode,
   usage,
   windowMs,
@@ -604,25 +640,16 @@ function ServerDetail({
   // Confirm gate for the remediation bulk action (consequence-stating).
   const [remediateOpen, setRemediateOpen] = useState(false);
 
-  // Input schemas for this server's tools, keyed by unprefixed tool name.
-  const schemaByTool = useMemo(() => {
-    const prefix = `${server.name}${TOOL_NAME_DELIMITER}`;
-    const map = new Map<string, Record<string, unknown>>();
-    for (const t of allTools) {
-      if (t.name.startsWith(prefix)) map.set(t.name.slice(prefix.length), t.inputSchema);
-    }
-    return map;
-  }, [allTools, server.name]);
-
   const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
-  // Scroll the expanded tool into view (e.g. after a global-search reveal).
-  // DOM-only side effect — no state updates.
+  // Scroll the selected tool into view (e.g. after a global-search reveal).
+  // `block: 'nearest'` no-ops when the row is already visible, so clicking a
+  // visible row to select it never jumps the list. DOM-only — no state writes.
   useEffect(() => {
-    if (!expanded) return;
+    if (!selectedTool) return;
     // Optional-chain: scrollIntoView is absent in jsdom and older embeds.
-    rowRefs.current.get(expanded)?.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
-  }, [expanded]);
+    rowRefs.current.get(selectedTool)?.scrollIntoView?.({ block: 'nearest', behavior: 'smooth' });
+  }, [selectedTool]);
 
   const saveLabel = dirty
     ? `Save ${diffCount} change${diffCount === 1 ? '' : 's'} & Reload`
@@ -702,9 +729,8 @@ function ServerDetail({
               </p>
             </Command.Empty>
             {visible.map((opt) => {
-              const isSelected = selected.has(opt.name);
-              const schema = schemaByTool.get(opt.name);
-              const isExpanded = expanded === opt.name;
+              const isEnabled = selected.has(opt.name);
+              const isActive = selectedTool === opt.name;
               const auditState = auditByTool.get(opt.name) ?? null;
               return (
                 <div
@@ -714,37 +740,48 @@ function ServerDetail({
                     else rowRefs.current.delete(opt.name);
                   }}
                   className={cn(
-                    'border-b border-border/20 last:border-b-0',
-                    isSelected && 'bg-primary/[0.03]',
+                    'border-b border-border/20 last:border-b-0 border-l-2',
+                    isActive
+                      ? 'border-l-primary bg-primary/[0.06]'
+                      : 'border-l-transparent',
+                    isEnabled && !isActive && 'bg-primary/[0.03]',
                   )}
                 >
                   <Command.Item
                     value={opt.name}
-                    onSelect={() => toggle(opt.name)}
-                    aria-checked={isSelected}
-                    aria-label={opt.name}
+                    onSelect={() => onSelect(opt.name)}
+                    aria-current={isActive}
+                    aria-label={`${opt.name} details`}
                     className={cn(
                       'flex items-start gap-2.5 px-3 py-2 cursor-pointer select-none outline-none transition-colors',
-                      'hover:bg-surface-highlight/50',
-                      '[&[data-selected=true]]:bg-primary/[0.06]',
+                      'hover:bg-surface-highlight/40',
+                      '[&[data-selected=true]]:bg-surface-highlight/40',
                     )}
                   >
-                    <div
+                    <button
+                      type="button"
+                      role="checkbox"
+                      aria-checked={isEnabled}
+                      aria-label={isEnabled ? `Disable ${opt.name}` : `Enable ${opt.name}`}
+                      onClick={(e) => {
+                        // Toggling exposure must not select the row for the panel.
+                        e.stopPropagation();
+                        toggle(opt.name);
+                      }}
                       className={cn(
                         'mt-0.5 w-3.5 h-3.5 rounded border flex items-center justify-center flex-shrink-0 transition-colors',
-                        isSelected
+                        isEnabled
                           ? 'bg-primary/20 border-primary/60'
-                          : 'border-border/60 bg-background/50',
+                          : 'border-border/60 bg-background/50 hover:border-primary/40',
                       )}
-                      aria-hidden="true"
                     >
-                      {isSelected && <Check size={10} className="text-primary" />}
-                    </div>
+                      {isEnabled && <Check size={10} className="text-primary" aria-hidden="true" />}
+                    </button>
                     <div className="flex-1 min-w-0">
                       <div
                         className={cn(
                           'text-xs font-mono truncate',
-                          isSelected ? 'text-text-primary' : 'text-text-secondary',
+                          isEnabled ? 'text-text-primary' : 'text-text-secondary',
                         )}
                       >
                         {opt.name}
@@ -775,35 +812,15 @@ function ServerDetail({
                         </div>
                       )}
                     </div>
-                    {schema && (
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          // Don't toggle selection when peeking the schema.
-                          e.stopPropagation();
-                          onToggleExpand(opt.name);
-                        }}
-                        aria-label={isExpanded ? `Hide ${opt.name} schema` : `Show ${opt.name} schema`}
-                        aria-expanded={isExpanded}
-                        className="flex-shrink-0 p-0.5 rounded text-text-muted hover:text-text-primary hover:bg-surface-highlight transition-colors"
-                      >
-                        <ChevronRight
-                          size={13}
-                          className={cn('transition-transform', isExpanded && 'rotate-90')}
-                        />
-                      </button>
-                    )}
+                    <ChevronRight
+                      size={13}
+                      className={cn(
+                        'flex-shrink-0 mt-0.5 transition-colors',
+                        isActive ? 'text-primary' : 'text-text-muted/40',
+                      )}
+                      aria-hidden="true"
+                    />
                   </Command.Item>
-                  {isExpanded && schema && (
-                    <div className="px-3 pb-2">
-                      <CodeViewer
-                        language="json"
-                        content={JSON.stringify(schema, null, 2)}
-                        ariaLabel={`${opt.name} input schema`}
-                        className="rounded-md border border-border/30 bg-background/80 max-h-64"
-                      />
-                    </div>
-                  )}
                 </div>
               );
             })}

--- a/web/src/hooks/usePolling.ts
+++ b/web/src/hooks/usePolling.ts
@@ -5,7 +5,7 @@ import { useRegistryStore } from '../stores/useRegistryStore';
 import { usePinsStore } from '../stores/usePinsStore';
 import { useUIStore } from '../stores/useUIStore';
 import { useTelemetryStore } from '../stores/useTelemetryStore';
-import { fetchStatus, fetchTools, fetchClients, fetchRegistryStatus, fetchRegistrySkills, fetchServerPins, fetchStackSpec, getTelemetryInventory, AuthError } from '../lib/api';
+import { fetchStatus, fetchTools, fetchToolCatalog, fetchClients, fetchRegistryStatus, fetchRegistrySkills, fetchServerPins, fetchStackSpec, getTelemetryInventory, AuthError } from '../lib/api';
 import { showToast } from '../components/ui/Toast';
 import { POLLING } from '../lib/constants';
 
@@ -17,6 +17,7 @@ export function usePolling() {
   const setGatewayStatus = useStackStore((s) => s.setGatewayStatus);
   const setClients = useStackStore((s) => s.setClients);
   const setTools = useStackStore((s) => s.setTools);
+  const setToolCatalog = useStackStore((s) => s.setToolCatalog);
   const setError = useStackStore((s) => s.setError);
   const setLoading = useStackStore((s) => s.setLoading);
   const setConnectionStatus = useStackStore((s) => s.setConnectionStatus);
@@ -27,13 +28,15 @@ export function usePolling() {
 
   const poll = useCallback(async () => {
     try {
-      const [status, toolsResult] = await Promise.all([
+      const [status, toolsResult, catalogResult] = await Promise.all([
         fetchStatus(),
         fetchTools(),
+        fetchToolCatalog(),
       ]);
 
       setGatewayStatus(status);
       setTools(toolsResult.tools);
+      setToolCatalog(catalogResult.tools);
       setAuthRequired(false);
 
       // Fetch clients separately — failure should not block core updates
@@ -123,7 +126,7 @@ export function usePolling() {
         setConnectionStatus('error');
       }
     }
-  }, [setGatewayStatus, setClients, setTools, setError, setConnectionStatus, setAuthRequired, setLoading, refreshNodesAndEdges]);
+  }, [setGatewayStatus, setClients, setTools, setToolCatalog, setError, setConnectionStatus, setAuthRequired, setLoading, refreshNodesAndEdges]);
 
   useEffect(() => {
     // Don't poll while auth prompt is showing

--- a/web/src/hooks/useToolsEditor.ts
+++ b/web/src/hooks/useToolsEditor.ts
@@ -6,6 +6,7 @@ import {
   AuthError,
   fetchStatus,
   fetchTools,
+  fetchToolCatalog,
   setServerTools,
   SetServerToolsError,
 } from '../lib/api';
@@ -78,17 +79,18 @@ export function useToolsEditor(
   savedTools: string[],
   serverTools?: string[],
 ): UseToolsEditor {
-  const tools = useStackStore((s) => s.tools);
+  const catalog = useStackStore((s) => s.toolCatalog);
 
   // Every tool the editor should render. The server's own advertised list
   // (from /api/status) is the authoritative source — it holds every tool
-  // regardless of code mode. The global tools store provides descriptions
-  // when available. A saved whitelist entry missing from both still renders
-  // so the user sees what's actually persisted in the YAML.
+  // regardless of code mode. The tool catalog (/api/tools/catalog) provides
+  // descriptions when available, including in code mode. A saved whitelist
+  // entry missing from both still renders so the user sees what's actually
+  // persisted in the YAML.
   const allTools: ToolRow[] = useMemo(() => {
     const prefix = `${serverName}${TOOL_NAME_DELIMITER}`;
     const descriptions = new Map<string, string | undefined>();
-    for (const t of tools ?? []) {
+    for (const t of catalog ?? []) {
       if (t.name.startsWith(prefix)) {
         descriptions.set(t.name.slice(prefix.length), t.description);
       }
@@ -104,7 +106,7 @@ export function useToolsEditor(
       if (!rows.has(name)) rows.set(name, { name });
     }
     return [...rows.values()];
-  }, [tools, serverName, savedTools, serverTools]);
+  }, [catalog, serverName, savedTools, serverTools]);
 
   // Saved selection in canonical form. When savedTools is empty, the YAML
   // has no whitelist, so the server is exposing every tool — we reflect that
@@ -216,9 +218,14 @@ export function useToolsEditor(
       // Refresh the global caches so the sidebar reflects the now-filtered
       // tool set. Best-effort; we've already persisted the write.
       try {
-        const [status, toolsList] = await Promise.all([fetchStatus(), fetchTools()]);
+        const [status, toolsList, catalogList] = await Promise.all([
+          fetchStatus(),
+          fetchTools(),
+          fetchToolCatalog(),
+        ]);
         useStackStore.getState().setGatewayStatus(status);
         useStackStore.getState().setTools(toolsList.tools);
+        useStackStore.getState().setToolCatalog(catalogList.tools);
       } catch {
         /* ignore refresh failures — the page will re-poll shortly */
       }
@@ -240,9 +247,14 @@ export function useToolsEditor(
             // on-disk state as the clean baseline; the hot reload can be
             // re-attempted via the Reload button elsewhere in the UI.
             try {
-              const [status, toolsList] = await Promise.all([fetchStatus(), fetchTools()]);
+              const [status, toolsList, catalogList] = await Promise.all([
+                fetchStatus(),
+                fetchTools(),
+                fetchToolCatalog(),
+              ]);
               useStackStore.getState().setGatewayStatus(status);
               useStackStore.getState().setTools(toolsList.tools);
+              useStackStore.getState().setToolCatalog(catalogList.tools);
             } catch {
               /* ignore refresh failures */
             }
@@ -292,9 +304,14 @@ export function useToolsEditor(
   const handleReloadFromDisk = async () => {
     setConflict(null);
     try {
-      const [status, toolsList] = await Promise.all([fetchStatus(), fetchTools()]);
+      const [status, toolsList, catalogList] = await Promise.all([
+        fetchStatus(),
+        fetchTools(),
+        fetchToolCatalog(),
+      ]);
       useStackStore.getState().setGatewayStatus(status);
       useStackStore.getState().setTools(toolsList.tools);
+      useStackStore.getState().setToolCatalog(catalogList.tools);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Refresh failed';
       showToast('error', msg);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -122,6 +122,17 @@ export async function fetchTools(): Promise<ToolsListResult> {
 }
 
 /**
+ * Fetch the full downstream tool inventory with each tool's raw description and
+ * input schema, regardless of code mode. Unlike /api/tools (which returns only
+ * the meta-tools when code mode is on), this informational endpoint always
+ * carries the real per-tool detail the Tools workspace renders.
+ * GET /api/tools/catalog
+ */
+export async function fetchToolCatalog(): Promise<ToolsListResult> {
+  return fetchJSON<ToolsListResult>('/api/tools/catalog');
+}
+
+/**
  * Fetch per-(server, tool) usage: cumulative call counts + last-called
  * timestamps observed by the gateway. Powers Tools workspace Audit Mode.
  * Survives gateway restarts for servers with metrics persistence enabled.

--- a/web/src/pages/DetachedSidebarPage.tsx
+++ b/web/src/pages/DetachedSidebarPage.tsx
@@ -20,7 +20,7 @@ import { IconButton } from '../components/ui/IconButton';
 import { ZoomControls } from '../components/ui/ZoomControls';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
 import { useLogFontSize } from '../hooks/useLogFontSize';
-import { fetchStatus, fetchTools } from '../lib/api';
+import { fetchStatus, fetchTools, fetchToolCatalog } from '../lib/api';
 import { getTransportIcon, getTransportColorClasses } from '../lib/transport';
 import { POLLING } from '../lib/constants';
 import { useStackStore } from '../stores/useStackStore';
@@ -99,7 +99,11 @@ function DetachedSidebarPageContent() {
   // Fetch data
   const fetchData = useCallback(async () => {
     try {
-      const [status, toolsResult] = await Promise.all([fetchStatus(), fetchTools()]);
+      const [status, toolsResult, catalogResult] = await Promise.all([
+        fetchStatus(),
+        fetchTools(),
+        fetchToolCatalog(),
+      ]);
 
       const nodeList: NodeOption[] = [
         ...(status['mcp-servers'] ?? []).map((s) => ({
@@ -119,6 +123,7 @@ function DetachedSidebarPageContent() {
       // store) has the same tool descriptions as the primary sidebar.
       useStackStore.getState().setGatewayStatus(status);
       useStackStore.getState().setTools(toolsResult.tools ?? []);
+      useStackStore.getState().setToolCatalog(catalogResult.tools ?? []);
       setIsLoading(false);
     } catch {
       setIsLoading(false);

--- a/web/src/stores/useStackStore.ts
+++ b/web/src/stores/useStackStore.ts
@@ -50,6 +50,11 @@ interface StackState {
   resources: ResourceStatus[];
   clients: ClientStatus[];  // Detected/linked LLM clients
   tools: Tool[];
+  // Full downstream tool inventory (raw descriptions + schemas) from
+  // /api/tools/catalog. Unlike `tools` (the MCP-facing aggregated list, which
+  // is just the meta-tools in code mode), this always carries per-tool detail,
+  // so the Tools workspace sources descriptions/schemas/search from it.
+  toolCatalog: Tool[];
   sessions: number;
   codeMode: string | null;  // Gateway code mode status ("on" when active)
   tokenUsage: TokenUsage | null; // Token usage metrics from status response
@@ -78,6 +83,7 @@ interface StackState {
   setGatewayStatus: (status: GatewayStatus) => void;
   setClients: (clients: ClientStatus[]) => void;
   setTools: (tools: Tool[]) => void;
+  setToolCatalog: (toolCatalog: Tool[]) => void;
   setError: (error: string | null) => void;
   setLoading: (loading: boolean) => void;
   setConnectionStatus: (status: ConnectionStatus) => void;
@@ -98,6 +104,7 @@ export const useStackStore = create<StackState>()(
     resources: [],
     clients: [],
     tools: [],
+    toolCatalog: [],
     sessions: 0,
     codeMode: null,
     tokenUsage: null,
@@ -152,6 +159,8 @@ export const useStackStore = create<StackState>()(
     },
 
     setTools: (tools) => set({ tools }),
+
+    setToolCatalog: (toolCatalog) => set({ toolCatalog }),
 
     setError: (error) => set({
       error,


### PR DESCRIPTION
## Summary

Clicking a tool row in the **Tools** workspace now selects it and shows its **description, input schema, and metadata** in the right rail (previously empty space). The enable/disable toggle is narrowed to the row **checkbox**, so selecting a tool no longer changes its exposure.

This matches the master-detail layout of Anthropic's MCP Inspector and fills the dead space on the right of the workspace.

## What changed

**Backend**
- New read-only `GET /api/tools/catalog` returns the full downstream tool inventory (raw descriptions + schemas) **regardless of code mode**. The MCP-facing `/api/tools` returns only the `search`/`execute` meta-tools in code mode, so per-tool detail was unavailable to the UI there. Backed by `Router.CatalogTools()` (mirrors `AggregatedTools()` but leaves descriptions unwrapped). Does **not** change what MCP clients see from `tools/list`.

**Frontend**
- Tools workspace sources descriptions, schemas, and global search from the catalog, so they work in **both passthrough and code mode**.
- Row click → selects the tool (drives the panel); checkbox click → toggles exposure (with `stopPropagation`). Distinct highlights for the active row vs. enabled rows.
- New `ToolDetailPanel` mounted in the `WorkspaceShell` right rail: schema via the shared `CodeViewer` (matches the Spec tab), description as text, audit/usage metadata, and an explicit empty state.
- Replaces the inline chevron schema-peek with the panel.

## Why code mode matters here

Code mode hides downstream tools behind meta-tools to save context, so the UI had no descriptions/schemas for them. The gateway already holds the full inventory in memory; the catalog endpoint simply exposes it to the console. This keeps the panel useful as code mode moves toward the default.

## Testing

- `go test -race ./pkg/mcp/ ./internal/api/` — pass (incl. new `TestGateway_HandleToolsCatalog_CodeMode`)
- `golangci-lint run pkg/mcp/... internal/api/...` — 0 issues
- Web: `vitest run` — 749 pass (Tools workspace / editor tests updated for the new model; added panel + checkbox-toggle tests)
- `npm run build` and ESLint on changed files — clean

> Note: verified via unit/integration tests and type/build checks; a visual pass in a live code-mode stack is recommended before merge.