### PR TITLE
feat: group the Skills Library by provenance

### DIFF
--- a/web/src/__tests__/LibraryWorkspace.test.tsx
+++ b/web/src/__tests__/LibraryWorkspace.test.tsx
@@ -6,7 +6,7 @@ import { LibraryWorkspace } from '../components/workspaces/LibraryWorkspace';
 import { useRegistryStore } from '../stores/useRegistryStore';
 import { showToast } from '../components/ui/Toast';
 import { CommandRegistryProvider } from '../hooks/useCommandRegistry';
-import type { AgentSkill } from '../types';
+import type { AgentSkill, SkillSourceStatus } from '../types';
 
 vi.mock('../components/ui/Toast', () => ({
   showToast: vi.fn(),
@@ -16,6 +16,8 @@ vi.mock('../components/ui/Toast', () => ({
 vi.mock('../lib/api', () => ({
   fetchRegistryStatus: vi.fn().mockResolvedValue({ totalSkills: 0, activeSkills: 0 }),
   fetchRegistrySkills: vi.fn().mockResolvedValue([]),
+  fetchSkillSources: vi.fn().mockResolvedValue([]),
+  updateSkillSource: vi.fn().mockResolvedValue({ source: 'acme-skills', results: [] }),
   activateRegistrySkill: vi.fn().mockResolvedValue(undefined),
   disableRegistrySkill: vi.fn().mockResolvedValue(undefined),
   deleteRegistrySkill: vi.fn().mockResolvedValue(undefined),
@@ -40,6 +42,20 @@ const SAMPLE_SKILLS: AgentSkill[] = [
   { name: 'draft-summarizer', description: 'summarize drafts', state: 'draft', dir: 'tools', fileCount: 1 },
   // @ts-expect-error partial AgentSkill is fine for the test
   { name: 'disabled-skill', description: 'paused', state: 'disabled', dir: 'archive', fileCount: 1 },
+];
+
+// One imported source that owns `draft-summarizer`; the other two skills are
+// local ("My Skills").
+const SAMPLE_SOURCES: SkillSourceStatus[] = [
+  {
+    name: 'acme-skills',
+    repo: 'https://github.com/acme/skills',
+    commitSha: 'abcdef1234567',
+    autoUpdate: false,
+    updateInterval: '',
+    updateAvailable: false,
+    skills: [{ name: 'draft-summarizer', description: 'summarize drafts', state: 'draft', isRemote: true }],
+  },
 ];
 
 function LocationProbe({ onChange }: { onChange: (search: string) => void }) {
@@ -74,7 +90,9 @@ function renderAt(path: string, onLocationChange?: (search: string) => void) {
 describe('LibraryWorkspace', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useRegistryStore.setState({ skills: SAMPLE_SKILLS, status: { totalSkills: 3, activeSkills: 1 } });
+    // Reset sources to null so provenance grouping is off by default; tests that
+    // exercise grouping opt in explicitly.
+    useRegistryStore.setState({ skills: SAMPLE_SKILLS, status: { totalSkills: 3, activeSkills: 1 }, sources: null });
   });
 
   it('renders the skill grid with all skills when filter is all', () => {
@@ -125,5 +143,90 @@ describe('LibraryWorkspace', () => {
     useRegistryStore.setState({ skills: null });
     renderAt('/library/never-existed');
     expect(showToast).not.toHaveBeenCalled();
+  });
+
+  describe('provenance grouping', () => {
+    it('shows no grouping control or "My Skills" header when there are no sources', () => {
+      renderAt('/library');
+      expect(screen.queryByRole('group', { name: 'Group skills by' })).not.toBeInTheDocument();
+      expect(screen.queryByText('My Skills')).not.toBeInTheDocument();
+      // All skills still render (category/flat behavior is unchanged).
+      expect(screen.getByText('incident-triage')).toBeInTheDocument();
+      expect(screen.getByText('draft-summarizer')).toBeInTheDocument();
+    });
+
+    it('defaults to source grouping with "My Skills" + per-source sections when sources exist', () => {
+      useRegistryStore.setState({ sources: SAMPLE_SOURCES });
+      renderAt('/library');
+      expect(screen.getByRole('group', { name: 'Group skills by' })).toBeInTheDocument();
+      expect(screen.getByText('My Skills')).toBeInTheDocument();
+      expect(screen.getByText('acme/skills')).toBeInTheDocument();
+      // Everything is still visible — grouping organizes, it does not hide.
+      expect(screen.getByText('incident-triage')).toBeInTheDocument();
+      expect(screen.getByText('draft-summarizer')).toBeInTheDocument();
+      expect(screen.getByText('disabled-skill')).toBeInTheDocument();
+    });
+
+    it('shows the short commit SHA in the source header', () => {
+      useRegistryStore.setState({ sources: SAMPLE_SOURCES });
+      renderAt('/library');
+      expect(screen.getByText('abcdef1')).toBeInTheDocument();
+    });
+
+    it('reflects the Group by selection in ?group= (and omits the default)', async () => {
+      useRegistryStore.setState({ sources: SAMPLE_SOURCES });
+      let currentSearch = '';
+      renderAt('/library', (s) => { currentSearch = s; });
+
+      fireEvent.click(screen.getByRole('button', { name: 'None' }));
+      await waitFor(() => expect(currentSearch).toContain('group=none'));
+
+      fireEvent.click(screen.getByRole('button', { name: 'Source' }));
+      await waitFor(() => expect(currentSearch).not.toContain('group='));
+    });
+
+    it('restores grouping from ?group=none on initial render', () => {
+      useRegistryStore.setState({ sources: SAMPLE_SOURCES });
+      renderAt('/library?group=none');
+      // Flat mode → no group headers.
+      expect(screen.queryByText('My Skills')).not.toBeInTheDocument();
+      expect(screen.queryByText('acme/skills')).not.toBeInTheDocument();
+      expect(screen.getByText('draft-summarizer')).toBeInTheDocument();
+    });
+
+    it('isolates a source when its header is clicked and sets ?source=', async () => {
+      useRegistryStore.setState({ sources: SAMPLE_SOURCES });
+      let currentSearch = '';
+      renderAt('/library', (s) => { currentSearch = s; });
+
+      fireEvent.click(screen.getByText('acme/skills'));
+      await waitFor(() => expect(currentSearch).toContain('source=acme-skills'));
+      // Only the imported skill remains; local skills are hidden.
+      expect(screen.getByText('draft-summarizer')).toBeInTheDocument();
+      expect(screen.queryByText('incident-triage')).not.toBeInTheDocument();
+    });
+
+    it('restores the isolate from ?source= and clears it via "Show all"', async () => {
+      useRegistryStore.setState({ sources: SAMPLE_SOURCES });
+      let currentSearch = '?source=acme-skills';
+      renderAt('/library?source=acme-skills', (s) => { currentSearch = s; });
+
+      expect(screen.queryByText('incident-triage')).not.toBeInTheDocument();
+      // The "Showing …" chip is the persistent clear control.
+      fireEvent.click(screen.getByRole('button', { name: /show all groups/i }));
+      await waitFor(() => expect(currentSearch).not.toContain('source='));
+      expect(screen.getByText('incident-triage')).toBeInTheDocument();
+    });
+
+    it('isolates "My Skills" with ?source=local', async () => {
+      useRegistryStore.setState({ sources: SAMPLE_SOURCES });
+      let currentSearch = '';
+      renderAt('/library', (s) => { currentSearch = s; });
+
+      fireEvent.click(screen.getByText('My Skills'));
+      await waitFor(() => expect(currentSearch).toContain('source=local'));
+      expect(screen.getByText('incident-triage')).toBeInTheDocument();
+      expect(screen.queryByText('draft-summarizer')).not.toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/library/useLibraryCommands.ts
+++ b/web/src/components/library/useLibraryCommands.ts
@@ -4,6 +4,8 @@ import {
   CheckCircle2,
   ExternalLink,
   FileText,
+  FolderGit2,
+  Layers,
   List,
   Plus,
   PowerOff,
@@ -11,6 +13,7 @@ import {
 } from 'lucide-react';
 import { useCommandRegistry } from '../../hooks/useCommandRegistry';
 import type { PaletteCommand } from '../../types/palette';
+import type { GroupMode } from '../registry/LibraryGrid';
 
 export type LibraryFilter = 'all' | 'active' | 'draft' | 'disabled';
 
@@ -20,6 +23,8 @@ interface UseLibraryCommandsOptions {
   onShowAll: () => void;
   onFilter: (filter: LibraryFilter) => void;
   onOpenInNewWindow: () => void;
+  /** Optional: switch the grouping axis (Source / Category / None). */
+  onSetGroup?: (mode: GroupMode) => void;
 }
 
 /**
@@ -32,6 +37,7 @@ export function useLibraryCommands({
   onShowAll,
   onFilter,
   onOpenInNewWindow,
+  onSetGroup,
 }: UseLibraryCommandsOptions): void {
   const { registerCommands, unregisterCommands } = useCommandRegistry();
 
@@ -101,6 +107,39 @@ export function useLibraryCommands({
         onSelect: onOpenInNewWindow,
       },
     ];
+
+    if (onSetGroup) {
+      commands.push(
+        {
+          id: 'library:group-source',
+          label: 'Library: Group by Source',
+          section: 'registry',
+          workspaces: ['library'],
+          icon: createElement(FolderGit2, { size: 14 }),
+          keywords: ['group', 'source', 'provenance', 'origin', 'repo'],
+          onSelect: () => onSetGroup('source'),
+        },
+        {
+          id: 'library:group-category',
+          label: 'Library: Group by Category',
+          section: 'registry',
+          workspaces: ['library'],
+          icon: createElement(Layers, { size: 14 }),
+          keywords: ['group', 'category', 'directory', 'folder'],
+          onSelect: () => onSetGroup('category'),
+        },
+        {
+          id: 'library:group-none',
+          label: 'Library: No Grouping',
+          section: 'registry',
+          workspaces: ['library'],
+          icon: createElement(List, { size: 14 }),
+          keywords: ['group', 'none', 'flat', 'ungroup'],
+          onSelect: () => onSetGroup('none'),
+        },
+      );
+    }
+
     registerCommands('library', commands);
     return () => unregisterCommands('library');
   }, [
@@ -111,5 +150,6 @@ export function useLibraryCommands({
     onShowAll,
     onFilter,
     onOpenInNewWindow,
+    onSetGroup,
   ]);
 }

--- a/web/src/components/registry/LibraryGrid.tsx
+++ b/web/src/components/registry/LibraryGrid.tsx
@@ -1,6 +1,10 @@
+import { Fragment } from 'react';
 import { cn } from '../../lib/cn';
 import { SkillCard } from './SkillCard';
-import type { AgentSkill } from '../../types';
+import { SourceGroupHeader } from './SourceGroupHeader';
+import type { AgentSkill, SkillSourceStatus } from '../../types';
+
+export type GroupMode = 'source' | 'category' | 'none';
 
 function getGroupKey(dir?: string): string {
   if (!dir) return '';
@@ -21,6 +25,12 @@ function toTitleCase(key: string): string {
   return key.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+const GRID_STYLE: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+  gap: '12px',
+};
+
 export interface LibraryGridProps {
   skills: AgentSkill[];
   hasSearch: boolean;
@@ -29,14 +39,28 @@ export interface LibraryGridProps {
   onEdit: (skill: AgentSkill) => void;
   onDelete: (skill: AgentSkill) => void;
   className?: string;
+  /**
+   * Grouping mode. When omitted, the grid uses its legacy category-or-flat
+   * heuristic — keeping the detached registry window and existing callers
+   * unchanged.
+   */
+  groupMode?: GroupMode;
+  /** skill name → owning source, used for provenance grouping and card badges. */
+  sourceMap?: Map<string, SkillSourceStatus>;
+  /** Active provenance isolate: a source name, `local`, or null. */
+  activeSource?: string | null;
+  onIsolateSource?: (key: string | null) => void;
+  /** Refresh callback invoked after an inline source update. */
+  onRefresh?: () => void;
 }
 
 /**
  * Card grid used by both the in-app Library workspace and the detached
- * /library-window page. Groups skills by their top-level directory when the
- * structure is meaningful (2+ groups with at least one populated group);
- * otherwise renders a flat grid so single-skill "groups" don't waste a
- * full-width header.
+ * /library-window page. With `groupMode` omitted (or `'category'`), it groups
+ * skills by their top-level directory when the structure is meaningful (2+
+ * groups with at least one populated group) and otherwise renders a flat grid.
+ * `groupMode='source'` groups by provenance ("My Skills" + one section per
+ * imported source); `groupMode='none'` renders a flat grid.
  */
 export function LibraryGrid({
   skills,
@@ -46,90 +70,119 @@ export function LibraryGrid({
   onEdit,
   onDelete,
   className,
+  groupMode,
+  sourceMap,
+  activeSource = null,
+  onIsolateSource,
+  onRefresh,
 }: LibraryGridProps) {
-  const groups = groupSkills(skills);
-  const hasMeaningfulGrouping =
-    groups.size > 1 && Array.from(groups.values()).some((g) => g.length > 1);
+  const cardHandlers = { onEnable, onDisable, onEdit, onDelete };
 
-  const gridStyle: React.CSSProperties = {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
-    gap: '12px',
-  };
+  const renderCard = (skill: AgentSkill, i: number) => (
+    <SkillCard
+      key={skill.name}
+      skill={skill}
+      source={sourceMap?.get(skill.name)}
+      className={cn(
+        'motion-safe:animate-fade-in-scale',
+        skill.metadata?.colspan === '2' ? 'col-span-2' : undefined,
+      )}
+      style={{ animationDelay: `${Math.min(i, 10) * 30}ms` }}
+      {...cardHandlers}
+    />
+  );
 
-  if (!hasMeaningfulGrouping) {
+  // Provenance grouping: "My Skills" first, then imported sources by name.
+  if (groupMode === 'source' && sourceMap) {
+    const local: AgentSkill[] = [];
+    const bySource = new Map<string, { source: SkillSourceStatus; skills: AgentSkill[] }>();
+    for (const skill of skills) {
+      const src = sourceMap.get(skill.name);
+      if (!src) {
+        local.push(skill);
+        continue;
+      }
+      const group = bySource.get(src.name);
+      if (group) group.skills.push(skill);
+      else bySource.set(src.name, { source: src, skills: [skill] });
+    }
+    const sourceGroups = Array.from(bySource.values()).sort((a, b) =>
+      a.source.name.localeCompare(b.source.name),
+    );
+
     return (
-      <div className={cn('p-4', className)} style={gridStyle}>
-        {skills.map((skill, i) => (
-          <SkillCard
-            key={skill.name}
-            skill={skill}
-            className={cn('motion-safe:animate-fade-in-scale', skill.metadata?.colspan === '2' ? 'col-span-2' : undefined)}
-            style={{ animationDelay: `${Math.min(i, 10) * 30}ms` }}
-            onEnable={onEnable}
-            onDisable={onDisable}
-            onEdit={onEdit}
-            onDelete={onDelete}
-          />
+      <div className={cn('p-4', className)} style={GRID_STYLE}>
+        {local.length > 0 && (
+          <>
+            <SourceGroupHeader
+              count={local.length}
+              hasSearch={hasSearch}
+              isActive={activeSource === 'local'}
+              onToggle={() => onIsolateSource?.(activeSource === 'local' ? null : 'local')}
+            />
+            {local.map(renderCard)}
+          </>
+        )}
+        {sourceGroups.map(({ source, skills: groupSkills }) => (
+          <Fragment key={source.name}>
+            <SourceGroupHeader
+              source={source}
+              count={groupSkills.length}
+              hasSearch={hasSearch}
+              isActive={activeSource === source.name}
+              onToggle={() => onIsolateSource?.(activeSource === source.name ? null : source.name)}
+              onUpdated={onRefresh}
+            />
+            {groupSkills.map(renderCard)}
+          </Fragment>
         ))}
       </div>
     );
   }
 
+  // Explicit flat mode.
+  if (groupMode === 'none') {
+    return (
+      <div className={cn('p-4', className)} style={GRID_STYLE}>
+        {skills.map(renderCard)}
+      </div>
+    );
+  }
+
+  // Legacy / category mode: group by top-level directory when meaningful.
+  const groups = groupSkills(skills);
+  const hasMeaningfulGrouping =
+    groups.size > 1 && Array.from(groups.values()).some((g) => g.length > 1);
+
+  if (!hasMeaningfulGrouping) {
+    return (
+      <div className={cn('p-4', className)} style={GRID_STYLE}>
+        {skills.map(renderCard)}
+      </div>
+    );
+  }
+
   return (
-    <div className={cn('p-4', className)} style={gridStyle}>
+    <div className={cn('p-4', className)} style={GRID_STYLE}>
       {Array.from(groups.entries()).map(([key, groupSkillList]) => (
-        <GroupSection
-          key={key || '__ungrouped__'}
-          groupKey={key}
-          skills={groupSkillList}
-          hasSearch={hasSearch}
-          onEnable={onEnable}
-          onDisable={onDisable}
-          onEdit={onEdit}
-          onDelete={onDelete}
-        />
+        <Fragment key={key || '__ungrouped__'}>
+          <div
+            style={{ gridColumn: '1 / -1' }}
+            className="flex flex-col gap-1 mt-2 first:mt-0 animate-fade-in-scale"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] uppercase tracking-widest text-text-muted font-medium">
+                {key ? toTitleCase(key) : 'Other'}
+              </span>
+              <span className="text-[10px] px-1.5 rounded-full bg-surface-highlight text-text-muted">
+                {groupSkillList.length} {hasSearch ? 'matched' : 'skills'}
+              </span>
+            </div>
+            <div className="border-b border-border/30" />
+          </div>
+          {groupSkillList.map(renderCard)}
+        </Fragment>
       ))}
     </div>
-  );
-}
-
-interface GroupSectionProps {
-  groupKey: string;
-  skills: AgentSkill[];
-  hasSearch: boolean;
-  onEnable: (skill: AgentSkill) => void;
-  onDisable: (skill: AgentSkill) => void;
-  onEdit: (skill: AgentSkill) => void;
-  onDelete: (skill: AgentSkill) => void;
-}
-
-function GroupSection({ groupKey, skills, hasSearch, onEnable, onDisable, onEdit, onDelete }: GroupSectionProps) {
-  return (
-    <>
-      <div style={{ gridColumn: '1 / -1' }} className="flex flex-col gap-1 mt-2 first:mt-0 animate-fade-in-scale">
-        <div className="flex items-center justify-between">
-          <span className="text-[10px] uppercase tracking-widest text-text-muted font-medium">
-            {groupKey ? toTitleCase(groupKey) : 'Other'}
-          </span>
-          <span className="text-[10px] px-1.5 rounded-full bg-surface-highlight text-text-muted">
-            {skills.length} {hasSearch ? 'matched' : 'skills'}
-          </span>
-        </div>
-        <div className="border-b border-border/30" />
-      </div>
-      {skills.map((skill, i) => (
-        <SkillCard
-          key={skill.name}
-          skill={skill}
-          className={cn('motion-safe:animate-fade-in-scale', skill.metadata?.colspan === '2' ? 'col-span-2' : undefined)}
-          style={{ animationDelay: `${Math.min(i, 10) * 30}ms` }}
-          onEnable={onEnable}
-          onDisable={onDisable}
-          onEdit={onEdit}
-          onDelete={onDelete}
-        />
-      ))}
-    </>
   );
 }

--- a/web/src/components/registry/SkillCard.tsx
+++ b/web/src/components/registry/SkillCard.tsx
@@ -1,9 +1,9 @@
 import { memo } from 'react';
-import { BookOpen } from 'lucide-react';
+import { BookOpen, GitBranch } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { StateBadge } from './StateBadge';
 import { SkillActions } from './SkillActions';
-import type { AgentSkill } from '../../types';
+import type { AgentSkill, SkillSourceStatus } from '../../types';
 
 export interface SkillCardProps {
   skill: AgentSkill;
@@ -11,6 +11,8 @@ export interface SkillCardProps {
   onDisable: (skill: AgentSkill) => void;
   onEdit: (skill: AgentSkill) => void;
   onDelete: (skill: AgentSkill) => void;
+  /** Imported-from source, when this skill came from a git source. */
+  source?: SkillSourceStatus;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -21,6 +23,7 @@ export const SkillCard = memo(({
   onDisable,
   onEdit,
   onDelete,
+  source,
   className,
   style,
 }: SkillCardProps) => {
@@ -53,6 +56,15 @@ export const SkillCard = memo(({
           <span className="font-semibold log-text text-text-primary truncate flex-1 min-w-0 leading-tight mt-0.5">
             {skill.name}
           </span>
+          {source && (
+            <span
+              title={source.repo}
+              aria-label={`Imported from ${source.repo}`}
+              className="flex-shrink-0 inline-flex items-center text-text-muted/50 transition-colors group-hover:text-text-muted/80 mt-0.5"
+            >
+              <GitBranch size={12} />
+            </span>
+          )}
           <StateBadge state={skill.state} />
         </div>
 

--- a/web/src/components/registry/SourceGroupHeader.tsx
+++ b/web/src/components/registry/SourceGroupHeader.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { ExternalLink, FolderGit2, PenLine, RefreshCw } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { showToast } from '../ui/Toast';
+import { updateSkillSource } from '../../lib/api';
+import { extractRepoInfo } from '../../lib/repo';
+import type { SkillSourceStatus } from '../../types';
+
+interface SourceGroupHeaderProps {
+  /** The imported source for this group, or undefined for the "My Skills" group. */
+  source?: SkillSourceStatus;
+  count: number;
+  hasSearch: boolean;
+  /** True when this group is the active provenance isolate. */
+  isActive: boolean;
+  /** Toggle isolate on this group (clears when re-toggled). */
+  onToggle: () => void;
+  /** Called after a successful inline source update so the caller can refresh. */
+  onUpdated?: () => void;
+}
+
+/**
+ * Full-width section header for the Library's provenance grouping. Mirrors the
+ * category GroupSection header but is a clickable isolate control: the label
+ * button toggles "show only this group", and imported sources additionally
+ * expose a repo link, short commit SHA, and an inline Update action when an
+ * update is available. The "My Skills" variant (no source) shows an authored
+ * indicator and is isolatable via the `local` key.
+ */
+export function SourceGroupHeader({
+  source,
+  count,
+  hasSearch,
+  isActive,
+  onToggle,
+  onUpdated,
+}: SourceGroupHeaderProps) {
+  const [updating, setUpdating] = useState(false);
+
+  const repoInfo = source ? extractRepoInfo(source.repo) : null;
+  const label = source ? (repoInfo ? `${repoInfo.owner}/${repoInfo.repo}` : source.name) : 'My Skills';
+  const shortSha = source?.commitSha ? source.commitSha.slice(0, 7) : null;
+
+  const handleUpdate = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!source || updating) return;
+    setUpdating(true);
+    try {
+      await updateSkillSource(source.name);
+      showToast('success', `Updated "${source.name}"`);
+      onUpdated?.();
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'Update failed');
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  return (
+    <div
+      style={{ gridColumn: '1 / -1' }}
+      className="flex flex-col gap-1 mt-2 first:mt-0 animate-fade-in-scale"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <button
+            onClick={onToggle}
+            aria-pressed={isActive}
+            title={isActive ? 'Show all groups' : `Show only ${label}`}
+            className={cn(
+              'flex items-center gap-1.5 rounded-md px-1.5 py-0.5 -ml-1.5 transition-colors',
+              isActive
+                ? 'text-primary'
+                : 'text-text-muted hover:text-text-secondary hover:bg-surface-highlight',
+            )}
+          >
+            {source ? (
+              <FolderGit2 size={11} className="flex-shrink-0" />
+            ) : (
+              <PenLine size={11} className="flex-shrink-0" />
+            )}
+            <span className="text-[10px] uppercase tracking-widest font-medium truncate">{label}</span>
+          </button>
+          {shortSha && (
+            <span className="text-[10px] font-mono text-text-muted/60" title={source?.commitSha}>
+              {shortSha}
+            </span>
+          )}
+          {source && repoInfo && (
+            <a
+              href={`https://github.com/${repoInfo.owner}/${repoInfo.repo}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              title="Open repository on GitHub"
+              aria-label={`Open ${label} on GitHub`}
+              className="text-text-muted/50 hover:text-primary transition-colors flex-shrink-0"
+            >
+              <ExternalLink size={11} />
+            </a>
+          )}
+          {source?.updateAvailable && (
+            <button
+              onClick={handleUpdate}
+              disabled={updating}
+              title="Update available — pull latest"
+              className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full border border-amber-400/30 bg-amber-400/10 text-amber-300 hover:bg-amber-400/20 transition-colors disabled:opacity-60 flex-shrink-0"
+            >
+              <RefreshCw size={10} className={updating ? 'animate-spin' : undefined} />
+              {updating ? 'Updating…' : 'Update'}
+            </button>
+          )}
+        </div>
+        <span className="text-[10px] px-1.5 rounded-full bg-surface-highlight text-text-muted flex-shrink-0">
+          {count} {hasSearch ? 'matched' : 'skills'}
+        </span>
+      </div>
+      <div className="border-b border-border/30" />
+    </div>
+  );
+}

--- a/web/src/components/wizard/steps/AddSourceStep.tsx
+++ b/web/src/components/wizard/steps/AddSourceStep.tsx
@@ -14,6 +14,7 @@ import {
   X,
 } from 'lucide-react';
 import { cn } from '../../../lib/cn';
+import { extractRepoInfo } from '../../../lib/repo';
 import { Button } from '../../ui/Button';
 import {
   previewSkillSource,
@@ -97,12 +98,6 @@ export function AddSourceStep({ onPreviewLoaded }: AddSourceStepProps) {
 
   const isValidUrl = (val: string) => {
     return GIT_URL_REGEX.test(val.trim()) || GITHUB_URL_REGEX.test(val.trim());
-  };
-
-  const extractRepoInfo = (val: string): { owner: string; repo: string } | null => {
-    const match = val.match(/github\.com[/:]([^/]+)\/([^/.]+)/);
-    if (match) return { owner: match[1], repo: match[2] };
-    return null;
   };
 
   // Build a SkillAuth from the current card state, or undefined to signal

--- a/web/src/components/workspaces/LibraryWorkspace.tsx
+++ b/web/src/components/workspaces/LibraryWorkspace.tsx
@@ -12,7 +12,7 @@ import { IconButton } from '../ui/IconButton';
 import { PopoutButton } from '../ui/PopoutButton';
 import { SkillEditor } from '../registry/SkillEditor';
 import { SkillCardSkeleton } from '../registry/SkillCardSkeleton';
-import { LibraryGrid } from '../registry/LibraryGrid';
+import { LibraryGrid, type GroupMode } from '../registry/LibraryGrid';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { showToast } from '../ui/Toast';
 import { useFuzzySearch } from '../../hooks/useFuzzySearch';
@@ -26,11 +26,17 @@ import {
   disableRegistrySkill,
   fetchRegistrySkills,
   fetchRegistryStatus,
+  fetchSkillSources,
 } from '../../lib/api';
+import { extractRepoInfo } from '../../lib/repo';
 import { WorkspaceShell } from '../layout/WorkspaceShell';
-import type { AgentSkill, ItemState } from '../../types';
+import type { AgentSkill, ItemState, SkillSourceStatus } from '../../types';
 
 type FilterTab = 'all' | ItemState;
+
+function isGroupMode(value: string | null): value is GroupMode {
+  return value === 'source' || value === 'category' || value === 'none';
+}
 
 const TABS: { key: FilterTab; label: string }[] = [
   { key: 'all', label: 'All' },
@@ -59,6 +65,7 @@ export function LibraryWorkspace() {
   // the store instead of starting a second polling loop here.
   const skills = useRegistryStore((s) => s.skills);
   const status = useRegistryStore((s) => s.status);
+  const sources = useRegistryStore((s) => s.sources);
 
   // null means "not loaded yet"; the deep-link error toast must wait for a
   // resolved fetch so a transient mid-fetch render doesn't false-positive.
@@ -92,6 +99,55 @@ export function LibraryWorkspace() {
         const next = new URLSearchParams(prev);
         if (tab === 'all') next.delete('filter');
         else next.set('filter', tab);
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  // Provenance grouping state. The default grouping is Source when any source
+  // exists, else Category (today's behavior) — so the default value is omitted
+  // from the URL and a no-source registry is untouched.
+  const hasSources = (sources ?? []).length > 0;
+  const defaultGroup: GroupMode = hasSources ? 'source' : 'category';
+  const groupParam = searchParams.get('group');
+  const groupMode: GroupMode = isGroupMode(groupParam) ? groupParam : defaultGroup;
+  const sourceParam = searchParams.get('source');
+  const activeSource = groupMode === 'source' ? sourceParam : null;
+
+  // Join skills to sources by skill name. Verified against internal/api/skills.go:
+  // source entries are built from the same registry store, so SkillSourceEntry.name
+  // === AgentSkill.name. Caveat (deferred): a skill kept after its source is removed,
+  // or a name shared across sources, maps to the first owning source or "My Skills".
+  const sourceMap = useMemo(() => {
+    const map = new Map<string, SkillSourceStatus>();
+    for (const src of sources ?? []) {
+      for (const entry of src.skills ?? []) {
+        if (!map.has(entry.name)) map.set(entry.name, src);
+      }
+    }
+    return map;
+  }, [sources]);
+
+  const setGroupMode = useCallback((mode: GroupMode) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (mode === defaultGroup) next.delete('group');
+        else next.set('group', mode);
+        if (mode !== 'source') next.delete('source'); // isolate only applies in source mode
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams, defaultGroup]);
+
+  const setActiveSource = useCallback((key: string | null) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (!key) next.delete('source');
+        else next.set('source', key);
         return next;
       },
       { replace: true },
@@ -150,6 +206,18 @@ export function LibraryWorkspace() {
       showToast('error', err instanceof Error ? err.message : 'Refresh failed');
     }
   }, []);
+
+  // Refresh registry + sources together — used after an inline source update so
+  // the "update available" badge clears and any new/removed skills appear.
+  const refreshAll = useCallback(async () => {
+    await refreshRegistry();
+    try {
+      const srcs = await fetchSkillSources();
+      useRegistryStore.getState().setSources(srcs);
+    } catch {
+      // Sources unavailable — progressive disclosure.
+    }
+  }, [refreshRegistry]);
 
   const handleEnable = useCallback(async (skill: AgentSkill) => {
     try {
@@ -219,6 +287,7 @@ export function LibraryWorkspace() {
     onShowAll: handleShowAll,
     onFilter: handleFilter,
     onOpenInNewWindow: handlePopout,
+    onSetGroup: setGroupMode,
   });
 
   const searchResults = useFuzzySearch(skills ?? [], searchQuery);
@@ -234,6 +303,25 @@ export function LibraryWorkspace() {
     if (activeTab === 'all') return searchResults;
     return searchResults.filter((s) => s.state === activeTab);
   }, [searchResults, activeTab]);
+
+  // Apply the provenance isolate on top of search + tab filtering, so empty
+  // states and the grid see a coherent set.
+  const visibleSkills = useMemo(() => {
+    if (groupMode !== 'source' || !activeSource) return displayedSkills;
+    return displayedSkills.filter((s) => {
+      const src = sourceMap.get(s.name);
+      return activeSource === 'local' ? !src : src?.name === activeSource;
+    });
+  }, [displayedSkills, groupMode, activeSource, sourceMap]);
+
+  // Human-readable label for the active isolate, shown in the "Show all" chip.
+  const activeSourceLabel = useMemo(() => {
+    if (!activeSource) return null;
+    if (activeSource === 'local') return 'My Skills';
+    const src = (sources ?? []).find((s) => s.name === activeSource);
+    const info = src ? extractRepoInfo(src.repo) : null;
+    return info ? `${info.owner}/${info.repo}` : activeSource;
+  }, [activeSource, sources]);
 
   return (
     <div className="absolute inset-0 flex flex-col bg-background text-text-primary overflow-hidden">
@@ -270,32 +358,51 @@ export function LibraryWorkspace() {
               )}
             </div>
 
-            <div className="flex gap-1 flex-wrap">
-              {TABS.map((tab) => (
-                <button
-                  key={tab.key}
-                  onClick={() => setActiveTab(tab.key)}
-                  className={cn(
-                    'flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-medium transition-colors',
-                    activeTab === tab.key
-                      ? 'bg-primary/10 text-primary border border-primary/25'
-                      : 'text-text-muted hover:text-text-secondary hover:bg-surface-highlight border border-transparent',
-                  )}
-                >
-                  {tab.label}
-                  <span
+            <div className="flex items-center justify-between gap-2 flex-wrap">
+              <div className="flex gap-1 flex-wrap">
+                {TABS.map((tab) => (
+                  <button
+                    key={tab.key}
+                    onClick={() => setActiveTab(tab.key)}
                     className={cn(
-                      'text-[10px] px-1.5 py-0 rounded-full font-mono min-w-[18px] text-center transition-colors',
+                      'flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-medium transition-colors',
                       activeTab === tab.key
-                        ? 'bg-primary/15 text-primary'
-                        : 'bg-surface-highlight text-text-muted',
+                        ? 'bg-primary/10 text-primary border border-primary/25'
+                        : 'text-text-muted hover:text-text-secondary hover:bg-surface-highlight border border-transparent',
                     )}
                   >
-                    {tabCounts[tab.key]}
-                  </span>
-                </button>
-              ))}
+                    {tab.label}
+                    <span
+                      className={cn(
+                        'text-[10px] px-1.5 py-0 rounded-full font-mono min-w-[18px] text-center transition-colors',
+                        activeTab === tab.key
+                          ? 'bg-primary/15 text-primary'
+                          : 'bg-surface-highlight text-text-muted',
+                      )}
+                    >
+                      {tabCounts[tab.key]}
+                    </span>
+                  </button>
+                ))}
+              </div>
+              {hasSources && (
+                <GroupByControl mode={groupMode} onChange={setGroupMode} />
+              )}
             </div>
+
+            {groupMode === 'source' && activeSource && activeSourceLabel && (
+              <div className="flex">
+                <button
+                  onClick={() => setActiveSource(null)}
+                  aria-label={`Showing ${activeSourceLabel} only — show all groups`}
+                  className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full border border-primary/25 bg-primary/10 text-primary hover:bg-primary/15 transition-colors"
+                >
+                  <span className="text-text-muted">Showing</span>
+                  <span className="font-medium">{activeSourceLabel}</span>
+                  <X size={11} />
+                </button>
+              </div>
+            )}
           </div>
 
           <div className="flex-1 overflow-y-auto scrollbar-dark">
@@ -324,7 +431,7 @@ export function LibraryWorkspace() {
               </div>
             )}
 
-            {!isLoading && hasSkills && displayedSkills.length === 0 && (
+            {!isLoading && hasSkills && visibleSkills.length === 0 && (
               <div className="h-full flex flex-col items-center justify-center text-text-muted gap-3 animate-fade-in-scale p-8">
                 <div className="p-4 rounded-xl bg-surface-elevated/50 border border-border/30">
                   <Search size={28} className="text-text-muted/50" />
@@ -343,10 +450,15 @@ export function LibraryWorkspace() {
               </div>
             )}
 
-            {!isLoading && displayedSkills.length > 0 && (
+            {!isLoading && visibleSkills.length > 0 && (
               <LibraryGrid
-                skills={displayedSkills}
+                skills={visibleSkills}
                 hasSearch={searchQuery.length > 0}
+                groupMode={groupMode}
+                sourceMap={sourceMap}
+                activeSource={activeSource}
+                onIsolateSource={setActiveSource}
+                onRefresh={refreshAll}
                 onEnable={handleEnable}
                 onDisable={handleDisable}
                 onEdit={(s) => { setEditingSkill(s); setShowEditor(true); }}
@@ -384,6 +496,36 @@ export function LibraryWorkspace() {
         onSaved={refreshRegistry}
         skill={editingSkill}
       />
+    </div>
+  );
+}
+
+const GROUP_OPTIONS: { key: GroupMode; label: string }[] = [
+  { key: 'source', label: 'Source' },
+  { key: 'category', label: 'Category' },
+  { key: 'none', label: 'None' },
+];
+
+/** Segmented control to switch the Library's grouping axis. */
+function GroupByControl({ mode, onChange }: { mode: GroupMode; onChange: (m: GroupMode) => void }) {
+  return (
+    <div className="flex items-center gap-1" role="group" aria-label="Group skills by">
+      <span className="text-[10px] uppercase tracking-wider text-text-muted/60 mr-0.5">Group</span>
+      {GROUP_OPTIONS.map((opt) => (
+        <button
+          key={opt.key}
+          onClick={() => onChange(opt.key)}
+          aria-pressed={mode === opt.key}
+          className={cn(
+            'px-2 py-1 rounded-md text-[11px] font-medium transition-colors',
+            mode === opt.key
+              ? 'bg-primary/10 text-primary border border-primary/25'
+              : 'text-text-muted hover:text-text-secondary hover:bg-surface-highlight border border-transparent',
+          )}
+        >
+          {opt.label}
+        </button>
+      ))}
     </div>
   );
 }

--- a/web/src/hooks/usePolling.ts
+++ b/web/src/hooks/usePolling.ts
@@ -5,7 +5,7 @@ import { useRegistryStore } from '../stores/useRegistryStore';
 import { usePinsStore } from '../stores/usePinsStore';
 import { useUIStore } from '../stores/useUIStore';
 import { useTelemetryStore } from '../stores/useTelemetryStore';
-import { fetchStatus, fetchTools, fetchToolCatalog, fetchClients, fetchRegistryStatus, fetchRegistrySkills, fetchServerPins, fetchStackSpec, getTelemetryInventory, AuthError } from '../lib/api';
+import { fetchStatus, fetchTools, fetchToolCatalog, fetchClients, fetchRegistryStatus, fetchRegistrySkills, fetchSkillSources, fetchServerPins, fetchStackSpec, getTelemetryInventory, AuthError } from '../lib/api';
 import { showToast } from '../components/ui/Toast';
 import { POLLING } from '../lib/constants';
 
@@ -107,6 +107,16 @@ export function usePolling() {
         }
       } catch {
         // Registry not available — not an error (progressive disclosure)
+      }
+
+      // Fetch skill sources (provenance) independently. A failure here must not
+      // affect the registry list above — the Library just falls back to
+      // category grouping with no source headers/badges.
+      try {
+        const sources = await fetchSkillSources();
+        useRegistryStore.getState().setSources(sources);
+      } catch {
+        // Sources unavailable — progressive disclosure, not an error.
       }
     } catch (error) {
       if (error instanceof AuthError) {

--- a/web/src/lib/repo.ts
+++ b/web/src/lib/repo.ts
@@ -1,0 +1,18 @@
+// Helpers for parsing Git repository URLs into display-friendly parts.
+
+export interface RepoInfo {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Extract `{ owner, repo }` from a GitHub URL. Handles both the HTTPS form
+ * (`https://github.com/owner/repo[.git]`) and the SSH form
+ * (`git@github.com:owner/repo[.git]`). Returns null for non-GitHub or
+ * unparseable URLs.
+ */
+export function extractRepoInfo(url: string): RepoInfo | null {
+  const match = url.match(/github\.com[/:]([^/]+)\/([^/.]+)/);
+  if (match) return { owner: match[1], repo: match[2] };
+  return null;
+}

--- a/web/src/stores/useRegistryStore.ts
+++ b/web/src/stores/useRegistryStore.ts
@@ -1,11 +1,13 @@
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
-import type { AgentSkill, RegistryStatus } from '../types';
+import type { AgentSkill, RegistryStatus, SkillSourceStatus } from '../types';
 
 interface RegistryState {
   // Data
   skills: AgentSkill[] | null;
   status: RegistryStatus | null;
+  // Configured skill sources (provenance). null = not loaded yet.
+  sources: SkillSourceStatus[] | null;
 
   // Loading state
   isLoading: boolean;
@@ -14,6 +16,7 @@ interface RegistryState {
   // Actions
   setSkills: (skills: AgentSkill[]) => void;
   setStatus: (status: RegistryStatus) => void;
+  setSources: (sources: SkillSourceStatus[]) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
 
@@ -26,11 +29,13 @@ export const useRegistryStore = create<RegistryState>()(
   subscribeWithSelector((set, get) => ({
     skills: null,
     status: null,
+    sources: null,
     isLoading: false,
     error: null,
 
     setSkills: (skills) => set({ skills: skills ?? [] }),
     setStatus: (status) => set({ status }),
+    setSources: (sources) => set({ sources: sources ?? [] }),
     setLoading: (isLoading) => set({ isLoading }),
     setError: (error) => set({ error }),
 


### PR DESCRIPTION
## Description

Reorganizes the Library workspace from a flat card catalog into provenance-grouped sections — "My Skills" (locally authored) plus one section per imported git source — so it is obvious which skills came from where, from which repo, and whether an update is available. Frontend-only: it joins the already-wired skill-sources data to the registry list client-side.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- **Group by Source / Category / None** toggle, URL-synced via `?group=` (default omitted; Source is the default only when ≥1 source exists, so a no-source registry is unchanged).
- **Clickable source headers** isolate a group (URL-synced `?source=<name>` / `?source=local`); a persistent "Showing …" chip clears it. Composes with fuzzy search and status tabs.
- **Rich source header**: `owner/repo`, GitHub link, short commit SHA, skill count, and an inline **Update** action when an update is available.
- **Per-card origin badge** (tooltip = repo) shows provenance in every grouping mode and while searching.
- `useRegistryStore` gains `sources`; `usePolling` fetches sources in its own progressive-disclosure try/catch (a sources failure degrades silently to category grouping).
- Extracted `extractRepoInfo` into a shared `lib/repo.ts` util (de-duplicated from the import wizard).
- New `LibraryGrid` props are optional and default to the prior category/flat behavior, so the detached registry window and existing callers are unaffected.

## Testing

- `npm run build` ✓ · `npm run test` ✓ (757 passing, incl. 8 new grouping/isolate cases) · lint clean on changed files (one pre-existing `set-state-in-effect` on an untouched deep-link effect remains).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #718