### PR TITLE
feat: Skills Library inspector pane

### DIFF
--- a/web/src/__tests__/LibraryWorkspace.test.tsx
+++ b/web/src/__tests__/LibraryWorkspace.test.tsx
@@ -21,6 +21,8 @@ vi.mock('../lib/api', () => ({
   activateRegistrySkill: vi.fn().mockResolvedValue(undefined),
   disableRegistrySkill: vi.fn().mockResolvedValue(undefined),
   deleteRegistrySkill: vi.fn().mockResolvedValue(undefined),
+  // Used by SkillFileTree (mounted only on the inspector's Files tab).
+  fetchSkillFiles: vi.fn().mockResolvedValue([]),
 }));
 
 // SkillEditor is heavy and unrelated to the workspace's URL-state behavior.
@@ -143,6 +145,51 @@ describe('LibraryWorkspace', () => {
     useRegistryStore.setState({ skills: null });
     renderAt('/library/never-existed');
     expect(showToast).not.toHaveBeenCalled();
+  });
+
+  describe('inspector pane', () => {
+    it('shows the empty state when nothing is selected', () => {
+      renderAt('/library');
+      expect(screen.getByText(/select a skill to inspect/i)).toBeInTheDocument();
+    });
+
+    it('opens the inspector and sets ?selected= when a card is clicked', async () => {
+      let currentSearch = '';
+      renderAt('/library', (s) => { currentSearch = s; });
+
+      fireEvent.click(screen.getByText('incident-triage'));
+      await waitFor(() => expect(currentSearch).toContain('selected=incident-triage'));
+      // The inspector header (h2) carries the selected skill's name.
+      expect(screen.getByRole('heading', { name: 'incident-triage' })).toBeInTheDocument();
+    });
+
+    it('restores the inspector from ?selected= on initial render', () => {
+      renderAt('/library?selected=draft-summarizer');
+      expect(screen.getByRole('heading', { name: 'draft-summarizer' })).toBeInTheDocument();
+    });
+
+    it('ignores an unknown ?selected= gracefully (empty state)', () => {
+      renderAt('/library?selected=never-existed');
+      expect(screen.getByText(/select a skill to inspect/i)).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: 'never-existed' })).not.toBeInTheDocument();
+    });
+
+    it('clears the selection and ?selected= when the inspector is closed', async () => {
+      let currentSearch = '?selected=incident-triage';
+      renderAt('/library?selected=incident-triage', (s) => { currentSearch = s; });
+
+      expect(screen.getByRole('heading', { name: 'incident-triage' })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /close inspector/i }));
+      await waitFor(() => expect(currentSearch).not.toContain('selected='));
+      expect(screen.getByText(/select a skill to inspect/i)).toBeInTheDocument();
+    });
+
+    it('promotes to the editor when the inspector Edit button is clicked', async () => {
+      renderAt('/library?selected=incident-triage');
+      fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+      await waitFor(() => expect(screen.getByTestId('skill-editor')).toBeInTheDocument());
+      expect(screen.getByTestId('editing-skill-name').textContent).toBe('incident-triage');
+    });
   });
 
   describe('provenance grouping', () => {

--- a/web/src/__tests__/SkillDetailPanel.test.tsx
+++ b/web/src/__tests__/SkillDetailPanel.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SkillDetailPanel } from '../components/registry/SkillDetailPanel';
+import type { AgentSkill } from '../types';
+
+// SkillFileTree fetches its own file list; stub it so the Files tab is inert.
+vi.mock('../components/registry/SkillFileTree', () => ({
+  SkillFileTree: ({ skillName, readOnly }: { skillName: string; readOnly?: boolean }) => (
+    <div data-testid="file-tree" data-skill={skillName} data-readonly={String(!!readOnly)} />
+  ),
+}));
+
+const SKILL: AgentSkill = {
+  name: 'incident-triage',
+  description: 'Triage incidents quickly',
+  license: 'Apache-2.0',
+  compatibility: 'Requires git',
+  allowedTools: 'Bash(git:*) Read Write',
+  metadata: { author: 'ops' },
+  acceptanceCriteria: ['GIVEN an alert WHEN it is triaged THEN severity is set'],
+  state: 'active',
+  body: '# Triage\n\nFollow the runbook.',
+  fileCount: 2,
+  dir: 'ops/incident-triage',
+};
+
+function noop() {}
+
+function renderPanel(overrides: Partial<React.ComponentProps<typeof SkillDetailPanel>> = {}) {
+  return render(
+    <SkillDetailPanel
+      skill={SKILL}
+      onClose={noop}
+      onEdit={noop}
+      onToggle={noop}
+      onDelete={noop}
+      {...overrides}
+    />,
+  );
+}
+
+describe('SkillDetailPanel', () => {
+  it('renders an empty state when no skill is selected', () => {
+    render(
+      <SkillDetailPanel skill={null} onClose={noop} onEdit={noop} onToggle={noop} onDelete={noop} />,
+    );
+    expect(screen.getByText(/select a skill to inspect/i)).toBeInTheDocument();
+  });
+
+  it('shows the header with name, state badge, and three tabs', () => {
+    renderPanel();
+    expect(screen.getByRole('heading', { name: 'incident-triage' })).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Instructions' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Files' })).toBeInTheDocument();
+  });
+
+  it('renders Overview content: description, allowed-tools chips, and criteria', () => {
+    renderPanel();
+    expect(screen.getByText('Triage incidents quickly')).toBeInTheDocument();
+    expect(screen.getByText('Bash(git:*)')).toBeInTheDocument();
+    expect(screen.getByText('Read')).toBeInTheDocument();
+    expect(screen.getByText('Write')).toBeInTheDocument();
+    // GIVEN/WHEN/THEN parsed into parts.
+    expect(screen.getByText('an alert')).toBeInTheDocument();
+    expect(screen.getByText('it is triaged')).toBeInTheDocument();
+    expect(screen.getByText('severity is set')).toBeInTheDocument();
+  });
+
+  it('shows the rendered body on the Instructions tab', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('tab', { name: 'Instructions' }));
+    expect(screen.getByText('Follow the runbook.')).toBeInTheDocument();
+  });
+
+  it('mounts the read-only file tree only on the Files tab', () => {
+    renderPanel();
+    expect(screen.queryByTestId('file-tree')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: 'Files' }));
+    const tree = screen.getByTestId('file-tree');
+    expect(tree).toHaveAttribute('data-skill', 'incident-triage');
+    expect(tree).toHaveAttribute('data-readonly', 'true');
+  });
+
+  it('moves between tabs with Left/Right arrow keys', () => {
+    renderPanel();
+    const overview = screen.getByRole('tab', { name: 'Overview' });
+    fireEvent.keyDown(overview, { key: 'ArrowRight' });
+    expect(screen.getByRole('tab', { name: 'Instructions' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('wires each tabpanel to its tab via aria-labelledby', () => {
+    renderPanel();
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).toHaveAttribute('aria-labelledby', 'skill-tab-overview');
+  });
+
+  it('calls onEdit when the Edit button is clicked', () => {
+    const onEdit = vi.fn();
+    renderPanel({ onEdit });
+    fireEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+    expect(onEdit).toHaveBeenCalledWith(SKILL);
+  });
+
+  it('calls onToggle / onDelete from the header actions', () => {
+    const onToggle = vi.fn();
+    const onDelete = vi.fn();
+    renderPanel({ onToggle, onDelete });
+    fireEvent.click(screen.getByRole('button', { name: /disable skill/i }));
+    fireEvent.click(screen.getByRole('button', { name: /delete skill/i }));
+    expect(onToggle).toHaveBeenCalledWith(SKILL);
+    expect(onDelete).toHaveBeenCalledWith(SKILL);
+  });
+
+  it('lists related skills and selects one on click', () => {
+    const onSelectRelated = vi.fn();
+    const related: AgentSkill = { ...SKILL, name: 'incident-postmortem', acceptanceCriteria: [] };
+    renderPanel({ relatedSkills: [related], onSelectRelated });
+    fireEvent.click(screen.getByText('incident-postmortem'));
+    expect(onSelectRelated).toHaveBeenCalledWith('incident-postmortem');
+  });
+});

--- a/web/src/components/inspector/InspectorTabList.tsx
+++ b/web/src/components/inspector/InspectorTabList.tsx
@@ -33,6 +33,8 @@ interface InspectorTabButtonProps {
   onClick: () => void;
   label: string;
   controls: string;
+  /** Optional id so a paired tabpanel can reference it via aria-labelledby. */
+  id?: string;
 }
 
 export function InspectorTabButton({
@@ -40,13 +42,16 @@ export function InspectorTabButton({
   onClick,
   label,
   controls,
+  id,
 }: InspectorTabButtonProps) {
   return (
     <button
       type="button"
+      id={id}
       role="tab"
       aria-selected={active}
       aria-controls={controls}
+      tabIndex={active ? 0 : -1}
       onClick={onClick}
       className={cn(
         'px-3 py-1.5 -mb-px',

--- a/web/src/components/registry/LibraryGrid.tsx
+++ b/web/src/components/registry/LibraryGrid.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react';
 import { cn } from '../../lib/cn';
+import { toTitleCase } from '../../lib/text';
 import { SkillCard } from './SkillCard';
 import { SourceGroupHeader } from './SourceGroupHeader';
 import type { AgentSkill, SkillSourceStatus } from '../../types';
@@ -19,10 +20,6 @@ function groupSkills(skills: AgentSkill[]): Map<string, AgentSkill[]> {
     groups.get(key)!.push(skill);
   }
   return groups;
-}
-
-function toTitleCase(key: string): string {
-  return key.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 const GRID_STYLE: React.CSSProperties = {
@@ -52,6 +49,11 @@ export interface LibraryGridProps {
   onIsolateSource?: (key: string | null) => void;
   /** Refresh callback invoked after an inline source update. */
   onRefresh?: () => void;
+  /** Select a card into the inspector. Optional so the detached grid (which
+   *  has no inspector rail) is unaffected. */
+  onSelect?: (skill: AgentSkill) => void;
+  /** Name of the skill currently shown in the inspector, for active styling. */
+  activeSkillName?: string | null;
 }
 
 /**
@@ -75,6 +77,8 @@ export function LibraryGrid({
   activeSource = null,
   onIsolateSource,
   onRefresh,
+  onSelect,
+  activeSkillName = null,
 }: LibraryGridProps) {
   const cardHandlers = { onEnable, onDisable, onEdit, onDelete };
 
@@ -83,6 +87,8 @@ export function LibraryGrid({
       key={skill.name}
       skill={skill}
       source={sourceMap?.get(skill.name)}
+      onSelect={onSelect}
+      isActive={skill.name === activeSkillName}
       className={cn(
         'motion-safe:animate-fade-in-scale',
         skill.metadata?.colspan === '2' ? 'col-span-2' : undefined,

--- a/web/src/components/registry/MarkdownPreview.tsx
+++ b/web/src/components/registry/MarkdownPreview.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import { marked } from 'marked';
+import { cn } from '../../lib/cn';
+
+/** Render SKILL.md markdown to HTML with GFM + line breaks. */
+export function renderMarkdown(content: string): string {
+  return marked.parse(content, { breaks: true, gfm: true }) as string;
+}
+
+interface MarkdownPreviewProps {
+  content: string;
+  /** Placeholder shown when content is empty. */
+  emptyHint?: string;
+}
+
+/**
+ * Read-only markdown renderer shared by the SkillEditor preview pane and the
+ * Library inspector's Instructions tab, so both render SKILL.md bodies with the
+ * same `prose` treatment.
+ */
+export function MarkdownPreview({
+  content,
+  emptyHint = 'Preview will appear here as you type...',
+}: MarkdownPreviewProps) {
+  const html = useMemo(() => (content ? renderMarkdown(content) : ''), [content]);
+
+  if (!content) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-[200px]">
+        <p className="text-text-muted/40 text-sm italic">{emptyHint}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'prose prose-invert prose-sm max-w-none',
+        // Headings
+        'prose-headings:text-text-primary prose-headings:font-semibold prose-headings:tracking-tight',
+        'prose-h1:text-lg prose-h1:border-b prose-h1:border-border/30 prose-h1:pb-2 prose-h1:mb-4',
+        'prose-h2:text-base prose-h2:mt-6 prose-h2:mb-2',
+        'prose-h3:text-sm prose-h3:mt-4 prose-h3:mb-1',
+        // Body text
+        'prose-p:text-text-secondary prose-p:text-sm prose-p:leading-relaxed',
+        // Code
+        'prose-code:text-primary prose-code:bg-surface-highlight prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-xs prose-code:font-mono prose-code:before:content-none prose-code:after:content-none',
+        'prose-pre:bg-background/60 prose-pre:border prose-pre:border-border/30 prose-pre:rounded-lg prose-pre:text-xs',
+        // Links
+        'prose-a:text-primary prose-a:no-underline hover:prose-a:underline',
+        // Lists
+        'prose-li:text-text-secondary prose-li:text-sm prose-li:marker:text-text-muted',
+        'prose-ul:my-2 prose-ol:my-2',
+        // Strong / emphasis
+        'prose-strong:text-text-primary',
+        'prose-em:text-text-secondary',
+        // Blockquotes
+        'prose-blockquote:border-primary/40 prose-blockquote:text-text-muted prose-blockquote:not-italic',
+        // Tables
+        'prose-th:text-text-primary prose-th:text-xs prose-th:uppercase prose-th:tracking-wider prose-th:font-medium',
+        'prose-td:text-text-secondary prose-td:text-sm',
+        // Horizontal rules
+        'prose-hr:border-border/30',
+      )}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/web/src/components/registry/SkillCard.tsx
+++ b/web/src/components/registry/SkillCard.tsx
@@ -13,6 +13,11 @@ export interface SkillCardProps {
   onDelete: (skill: AgentSkill) => void;
   /** Imported-from source, when this skill came from a git source. */
   source?: SkillSourceStatus;
+  /** Select this card into the inspector. When omitted (e.g. the detached
+   *  grid), the card body is not interactive. */
+  onSelect?: (skill: AgentSkill) => void;
+  /** Whether this card is the one shown in the inspector. */
+  isActive?: boolean;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -24,6 +29,8 @@ export const SkillCard = memo(({
   onEdit,
   onDelete,
   source,
+  onSelect,
+  isActive = false,
   className,
   style,
 }: SkillCardProps) => {
@@ -35,19 +42,41 @@ export const SkillCard = memo(({
   return (
     <div
       style={style}
+      aria-current={isActive ? 'true' : undefined}
       className={cn(
         'group relative rounded-xl overflow-hidden flex flex-col',
         'backdrop-blur-xl border transition-all duration-200 ease-out',
         'bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.02]',
         'border-white/[0.08] hover:border-primary/40 focus-within:border-primary/40 hover:shadow-node-hover',
+        isActive && 'border-primary/50 bg-primary/[0.06] shadow-node-hover',
         className,
       )}
     >
-      {/* Top accent line — muted at rest, warms on hover/focus */}
-      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/10 group-hover:via-primary/40 group-focus-within:via-primary/40 to-transparent transition-colors duration-200" />
+      {/* Top accent line — muted at rest, warms on hover/focus (and when active) */}
+      <div className={cn(
+        'absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent to-transparent transition-colors duration-200',
+        'via-white/10 group-hover:via-primary/40 group-focus-within:via-primary/40',
+        isActive && 'via-primary/50',
+      )} />
 
-      {/* Card body */}
-      <div className="p-3 flex flex-col gap-2 flex-1">
+      {/* Card body — clickable to open the inspector */}
+      <div
+        className={cn('p-3 flex flex-col gap-2 flex-1', onSelect && 'cursor-pointer')}
+        role={onSelect ? 'button' : undefined}
+        tabIndex={onSelect ? 0 : undefined}
+        aria-label={onSelect ? `Inspect ${skill.name}` : undefined}
+        onClick={onSelect ? () => onSelect(skill) : undefined}
+        onKeyDown={
+          onSelect
+            ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onSelect(skill);
+                }
+              }
+            : undefined
+        }
+      >
         {/* Header: icon + name + state badge */}
         <div className="flex items-start gap-2">
           <div className="p-1.5 rounded-md border bg-surface-highlight/60 border-border/40 flex-shrink-0 mt-0.5 transition-colors duration-200 group-hover:bg-primary/10 group-hover:border-primary/20 group-focus-within:bg-primary/10 group-focus-within:border-primary/20">

--- a/web/src/components/registry/SkillDetailPanel.tsx
+++ b/web/src/components/registry/SkillDetailPanel.tsx
@@ -1,0 +1,358 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { BookOpen, GitBranch, Pencil, Power, PowerOff, Trash2 } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { extractRepoInfo } from '../../lib/repo';
+import { toTitleCase } from '../../lib/text';
+import { parseAcceptanceCriterion } from '../../lib/skillCriteria';
+import { InspectorHeader, InspectorTabList, InspectorTabButton } from '../inspector';
+import { IconButton } from '../ui/IconButton';
+import { StateBadge } from './StateBadge';
+import { MarkdownPreview } from './MarkdownPreview';
+import { SkillFileTree } from './SkillFileTree';
+import type { AgentSkill, SkillSourceStatus } from '../../types';
+
+type SkillTab = 'overview' | 'instructions' | 'files';
+
+const TABS: { key: SkillTab; label: string }[] = [
+  { key: 'overview', label: 'Overview' },
+  { key: 'instructions', label: 'Instructions' },
+  { key: 'files', label: 'Files' },
+];
+
+const tabBtnId = (tab: SkillTab) => `skill-tab-${tab}`;
+const tabPanelId = (tab: SkillTab) => `skill-tabpanel-${tab}`;
+
+export interface SkillDetailPanelProps {
+  /** The selected skill, or null for the empty state. */
+  skill: AgentSkill | null;
+  /** Owning source, when the skill was imported from a git source. */
+  source?: SkillSourceStatus;
+  /** Other skills in the same top-level category, for the "Related" list. */
+  relatedSkills?: AgentSkill[];
+  onClose: () => void;
+  onEdit: (skill: AgentSkill) => void;
+  onToggle: (skill: AgentSkill) => void;
+  onDelete: (skill: AgentSkill) => void;
+  onSelectRelated?: (name: string) => void;
+}
+
+/**
+ * SkillDetailPanel fills the Library workspace right rail with a read-first,
+ * tabbed view of the selected skill (Overview / Instructions / Files). It is a
+ * pure presentational sibling of the grid — selection lives in the workspace.
+ * The header stays fixed across tabs; "Edit" promotes to the SkillEditor modal.
+ */
+export function SkillDetailPanel({
+  skill,
+  source,
+  relatedSkills = [],
+  onClose,
+  onEdit,
+  onToggle,
+  onDelete,
+  onSelectRelated,
+}: SkillDetailPanelProps) {
+  const [activeTab, setActiveTab] = useState<SkillTab>('overview');
+  const tablistRef = useRef<HTMLDivElement>(null);
+
+  // Reset to Overview when the selected skill changes, so switching skills never
+  // strands the user on Files (which would refetch for the new skill).
+  useEffect(() => {
+    setActiveTab('overview');
+  }, [skill?.name]);
+
+  if (!skill) {
+    return (
+      <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle">
+        <SkillDetailEmpty />
+      </aside>
+    );
+  }
+
+  // APG tabs: Left/Right (and Home/End) move the active tab, focusing it.
+  const onTabsKeyDown = (e: React.KeyboardEvent) => {
+    const idx = TABS.findIndex((t) => t.key === activeTab);
+    let next = idx;
+    if (e.key === 'ArrowRight') next = (idx + 1) % TABS.length;
+    else if (e.key === 'ArrowLeft') next = (idx - 1 + TABS.length) % TABS.length;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = TABS.length - 1;
+    else return;
+    e.preventDefault();
+    setActiveTab(TABS[next].key);
+    const buttons = tablistRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    buttons?.[next]?.focus();
+  };
+
+  const repoInfo = source ? extractRepoInfo(source.repo) : null;
+
+  return (
+    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle">
+      <InspectorHeader
+        title={skill.name}
+        icon={BookOpen}
+        accent="primary"
+        onClose={onClose}
+        subtitle={
+          <div className="flex items-center gap-1.5 flex-wrap mt-0.5">
+            <StateBadge state={skill.state} />
+            {source && (
+              <span
+                title={source.repo}
+                className="inline-flex items-center gap-1 text-[10px] font-mono px-1.5 py-0.5 rounded bg-surface-elevated text-text-muted"
+              >
+                <GitBranch size={10} />
+                {repoInfo ? `${repoInfo.owner}/${repoInfo.repo}` : source.name}
+              </span>
+            )}
+          </div>
+        }
+        actions={
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              onClick={() => onEdit(skill)}
+              className="flex items-center gap-1 px-2 py-1 text-[11px] font-medium text-primary hover:text-primary/80 bg-primary/10 hover:bg-primary/15 border border-primary/20 rounded-md transition-colors"
+            >
+              <Pencil size={11} /> Edit
+            </button>
+            <IconButton
+              icon={skill.state === 'active' ? PowerOff : Power}
+              size="sm"
+              variant="ghost"
+              onClick={() => onToggle(skill)}
+              tooltip={skill.state === 'active' ? 'Disable skill' : 'Activate skill'}
+              className={skill.state === 'active' ? 'hover:text-amber-400' : 'hover:text-emerald-400'}
+            />
+            <IconButton
+              icon={Trash2}
+              size="sm"
+              variant="ghost"
+              onClick={() => onDelete(skill)}
+              tooltip="Delete skill"
+              className="hover:text-status-error"
+            />
+          </div>
+        }
+      />
+
+      <div ref={tablistRef} onKeyDown={onTabsKeyDown}>
+        <InspectorTabList ariaLabel={`${skill.name} detail tabs`}>
+          {TABS.map((tab) => (
+            <InspectorTabButton
+              key={tab.key}
+              id={tabBtnId(tab.key)}
+              active={activeTab === tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              label={tab.label}
+              controls={tabPanelId(tab.key)}
+            />
+          ))}
+        </InspectorTabList>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark">
+        {/* Overview */}
+        <div
+          role="tabpanel"
+          id={tabPanelId('overview')}
+          aria-labelledby={tabBtnId('overview')}
+          hidden={activeTab !== 'overview'}
+          className="px-4 py-4 space-y-5"
+        >
+          {activeTab === 'overview' && (
+            <SkillOverview
+              skill={skill}
+              relatedSkills={relatedSkills}
+              onSelectRelated={onSelectRelated}
+            />
+          )}
+        </div>
+
+        {/* Instructions */}
+        <div
+          role="tabpanel"
+          id={tabPanelId('instructions')}
+          aria-labelledby={tabBtnId('instructions')}
+          hidden={activeTab !== 'instructions'}
+          className="px-4 py-4"
+        >
+          {activeTab === 'instructions' && (
+            <MarkdownPreview
+              content={skill.body}
+              emptyHint="This skill has no instructions."
+            />
+          )}
+        </div>
+
+        {/* Files */}
+        <div
+          role="tabpanel"
+          id={tabPanelId('files')}
+          aria-labelledby={tabBtnId('files')}
+          hidden={activeTab !== 'files'}
+        >
+          {/* Mount the tree only while the Files tab is active so switching
+              skills/tabs doesn't fire the file fetch for unviewed tabs. */}
+          {activeTab === 'files' && <SkillFileTree skillName={skill.name} readOnly />}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function SkillOverview({
+  skill,
+  relatedSkills,
+  onSelectRelated,
+}: {
+  skill: AgentSkill;
+  relatedSkills: AgentSkill[];
+  onSelectRelated?: (name: string) => void;
+}) {
+  const category = skill.dir ? toTitleCase(skill.dir.split('/')[0]) : null;
+  const tools = (skill.allowedTools ?? '').split(/\s+/).filter(Boolean);
+  const metadataEntries = Object.entries(skill.metadata ?? {});
+  const criteria = skill.acceptanceCriteria ?? [];
+
+  return (
+    <>
+      <Section title="Description">
+        {skill.description ? (
+          <p className="text-xs text-text-secondary leading-relaxed whitespace-pre-wrap break-words">
+            {skill.description}
+          </p>
+        ) : (
+          <p className="text-[11px] text-text-muted/70 italic">No description.</p>
+        )}
+      </Section>
+
+      <Section title="Details">
+        <dl className="space-y-1.5">
+          {category && <MetaRow label="Category" value={category} />}
+          {skill.license && <MetaRow label="License" value={skill.license} mono />}
+          {skill.compatibility && <MetaRow label="Compatibility" value={skill.compatibility} />}
+          <MetaRow label="Files" value={String(skill.fileCount)} mono />
+        </dl>
+      </Section>
+
+      {tools.length > 0 && (
+        <Section title="Allowed tools">
+          <div className="flex flex-wrap gap-1">
+            {tools.map((tool) => (
+              <span
+                key={tool}
+                className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-surface-elevated text-text-secondary border border-border/30"
+              >
+                {tool}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {metadataEntries.length > 0 && (
+        <Section title="Metadata">
+          <dl className="space-y-1.5">
+            {metadataEntries.map(([key, value]) => (
+              <MetaRow key={key} label={key} value={value} mono />
+            ))}
+          </dl>
+        </Section>
+      )}
+
+      {criteria.length > 0 && (
+        <Section title="Acceptance criteria">
+          <ul className="space-y-2">
+            {criteria.map((raw, i) => {
+              const c = parseAcceptanceCriterion(raw);
+              return (
+                <li
+                  key={i}
+                  className="rounded-lg border border-border/30 bg-background/40 p-2.5 space-y-1"
+                >
+                  {c.matched ? (
+                    <>
+                      <CriterionRow keyword="GIVEN" text={c.given} />
+                      <CriterionRow keyword="WHEN" text={c.when} />
+                      <CriterionRow keyword="THEN" text={c.then} />
+                    </>
+                  ) : (
+                    <p className="text-xs text-text-secondary leading-relaxed">{c.raw}</p>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </Section>
+      )}
+
+      {relatedSkills.length > 0 && (
+        <Section title="Related skills">
+          <div className="space-y-1">
+            {relatedSkills.map((rel) => (
+              <button
+                key={rel.name}
+                type="button"
+                onClick={() => onSelectRelated?.(rel.name)}
+                className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-left hover:bg-surface-highlight/60 transition-colors group"
+              >
+                <BookOpen size={12} className="text-text-muted group-hover:text-primary/70 flex-shrink-0 transition-colors" />
+                <span className="text-xs text-text-secondary group-hover:text-text-primary truncate flex-1 transition-colors">
+                  {rel.name}
+                </span>
+                <StateBadge state={rel.state} />
+              </button>
+            ))}
+          </div>
+        </Section>
+      )}
+    </>
+  );
+}
+
+function CriterionRow({ keyword, text }: { keyword: string; text: string }) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className="text-[9px] text-text-muted uppercase tracking-wider w-10 pt-0.5 flex-shrink-0 font-mono">
+        {keyword}
+      </span>
+      <span className="text-xs text-text-secondary leading-relaxed flex-1 break-words">{text}</span>
+    </div>
+  );
+}
+
+function MetaRow({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <dt className="text-[11px] text-text-muted flex-shrink-0">{label}</dt>
+      <dd className={cn('text-[11px] text-text-secondary text-right break-words', mono && 'font-mono')}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function SkillDetailEmpty() {
+  return (
+    <div className="h-full flex items-center justify-center px-6 text-center">
+      <div className="space-y-3">
+        <div className="mx-auto w-12 h-12 rounded-2xl bg-surface-highlight/40 border border-border/40 flex items-center justify-center">
+          <BookOpen size={20} className="text-text-muted/60" aria-hidden="true" />
+        </div>
+        <p className="text-xs text-text-muted leading-relaxed max-w-[220px]">
+          Select a skill to inspect its details, instructions, and files.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/registry/SkillEditor.tsx
+++ b/web/src/components/registry/SkillEditor.tsx
@@ -13,11 +13,12 @@ import {
   Eye,
   EyeOff,
 } from 'lucide-react';
-import { marked } from 'marked';
 import { Modal } from '../ui/Modal';
 import { showToast } from '../ui/Toast';
 import { SkillFileTree } from './SkillFileTree';
+import { MarkdownPreview } from './MarkdownPreview';
 import { createRegistrySkill, updateRegistrySkill, validateSkillContent } from '../../lib/api';
+import { parseAcceptanceCriterion } from '../../lib/skillCriteria';
 import { cn } from '../../lib/cn';
 import type { AgentSkill, ItemState, SkillValidationResult } from '../../types';
 
@@ -69,12 +70,6 @@ function buildSkillMDContent(fields: {
   }
   if (fields.state) lines.push(`state: ${fields.state}`);
   return `---\n${lines.join('\n')}\n---\n\n${fields.body}`;
-}
-
-// --- Markdown rendering ---
-
-function renderMarkdown(content: string): string {
-  return marked.parse(content, { breaks: true, gfm: true }) as string;
 }
 
 // --- Debounced validation ---
@@ -303,56 +298,6 @@ function AcceptanceCriteriaEditor({
   );
 }
 
-// --- MarkdownPreview ---
-
-function MarkdownPreview({ content }: { content: string }) {
-  const html = useMemo(() => (content ? renderMarkdown(content) : ''), [content]);
-
-  if (!content) {
-    return (
-      <div className="flex items-center justify-center h-full min-h-[200px]">
-        <p className="text-text-muted/40 text-sm italic">
-          Preview will appear here as you type...
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      className={cn(
-        'prose prose-invert prose-sm max-w-none',
-        // Headings
-        'prose-headings:text-text-primary prose-headings:font-semibold prose-headings:tracking-tight',
-        'prose-h1:text-lg prose-h1:border-b prose-h1:border-border/30 prose-h1:pb-2 prose-h1:mb-4',
-        'prose-h2:text-base prose-h2:mt-6 prose-h2:mb-2',
-        'prose-h3:text-sm prose-h3:mt-4 prose-h3:mb-1',
-        // Body text
-        'prose-p:text-text-secondary prose-p:text-sm prose-p:leading-relaxed',
-        // Code
-        'prose-code:text-primary prose-code:bg-surface-highlight prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-xs prose-code:font-mono prose-code:before:content-none prose-code:after:content-none',
-        'prose-pre:bg-background/60 prose-pre:border prose-pre:border-border/30 prose-pre:rounded-lg prose-pre:text-xs',
-        // Links
-        'prose-a:text-primary prose-a:no-underline hover:prose-a:underline',
-        // Lists
-        'prose-li:text-text-secondary prose-li:text-sm prose-li:marker:text-text-muted',
-        'prose-ul:my-2 prose-ol:my-2',
-        // Strong / emphasis
-        'prose-strong:text-text-primary',
-        'prose-em:text-text-secondary',
-        // Blockquotes
-        'prose-blockquote:border-primary/40 prose-blockquote:text-text-muted prose-blockquote:not-italic',
-        // Tables
-        'prose-th:text-text-primary prose-th:text-xs prose-th:uppercase prose-th:tracking-wider prose-th:font-medium',
-        'prose-td:text-text-secondary prose-td:text-sm',
-        // Horizontal rules
-        'prose-hr:border-border/30',
-      )}
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
-  );
-}
-
 // --- SplitPaneHandle ---
 
 function SplitPaneHandle({
@@ -472,12 +417,12 @@ export function SkillEditor({
       setAllowedTools(skill.allowedTools ?? '');
       setCriteria(
         (skill.acceptanceCriteria ?? []).map((c) => {
-          const m = c.match(/GIVEN\s+(.+?)\s+WHEN\s+(.+?)\s+THEN\s+(.+)/i);
+          const parsed = parseAcceptanceCriterion(c);
           return {
             id: ++idCounter.current,
-            given: m?.[1] ?? c,
-            when: m?.[2] ?? '',
-            then: m?.[3] ?? '',
+            given: parsed.given,
+            when: parsed.when,
+            then: parsed.then,
           };
         }),
       );

--- a/web/src/components/registry/SkillFileTree.tsx
+++ b/web/src/components/registry/SkillFileTree.tsx
@@ -15,9 +15,12 @@ import type { SkillFile } from '../../types';
 interface SkillFileTreeProps {
   skillName: string;
   onSelectFile?: (path: string, content: string) => void;
+  /** Hide the write affordances (add file, delete file) for read-only surfaces
+   *  like the Library inspector. Defaults to false (full editor behavior). */
+  readOnly?: boolean;
 }
 
-export function SkillFileTree({ skillName, onSelectFile }: SkillFileTreeProps) {
+export function SkillFileTree({ skillName, onSelectFile, readOnly = false }: SkillFileTreeProps) {
   const [files, setFiles] = useState<SkillFile[]>([]);
   const [loading, setLoading] = useState(false);
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set(['scripts', 'references', 'assets']));
@@ -79,16 +82,18 @@ export function SkillFileTree({ skillName, onSelectFile }: SkillFileTreeProps) {
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-1.5">
         <span className="text-[10px] text-text-muted uppercase tracking-wider">Files</span>
-        <button
-          onClick={() => setShowNewFile(!showNewFile)}
-          className="text-[10px] text-primary hover:text-primary/80 flex items-center gap-0.5 transition-colors"
-        >
-          <Plus size={10} /> Add
-        </button>
+        {!readOnly && (
+          <button
+            onClick={() => setShowNewFile(!showNewFile)}
+            className="text-[10px] text-primary hover:text-primary/80 flex items-center gap-0.5 transition-colors"
+          >
+            <Plus size={10} /> Add
+          </button>
+        )}
       </div>
 
       {/* New file input */}
-      {showNewFile && (
+      {!readOnly && showNewFile && (
         <div className="px-3 pb-2 flex items-center gap-1.5">
           <input
             value={newFilePath}
@@ -139,14 +144,16 @@ export function SkillFileTree({ skillName, onSelectFile }: SkillFileTreeProps) {
                       <span className="text-[10px] text-text-muted font-mono">
                         {formatFileSize(file.size)}
                       </span>
-                      <button
-                        type="button"
-                        onClick={() => handleDeleteFile(file.path)}
-                        title="Delete file"
-                        className="opacity-0 group-hover:opacity-100 p-1.5 rounded text-text-muted hover:text-status-error hover:bg-status-error/10 focus:outline-none focus:ring-2 focus:ring-status-error/30 focus:opacity-100 transition-all"
-                      >
-                        <Trash2 size={10} />
-                      </button>
+                      {!readOnly && (
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteFile(file.path)}
+                          title="Delete file"
+                          className="opacity-0 group-hover:opacity-100 p-1.5 rounded text-text-muted hover:text-status-error hover:bg-status-error/10 focus:outline-none focus:ring-2 focus:ring-status-error/30 focus:opacity-100 transition-all"
+                        >
+                          <Trash2 size={10} />
+                        </button>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/web/src/components/workspaces/LibraryWorkspace.tsx
+++ b/web/src/components/workspaces/LibraryWorkspace.tsx
@@ -13,6 +13,7 @@ import { PopoutButton } from '../ui/PopoutButton';
 import { SkillEditor } from '../registry/SkillEditor';
 import { SkillCardSkeleton } from '../registry/SkillCardSkeleton';
 import { LibraryGrid, type GroupMode } from '../registry/LibraryGrid';
+import { SkillDetailPanel } from '../registry/SkillDetailPanel';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { showToast } from '../ui/Toast';
 import { useFuzzySearch } from '../../hooks/useFuzzySearch';
@@ -154,6 +155,22 @@ export function LibraryWorkspace() {
     );
   }, [setSearchParams]);
 
+  // Inspector selection — the skill shown in the right-rail SkillDetailPanel.
+  // URL-synced as ?selected=<name> (replace history) so reload and deep-links
+  // restore it; kept distinct from /library/:skillName, which opens the editor.
+  const selectedName = searchParams.get('selected');
+  const setSelectedName = useCallback((name: string | null) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (name) next.set('selected', name);
+        else next.delete('selected');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
   // Editor + delete confirm state
   const [showEditor, setShowEditor] = useState(false);
   const [editingSkill, setEditingSkill] = useState<AgentSkill | undefined>();
@@ -193,6 +210,20 @@ export function LibraryWorkspace() {
       navigate({ pathname: '/library', search: searchParams.toString() }, { replace: true });
     }
   }, [navigate, searchParams, skillName]);
+
+  // Esc closes the inspector — but only when no modal is open and focus isn't in
+  // a text input (the search box keeps its own clear affordance).
+  useEffect(() => {
+    if (!selectedName) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || showEditor) return;
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+      setSelectedName(null);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [selectedName, showEditor, setSelectedName]);
 
   const refreshRegistry = useCallback(async () => {
     try {
@@ -245,12 +276,15 @@ export function LibraryWorkspace() {
       await deleteRegistrySkill(confirmDelete);
       showToast('success', 'Skill deleted');
       refreshRegistry();
+      // Drop the inspector selection if it pointed at the deleted skill, so the
+      // URL doesn't carry a dead ?selected= param.
+      if (confirmDelete === selectedName) setSelectedName(null);
     } catch (err) {
       showToast('error', err instanceof Error ? err.message : 'Delete failed');
     } finally {
       setConfirmDelete(null);
     }
-  }, [confirmDelete, refreshRegistry]);
+  }, [confirmDelete, refreshRegistry, selectedName, setSelectedName]);
 
   const handleNewSkill = useCallback(() => {
     setEditingSkill(undefined);
@@ -323,9 +357,44 @@ export function LibraryWorkspace() {
     return info ? `${info.owner}/${info.repo}` : activeSource;
   }, [activeSource, sources]);
 
+  // Inspector state, derived from the in-store skills (no per-skill fetch). An
+  // unknown ?selected= simply yields null → the panel's empty state.
+  const selectedSkillObj = useMemo(
+    () => (selectedName ? (skills ?? []).find((s) => s.name === selectedName) ?? null : null),
+    [selectedName, skills],
+  );
+
+  // Other skills sharing the selected skill's top-level category, for the
+  // inspector's "Related skills" list.
+  const relatedSkills = useMemo(() => {
+    if (!selectedSkillObj?.dir) return [];
+    const key = selectedSkillObj.dir.split('/')[0];
+    return (skills ?? []).filter(
+      (s) => s.name !== selectedSkillObj.name && s.dir?.split('/')[0] === key,
+    );
+  }, [selectedSkillObj, skills]);
+
+  const inspector = (
+    <SkillDetailPanel
+      skill={selectedSkillObj}
+      source={selectedSkillObj ? sourceMap.get(selectedSkillObj.name) : undefined}
+      relatedSkills={relatedSkills}
+      onClose={() => setSelectedName(null)}
+      onEdit={(s) => { setEditingSkill(s); setShowEditor(true); }}
+      onToggle={(s) => (s.state === 'active' ? handleDisable(s) : handleEnable(s))}
+      onDelete={(s) => setConfirmDelete(s.name)}
+      onSelectRelated={(name) => setSelectedName(name)}
+    />
+  );
+
   return (
     <div className="absolute inset-0 flex flex-col bg-background text-text-primary overflow-hidden">
-      <WorkspaceShell workspace="library" defaultLeftPct={0} defaultRightPct={0}>
+      <WorkspaceShell
+        workspace="library"
+        defaultRightPct={30}
+        minRightPx={300}
+        right={inspector}
+      >
         <main className="flex flex-col h-full overflow-hidden">
           <LibraryHeader
             onNewSkill={handleNewSkill}
@@ -463,6 +532,8 @@ export function LibraryWorkspace() {
                 onDisable={handleDisable}
                 onEdit={(s) => { setEditingSkill(s); setShowEditor(true); }}
                 onDelete={(s) => setConfirmDelete(s.name)}
+                onSelect={(s) => setSelectedName(s.name)}
+                activeSkillName={selectedName}
               />
             )}
           </div>

--- a/web/src/lib/skillCriteria.ts
+++ b/web/src/lib/skillCriteria.ts
@@ -1,0 +1,29 @@
+// Parsing for the gridctl "GIVEN … WHEN … THEN …" acceptance-criteria strings
+// carried on AgentSkill.acceptanceCriteria. Shared by the SkillEditor (which
+// splits criteria into editable fields) and the Library inspector (which
+// renders them read-only).
+
+export interface ParsedCriterion {
+  given: string;
+  when: string;
+  then: string;
+  /** True when the string matched the GIVEN/WHEN/THEN shape. */
+  matched: boolean;
+  /** The original, unparsed string. */
+  raw: string;
+}
+
+const CRITERION_RE = /GIVEN\s+(.+?)\s+WHEN\s+(.+?)\s+THEN\s+(.+)/i;
+
+/**
+ * Split a "GIVEN … WHEN … THEN …" criterion into its three parts. When the
+ * string doesn't match the shape, `given` falls back to the raw string (so the
+ * editor still shows the text) and `matched` is false.
+ */
+export function parseAcceptanceCriterion(raw: string): ParsedCriterion {
+  const m = raw.match(CRITERION_RE);
+  if (m) {
+    return { given: m[1], when: m[2], then: m[3], matched: true, raw };
+  }
+  return { given: raw, when: '', then: '', matched: false, raw };
+}

--- a/web/src/lib/text.ts
+++ b/web/src/lib/text.ts
@@ -1,0 +1,9 @@
+// Small string-formatting helpers shared across the UI.
+
+/**
+ * Turn a kebab/lower key into a Title-Cased label, e.g.
+ * `git-workflow` → `Git Workflow`.
+ */
+export function toTitleCase(key: string): string {
+  return key.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}


### PR DESCRIPTION
## Description

Adds a read-first, tabbed inspector pane to the Skills Library, replacing the modal-only read path. Selecting a skill card opens a persistent right-rail inspector (Overview / Instructions / Files); an Edit button promotes to the existing editor modal for mutation. This mirrors the master-detail pattern the Tools workspace established in #713–#717 and eliminates the open/close "pogo-stick" of reading skills via a modal.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- New `SkillDetailPanel` — tabbed inspector (Overview / Instructions / Files) with a persistent header (state badge, source pill, Edit/toggle/delete), reusing the shared inspector kit.
- Card-body selection threaded through `LibraryGrid` → `SkillCard` with an `aria-current` active accent; footer actions never trigger selection.
- Selection is URL-synced as `?selected=<name>` (restored on reload), kept distinct from `/library/:skillName` which opens the editor. `Esc`/close clear it; the `[`/`]` rail toggle still works.
- Reads the full skill (incl. body) from the registry store — no backend change and no per-skill fetch; only the Files tab lazily lists files.
- Supporting refactors (behavior-preserving): extracted a shared `MarkdownPreview`, a `GIVEN/WHEN/THEN` criteria parser, and `toTitleCase`; added a `readOnly` mode to `SkillFileTree`; added an optional tab `id` + roving `tabIndex` to the inspector tab kit.

## Testing

- `npm run build` (tsc + vite) passes.
- Full web suite green (773 tests), including a new `SkillDetailPanel` suite and added `LibraryWorkspace` selection/URL cases.
- Tab panels carry `role="tabpanel"` + `aria-labelledby`; Left/Right arrows move between tabs.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #721