### PR TITLE
feat: add table view and bulk actions to the Skills Library

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -322,6 +322,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/registry/skills", s.handleRegistrySkillsList)
 	mux.HandleFunc("POST /api/registry/skills", s.handleRegistrySkillCreate)
 	mux.HandleFunc("POST /api/registry/skills/validate", s.handleRegistryValidate)
+	mux.HandleFunc("PUT /api/registry/skills/batch", s.handleRegistrySkillsBatch)
 	mux.HandleFunc("GET /api/registry/skills/{name}", s.handleRegistrySkillGet)
 	mux.HandleFunc("PUT /api/registry/skills/{name}", s.handleRegistrySkillPut)
 	mux.HandleFunc("DELETE /api/registry/skills/{name}", s.handleRegistrySkillDelete)

--- a/internal/api/registry.go
+++ b/internal/api/registry.go
@@ -168,6 +168,100 @@ func (s *Server) handleRegistrySkillStateChange(w http.ResponseWriter, name, act
 	writeJSON(w, sk)
 }
 
+// setRegistrySkillsBatchRequest is the wire shape for PUT /api/registry/skills/batch.
+type setRegistrySkillsBatchRequest struct {
+	Skills []batchSkillStateEntry `json:"skills"`
+}
+
+type batchSkillStateEntry struct {
+	Name  string             `json:"name"`
+	State registry.ItemState `json:"state"`
+}
+
+// batchSkillResult reports one skill's applied state in a batch success.
+type batchSkillResult struct {
+	Name  string             `json:"name"`
+	State registry.ItemState `json:"state"`
+}
+
+type setRegistrySkillsBatchResponse struct {
+	Skills []batchSkillResult `json:"skills"`
+}
+
+// handleRegistrySkillsBatch sets the state of MULTIPLE skills in one request,
+// then refreshes the registry router once instead of once per skill.
+//
+// Transaction semantics are all-or-nothing on validation: every entry is
+// checked up front (known skill, and a target state of active or disabled)
+// before any write, so an unknown skill (404) or an invalid state (400) rejects
+// the whole batch with nothing changed. Only active and disabled are accepted
+// (bulk actions enable or disable; they never set draft). The write phase
+// itself is best-effort rather than transactional: a mid-batch SaveSkill
+// failure (500) can leave earlier entries persisted, matching the per-skill
+// endpoint's non-atomic behavior across calls. Unlike the MCP tools batch, the
+// registry store has no external-edit/reload model, so there is no 409 path.
+//
+// PUT /api/registry/skills/batch
+func (s *Server) handleRegistrySkillsBatch(w http.ResponseWriter, r *http.Request) {
+	if s.registryServer == nil {
+		writeJSONError(w, "Registry not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req setRegistrySkillsBatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(req.Skills) == 0 {
+		writeJSONError(w, "Request body must include a non-empty skills array", http.StatusBadRequest)
+		return
+	}
+
+	// Validate and resolve every entry before any write touches disk.
+	store := s.registryServer.Store()
+	updates := make([]*registry.AgentSkill, 0, len(req.Skills))
+	seen := make(map[string]struct{}, len(req.Skills))
+	for _, entry := range req.Skills {
+		if entry.Name == "" {
+			writeJSONError(w, "Each skill entry must include a name", http.StatusBadRequest)
+			return
+		}
+		if _, dup := seen[entry.Name]; dup {
+			writeJSONError(w, "Duplicate skill in batch: "+entry.Name, http.StatusBadRequest)
+			return
+		}
+		seen[entry.Name] = struct{}{}
+
+		if entry.State != registry.StateActive && entry.State != registry.StateDisabled {
+			writeJSONError(w, "Skill "+entry.Name+" has invalid state; must be active or disabled", http.StatusBadRequest)
+			return
+		}
+		sk, err := store.GetSkill(entry.Name)
+		if err != nil {
+			writeJSONError(w, "Skill not found: "+entry.Name, http.StatusNotFound)
+			return
+		}
+		sk.State = entry.State
+		updates = append(updates, sk)
+	}
+
+	// All entries validated; apply the writes, then refresh once.
+	for _, sk := range updates {
+		if err := store.SaveSkill(sk); err != nil {
+			writeJSONError(w, "Failed to update skill "+sk.Name+": "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	s.refreshRegistryRouter()
+
+	resp := setRegistrySkillsBatchResponse{Skills: make([]batchSkillResult, 0, len(updates))}
+	for _, sk := range updates {
+		resp.Skills = append(resp.Skills, batchSkillResult{Name: sk.Name, State: sk.State})
+	}
+	writeJSON(w, resp)
+}
+
 // handleRegistrySkillFileList lists files in a skill directory.
 // GET /api/registry/skills/{name}/files
 func (s *Server) handleRegistrySkillFileList(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/registry_test.go
+++ b/internal/api/registry_test.go
@@ -794,3 +794,98 @@ func TestDetectContentType(t *testing.T) {
 	}
 }
 
+// --- Batch state endpoint ---
+
+// skillsBatchRequest PUTs a batch state-change payload and returns the recorder.
+func skillsBatchRequest(t *testing.T, srv *Server, payload any) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal batch payload: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/registry/skills/batch", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHandleRegistry_SkillsBatch_SetsMultipleStates(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkill(t, regServer, "alpha", registry.StateDraft)
+	seedSkill(t, regServer, "beta", registry.StateActive)
+
+	rec := skillsBatchRequest(t, srv, map[string]any{
+		"skills": []map[string]any{
+			{"name": "alpha", "state": "active"},
+			{"name": "beta", "state": "disabled"},
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp setRegistrySkillsBatchResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(resp.Skills) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(resp.Skills))
+	}
+
+	alpha, _ := regServer.Store().GetSkill("alpha")
+	beta, _ := regServer.Store().GetSkill("beta")
+	if alpha.State != registry.StateActive {
+		t.Errorf("alpha: expected active, got %q", alpha.State)
+	}
+	if beta.State != registry.StateDisabled {
+		t.Errorf("beta: expected disabled, got %q", beta.State)
+	}
+}
+
+func TestHandleRegistry_SkillsBatch_UnknownSkillWritesNothing(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkill(t, regServer, "alpha", registry.StateDraft)
+
+	rec := skillsBatchRequest(t, srv, map[string]any{
+		"skills": []map[string]any{
+			{"name": "alpha", "state": "active"},   // valid on its own
+			{"name": "ghost", "state": "disabled"}, // missing → reject all
+		},
+	})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// All-or-nothing: alpha must be untouched because the batch was rejected.
+	alpha, _ := regServer.Store().GetSkill("alpha")
+	if alpha.State != registry.StateDraft {
+		t.Errorf("alpha must be unchanged after a rejected batch, got %q", alpha.State)
+	}
+}
+
+func TestHandleRegistry_SkillsBatch_InvalidState(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkill(t, regServer, "alpha", registry.StateActive)
+
+	rec := skillsBatchRequest(t, srv, map[string]any{
+		"skills": []map[string]any{
+			{"name": "alpha", "state": "draft"}, // bulk cannot set draft
+		},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	alpha, _ := regServer.Store().GetSkill("alpha")
+	if alpha.State != registry.StateActive {
+		t.Errorf("alpha must be unchanged after a rejected batch, got %q", alpha.State)
+	}
+}
+
+func TestHandleRegistry_SkillsBatch_EmptyArray(t *testing.T) {
+	srv, _ := setupRegistryTestServer(t)
+	rec := skillsBatchRequest(t, srv, map[string]any{"skills": []map[string]any{}})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+

--- a/web/src/__tests__/LibraryWorkspace.test.tsx
+++ b/web/src/__tests__/LibraryWorkspace.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { LibraryWorkspace } from '../components/workspaces/LibraryWorkspace';
 import { useRegistryStore } from '../stores/useRegistryStore';
+import { setRegistrySkillsBatch } from '../lib/api';
 import { showToast } from '../components/ui/Toast';
 import { CommandRegistryProvider } from '../hooks/useCommandRegistry';
 import type { AgentSkill, SkillSourceStatus } from '../types';
@@ -21,6 +22,7 @@ vi.mock('../lib/api', () => ({
   activateRegistrySkill: vi.fn().mockResolvedValue(undefined),
   disableRegistrySkill: vi.fn().mockResolvedValue(undefined),
   deleteRegistrySkill: vi.fn().mockResolvedValue(undefined),
+  setRegistrySkillsBatch: vi.fn().mockResolvedValue({ skills: [] }),
   // Used by SkillFileTree (mounted only on the inspector's Files tab).
   fetchSkillFiles: vi.fn().mockResolvedValue([]),
 }));
@@ -379,6 +381,47 @@ describe('LibraryWorkspace', () => {
         expect(currentSearch).not.toContain('q=');
         expect(currentSearch).not.toContain('filter=');
       });
+    });
+  });
+
+  describe('table view + multi-select', () => {
+    it('toggles to the table view via ?view=table', async () => {
+      let currentSearch = '';
+      renderAt('/library', (s) => { currentSearch = s; });
+      fireEvent.click(screen.getByRole('button', { name: 'Table view' }));
+      await waitFor(() => expect(currentSearch).toContain('view=table'));
+      // The table-only header select-all checkbox is now present.
+      expect(screen.getByRole('checkbox', { name: /select all skills/i })).toBeInTheDocument();
+    });
+
+    it('selecting a card reveals the bulk action bar with a live count', async () => {
+      renderAt('/library?group=none');
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Select incident-triage' }));
+      expect(await screen.findByRole('region', { name: 'Bulk actions' })).toBeInTheDocument();
+      expect(screen.getByText('1 selected')).toBeInTheDocument();
+    });
+
+    it('bulk Enable calls the batch endpoint for the selection', async () => {
+      renderAt('/library?group=none');
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Select draft-summarizer' }));
+      fireEvent.click(await screen.findByRole('button', { name: 'Enable' }));
+      await waitFor(() =>
+        expect(setRegistrySkillsBatch).toHaveBeenCalledWith([{ name: 'draft-summarizer', state: 'active' }]),
+      );
+    });
+
+    it('select-all in the table selects every row', async () => {
+      renderAt('/library?view=table');
+      fireEvent.click(screen.getByRole('checkbox', { name: /select all skills/i }));
+      expect(await screen.findByText('3 selected')).toBeInTheDocument();
+    });
+
+    it('clears the selection with the bulk bar Clear button', async () => {
+      renderAt('/library?group=none');
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Select incident-triage' }));
+      expect(await screen.findByText('1 selected')).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /clear selection/i }));
+      await waitFor(() => expect(screen.queryByRole('region', { name: 'Bulk actions' })).not.toBeInTheDocument());
     });
   });
 });

--- a/web/src/components/registry/LibraryGrid.tsx
+++ b/web/src/components/registry/LibraryGrid.tsx
@@ -50,6 +50,11 @@ export interface LibraryGridProps {
   onSelect?: (skill: AgentSkill) => void;
   /** Name of the skill currently shown in the inspector, for active styling. */
   activeSkillName?: string | null;
+  /** Multi-select set (skill names). Optional so the detached grid renders no
+   *  checkboxes. */
+  selectedNames?: Set<string>;
+  /** Toggle a card's membership in the multi-select set. */
+  onToggleSelect?: (skill: AgentSkill) => void;
 }
 
 /**
@@ -75,8 +80,11 @@ export function LibraryGrid({
   onRefresh,
   onSelect,
   activeSkillName = null,
+  selectedNames,
+  onToggleSelect,
 }: LibraryGridProps) {
   const cardHandlers = { onEnable, onDisable, onEdit, onDelete };
+  const selectionActive = (selectedNames?.size ?? 0) > 0;
 
   const renderCard = (skill: AgentSkill, i: number) => (
     <SkillCard
@@ -85,6 +93,9 @@ export function LibraryGrid({
       source={sourceMap?.get(skill.name)}
       onSelect={onSelect}
       isActive={skill.name === activeSkillName}
+      onToggleSelect={onToggleSelect}
+      selected={selectedNames?.has(skill.name) ?? false}
+      selectionActive={selectionActive}
       className={cn(
         'motion-safe:animate-fade-in-scale',
         skill.metadata?.colspan === '2' ? 'col-span-2' : undefined,

--- a/web/src/components/registry/LibraryTable.tsx
+++ b/web/src/components/registry/LibraryTable.tsx
@@ -1,0 +1,185 @@
+import { Check, GitBranch } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { StateBadge } from './StateBadge';
+import { SkillActions } from './SkillActions';
+import { skillCategory } from '../../lib/skillMeta';
+import { toTitleCase } from '../../lib/text';
+import type { AgentSkill, SkillSourceStatus } from '../../types';
+
+// The sortable column keys. Declared locally (rather than imported from the
+// workspace) so the table has no dependency cycle with its parent; the union
+// matches the workspace's SortMode for the sortable axes.
+export type LibraryTableSort = 'name' | 'state' | 'files';
+
+const SORT_COLUMNS: { key: LibraryTableSort; label: string }[] = [
+  { key: 'state', label: 'State' },
+  { key: 'name', label: 'Name' },
+  { key: 'files', label: 'Files' },
+];
+
+export interface LibraryTableProps {
+  skills: AgentSkill[];
+  sortMode: LibraryTableSort;
+  onSort: (mode: LibraryTableSort) => void;
+  selectedNames: Set<string>;
+  onToggleSelect: (skill: AgentSkill) => void;
+  onSelectAll: () => void;
+  onClearSelection: () => void;
+  allSelected: boolean;
+  someSelected: boolean;
+  onSelect: (skill: AgentSkill) => void;
+  activeSkillName: string | null;
+  sourceMap?: Map<string, SkillSourceStatus>;
+  onEnable: (skill: AgentSkill) => void;
+  onDisable: (skill: AgentSkill) => void;
+  onEdit: (skill: AgentSkill) => void;
+  onDelete: (skill: AgentSkill) => void;
+  compact: boolean;
+}
+
+/**
+ * Power-user table view of the Library. A flat, sortable list (grouping is a
+ * cards-view concept) with a multi-select column. State, Name, and Files
+ * headers drive the shared ?sort axis; the header checkbox selects or clears
+ * all rows with an indeterminate middle state.
+ */
+export function LibraryTable({
+  skills,
+  sortMode,
+  onSort,
+  selectedNames,
+  onToggleSelect,
+  onSelectAll,
+  onClearSelection,
+  allSelected,
+  someSelected,
+  onSelect,
+  activeSkillName,
+  sourceMap,
+  onEnable,
+  onDisable,
+  onEdit,
+  onDelete,
+  compact,
+}: LibraryTableProps) {
+  const handleToggle = (s: AgentSkill) => (s.state === 'active' ? onDisable(s) : onEnable(s));
+  const cellPad = compact ? 'py-1.5' : 'py-2.5';
+  const selectAllChecked = allSelected ? 'true' : someSelected ? 'mixed' : 'false';
+
+  return (
+    <div className="p-4">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b border-border/40">
+            <th scope="col" className="w-8 px-2 py-2 text-left">
+              <button
+                type="button"
+                role="checkbox"
+                aria-checked={selectAllChecked}
+                aria-label={allSelected ? 'Clear selection' : 'Select all skills'}
+                onClick={() => (allSelected ? onClearSelection() : onSelectAll())}
+                className={cn(
+                  'w-4 h-4 rounded border flex items-center justify-center transition-colors',
+                  allSelected || someSelected
+                    ? 'bg-primary/20 border-primary/50 text-primary'
+                    : 'border-border/50 text-transparent hover:border-border',
+                )}
+              >
+                {allSelected ? (
+                  <Check size={11} />
+                ) : someSelected ? (
+                  <span aria-hidden="true" className="w-2 h-px bg-primary" />
+                ) : null}
+              </button>
+            </th>
+            {SORT_COLUMNS.map((col) => (
+              <th key={col.key} scope="col" className="px-2 py-2 text-left">
+                <button
+                  type="button"
+                  onClick={() => onSort(col.key)}
+                  aria-pressed={sortMode === col.key}
+                  className={cn(
+                    'inline-flex items-center gap-1 text-[10px] uppercase tracking-wider font-medium transition-colors',
+                    sortMode === col.key ? 'text-primary' : 'text-text-muted hover:text-text-secondary',
+                  )}
+                >
+                  {col.label}
+                  {sortMode === col.key && <span aria-hidden="true">↓</span>}
+                </button>
+              </th>
+            ))}
+            <th scope="col" className="px-2 py-2 text-left text-[10px] uppercase tracking-wider font-medium text-text-muted">
+              Category
+            </th>
+            <th scope="col" className="px-2 py-2 text-right text-[10px] uppercase tracking-wider font-medium text-text-muted">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {skills.map((skill) => {
+            const isSel = selectedNames.has(skill.name);
+            const src = sourceMap?.get(skill.name);
+            const category = skillCategory(skill.dir);
+            return (
+              <tr
+                key={skill.name}
+                aria-current={skill.name === activeSkillName ? 'true' : undefined}
+                className={cn(
+                  'border-b border-border-subtle/40 transition-colors hover:bg-surface-highlight/40',
+                  skill.name === activeSkillName && 'bg-primary/[0.06]',
+                )}
+              >
+                <td className={cn('px-2', cellPad)}>
+                  <button
+                    type="button"
+                    role="checkbox"
+                    aria-checked={isSel}
+                    aria-label={isSel ? `Deselect ${skill.name}` : `Select ${skill.name}`}
+                    onClick={() => onToggleSelect(skill)}
+                    className={cn(
+                      'w-4 h-4 rounded border flex items-center justify-center transition-colors',
+                      isSel
+                        ? 'bg-primary/20 border-primary/50 text-primary'
+                        : 'border-border/50 text-transparent hover:border-border',
+                    )}
+                  >
+                    <Check size={11} />
+                  </button>
+                </td>
+                <td className={cn('px-2', cellPad)}>
+                  <StateBadge state={skill.state} />
+                </td>
+                <td className={cn('px-2 min-w-0', cellPad)}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(skill)}
+                    className="inline-flex items-center gap-1.5 text-left text-text-primary hover:text-primary transition-colors max-w-full"
+                  >
+                    <span className="font-medium truncate">{skill.name}</span>
+                    {src && (
+                      <GitBranch
+                        size={11}
+                        className="text-text-muted/50 flex-shrink-0"
+                        aria-label={`Imported from ${src.repo}`}
+                      />
+                    )}
+                  </button>
+                </td>
+                <td className={cn('px-2 text-xs text-text-muted', cellPad)}>
+                  {category ? toTitleCase(category) : '–'}
+                </td>
+                <td className={cn('px-2 text-xs font-mono text-text-muted', cellPad)}>{skill.fileCount}</td>
+                <td className={cn('px-2 text-right', cellPad)}>
+                  <div className="inline-flex justify-end">
+                    <SkillActions skill={skill} onToggle={handleToggle} onEdit={onEdit} onDelete={onDelete} />
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/components/registry/SkillCard.tsx
+++ b/web/src/components/registry/SkillCard.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { BookOpen, GitBranch } from 'lucide-react';
+import { BookOpen, Check, GitBranch } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { StateBadge } from './StateBadge';
 import { SkillActions } from './SkillActions';
@@ -20,6 +20,14 @@ export interface SkillCardProps {
   onSelect?: (skill: AgentSkill) => void;
   /** Whether this card is the one shown in the inspector. */
   isActive?: boolean;
+  /** Toggle this card's membership in the multi-select set. When omitted, no
+   *  selection checkbox is rendered (e.g. the detached grid). */
+  onToggleSelect?: (skill: AgentSkill) => void;
+  /** Whether this card is currently in the multi-select set. */
+  selected?: boolean;
+  /** Whether any cards are selected, which keeps every checkbox visible while a
+   *  selection is in progress, not just on hover. */
+  selectionActive?: boolean;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -33,6 +41,9 @@ export const SkillCard = memo(({
   source,
   onSelect,
   isActive = false,
+  onToggleSelect,
+  selected = false,
+  selectionActive = false,
   className,
   style,
 }: SkillCardProps) => {
@@ -88,8 +99,27 @@ export const SkillCard = memo(({
             : undefined
         }
       >
-        {/* Header: icon + name + state badge */}
+        {/* Header: optional select checkbox + icon + name + state badge */}
         <div className="flex items-start gap-2">
+          {onToggleSelect && (
+            <button
+              type="button"
+              role="checkbox"
+              aria-checked={selected}
+              aria-label={selected ? `Deselect ${skill.name}` : `Select ${skill.name}`}
+              onClick={(e) => { e.stopPropagation(); onToggleSelect(skill); }}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') e.stopPropagation(); }}
+              className={cn(
+                'flex-shrink-0 mt-0.5 w-4 h-4 rounded border flex items-center justify-center transition-all duration-150',
+                selected
+                  ? 'bg-primary/20 border-primary/50 text-primary opacity-100'
+                  : 'border-border/50 text-transparent opacity-0 group-hover:opacity-100 group-focus-within:opacity-100',
+                selectionActive && !selected && 'opacity-100',
+              )}
+            >
+              <Check size={11} />
+            </button>
+          )}
           <div className="p-1.5 rounded-md border bg-surface-highlight/60 border-border/40 flex-shrink-0 mt-0.5 transition-colors duration-200 group-hover:bg-primary/10 group-hover:border-primary/20 group-focus-within:bg-primary/10 group-focus-within:border-primary/20">
             <BookOpen size={14} className="text-text-muted transition-colors duration-200 group-hover:text-primary/70 group-focus-within:text-primary/70" />
           </div>

--- a/web/src/components/workspaces/LibraryWorkspace.tsx
+++ b/web/src/components/workspaces/LibraryWorkspace.tsx
@@ -1,11 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import {
+  AlignJustify,
   BookOpen,
+  LayoutGrid,
+  List,
   Plus,
+  Power,
+  PowerOff,
   RefreshCw,
   Search,
+  Trash2,
   X,
+  type LucideIcon,
 } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { IconButton } from '../ui/IconButton';
@@ -13,6 +20,7 @@ import { PopoutButton } from '../ui/PopoutButton';
 import { SkillEditor } from '../registry/SkillEditor';
 import { SkillCardSkeleton } from '../registry/SkillCardSkeleton';
 import { LibraryGrid, type GroupMode } from '../registry/LibraryGrid';
+import { LibraryTable } from '../registry/LibraryTable';
 import { SkillDetailPanel } from '../registry/SkillDetailPanel';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { showToast } from '../ui/Toast';
@@ -28,6 +36,7 @@ import {
   fetchRegistrySkills,
   fetchRegistryStatus,
   fetchSkillSources,
+  setRegistrySkillsBatch,
 } from '../../lib/api';
 import { extractRepoInfo } from '../../lib/repo';
 import { WorkspaceShell } from '../layout/WorkspaceShell';
@@ -72,6 +81,7 @@ export function LibraryWorkspace() {
 
   const { openDetachedWindow } = useWindowManager();
   const compact = useUIStore((s) => s.compactMode.library);
+  const toggleCompact = useUIStore((s) => s.toggleCompactMode);
 
   // URL → local state for the search input. We round-trip through state so the
   // input keeps caret behavior; the URL is the source of truth on reload.
@@ -183,6 +193,21 @@ export function LibraryWorkspace() {
     );
   }, [setSearchParams]);
 
+  // View mode, URL-synced as ?view (cards default omitted), consistent with
+  // the workspace's URL-first state model. Row density stays in useUIStore.
+  const viewMode: 'cards' | 'table' = searchParams.get('view') === 'table' ? 'table' : 'cards';
+  const setViewMode = useCallback((mode: 'cards' | 'table') => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (mode === 'cards') next.delete('view');
+        else next.set('view', mode);
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
   // Clear every removable facet in one update. Grouping (?group) is a view axis,
   // not a facet, so it is intentionally left untouched.
   const clearAllFacets = useCallback(() => {
@@ -203,6 +228,21 @@ export function LibraryWorkspace() {
   const [showEditor, setShowEditor] = useState(false);
   const [editingSkill, setEditingSkill] = useState<AgentSkill | undefined>();
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
+
+  // Multi-select state. Names only (not skill objects) so the selection
+  // survives filter, sort, group, and refresh; stale names are pruned at the
+  // point of use against the live skill set.
+  const [selectedNames, setSelectedNames] = useState<Set<string>>(() => new Set());
+  const toggleSelect = useCallback((skill: AgentSkill) => {
+    setSelectedNames((prev) => {
+      const next = new Set(prev);
+      if (next.has(skill.name)) next.delete(skill.name);
+      else next.add(skill.name);
+      return next;
+    });
+  }, []);
+  const clearSelection = useCallback(() => setSelectedNames(new Set()), []);
 
   // Track the last skillName we resolved so we don't refire the toast on every
   // re-render. Reset whenever the param actually changes.
@@ -239,19 +279,24 @@ export function LibraryWorkspace() {
     }
   }, [navigate, searchParams, skillName]);
 
-  // Esc closes the inspector — but only when no modal is open and focus isn't in
-  // a text input (the search box keeps its own clear affordance).
+  // Esc clears an active multi-selection first, then (on a second press) closes
+  // the inspector. Ignored while a modal is open or focus is in a text input
+  // (the search box keeps its own clear affordance).
   useEffect(() => {
-    if (!selectedName) return;
+    if (!selectedName && selectedNames.size === 0) return;
     const handler = (e: KeyboardEvent) => {
       if (e.key !== 'Escape' || showEditor) return;
       const t = e.target as HTMLElement | null;
       if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+      if (selectedNames.size > 0) {
+        setSelectedNames(new Set());
+        return;
+      }
       setSelectedName(null);
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [selectedName, showEditor, setSelectedName]);
+  }, [selectedName, selectedNames.size, showEditor, setSelectedName]);
 
   const refreshRegistry = useCallback(async () => {
     try {
@@ -392,6 +437,44 @@ export function LibraryWorkspace() {
     return copy.sort(byName);
   }, [visibleSkills, sortMode]);
 
+  // Reconcile the selection against the live skill set so a skill deleted out
+  // from under the selection never lands in a bulk request (which would reject
+  // the whole batch).
+  const existingNames = useMemo(() => new Set((skills ?? []).map((s) => s.name)), [skills]);
+  const liveSelected = useMemo(
+    () => Array.from(selectedNames).filter((n) => existingNames.has(n)),
+    [selectedNames, existingNames],
+  );
+  const allSelected = sortedSkills.length > 0 && sortedSkills.every((s) => selectedNames.has(s.name));
+  const someSelected = sortedSkills.some((s) => selectedNames.has(s.name)) && !allSelected;
+  const selectAllVisible = useCallback(
+    () => setSelectedNames(new Set(sortedSkills.map((s) => s.name))),
+    [sortedSkills],
+  );
+
+  const handleBulkState = useCallback(async (state: 'active' | 'disabled') => {
+    if (liveSelected.length === 0) return;
+    try {
+      await setRegistrySkillsBatch(liveSelected.map((name) => ({ name, state })));
+      const n = liveSelected.length;
+      showToast('success', `${n} skill${n === 1 ? '' : 's'} ${state === 'active' ? 'enabled' : 'disabled'}`);
+      clearSelection();
+      refreshRegistry();
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'Bulk update failed');
+    }
+  }, [liveSelected, clearSelection, refreshRegistry]);
+
+  const handleBulkDelete = useCallback(async () => {
+    setConfirmBulkDelete(false);
+    if (liveSelected.length === 0) return;
+    const results = await Promise.allSettled(liveSelected.map((name) => deleteRegistrySkill(name)));
+    const ok = results.filter((r) => r.status === 'fulfilled').length;
+    showToast(ok === liveSelected.length ? 'success' : 'error', `Deleted ${ok} of ${liveSelected.length} skills`);
+    clearSelection();
+    refreshRegistry();
+  }, [liveSelected, clearSelection, refreshRegistry]);
+
   // Human-readable label for the active source isolate, shown in its facet chip.
   const activeSourceLabel = useMemo(() => {
     if (!activeSource) return null;
@@ -472,11 +555,23 @@ export function LibraryWorkspace() {
               )}
             </div>
 
-            {/* Controls row: sort axis (always) and, when sources exist, the
-                grouping axis on the right. */}
+            {/* Controls row: sort axis (always), then view controls, plus the
+                grouping axis in cards view when sources exist. */}
             <div className="flex items-center justify-between gap-2 flex-wrap">
               <SortControl mode={sortMode} onChange={setSortMode} />
-              {hasSources && <GroupByControl mode={groupMode} onChange={setGroupMode} />}
+              <div className="flex items-center gap-2 flex-wrap">
+                {hasSources && viewMode === 'cards' && (
+                  <GroupByControl mode={groupMode} onChange={setGroupMode} />
+                )}
+                <ViewToggle mode={viewMode} onChange={setViewMode} />
+                <IconButton
+                  icon={AlignJustify}
+                  onClick={() => toggleCompact('library')}
+                  tooltip={compact ? 'Comfortable rows' : 'Compact rows'}
+                  size="sm"
+                  variant={compact ? 'default' : 'ghost'}
+                />
+              </div>
             </div>
 
             <FacetChips
@@ -491,6 +586,18 @@ export function LibraryWorkspace() {
               onClearAll={clearAllFacets}
             />
           </div>
+
+          {liveSelected.length > 0 && (
+            <BulkActionBar
+              count={liveSelected.length}
+              allSelected={allSelected}
+              onSelectAll={selectAllVisible}
+              onEnable={() => handleBulkState('active')}
+              onDisable={() => handleBulkState('disabled')}
+              onDelete={() => setConfirmBulkDelete(true)}
+              onClear={clearSelection}
+            />
+          )}
 
           <div className="flex-1 overflow-y-auto scrollbar-dark">
             {isLoading && (
@@ -537,7 +644,7 @@ export function LibraryWorkspace() {
               </div>
             )}
 
-            {!isLoading && visibleSkills.length > 0 && (
+            {!isLoading && visibleSkills.length > 0 && viewMode === 'cards' && (
               <LibraryGrid
                 skills={sortedSkills}
                 hasSearch={searchQuery.length > 0}
@@ -552,6 +659,30 @@ export function LibraryWorkspace() {
                 onDelete={(s) => setConfirmDelete(s.name)}
                 onSelect={(s) => setSelectedName(s.name)}
                 activeSkillName={selectedName}
+                selectedNames={selectedNames}
+                onToggleSelect={toggleSelect}
+              />
+            )}
+
+            {!isLoading && visibleSkills.length > 0 && viewMode === 'table' && (
+              <LibraryTable
+                skills={sortedSkills}
+                sortMode={sortMode}
+                onSort={setSortMode}
+                selectedNames={selectedNames}
+                onToggleSelect={toggleSelect}
+                onSelectAll={selectAllVisible}
+                onClearSelection={clearSelection}
+                allSelected={allSelected}
+                someSelected={someSelected}
+                onSelect={(s) => setSelectedName(s.name)}
+                activeSkillName={selectedName}
+                sourceMap={sourceMap}
+                onEnable={handleEnable}
+                onDisable={handleDisable}
+                onEdit={(s) => { setEditingSkill(s); setShowEditor(true); }}
+                onDelete={(s) => setConfirmDelete(s.name)}
+                compact={compact}
               />
             )}
           </div>
@@ -574,6 +705,28 @@ export function LibraryWorkspace() {
         confirmLabel={
           <span>
             Delete <span className="font-mono">"{confirmDelete}"</span>
+          </span>
+        }
+        variant="danger"
+      />
+
+      <ConfirmDialog
+        isOpen={confirmBulkDelete}
+        onClose={() => setConfirmBulkDelete(false)}
+        onConfirm={handleBulkDelete}
+        title="Delete skills"
+        message={
+          <>
+            <p>
+              Delete <span className="font-mono text-primary">{liveSelected.length}</span> selected{' '}
+              {liveSelected.length === 1 ? 'skill' : 'skills'}?
+            </p>
+            <p>This action cannot be undone.</p>
+          </>
+        }
+        confirmLabel={
+          <span>
+            Delete {liveSelected.length} {liveSelected.length === 1 ? 'skill' : 'skills'}
           </span>
         }
         variant="danger"
@@ -711,6 +864,96 @@ function FacetChips({
           Clear all
         </button>
       )}
+    </div>
+  );
+}
+
+const VIEW_OPTIONS: { key: 'cards' | 'table'; label: string; icon: LucideIcon }[] = [
+  { key: 'cards', label: 'Cards', icon: LayoutGrid },
+  { key: 'table', label: 'Table', icon: List },
+];
+
+/** Segmented toggle between the card grid and the table view. */
+function ViewToggle({ mode, onChange }: { mode: 'cards' | 'table'; onChange: (m: 'cards' | 'table') => void }) {
+  return (
+    <div className="flex items-center gap-1" role="group" aria-label="View mode">
+      {VIEW_OPTIONS.map(({ key, label, icon: Icon }) => (
+        <button
+          key={key}
+          onClick={() => onChange(key)}
+          aria-pressed={mode === key}
+          aria-label={`${label} view`}
+          className={cn(
+            'p-1.5 rounded-md border transition-colors',
+            mode === key
+              ? 'bg-primary/10 text-primary border-primary/25'
+              : 'text-text-muted hover:text-text-secondary hover:bg-surface-highlight border-transparent',
+          )}
+        >
+          <Icon size={13} />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+interface BulkActionBarProps {
+  count: number;
+  allSelected: boolean;
+  onSelectAll: () => void;
+  onEnable: () => void;
+  onDisable: () => void;
+  onDelete: () => void;
+  onClear: () => void;
+}
+
+/**
+ * Contextual bar shown while a multi-selection is active. The count is an
+ * aria-live region so bulk results are announced. Destructive deletes are
+ * confirmed upstream via ConfirmDialog.
+ */
+function BulkActionBar({ count, allSelected, onSelectAll, onEnable, onDisable, onDelete, onClear }: BulkActionBarProps) {
+  return (
+    <div
+      role="region"
+      aria-label="Bulk actions"
+      className="flex items-center gap-2 flex-wrap px-4 py-2 bg-primary/[0.06] border-b border-primary/20 flex-shrink-0"
+    >
+      <span aria-live="polite" className="text-xs font-medium text-text-secondary">
+        {count} selected
+      </span>
+      {!allSelected && (
+        <button onClick={onSelectAll} className="text-[11px] text-text-muted hover:text-text-secondary transition-colors">
+          Select all
+        </button>
+      )}
+      <div className="ml-auto flex items-center gap-1.5">
+        <button
+          onClick={onEnable}
+          className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium text-emerald-400 border border-emerald-400/25 hover:bg-emerald-400/10 transition-colors"
+        >
+          <Power size={11} /> Enable
+        </button>
+        <button
+          onClick={onDisable}
+          className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium text-text-muted border border-border/40 hover:bg-surface-highlight transition-colors"
+        >
+          <PowerOff size={11} /> Disable
+        </button>
+        <button
+          onClick={onDelete}
+          className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium text-red-400 border border-red-400/25 hover:bg-red-400/10 transition-colors"
+        >
+          <Trash2 size={11} /> Delete
+        </button>
+        <button
+          onClick={onClear}
+          aria-label="Clear selection"
+          className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] text-text-muted border border-transparent hover:bg-surface-highlight transition-colors"
+        >
+          <X size={11} /> Clear
+        </button>
+      </div>
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, RegistryStatus, AgentSkill, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
+import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, RegistryStatus, AgentSkill, ItemState, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
 
 // Base URL for API calls - empty for same origin
 const API_BASE = '';
@@ -563,6 +563,24 @@ export async function activateRegistrySkill(name: string): Promise<AgentSkill> {
 
 export async function disableRegistrySkill(name: string): Promise<AgentSkill> {
   return mutateJSON<AgentSkill>(`/api/registry/skills/${encodeURIComponent(name)}/disable`, 'POST');
+}
+
+export interface RegistrySkillBatchEntry {
+  name: string;
+  // Bulk actions enable or disable; they never set draft.
+  state: Extract<ItemState, 'active' | 'disabled'>;
+}
+
+export interface SetRegistrySkillsBatchResponse {
+  skills: { name: string; state: ItemState }[];
+}
+
+// PUT /api/registry/skills/batch: set the state of multiple skills in one
+// all-or-nothing request (the whole batch is validated before any write).
+export async function setRegistrySkillsBatch(
+  skills: RegistrySkillBatchEntry[],
+): Promise<SetRegistrySkillsBatchResponse> {
+  return mutateJSON<SetRegistrySkillsBatchResponse>('/api/registry/skills/batch', 'PUT', { skills });
 }
 
 // --- Skill File Management ---


### PR DESCRIPTION
## Description

Adds a power-user table view, multi-select, and bulk actions to the Skills Library, backed by a new all-or-nothing batch state endpoint. This is the largest step of the dashboard work and the first to touch the backend.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

**Backend**
- `PUT /api/registry/skills/batch` sets the state of multiple skills in one request. Every entry is validated up front (known skill, target state of active or disabled) before any write, so an unknown skill (404) or invalid state (400) rejects the whole batch with nothing changed. Only active/disabled are accepted (bulk enable/disable, never draft). The write phase is best-effort (documented), mirroring the per-skill endpoint; the registry store has no external-edit model, so there is no 409 path.

**Frontend**
- `setRegistrySkillsBatch` client.
- Cards/Table view toggle synced to `?view` (cards default omitted); a density toggle reusing the existing `compactMode.library`.
- New `LibraryTable`: a flat, sortable table (State/Name/Files headers drive the shared `?sort` axis) with a multi-select column and an indeterminate select-all.
- Optional, keyboard-safe select checkbox on cards; selection is name-based so it survives filter/sort/group changes and is pruned against the live skill set before any batch call.
- Bulk action bar (Enable/Disable/Delete/Clear) with an aria-live count; Enable/Disable go through the batch endpoint, Delete confirms via ConfirmDialog. Esc clears an active selection before closing the inspector.

## Testing

- `go test ./internal/api/`: passes, including 4 new batch tests (multi-state apply, unknown-skill writes nothing, invalid state rejected, empty array).
- `vitest run`: 804/804 web tests pass, including 5 new table/multi-select tests.
- `tsc -b` clean; `make build` embeds the web assets cleanly.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #727