### PR TITLE
feat: add Grok Build as a supported client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to gridctl will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Grok Build client support.** `gridctl link grok` / `gridctl unlink grok`
+  now manage the gateway entry in xAI Grok Build's `~/.grok/config.toml`,
+  writing an `[mcp_servers.<name>]` table over native streamable HTTP. It is
+  auto-detected by the interactive `link` and `--all` flows and appears in the
+  web UI client list. This is gridctl's first TOML-based client provisioner.
+
 ### Removed
 
 - **Agent runtime surface removed.** gridctl 0.1.x retires the typed-skill

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ gridctl link claude       # Link a specific client
 gridctl link --all        # Link all detected clients at once
 ```
 
-Supported clients: Claude Desktop, Claude Code, Cursor, Windsurf, VS Code, Gemini, OpenCode, Continue, Cline, AnythingLLM, Roo, Zed, Goose
+Supported clients: Claude Desktop, Claude Code, Cursor, Windsurf, VS Code, Gemini, OpenCode, Grok Build, Continue, Cline, AnythingLLM, Roo, Zed, Goose
 
 <details>
 <summary>Manual configuration</summary>

--- a/cmd/gridctl/link.go
+++ b/cmd/gridctl/link.go
@@ -30,7 +30,7 @@ var linkCmd = &cobra.Command{
 Without arguments, detects installed LLM clients and presents a selection list.
 With a client name, links that specific client directly.
 
-Supported clients: claude, claude-code, cursor, windsurf, vscode, gemini, opencode, continue, cline, anythingllm, roo, zed, goose`,
+Supported clients: claude, claude-code, cursor, windsurf, vscode, gemini, opencode, grok, continue, cline, anythingllm, roo, zed, goose`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var client string

--- a/cmd/gridctl/unlink.go
+++ b/cmd/gridctl/unlink.go
@@ -27,7 +27,7 @@ var unlinkCmd = &cobra.Command{
 Without arguments, detects linked clients and presents a selection.
 With a client name, unlinks that specific client directly.
 
-Supported clients: claude, claude-code, cursor, windsurf, vscode, gemini, opencode, continue, cline, anythingllm, roo, zed, goose`,
+Supported clients: claude, claude-code, cursor, windsurf, vscode, gemini, opencode, grok, continue, cline, anythingllm, roo, zed, goose`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var client string

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.7.10
 	github.com/mattn/go-isatty v0.0.22
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tailscale/hujson v0.0.0-20250605163823-992244df8c5a

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
+github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=

--- a/pkg/provisioner/common.go
+++ b/pkg/provisioner/common.go
@@ -125,8 +125,10 @@ func (p *mcpServersProvisioner) Unlink(configPath string, serverName string) err
 	return writeJSONFile(configPath, data)
 }
 
-// HasComments checks if a config file contains JSONC comments that would be
-// lost on write. Returns false if the file doesn't exist.
+// HasComments checks if a config file contains comments that would be lost on
+// write. The comment syntax depends on the file format: TOML and YAML use '#'
+// line comments, while JSON/JSONC uses '//' and '/*'. Returns false if the file
+// doesn't exist.
 func HasComments(configPath string) bool {
 	if !fileExists(configPath) {
 		return false
@@ -135,7 +137,18 @@ func HasComments(configPath string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.Contains(string(raw), "//") || strings.Contains(string(raw), "/*")
+	switch strings.ToLower(filepath.Ext(configPath)) {
+	case ".toml", ".yaml", ".yml":
+		// '#' line comments. Avoids false positives on '//' inside URLs.
+		for _, line := range strings.Split(string(raw), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "#") {
+				return true
+			}
+		}
+		return false
+	default:
+		return strings.Contains(string(raw), "//") || strings.Contains(string(raw), "/*")
+	}
 }
 
 // DryRunDiff returns the before/after config for a dry run.
@@ -150,6 +163,18 @@ func DryRunDiff(configPath string, prov ClientProvisioner, opts LinkOptions) (be
 		dataCopy := deepCopyMap(data)
 		simulateLink(dataCopy, prov, opts)
 		after = formatYAML(dataCopy)
+		return before, after, nil
+	}
+
+	if isTOMLProvisioner(prov) {
+		data, err := readOrCreateTOMLFile(configPath)
+		if err != nil {
+			return "", "", err
+		}
+		before = formatTOML(data)
+		dataCopy := deepCopyMap(data)
+		simulateLink(dataCopy, prov, opts)
+		after = formatTOML(dataCopy)
 		return before, after, nil
 	}
 
@@ -168,6 +193,12 @@ func DryRunDiff(configPath string, prov ClientProvisioner, opts LinkOptions) (be
 // isYAMLProvisioner returns true if the provisioner uses YAML config format.
 func isYAMLProvisioner(prov ClientProvisioner) bool {
 	_, ok := prov.(*Goose)
+	return ok
+}
+
+// isTOMLProvisioner returns true if the provisioner uses TOML config format.
+func isTOMLProvisioner(prov ClientProvisioner) bool {
+	_, ok := prov.(*GrokBuild)
 	return ok
 }
 
@@ -197,6 +228,10 @@ func simulateLink(data map[string]any, prov ClientProvisioner, opts LinkOptions)
 		extensions := getOrCreateMap(data, "extensions")
 		extensions[opts.ServerName] = p.buildEntry(opts)
 		data["extensions"] = extensions
+	case *GrokBuild:
+		servers := getOrCreateMap(data, "mcp_servers")
+		servers[opts.ServerName] = p.buildEntry(opts)
+		data["mcp_servers"] = servers
 	default:
 		if mp, ok := getProvisionerBase(prov); ok {
 			servers := getOrCreateMap(data, "mcpServers")

--- a/pkg/provisioner/grok.go
+++ b/pkg/provisioner/grok.go
@@ -1,0 +1,140 @@
+package provisioner
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+)
+
+// GrokBuild provisions the Grok Build (xAI `grok` CLI) MCP config.
+// Transport: native streamable HTTP (no bridge needed).
+// Uses TOML format with an "mcp_servers" table keyed by server name.
+type GrokBuild struct {
+	name  string
+	slug  string
+	paths map[string]string
+}
+
+var _ ClientProvisioner = (*GrokBuild)(nil)
+
+func newGrokBuild() *GrokBuild {
+	return &GrokBuild{
+		name: "Grok Build",
+		slug: "grok",
+		paths: map[string]string{
+			"darwin":  "~/.grok/config.toml",
+			"linux":   "~/.grok/config.toml",
+			"windows": "%USERPROFILE%\\.grok\\config.toml",
+		},
+	}
+}
+
+func (g *GrokBuild) Name() string      { return g.name }
+func (g *GrokBuild) Slug() string      { return g.slug }
+func (g *GrokBuild) NeedsBridge() bool { return false }
+
+func (g *GrokBuild) Detect() (string, bool) {
+	path := configPathForPlatform(g.paths)
+	if path == "" {
+		return "", false
+	}
+	if fileExists(path) {
+		return path, true
+	}
+	// Check if ~/.grok/ exists (CLI installed but no config yet).
+	if dirExists(filepath.Dir(path)) {
+		return path, true
+	}
+	return "", false
+}
+
+func (g *GrokBuild) buildEntry(opts LinkOptions) map[string]any {
+	url := opts.GatewayURL
+	if opts.Port > 0 {
+		url = GatewayHTTPURL(opts.Port)
+	}
+	return map[string]any{
+		"url":     url,
+		"type":    "http",
+		"enabled": true,
+	}
+}
+
+func (g *GrokBuild) IsLinked(configPath string, serverName string) (bool, error) {
+	if !fileExists(configPath) {
+		return false, nil
+	}
+	data, err := readTOMLFile(configPath)
+	if err != nil {
+		return false, err
+	}
+	servers := getMap(data, "mcp_servers")
+	if servers == nil {
+		return false, nil
+	}
+	_, exists := servers[serverName]
+	return exists, nil
+}
+
+func (g *GrokBuild) Link(configPath string, opts LinkOptions) error {
+	data, err := readOrCreateTOMLFile(configPath)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+
+	servers := getOrCreateMap(data, "mcp_servers")
+	entry := g.buildEntry(opts)
+
+	existing, exists := servers[opts.ServerName]
+	if exists && !opts.Force {
+		existingMap, ok := toStringMap(existing)
+		if ok && reflect.DeepEqual(normalizeMap(existingMap), normalizeMap(entry)) {
+			return ErrAlreadyLinked
+		}
+		if !looksLikeGridctlEntry(existingMap, opts.GatewayURL, false) {
+			return ErrConflict
+		}
+	}
+
+	if opts.DryRun {
+		return nil
+	}
+
+	if _, err := createBackup(configPath); err != nil {
+		return fmt.Errorf("creating backup: %w", err)
+	}
+
+	servers[opts.ServerName] = entry
+	data["mcp_servers"] = servers
+
+	return writeTOMLFile(configPath, data)
+}
+
+func (g *GrokBuild) Unlink(configPath string, serverName string) error {
+	if !fileExists(configPath) {
+		return ErrNotLinked
+	}
+
+	data, err := readTOMLFile(configPath)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+
+	servers := getMap(data, "mcp_servers")
+	if servers == nil {
+		return ErrNotLinked
+	}
+
+	if _, exists := servers[serverName]; !exists {
+		return ErrNotLinked
+	}
+
+	if _, err := createBackup(configPath); err != nil {
+		return fmt.Errorf("creating backup: %w", err)
+	}
+
+	delete(servers, serverName)
+	data["mcp_servers"] = servers
+
+	return writeTOMLFile(configPath, data)
+}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -84,6 +84,7 @@ func NewRegistry() *Registry {
 			newVSCode(),
 			newGeminiCLI(),
 			newOpenCode(),
+			newGrokBuild(),
 			// Tier 2
 			newContinueDev(),
 			newCline(),
@@ -158,7 +159,7 @@ func TransportDescriptionFor(prov ClientProvisioner) string {
 		return "mcp-remote bridge"
 	}
 	switch prov.(type) {
-	case *ClaudeCode, *GeminiCLI, *OpenCode:
+	case *ClaudeCode, *GeminiCLI, *OpenCode, *GrokBuild:
 		return "native HTTP"
 	default:
 		return "native SSE"

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -51,7 +51,7 @@ func TestNewRegistry(t *testing.T) {
 	slugs := r.AllSlugs()
 
 	expected := []string{
-		"claude", "claude-code", "cursor", "windsurf", "vscode", "gemini", "opencode",
+		"claude", "claude-code", "cursor", "windsurf", "vscode", "gemini", "opencode", "grok",
 		"continue", "cline", "anythingllm", "roo", "zed", "goose",
 	}
 	if len(slugs) != len(expected) {
@@ -79,6 +79,7 @@ func TestRegistry_FindBySlug(t *testing.T) {
 		{"vscode", true, "VS Code"},
 		{"gemini", true, "Gemini CLI"},
 		{"opencode", true, "OpenCode"},
+		{"grok", true, "Grok Build"},
 		{"continue", true, "Continue"},
 		{"cline", true, "Cline"},
 		{"anythingllm", true, "AnythingLLM"},
@@ -971,6 +972,7 @@ func TestClientProvisioners_ImplementInterface(t *testing.T) {
 		newVSCode(),
 		newGeminiCLI(),
 		newOpenCode(),
+		newGrokBuild(),
 		newContinueDev(),
 		newCline(),
 		newAnythingLLM(),
@@ -1082,6 +1084,22 @@ func writeTestYAML(t *testing.T, path string, data map[string]any) {
 	t.Helper()
 	if err := writeYAMLFile(path, data); err != nil {
 		t.Fatalf("writing YAML %s: %v", path, err)
+	}
+}
+
+func readTestTOML(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := readTOMLFile(path)
+	if err != nil {
+		t.Fatalf("reading TOML %s: %v", path, err)
+	}
+	return data
+}
+
+func writeTestTOML(t *testing.T, path string, data map[string]any) {
+	t.Helper()
+	if err := writeTOMLFile(path, data); err != nil {
+		t.Fatalf("writing TOML %s: %v", path, err)
 	}
 }
 
@@ -2563,6 +2581,7 @@ func TestTransportDescriptionFor(t *testing.T) {
 		{"Claude Code", newClaudeCode(), "native HTTP"},
 		{"GeminiCLI", newGeminiCLI(), "native HTTP"},
 		{"OpenCode", newOpenCode(), "native HTTP"},
+		{"Grok Build", newGrokBuild(), "native HTTP"},
 		{"VS Code", newVSCode(), "native SSE"},
 		{"Zed", newZed(), "native SSE"},
 		{"Goose", newGoose(), "native SSE"},
@@ -2586,7 +2605,7 @@ func TestNewRegistry_WithNewClients(t *testing.T) {
 	slugs := r.AllSlugs()
 
 	expected := []string{
-		"claude", "claude-code", "cursor", "windsurf", "vscode", "gemini", "opencode",
+		"claude", "claude-code", "cursor", "windsurf", "vscode", "gemini", "opencode", "grok",
 		"continue", "cline", "anythingllm", "roo", "zed", "goose",
 	}
 	if len(slugs) != len(expected) {
@@ -2609,6 +2628,7 @@ func TestRegistry_FindBySlug_NewClients(t *testing.T) {
 	}{
 		{"claude-code", true, "Claude Code"},
 		{"gemini", true, "Gemini CLI"},
+		{"grok", true, "Grok Build"},
 		{"zed", true, "Zed"},
 		{"goose", true, "Goose"},
 	}
@@ -2691,6 +2711,7 @@ func TestNewClientProvisioners_ImplementInterface(t *testing.T) {
 		newClaudeCode(),
 		newGeminiCLI(),
 		newOpenCode(),
+		newGrokBuild(),
 		newZed(),
 		newGoose(),
 	}
@@ -2707,5 +2728,316 @@ func TestNewClientProvisioners_ImplementInterface(t *testing.T) {
 				t.Error("NeedsBridge() should be false for new clients")
 			}
 		})
+	}
+}
+
+// --- Grok Build Tests ---
+
+func grokLinkOpts() LinkOptions {
+	return LinkOptions{
+		GatewayURL: "http://localhost:8180/sse",
+		Port:       8180,
+		ServerName: "gridctl",
+	}
+}
+
+func TestGrokBuild_Link(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	g := newGrokBuild()
+	opts := grokLinkOpts()
+
+	if err := g.Link(configPath, opts); err != nil {
+		t.Fatal(err)
+	}
+
+	data := readTestTOML(t, configPath)
+	servers := data["mcp_servers"].(map[string]any)
+	entry := servers["gridctl"].(map[string]any)
+	if entry["url"] != "http://localhost:8180/mcp" {
+		t.Errorf("expected url=http://localhost:8180/mcp, got %v", entry["url"])
+	}
+	if entry["type"] != "http" {
+		t.Errorf("expected type=http, got %v", entry["type"])
+	}
+	if entry["enabled"] != true {
+		t.Errorf("expected enabled=true, got %v", entry["enabled"])
+	}
+}
+
+func TestGrokBuild_Link_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	g := newGrokBuild()
+	opts := grokLinkOpts()
+
+	if err := g.Link(configPath, opts); err != nil {
+		t.Fatal(err)
+	}
+
+	err := g.Link(configPath, opts)
+	if err != ErrAlreadyLinked {
+		t.Errorf("expected ErrAlreadyLinked, got: %v", err)
+	}
+}
+
+func TestGrokBuild_Link_Conflict(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	writeTestTOML(t, configPath, map[string]any{
+		"mcp_servers": map[string]any{
+			"gridctl": map[string]any{
+				"url":     "https://remote.example.com/mcp",
+				"type":    "http",
+				"enabled": true,
+			},
+		},
+	})
+
+	g := newGrokBuild()
+	opts := grokLinkOpts()
+
+	err := g.Link(configPath, opts)
+	if err != ErrConflict {
+		t.Errorf("expected ErrConflict, got: %v", err)
+	}
+}
+
+func TestGrokBuild_Link_Force(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	writeTestTOML(t, configPath, map[string]any{
+		"mcp_servers": map[string]any{
+			"gridctl": map[string]any{
+				"url":     "https://remote.example.com/mcp",
+				"type":    "http",
+				"enabled": true,
+			},
+		},
+	})
+
+	g := newGrokBuild()
+	opts := grokLinkOpts()
+	opts.Force = true
+
+	if err := g.Link(configPath, opts); err != nil {
+		t.Fatal(err)
+	}
+
+	data := readTestTOML(t, configPath)
+	servers := data["mcp_servers"].(map[string]any)
+	entry := servers["gridctl"].(map[string]any)
+	if entry["url"] != "http://localhost:8180/mcp" {
+		t.Errorf("expected url after force, got %v", entry["url"])
+	}
+}
+
+func TestGrokBuild_Link_PreservesOtherConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	writeTestTOML(t, configPath, map[string]any{
+		"ui": map[string]any{
+			"yolo": false,
+		},
+		"mcp_servers": map[string]any{
+			"other": map[string]any{
+				"url":     "https://other.example.com/mcp",
+				"type":    "http",
+				"enabled": true,
+			},
+		},
+	})
+
+	g := newGrokBuild()
+	if err := g.Link(configPath, grokLinkOpts()); err != nil {
+		t.Fatal(err)
+	}
+
+	data := readTestTOML(t, configPath)
+	if _, ok := data["ui"]; !ok {
+		t.Error("top-level [ui] table should be preserved")
+	}
+	servers := data["mcp_servers"].(map[string]any)
+	if _, ok := servers["other"]; !ok {
+		t.Error("existing mcp_servers entry should be preserved")
+	}
+	if _, ok := servers["gridctl"]; !ok {
+		t.Error("gridctl entry should be added")
+	}
+}
+
+func TestGrokBuild_Unlink(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	writeTestTOML(t, configPath, map[string]any{
+		"mcp_servers": map[string]any{
+			"gridctl": map[string]any{
+				"url":     "http://localhost:8180/mcp",
+				"type":    "http",
+				"enabled": true,
+			},
+			"other": map[string]any{
+				"url":     "https://other.example.com/mcp",
+				"type":    "http",
+				"enabled": true,
+			},
+		},
+	})
+
+	g := newGrokBuild()
+	if err := g.Unlink(configPath, "gridctl"); err != nil {
+		t.Fatal(err)
+	}
+
+	data := readTestTOML(t, configPath)
+	servers := data["mcp_servers"].(map[string]any)
+	if _, ok := servers["gridctl"]; ok {
+		t.Error("gridctl should have been removed")
+	}
+	if _, ok := servers["other"]; !ok {
+		t.Error("other entry should be preserved")
+	}
+}
+
+func TestGrokBuild_Unlink_NotLinked(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	writeTestTOML(t, configPath, map[string]any{
+		"mcp_servers": map[string]any{},
+	})
+
+	g := newGrokBuild()
+	err := g.Unlink(configPath, "gridctl")
+	if err != ErrNotLinked {
+		t.Errorf("expected ErrNotLinked, got: %v", err)
+	}
+}
+
+func TestGrokBuild_Detect(t *testing.T) {
+	dir := t.TempDir()
+	grokDir := filepath.Join(dir, ".grok")
+	if err := os.MkdirAll(grokDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(grokDir, "config.toml")
+
+	g := newGrokBuild()
+	g.paths = map[string]string{
+		"linux":   configPath,
+		"darwin":  configPath,
+		"windows": configPath,
+	}
+
+	path, found := g.Detect()
+	if !found {
+		t.Error("expected Detect to find Grok Build via directory")
+	}
+	if path != configPath {
+		t.Errorf("expected path %q, got %q", configPath, path)
+	}
+}
+
+func TestGrokBuild_Detect_Negative(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "nope", ".grok", "config.toml")
+
+	g := newGrokBuild()
+	g.paths = map[string]string{
+		"linux":   configPath,
+		"darwin":  configPath,
+		"windows": configPath,
+	}
+
+	_, found := g.Detect()
+	if found {
+		t.Error("expected Detect to not find Grok Build")
+	}
+}
+
+func TestGrokBuild_IsLinked(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	g := newGrokBuild()
+
+	linked, err := g.IsLinked(configPath, "gridctl")
+	if err != nil || linked {
+		t.Errorf("expected not linked, got linked=%v err=%v", linked, err)
+	}
+
+	if err := g.Link(configPath, grokLinkOpts()); err != nil {
+		t.Fatal(err)
+	}
+
+	linked, err = g.IsLinked(configPath, "gridctl")
+	if err != nil || !linked {
+		t.Errorf("expected linked, got linked=%v err=%v", linked, err)
+	}
+}
+
+func TestDryRunDiff_GrokBuild(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	writeTestTOML(t, configPath, map[string]any{})
+
+	g := newGrokBuild()
+	opts := grokLinkOpts()
+
+	before, after, err := DryRunDiff(configPath, g, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(before, "gridctl") {
+		t.Error("before should not contain gridctl")
+	}
+	if !strings.Contains(after, "gridctl") {
+		t.Error("after should contain gridctl")
+	}
+	if !strings.Contains(after, "mcp_servers") {
+		t.Error("after should contain mcp_servers key")
+	}
+	if !strings.Contains(after, "http://localhost:8180/mcp") {
+		t.Error("after should contain the HTTP gateway URL")
+	}
+}
+
+func TestHasComments(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		filename string
+		content  string
+		want     bool
+	}{
+		{"toml url with slashes is not a comment", "config.toml", "url = 'http://localhost:8180/mcp'\n", false},
+		{"toml hash comment", "config.toml", "# a comment\nurl = 'x'\n", true},
+		{"yaml hash comment", "config.yaml", "# note\nkey: val\n", true},
+		{"json line comment", "config.json", "{\n  // c\n  \"a\": 1\n}\n", true},
+		{"json block comment", "config.json", "{ /* c */ \"a\": 1 }\n", true},
+		{"plain json no comment", "config.json", "{\"a\": 1}\n", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, tt.name+"-"+tt.filename)
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if got := HasComments(path); got != tt.want {
+				t.Errorf("HasComments(%s) = %v, want %v", tt.filename, got, tt.want)
+			}
+		})
+	}
+
+	if HasComments(filepath.Join(dir, "does-not-exist.toml")) {
+		t.Error("HasComments on missing file should be false")
 	}
 }

--- a/pkg/provisioner/toml.go
+++ b/pkg/provisioner/toml.go
@@ -1,0 +1,65 @@
+package provisioner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// readTOMLFile reads a TOML file into a map.
+func readTOMLFile(path string) (map[string]any, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var data map[string]any
+	if err := toml.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("parsing TOML: %w", err)
+	}
+	if data == nil {
+		data = make(map[string]any)
+	}
+	return data, nil
+}
+
+// writeTOMLFile atomically writes a map as TOML.
+func writeTOMLFile(path string, data map[string]any) error {
+	out, err := toml.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshaling TOML: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating directory: %w", err)
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, out, 0644); err != nil {
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+
+	return nil
+}
+
+// readOrCreateTOMLFile reads an existing TOML file or returns an empty map.
+func readOrCreateTOMLFile(path string) (map[string]any, error) {
+	if fileExists(path) {
+		return readTOMLFile(path)
+	}
+	return make(map[string]any), nil
+}
+
+// formatTOML returns a TOML string for display purposes.
+func formatTOML(data map[string]any) string {
+	out, err := toml.Marshal(data)
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}


### PR DESCRIPTION
## Description

Adds xAI Grok Build as gridctl's 14th supported MCP client. `gridctl link grok` / `unlink grok` now manage the gateway entry in `~/.grok/config.toml`, and Grok Build is auto-detected by the interactive `link`/`--all` flows and surfaced in the web UI client list. This is the first TOML-based client provisioner.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- New `GrokBuild` provisioner (`pkg/provisioner/grok.go`) writing an `[mcp_servers.<name>]` table over native streamable HTTP, modeled on the standalone Goose provisioner.
- New TOML helper layer (`pkg/provisioner/toml.go`) mirroring the YAML helpers; adds the `github.com/pelletier/go-toml/v2` dependency.
- Wired into the registry, `TransportDescriptionFor` (native HTTP), `simulateLink`, and a TOML branch in `DryRunDiff`. The `/api/clients` endpoint and web UI propagate automatically.
- Made `HasComments` format-aware so the comment-loss warning no longer false-fires on `//` inside config URLs (and now detects YAML/TOML `#` comments).
- Help text, README, and CHANGELOG updated; full test coverage (provisioner round-trip, registry/transport tables, `HasComments`).

## Testing

- `go test -race ./pkg/provisioner/... ./internal/api/... ./cmd/...` passes; `golangci-lint` clean; `go build` and `npm run build` succeed.
- Verified end-to-end against a live grok 0.2.3 install: `grok mcp doctor` connected to the gateway (handshake OK, tools discovered); link, idempotent re-link, and unlink all behaved correctly.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #725