### PR TITLE
docs: sync docs to canonical gridctl var surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Learn more → [Skills guide](docs/skills.md)
 | [`code-mode-basic.yaml`](examples/code-mode/code-mode-basic.yaml) | Gateway code mode with search + execute meta-tools |
 | [`github-mcp.yaml`](examples/platforms/github-mcp.yaml) | GitHub MCP server integration |
 | [`registry-basic.yaml`](examples/registry/registry-basic.yaml) | Skills registry with a single server |
-| [`vault-basic.yaml`](examples/secrets-vault/vault-basic.yaml) | Reference vault secrets with `${vault:KEY}` syntax |
+| [`var-basic.yaml`](examples/secrets-vault/var-basic.yaml) | Reference variable-store secrets with `${var:KEY}` syntax |
 | [`otlp-jaeger.yaml`](examples/tracing/otlp-jaeger.yaml) | Export traces to Jaeger via OTLP |
 
 ## 📖 Documentation

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,8 @@ New to gridctl? Read in this order:
 
 | Document | Description |
 |----------|-------------|
-| [CLI Reference](cli-reference.md) | Every `gridctl` command, grouped by domain - stack lifecycle, skills, vault, optimize, telemetry, traces, upgrade |
-| [Configuration Reference](config-schema.md) | Every field in `stack.yaml` - server types, networks, resources, auth, vault |
+| [CLI Reference](cli-reference.md) | Every `gridctl` command, grouped by domain - stack lifecycle, skills, variables, optimize, telemetry, traces, upgrade |
+| [Configuration Reference](config-schema.md) | Every field in `stack.yaml` - server types, networks, resources, auth, variables |
 | [REST API Reference](api-reference.md) | Gateway endpoints, request/response formats, authentication |
 
 ## Guides

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -625,18 +625,18 @@ Env-var values present in the request body are scrubbed from error messages and 
 
 ---
 
-### Vault (Secrets Management)
+### Variables (Secrets & Config)
 
-The vault stores secrets locally with optional encryption. Secrets can be organized into variable sets for scoped injection.
+The variable store holds secrets (encrypted at rest) and plaintext config, organized into variable sets for scoped injection. The canonical route prefix is `/api/var`; `/api/vault/*` remains as a deprecated alias (responses carry `Deprecation` and `Sunset` headers) and is removed at v1.0.
 
-#### `GET /api/vault/status`
+#### `GET /api/var/status`
 
 Returns vault lock state and counts. Does not require the vault to be unlocked.
 
 **Auth:** Yes
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/status
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var/status
 ```
 
 **Response:**
@@ -651,14 +651,14 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/status
 
 `secrets_count` and `sets_count` are only included when the vault is unlocked.
 
-#### `POST /api/vault/unlock`
+#### `POST /api/var/unlock`
 
 Unlocks an encrypted vault with a passphrase.
 
 **Auth:** Yes
 
 ```bash
-curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/unlock \
+curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var/unlock \
   -H "Content-Type: application/json" \
   -d '{"passphrase": "my-secret-passphrase"}'
 ```
@@ -668,14 +668,14 @@ curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/u
 {"status": "unlocked"}
 ```
 
-#### `POST /api/vault/lock`
+#### `POST /api/var/lock`
 
 Encrypts the vault with a passphrase.
 
 **Auth:** Yes
 
 ```bash
-curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/lock \
+curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var/lock \
   -H "Content-Type: application/json" \
   -d '{"passphrase": "my-secret-passphrase"}'
 ```
@@ -685,14 +685,14 @@ curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/l
 {"status": "locked"}
 ```
 
-#### `GET /api/vault`
+#### `GET /api/var`
 
 Lists all secret keys with their set assignments (values not included).
 
 **Auth:** Yes | **Requires:** Vault unlocked
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var
 ```
 
 **Response:**
@@ -703,14 +703,14 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault
 ]
 ```
 
-#### `POST /api/vault`
+#### `POST /api/var`
 
 Creates a new secret.
 
 **Auth:** Yes | **Requires:** Vault unlocked
 
 ```bash
-curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault \
+curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var \
   -H "Content-Type: application/json" \
   -d '{"key": "DB_PASSWORD", "value": "secret123", "set": "production"}'
 ```
@@ -722,14 +722,14 @@ curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault \
 
 Key names must match `[a-zA-Z_][a-zA-Z0-9_]*`.
 
-#### `GET /api/vault/{key}`
+#### `GET /api/var/{key}`
 
 Returns a secret value.
 
 **Auth:** Yes | **Requires:** Vault unlocked
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/DB_PASSWORD
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var/DB_PASSWORD
 ```
 
 **Response:**
@@ -737,14 +737,14 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/DB_PASSWO
 {"key": "DB_PASSWORD", "value": "secret123"}
 ```
 
-#### `PUT /api/vault/{key}`
+#### `PUT /api/var/{key}`
 
 Updates a secret value.
 
 **Auth:** Yes | **Requires:** Vault unlocked
 
 ```bash
-curl -X PUT -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/DB_PASSWORD \
+curl -X PUT -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var/DB_PASSWORD \
   -H "Content-Type: application/json" \
   -d '{"value": "new-secret"}'
 ```
@@ -754,36 +754,36 @@ curl -X PUT -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/DB
 {"key": "DB_PASSWORD", "status": "updated"}
 ```
 
-#### `DELETE /api/vault/{key}`
+#### `DELETE /api/var/{key}`
 
 Deletes a secret.
 
 **Auth:** Yes | **Requires:** Vault unlocked
 
 ```bash
-curl -X DELETE -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/DB_PASSWORD
+curl -X DELETE -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var/DB_PASSWORD
 ```
 
 **Response:** `204 No Content`
 
-#### `GET /api/vault/sets`
+#### `GET /api/var/sets`
 
 Lists all variable sets with member counts.
 
 **Auth:** Yes | **Requires:** Vault unlocked
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/sets
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var/sets
 ```
 
-#### `POST /api/vault/sets`
+#### `POST /api/var/sets`
 
 Creates a new variable set.
 
 **Auth:** Yes | **Requires:** Vault unlocked
 
 ```bash
-curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/sets \
+curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var/sets \
   -H "Content-Type: application/json" \
   -d '{"name": "production"}'
 ```
@@ -795,26 +795,26 @@ curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/s
 
 Set names must match `[a-z0-9][a-z0-9-]*`.
 
-#### `DELETE /api/vault/sets/{name}`
+#### `DELETE /api/var/sets/{name}`
 
 Deletes a variable set.
 
 **Auth:** Yes | **Requires:** Vault unlocked
 
 ```bash
-curl -X DELETE -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/sets/staging
+curl -X DELETE -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var/sets/staging
 ```
 
 **Response:** `204 No Content`
 
-#### `PUT /api/vault/{key}/set`
+#### `PUT /api/var/{key}/set`
 
 Assigns or unassigns a secret to a variable set.
 
 **Auth:** Yes | **Requires:** Vault unlocked
 
 ```bash
-curl -X PUT -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/DB_PASSWORD/set \
+curl -X PUT -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var/DB_PASSWORD/set \
   -H "Content-Type: application/json" \
   -d '{"set": "production"}'
 ```
@@ -824,14 +824,14 @@ curl -X PUT -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/DB
 {"key": "DB_PASSWORD", "set": "production", "status": "updated"}
 ```
 
-#### `POST /api/vault/import`
+#### `POST /api/var/import`
 
 Bulk imports secrets.
 
 **Auth:** Yes | **Requires:** Vault unlocked
 
 ```bash
-curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/vault/import \
+curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/var/import \
   -H "Content-Type: application/json" \
   -d '{"secrets": {"API_KEY": "key123", "DB_HOST": "localhost"}}'
 ```
@@ -845,7 +845,7 @@ When the vault is locked, all endpoints except `status`, `unlock`, and `lock` re
 ```json
 {
   "error": "vault is locked",
-  "hint": "POST /api/vault/unlock with passphrase"
+  "hint": "POST /api/var/unlock with passphrase"
 }
 ```
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -7,7 +7,7 @@ Commands are grouped by domain. Run `gridctl <command> --help` for the full flag
 - [Stack lifecycle](#stack-lifecycle)
 - [LLM clients](#llm-clients)
 - [Skills](#skills)
-- [Vault](#vault)
+- [Variables](#variables)
 - [Pins (TOFU schema pinning)](#pins-tofu-schema-pinning)
 - [Traces](#traces)
 - [Optimize](#optimize)
@@ -44,7 +44,7 @@ Skills are prose; the registry surfaces every active `SKILL.md` to MCP clients a
 | Command | Purpose |
 |---|---|
 | `gridctl skill list` | List skills in the registry (`--remote` for imported skills only). |
-| `gridctl skill add <repo-url>` | Import skills from a git repository. Auth flags: `--auth-token <pat>` (ephemeral HTTPS PAT, CI), `--vault-key <key>` (resolves from `${vault:KEY}`), `--ssh-key <path>` (SSH). |
+| `gridctl skill add <repo-url>` | Import skills from a git repository. Auth flags: `--auth-token <pat>` (ephemeral HTTPS PAT, CI), `--vault-key <key>` (resolves from `${var:KEY}`), `--ssh-key <path>` (SSH). |
 | `gridctl skill update [name]` | Update imported skills (all when name omitted). |
 | `gridctl skill remove <name>` | Remove an imported skill. |
 | `gridctl skill pin <name> <ref>` | Pin a skill to a specific git ref. |
@@ -53,18 +53,25 @@ Skills are prose; the registry surfaces every active `SKILL.md` to MCP clients a
 | `gridctl skill validate <name>` | Validate a skill definition. |
 | `gridctl activate <skill-name>` | Promote a skill from draft to active (exit `0`/`1`/`2`); `--format json` for machine output, `--quiet` to suppress the success line. |
 
-## Vault
+## Variables
+
+The variable store holds both secrets (encrypted at rest, redacted in logs) and plaintext configuration. Reference entries from stack YAML with `${var:KEY}` — see [Variable Expansion](config-schema.md#variable-expansion).
 
 | Command | Purpose |
 |---|---|
-| `gridctl vault set <key>` | Store a secret (interactive prompt, or `--value`); `--set <name>` to assign to a variable set. |
-| `gridctl vault get <key>` | Retrieve a secret (masked; `--plain` to unmask). |
-| `gridctl vault list` | List all vault keys with set assignments. |
-| `gridctl vault delete <key>` | Remove a secret (`--force` to skip confirmation). |
-| `gridctl vault import <file>` | Import from `.env` or `.json` (`--format` to override auto-detection). |
-| `gridctl vault export` | Export secrets (`--format env\|json`, `--plain` to unmask). |
-| `gridctl vault lock` / `unlock` | Encrypt / decrypt the vault. |
-| `gridctl vault change-passphrase` | Re-encrypt with a new passphrase. |
+| `gridctl var set <key>` | Store a variable (interactive prompt, or `--value`). Secret by default; `--plaintext` for non-sensitive config visible in logs. `--type <string\|json\|list\|number\|bool>` tags the value's shape; `--set <name>` assigns it to a variable set. |
+| `gridctl var get <key>` | Retrieve a variable (secrets masked; `--plain` to unmask). |
+| `gridctl var list` | List all variables with type, visibility, and set assignment (`--format json`). |
+| `gridctl var delete <key>` | Remove a variable (`--force` to skip confirmation). |
+| `gridctl var import <file>` | Import from `.env` or `.json` (`--format` to override auto-detection; `# @public` / `# @type=` markers tag entries). |
+| `gridctl var export` | Export variables (`--format env\|json`, `--plain` to unmask). |
+| `gridctl var sets list` | List variable sets and their member counts. |
+| `gridctl var sets create <name>` | Create a variable set. |
+| `gridctl var sets delete <name>` | Delete a variable set (members are unassigned, not deleted). |
+| `gridctl var lock` / `unlock` | Encrypt / decrypt the store (XChaCha20-Poly1305 + Argon2id). |
+| `gridctl var change-passphrase` | Re-encrypt with a new passphrase. |
+
+> `gridctl vault …` is a deprecated alias for `gridctl var …`, removed at v1.0. The `${vault:KEY}` reference syntax is likewise deprecated in favor of `${var:KEY}`.
 
 ## Pins (TOFU schema pinning)
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -58,7 +58,7 @@ gateway:
 | `output_format` | string | No | `"json"` | Default output format for tool call results: `"json"`, `"toon"`, `"csv"`, or `"text"`. Per-server `output_format` overrides this value |
 | `security` | object | No | - | Security settings (see [Security](#security)) |
 | `tokenizer` | string | No | `"embedded"` | Token counting mode: `"embedded"` (cl100k_base approximation) or `"api"` (exact counts via Anthropic `count_tokens` endpoint) |
-| `tokenizer_api_key` | string | No | - | Anthropic API key for `tokenizer: api`. Falls back to `ANTHROPIC_API_KEY` env var. Supports `${VAR}` and `${vault:KEY}` references |
+| `tokenizer_api_key` | string | No | - | Anthropic API key for `tokenizer: api`. Falls back to `ANTHROPIC_API_KEY` env var. Supports `${VAR}` and `${var:KEY}` references |
 | `tracing` | object | No | - | Distributed tracing configuration (see [Tracing](#tracing)) |
 
 ### Auth
@@ -75,7 +75,7 @@ gateway:
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `type` | string | **Yes** | - | Auth mechanism: `"bearer"` or `"api_key"` |
-| `token` | string | **Yes** | - | Expected token value. Supports `${VAR}` and `${vault:KEY}` references |
+| `token` | string | **Yes** | - | Expected token value. Supports `${VAR}` and `${var:KEY}` references |
 | `header` | string | No | `"Authorization"` | Header name. Only applicable when type is `"api_key"` |
 
 **Constraints:**
@@ -466,14 +466,14 @@ mcp-servers:
       ref: main
       auth:
         method: token
-        credential_ref: "${vault:GIT_TOKEN}"
+        credential_ref: "${var:GIT_TOKEN}"
     port: 3000
 ```
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `method` | string | **Yes** | - | One of `"token"`, `"ssh-agent"`, `"ssh-key"`, or `"none"` |
-| `credential_ref` | string | Conditional | - | `${vault:KEY}` reference resolved at clone time. Required for `"token"` |
+| `credential_ref` | string | Conditional | - | `${var:KEY}` reference resolved at clone time. Required for `"token"` |
 | `ssh_user` | string | No | `git` | SSH username used with `"ssh-agent"` or `"ssh-key"` |
 | `ssh_key_path` | string | Conditional | - | Path to a private key file. Supports `~` expansion. Required for `"ssh-key"` |
 
@@ -636,7 +636,7 @@ sources:
     ref: v1.2.0
     auth:
       method: token
-      credential_ref: "${vault:GIT_TOKEN}"
+      credential_ref: "${var:GIT_TOKEN}"
 
   - name: private-ssh
     repo: git@github.com:acme/private-skills.git
@@ -663,13 +663,13 @@ Declares how gridctl authenticates when cloning or fetching this repository. Raw
 ```yaml
 auth:
   method: token
-  credential_ref: "${vault:GIT_TOKEN}"
+  credential_ref: "${var:GIT_TOKEN}"
 ```
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `method` | string | **Yes** | - | One of `"token"`, `"ssh-agent"`, `"ssh-key"`, or `"none"` |
-| `credential_ref` | string | Conditional | - | `${vault:KEY}` reference resolved at clone/fetch time. Required for `"token"` |
+| `credential_ref` | string | Conditional | - | `${var:KEY}` reference resolved at clone/fetch time. Required for `"token"` |
 | `ssh_user` | string | No | `git` | SSH username used with `"ssh-agent"` or `"ssh-key"` |
 | `ssh_key_path` | string | Conditional | - | Path to a private key file. Required for `"ssh-key"` |
 
@@ -714,7 +714,7 @@ configuration. The on-disk metadata distinguishes them:
 | Stored as | CLI | Behaviour |
 |-----------|-----|-----------|
 | Secret (default) | `gridctl var set KEY` | Encrypted at rest when the store is locked; values are replaced with `[REDACTED]` in logs. |
-| Plaintext | `gridctl var set KEY value --plaintext` | Stored alongside secrets but kept legible in logs and the web UI. |
+| Plaintext | `gridctl var set KEY --value value --plaintext` | Stored alongside secrets but kept legible in logs and the web UI. |
 
 Secrets and plaintext variables share the same lookup path — `${var:KEY}`
 works for both. The unification means a `stack.yaml` can carry environment

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -68,7 +68,7 @@ Skills don't have to be authored locally. `gridctl skill add <repo-url>` clones 
 Supported auth flows for private repos:
 
 - `--auth-token <pat>` — an ephemeral HTTPS personal access token, suitable for CI.
-- `--vault-key <key>` — resolves the token from a `${vault:KEY}` entry; suitable for long-running daemons.
+- `--vault-key <key>` — resolves the token from a `${var:KEY}` entry; suitable for long-running daemons.
 - `--ssh-key <path>` — SSH private key path.
 
 ## What gridctl deliberately does not do

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,10 +137,9 @@ failed to start server on port 9000: listen tcp :9000: bind: address already in 
    gridctl destroy
    ```
 
-3. Change the gateway port in your `stack.yaml`:
-   ```yaml
-   gateway:
-     port: 9001  # Use a different port
+3. Start on a different port — `--port` sets the gateway/web UI port (default `8180`), `--base-port` sets the MCP server host-port allocation base (default `9000`):
+   ```bash
+   gridctl apply stack.yaml --port 8181 --base-port 9100
    ```
 
 4. If the port is in TIME_WAIT, wait a few seconds or use a different port.
@@ -326,7 +325,7 @@ Some servers reload successfully while others fail. The reload result shows erro
 **Symptoms:**
 
 ```
-vault is locked. Set GRIDCTL_VAULT_PASSPHRASE or run 'gridctl vault unlock'
+vault is locked. Set GRIDCTL_VAULT_PASSPHRASE or run 'gridctl var unlock'
 ```
 
 Or via the API:
@@ -337,10 +336,10 @@ Or via the API:
 
 **Resolution:**
 
-Unlock the vault before accessing secrets:
+Unlock the store before accessing secrets:
 
 ```bash
-gridctl vault unlock
+gridctl var unlock
 ```
 
 Or set the passphrase as an environment variable for non-interactive use:
@@ -360,21 +359,21 @@ wrong passphrase or corrupted vault
 **Causes:**
 
 - Incorrect passphrase entered
-- The vault file was corrupted (rare - disk error or interrupted write)
+- The store file was corrupted (rare - disk error or interrupted write)
 
 **Resolution:**
 
-1. Try the correct passphrase. The vault uses PBKDF2 key derivation - there is no way to recover a forgotten passphrase.
+1. Try the correct passphrase. The store uses Argon2id key derivation - there is no way to recover a forgotten passphrase.
 
-2. If the vault file is corrupted, check for a backup:
+2. If the store file is corrupted, check for a backup:
    ```bash
-   ls -la ~/.config/gridctl/vault*
+   ls -la ~/.gridctl/vault/
    ```
 
-3. As a last resort, delete the vault and recreate secrets:
+3. As a last resort, delete the store and recreate variables:
    ```bash
-   rm ~/.config/gridctl/vault.enc
-   gridctl vault init
+   rm -rf ~/.gridctl/vault
+   gridctl var set <KEY>   # the store is recreated on first write
    ```
 
 ---
@@ -479,9 +478,9 @@ Browser shows a blank page or connection refused when accessing the gateway URL.
    gridctl status
    ```
 
-2. Check that you're using the correct port (default: 9000):
+2. Check that you're using the correct port (default: 8180):
    ```
-   http://localhost:9000
+   http://localhost:8180
    ```
 
 3. The web UI requires a modern browser - Chrome, Firefox, Safari, or Edge.

--- a/examples/portable-stack/README.md
+++ b/examples/portable-stack/README.md
@@ -14,9 +14,9 @@ decides how they're handled at runtime.
 
 ```bash
 # Non-sensitive — appears unredacted in logs.
-gridctl var set REGION us-east-1 --plaintext
-gridctl var set CLUSTER_ID prod-cluster-42 --plaintext
-gridctl var set AWS_ACCOUNT_ID 123456789012 --plaintext
+gridctl var set REGION --value us-east-1 --plaintext
+gridctl var set CLUSTER_ID --value prod-cluster-42 --plaintext
+gridctl var set AWS_ACCOUNT_ID --value 123456789012 --plaintext
 
 # Secrets — Article XII default; redacted in logs.
 gridctl var set DB_PASSWORD                    # interactive

--- a/examples/portable-stack/stack.yaml
+++ b/examples/portable-stack/stack.yaml
@@ -13,9 +13,9 @@
 # Prerequisites:
 #
 #   # Non-sensitive config — visible in logs.
-#   gridctl var set REGION us-east-1 --plaintext
-#   gridctl var set CLUSTER_ID prod-cluster-42 --plaintext
-#   gridctl var set AWS_ACCOUNT_ID 123456789012 --plaintext
+#   gridctl var set REGION --value us-east-1 --plaintext
+#   gridctl var set CLUSTER_ID --value prod-cluster-42 --plaintext
+#   gridctl var set AWS_ACCOUNT_ID --value 123456789012 --plaintext
 #
 #   # Secrets — redacted in logs (Article XII default).
 #   gridctl var set DB_PASSWORD                    # interactive prompt

--- a/examples/registry/README.md
+++ b/examples/registry/README.md
@@ -8,7 +8,7 @@ Examples demonstrating the Agent Skills registry following the [agentskills.io](
 |------|-------------|
 | `registry-basic.yaml` | Single server with basic Agent Skills |
 | `registry-advanced.yaml` | Two servers with cross-server skills |
-| `skills.yaml` | Remote skill source list (public, private HTTPS via vault, private SSH via ssh-agent) |
+| `skills.yaml` | Remote skill source list (public, private HTTPS via the variable store, private SSH via ssh-agent) |
 | `items/workflow-basic/` | Executable workflow: sequential steps with inputs and output |
 | `items/workflow-parallel/` | Executable workflow: fan-out parallel execution |
 | `items/workflow-conditional/` | Executable workflow: retry policies and error handling |
@@ -41,7 +41,7 @@ Skills are managed via the REST API or Web UI - they are **not** declared in sta
 ```bash
 # Use the provided example (edit sources first, stage any vault keys):
 cp examples/registry/skills.yaml ~/.gridctl/skills.yaml
-gridctl vault set GIT_TOKEN ghp_xxxxxxxxxxxxxxxxxxxx   # only if using token auth
+gridctl var set GIT_TOKEN --value ghp_xxxxxxxxxxxxxxxxxxxx   # only if using token auth
 gridctl skill update
 ```
 
@@ -49,7 +49,7 @@ Private repos are supported via three auth methods, declared under `auth:`:
 
 | Method | Use when |
 |--------|----------|
-| `token` + `credential_ref: ${vault:KEY}` | Private HTTPS repo; PAT stored in the encrypted vault and re-resolved on every fetch |
+| `token` + `credential_ref: ${var:KEY}` | Private HTTPS repo; PAT stored in the encrypted variable store and re-resolved on every fetch |
 | `ssh-agent` | Private SSH URL; uses the user's ambient ssh-agent + `~/.ssh/known_hosts` |
 | `ssh-key` + `ssh_key_path` | Private SSH URL with an explicit on-disk key |
 

--- a/examples/registry/skills.yaml
+++ b/examples/registry/skills.yaml
@@ -24,15 +24,15 @@ sources:
     repo: https://github.com/acme/public-skills
     ref: main
 
-  # Private HTTPS repo — PAT resolved from the vault on every fetch.
+  # Private HTTPS repo — PAT resolved from the variable store on every fetch.
   # Pre-stage the secret first:
-  #   gridctl vault set GIT_TOKEN ghp_xxxxxxxxxxxxxxxxxxxx
+  #   gridctl var set GIT_TOKEN --value ghp_xxxxxxxxxxxxxxxxxxxx
   - name: private-skills
     repo: https://github.com/acme/private-skills
     ref: v1.2.0
     auth:
       method: token
-      credential_ref: "${vault:GIT_TOKEN}"
+      credential_ref: "${var:GIT_TOKEN}"
 
   # Private SSH repo — uses the user's ambient ssh-agent and ~/.ssh/known_hosts.
   # No credentials travel through gridctl at all.

--- a/examples/secrets-vault/README.md
+++ b/examples/secrets-vault/README.md
@@ -1,57 +1,71 @@
-# 🔒 Secrets Vault
+# 🔒 Variable Store
 
-Manage secrets with `gridctl vault` instead of exporting environment variables or hardcoding values in stack files.
+Manage secrets and configuration with `gridctl var` instead of exporting environment variables or hardcoding values in stack files.
 
 > [!NOTE]
-> The vault is not a production secrets manager - it's a local development tool. Instead of scattering API keys across shell profiles, `.env` files, and `export` statements that inevitably end up in the wrong place, the vault gives you a single place to store and reference secrets on your machine. If you're deploying to production, use a proper secrets manager like HashiCorp Vault, AWS Secrets Manager, or whatever your platform provides.
+> The variable store is not a production secrets manager - it's a local development tool. Instead of scattering API keys across shell profiles, `.env` files, and `export` statements that inevitably end up in the wrong place, the store gives you a single place to keep secrets and config on your machine. If you're deploying to production, use a proper secrets manager like HashiCorp Vault, AWS Secrets Manager, or whatever your platform provides.
 
 ## 📄 Examples
 
 | File | Description |
 |------|-------------|
-| `vault-basic.yaml` | Reference individual secrets with `${vault:KEY}` syntax |
-| `vault-sets.yaml` | Auto-inject grouped secrets via variable sets |
+| `var-basic.yaml` | Reference individual variables with `${var:KEY}` syntax |
+| `var-sets.yaml` | Auto-inject grouped variables via variable sets |
+| `vault-basic.yaml` | Deprecated `${vault:KEY}` syntax (kept as a regression example) |
+| `vault-sets.yaml` | Deprecated variable-set example using the `vault` aliases |
+
+> [!WARNING]
+> `gridctl vault …` and the `${vault:KEY}` reference syntax are deprecated aliases for `gridctl var …` and `${var:KEY}`. Both resolve through the same store during the beta cycle and are removed at v1.0. New stacks should use `var`.
 
 ## 💡 Concepts
 
 ### How It Works
 
-Secrets are stored locally in `~/.gridctl/vault/` and referenced in stack YAML using `${vault:KEY}` syntax. When you deploy a stack, gridctl resolves vault references and injects them as environment variables into your containers - keeping secrets out of your stack files and version control.
+Variables are stored locally in `~/.gridctl/vault/` and referenced in stack YAML using `${var:KEY}` syntax. When you deploy a stack, gridctl resolves the references and injects them as environment variables into your containers - keeping values out of your stack files and version control.
 
 ```yaml
 env:
-  GITHUB_PERSONAL_ACCESS_TOKEN: "${vault:GITHUB_TOKEN}"
-  OPENAI_API_KEY: "${vault:OPENAI_API_KEY}"
-  LOG_LEVEL: "info"   # Non-secret values work as usual
+  GITHUB_PERSONAL_ACCESS_TOKEN: "${var:GITHUB_TOKEN}"
+  OPENAI_API_KEY: "${var:OPENAI_API_KEY}"
+  LOG_LEVEL: "${var:LOG_LEVEL}"   # Plaintext variables work the same way
 ```
 
-### Storing Secrets
+### Secrets vs Plaintext
 
-Secrets are key-value pairs. Set them one at a time:
+The store is unified: it holds both secrets and non-sensitive configuration. Entries are secret by default (encrypted at rest when locked, redacted in logs). Use `--plaintext` for config that should stay legible in logs and the web UI.
+
+```bash
+gridctl var set OPENAI_API_KEY                         # secret (default)
+gridctl var set LOG_LEVEL --value info --plaintext     # plaintext config
+```
+
+### Storing Variables
+
+Set them one at a time:
 
 ```bash
 # Interactive (prompts for hidden input)
-gridctl vault set OPENAI_API_KEY
+gridctl var set OPENAI_API_KEY
 
 # Non-interactive with --value flag
-gridctl vault set OPENAI_API_KEY --value "sk-proj-..."
+gridctl var set OPENAI_API_KEY --value "sk-proj-..."
 
 # Piped input
-echo "ghp_abc123..." | gridctl vault set GITHUB_TOKEN
+echo "ghp_abc123..." | gridctl var set GITHUB_TOKEN
 
 # Database connection string
-gridctl vault set DATABASE_URL --value "postgres://admin:pass@db.example.com:5432/myapp"
+gridctl var set DATABASE_URL --value "postgres://admin:pass@db.example.com:5432/myapp"
 ```
 
-Key names must follow the pattern `[a-zA-Z_][a-zA-Z0-9_]*` (like environment variable names).
+Key names must follow the pattern `[a-zA-Z_][a-zA-Z0-9_]*` (like environment variable names). Use `--type <string|json|list|number|bool>` to tag and validate the value's shape.
 
 ### Bulk Import
 
-Import multiple secrets at once from `.env` or `.json` files:
+Import multiple variables at once from `.env` or `.json` files:
 
 ```bash
-gridctl vault import .env
-gridctl vault import secrets.json
+gridctl var import .env
+gridctl var import secrets.json
 ```
 
 Where `.env` looks like:
@@ -59,23 +73,27 @@ Where `.env` looks like:
 ```
 STRIPE_SECRET_KEY=sk_live_your_stripe_key_here
 SENDGRID_API_KEY=SG.your_sendgrid_key_here
+
+# @public            — store as plaintext (default is secret)
+# @type=list         — record the variable's type
+TAGS=app,backend,prod
 ```
 
 ### Variable Sets
 
-Group related secrets together and inject them into all containers automatically:
+Group related variables together and inject them into all containers automatically:
 
 ```bash
 # Create a set
-gridctl vault sets create production
+gridctl var sets create production
 
-# Add secrets to the set
-gridctl vault set DB_HOST --value "db.example.com" --set production
-gridctl vault set DB_PASSWORD --value "s3cur3Pa55" --set production
-gridctl vault set API_KEY --value "ak_prod_..." --set production
+# Add variables to the set
+gridctl var set DB_HOST --value "db.example.com" --set production --plaintext
+gridctl var set DB_PASSWORD --value "s3cur3Pa55" --set production
+gridctl var set API_KEY --value "ak_prod_..." --set production
 ```
 
-Then reference the set in your stack YAML - all secrets in the set are injected into every container's environment:
+Then reference the set in your stack YAML - all variables in the set are injected into every container's environment:
 
 ```yaml
 secrets:
@@ -90,13 +108,15 @@ mcp-servers:
       LOG_LEVEL: "info"   # Explicit values take precedence over set values
 ```
 
+> The stack field is named `secrets.sets` for backward compatibility; set membership is type-agnostic and works for both secrets and plaintext variables.
+
 ### Encryption
 
-Protect stored secrets with passphrase-based encryption (XChaCha20-Poly1305 + Argon2id):
+Protect the store with passphrase-based encryption (XChaCha20-Poly1305 + Argon2id):
 
 ```bash
-gridctl vault lock       # Encrypt with a passphrase
-gridctl vault unlock     # Decrypt for the session
+gridctl var lock       # Encrypt with a passphrase
+gridctl var unlock     # Decrypt for the session
 ```
 
 Set `GRIDCTL_VAULT_PASSPHRASE` to provide the passphrase non-interactively.
@@ -104,17 +124,18 @@ Set `GRIDCTL_VAULT_PASSPHRASE` to provide the passphrase non-interactively.
 ## 💻 Usage
 
 ```bash
-# Store required secrets first
-gridctl vault set GITHUB_TOKEN
-gridctl vault set OPENAI_API_KEY
+# Store required variables first
+gridctl var set GITHUB_TOKEN
+gridctl var set OPENAI_API_KEY
+gridctl var set LOG_LEVEL --value info --plaintext
 
 # Deploy the basic example
-gridctl apply examples/secrets-vault/vault-basic.yaml
+gridctl apply examples/secrets-vault/var-basic.yaml
 
-# Or set up variable sets and deploy
-gridctl vault sets create production
-gridctl vault set DB_HOST --value "db.example.com" --set production
-gridctl vault set DB_PASSWORD --set production
-gridctl vault set API_KEY --set production
-gridctl apply examples/secrets-vault/vault-sets.yaml
+# Or set up a variable set and deploy
+gridctl var sets create production
+gridctl var set DB_HOST --value "db.example.com" --set production --plaintext
+gridctl var set DB_PASSWORD --set production
+gridctl var set API_KEY --set production
+gridctl apply examples/secrets-vault/var-sets.yaml
 ```

--- a/examples/secrets-vault/var-basic.yaml
+++ b/examples/secrets-vault/var-basic.yaml
@@ -6,7 +6,7 @@
 # Prerequisites:
 #   gridctl var set GITHUB_TOKEN              # default: secret (Article XII)
 #   gridctl var set OPENAI_API_KEY            # default: secret
-#   gridctl var set LOG_LEVEL info --plaintext   # plaintext: visible in logs
+#   gridctl var set LOG_LEVEL --value info --plaintext   # plaintext: visible in logs
 #
 # Usage:
 #   gridctl apply examples/secrets-vault/var-basic.yaml

--- a/examples/secrets-vault/vault-sets.yaml
+++ b/examples/secrets-vault/vault-sets.yaml
@@ -1,7 +1,11 @@
-# Variable Sets Example
+# Variable Sets Example (deprecated `vault` aliases — kept as regression test)
 #
 # Groups related secrets into sets and injects them automatically
 # into all containers. Explicit env values take precedence.
+#
+# The `gridctl vault …` commands below are deprecated aliases for
+# `gridctl var …`; prefer var-sets.yaml. The aliases work through the beta
+# cycle and are removed at v1.0.
 #
 # Prerequisites:
 #   gridctl vault sets create production


### PR DESCRIPTION
## Description

Propagates the `vault` → `var` rename through the docs and examples. Code already treats `gridctl var`, `/api/var`, and `${var:KEY}` as canonical (with the `vault` forms as deprecated aliases removed at v1.0), but the docs still steered users to the deprecated surface and carried a few stale facts.

## Type of Change

- [x] Documentation

## Changes Made

- CLI reference: rewrote the **Vault** section as **Variables** (`gridctl var`, now covering `--secret`/`--plaintext`/`--type` and the `var sets` subcommands) with a deprecation note
- API reference: `/api/vault/*` → `/api/var/*` canonical, noted the deprecated alias and fixed the locked-error hint
- Config schema, skills, registry, portable-stack, secrets-vault: `${vault:KEY}` → `${var:KEY}`, `gridctl vault` → `gridctl var`
- Troubleshooting: corrected the unlock command, KDF (Argon2id), store paths, removed the nonexistent `vault init`, fixed the web UI default port (8180) and the nonexistent `gateway.port` field
- Fixed invalid positional `var set KEY VALUE` usages to `--value` (the CLI accepts exactly one positional arg)

## Testing

Verified every documented command/flag/route against source (`cmd/gridctl`, `internal/api`, `pkg/config`, `pkg/state`) and the built binary. Internal doc links re-checked.

## Notes

`examples/registry/README.md` still documents the removed executable-workflow surface (no matching routes or item files) — left for a separate focused docs pass. The deprecated `/api/vault/*` alias ships a `Sunset` header dated 2025-12-31, now in the past while the alias is still registered.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed