### PR TITLE
feat: differentiate skill cards with category and metadata

### DIFF
--- a/web/src/__tests__/SkillCard.test.tsx
+++ b/web/src/__tests__/SkillCard.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import { SkillCard } from '../components/registry/SkillCard';
+import type { AgentSkill, SkillSourceStatus } from '../types';
+
+beforeEach(() => {
+  cleanup();
+});
+
+function skill(overrides: Partial<AgentSkill> = {}): AgentSkill {
+  return {
+    name: 'branch-fork',
+    description: 'Create a feature branch',
+    state: 'active',
+    dir: 'git-workflow/branch-fork',
+    body: '',
+    fileCount: 3,
+    acceptanceCriteria: ['a', 'b', 'c', 'd'],
+    ...overrides,
+  } as AgentSkill;
+}
+
+const noop = () => {};
+
+function renderCard(s: AgentSkill, source?: SkillSourceStatus) {
+  return render(
+    <SkillCard
+      skill={s}
+      onEnable={noop}
+      onDisable={noop}
+      onEdit={noop}
+      onDelete={noop}
+      source={source}
+    />,
+  );
+}
+
+describe('SkillCard', () => {
+  it('shows a category label and metadata line for a skill with files and criteria', () => {
+    renderCard(skill());
+    // Category renders title-cased text (CSS uppercases it visually).
+    expect(screen.getByText('Git Workflow')).toBeInTheDocument();
+    expect(screen.getByText('3 files · 4 criteria')).toBeInTheDocument();
+  });
+
+  it('omits file/criteria segments when there are none, leaving an empty slot', () => {
+    renderCard(skill({ fileCount: 0, acceptanceCriteria: [] }));
+    expect(screen.queryByText(/\d+\s+files?/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/criteri/)).not.toBeInTheDocument();
+    // The fixed-height metadata slot is still present (only the category text).
+    const meta = screen.getByTestId('skill-meta');
+    expect(meta).toBeInTheDocument();
+    expect(meta).toHaveTextContent('Git Workflow');
+  });
+
+  it('renders a completely empty metadata slot for a skill with no category or summary', () => {
+    renderCard(skill({ dir: undefined, fileCount: 0, acceptanceCriteria: [] }));
+    expect(screen.queryByText('Git Workflow')).not.toBeInTheDocument();
+    // Slot still exists (reserves card height) but carries no visible text.
+    expect(screen.getByTestId('skill-meta').textContent).toBe('');
+  });
+
+  it('omits the category when the skill has no dir', () => {
+    renderCard(skill({ dir: undefined }));
+    expect(screen.queryByText('Git Workflow')).not.toBeInTheDocument();
+    // Summary still renders.
+    expect(screen.getByText('3 files · 4 criteria')).toBeInTheDocument();
+  });
+
+  it('keeps the StateBadge rendered in the header', () => {
+    renderCard(skill({ state: 'draft' }));
+    expect(screen.getByText('draft')).toBeInTheDocument();
+  });
+
+  it('still renders the #719 imported-source icon when a source is provided', () => {
+    const source: SkillSourceStatus = {
+      name: 'acme-skills',
+      repo: 'acme/skills',
+      autoUpdate: false,
+      updateInterval: '',
+      updateAvailable: false,
+      skills: [],
+    };
+    renderCard(skill(), source);
+    expect(screen.getByLabelText('Imported from acme/skills')).toBeInTheDocument();
+    // State badge remains alongside it.
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('uses singular nouns for a count of one', () => {
+    renderCard(skill({ fileCount: 1, acceptanceCriteria: ['only'] }));
+    const meta = screen.getByTestId('skill-meta');
+    expect(within(meta).getByText('1 file · 1 criterion')).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/skillMeta.test.ts
+++ b/web/src/__tests__/skillMeta.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { skillCategory, skillMetaSummary } from '../lib/skillMeta';
+import type { AgentSkill } from '../types';
+
+function skill(overrides: Partial<AgentSkill> = {}): AgentSkill {
+  return {
+    name: 'test-skill',
+    description: '',
+    state: 'active',
+    dir: 'git-workflow/branch-fork',
+    body: '',
+    fileCount: 0,
+    ...overrides,
+  } as AgentSkill;
+}
+
+describe('skillCategory', () => {
+  it('returns the top-level dir segment', () => {
+    expect(skillCategory('git-workflow/branch-fork')).toBe('git-workflow');
+  });
+
+  it('returns the whole value when there is no nesting', () => {
+    expect(skillCategory('ops')).toBe('ops');
+  });
+
+  it('returns "" for an absent or empty dir (matching the old getGroupKey)', () => {
+    expect(skillCategory(undefined)).toBe('');
+    expect(skillCategory('')).toBe('');
+  });
+});
+
+describe('skillMetaSummary', () => {
+  it('includes pluralized file and criteria counts', () => {
+    expect(
+      skillMetaSummary(skill({ fileCount: 3, acceptanceCriteria: ['a', 'b', 'c', 'd'] })),
+    ).toEqual(['3 files', '4 criteria']);
+  });
+
+  it('uses singular forms for a count of one', () => {
+    expect(
+      skillMetaSummary(skill({ fileCount: 1, acceptanceCriteria: ['only'] })),
+    ).toEqual(['1 file', '1 criterion']);
+  });
+
+  it('omits zero or absent files and criteria rather than showing "0"', () => {
+    expect(skillMetaSummary(skill({ fileCount: 0 }))).toEqual([]);
+    expect(skillMetaSummary(skill({ fileCount: 0, acceptanceCriteria: [] }))).toEqual([]);
+  });
+
+  it('appends license and compatibility only when present', () => {
+    expect(
+      skillMetaSummary(skill({ fileCount: 2, license: 'MIT', compatibility: 'Opus 4.7+' })),
+    ).toEqual(['2 files', 'MIT', 'Opus 4.7+']);
+  });
+});

--- a/web/src/components/registry/LibraryGrid.tsx
+++ b/web/src/components/registry/LibraryGrid.tsx
@@ -3,19 +3,15 @@ import { cn } from '../../lib/cn';
 import { toTitleCase } from '../../lib/text';
 import { SkillCard } from './SkillCard';
 import { SourceGroupHeader } from './SourceGroupHeader';
+import { skillCategory } from '../../lib/skillMeta';
 import type { AgentSkill, SkillSourceStatus } from '../../types';
 
 export type GroupMode = 'source' | 'category' | 'none';
 
-function getGroupKey(dir?: string): string {
-  if (!dir) return '';
-  return dir.split('/')[0];
-}
-
 function groupSkills(skills: AgentSkill[]): Map<string, AgentSkill[]> {
   const groups = new Map<string, AgentSkill[]>();
   for (const skill of skills) {
-    const key = getGroupKey(skill.dir);
+    const key = skillCategory(skill.dir);
     if (!groups.has(key)) groups.set(key, []);
     groups.get(key)!.push(skill);
   }

--- a/web/src/components/registry/SkillCard.tsx
+++ b/web/src/components/registry/SkillCard.tsx
@@ -3,6 +3,8 @@ import { BookOpen, GitBranch } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { StateBadge } from './StateBadge';
 import { SkillActions } from './SkillActions';
+import { skillCategory, skillMetaSummary } from '../../lib/skillMeta';
+import { toTitleCase } from '../../lib/text';
 import type { AgentSkill, SkillSourceStatus } from '../../types';
 
 export interface SkillCardProps {
@@ -39,6 +41,10 @@ export const SkillCard = memo(({
     else onEnable(s);
   };
 
+  // Scannability signals, both derived from fields the skill already carries.
+  const category = skillCategory(skill.dir);
+  const metaSummary = skillMetaSummary(skill).join(' · ');
+
   return (
     <div
       style={style}
@@ -58,6 +64,11 @@ export const SkillCard = memo(({
         'via-white/10 group-hover:via-primary/40 group-focus-within:via-primary/40',
         isActive && 'via-primary/50',
       )} />
+
+      {/* Left accent — a single neutral, static anchor for cross-card scanning.
+          Category-agnostic (not a per-category color), conveyed only as visual
+          rhythm; the category itself reads as text in the metadata line. */}
+      <div aria-hidden="true" className="absolute top-0 bottom-0 left-0 w-0.5 bg-white/10" />
 
       {/* Card body — clickable to open the inspector */}
       <div
@@ -104,6 +115,26 @@ export const SkillCard = memo(({
         )}>
           {skill.description || 'No description'}
         </p>
+
+        {/* Metadata line: category + weight summary, drawn only from existing
+            fields. Fixed height (h-4) keeps every card the same height and
+            reserves the trailing slot for a future validation chip — no
+            reflow when one lands. Empty when a skill has no category or
+            summary. */}
+        <div
+          data-testid="skill-meta"
+          className="flex items-center gap-1.5 h-4 min-w-0 log-text-detail text-text-muted"
+        >
+          {category && (
+            <span className="uppercase tracking-wider font-medium flex-shrink-0">
+              {toTitleCase(category)}
+            </span>
+          )}
+          {category && metaSummary && (
+            <span aria-hidden="true" className="text-text-muted/40">·</span>
+          )}
+          {metaSummary && <span className="truncate min-w-0">{metaSummary}</span>}
+        </div>
       </div>
 
       {/* Footer: actions */}

--- a/web/src/lib/skillMeta.ts
+++ b/web/src/lib/skillMeta.ts
@@ -1,0 +1,42 @@
+// Derivations shared by the Library card grid and (later) the table view: the
+// top-level category from a skill's `dir`, and a compact "weight" summary
+// (files / criteria / license / compatibility) built only from fields the
+// registry list payload already carries — no extra fetch.
+
+import type { AgentSkill } from '../types';
+
+/**
+ * Top-level category for a skill, taken from the first segment of its `dir`
+ * (e.g. "git-workflow/branch-fork" → "git-workflow"). Returns "" when `dir` is
+ * absent or empty. Single source of truth for "category from dir", shared by
+ * the card and by LibraryGrid's category grouping.
+ */
+export function skillCategory(dir?: string): string {
+  if (!dir) return '';
+  return dir.split('/')[0];
+}
+
+/**
+ * Ordered, human-readable metadata segments for a skill, excluding the
+ * category. Each present, non-zero field becomes one segment; absent or
+ * zero-valued fields are omitted so a card never shows "0 files". Returns an
+ * array (not a joined string) so callers pick their own separator and a future
+ * table view can consume the segments individually.
+ */
+export function skillMetaSummary(skill: AgentSkill): string[] {
+  const segments: string[] = [];
+
+  if (skill.fileCount > 0) {
+    segments.push(`${skill.fileCount} ${skill.fileCount === 1 ? 'file' : 'files'}`);
+  }
+
+  const criteria = skill.acceptanceCriteria?.length ?? 0;
+  if (criteria > 0) {
+    segments.push(`${criteria} ${criteria === 1 ? 'criterion' : 'criteria'}`);
+  }
+
+  if (skill.license) segments.push(skill.license);
+  if (skill.compatibility) segments.push(skill.compatibility);
+
+  return segments;
+}


### PR DESCRIPTION
## Description

Makes the Skills Library grid scannable by adding a category label and a secondary metadata line to each card, drawn only from fields the skill already carries. No new data or fetch. Builds alongside the #719 provenance origin badge.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- New `web/src/lib/skillMeta.ts`: `skillCategory(dir)` (top-level category) and `skillMetaSummary(skill)` (files/criteria/license/compatibility segments, pluralized, zero/absent omitted) — shared derivations a future table view can reuse.
- `SkillCard.tsx`: a fixed-height metadata line below the description (`Category · 3 files · 4 criteria`) plus a single neutral left accent bar. Capped at 3 indicators (state badge, source icon, metadata line); category folds into the line rather than adding a fourth badge.
- `LibraryGrid.tsx`: routes category grouping through the shared `skillCategory`, removing the duplicate local helper. Grouping behavior unchanged.
- Category accent is a single neutral color (no per-category palette); category and counts read as text, not color alone.
- The metadata line reserves a fixed-height trailing slot so a future validation/test chip can land without reflow.

## Testing

- `npm run test` — full suite passes (787). New `skillMeta.test.ts` (derivations) and `SkillCard.test.tsx` (category label, metadata line, omission, empty slot, no-dir, state badge, source icon, singular nouns).
- `npm run build` clean; changed files lint clean.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #723