### PR TITLE
feat: skill usage analytics (backend)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -227,6 +227,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/tools", s.handleTools)
 	mux.HandleFunc("GET /api/tools/catalog", s.handleToolsCatalog)
 	mux.HandleFunc("GET /api/tools/usage", s.handleToolsUsage)
+	mux.HandleFunc("GET /api/skills/usage", s.handleSkillsUsage)
 	mux.HandleFunc("/api/logs", s.handleGatewayLogs)
 	mux.HandleFunc("/api/metrics/tokens", s.handleMetricsTokens)
 	mux.HandleFunc("/api/metrics/cost", s.handleMetricsCost)

--- a/internal/api/skills_usage.go
+++ b/internal/api/skills_usage.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net/http"
+	"time"
+)
+
+// skillUsageStat is the wire shape for one skill's usage in
+// GET /api/skills/usage. LastCalledAt is a pointer rendered as null (not
+// omitted) so the documented { calls, lastCalledAt } shape is stable for the
+// frontend join even for a skill with a recorded count but no stamped time.
+type skillUsageStat struct {
+	Calls        int64      `json:"calls"`
+	LastCalledAt *time.Time `json:"lastCalledAt"`
+}
+
+// skillUsageResponse is the GET /api/skills/usage envelope. Skills maps each
+// registry skill name to its cumulative prompts/get usage. ObservedSince is
+// when this gateway process began recording; with metrics persistence enabled
+// the restored counts may predate it, so the Skills Library uses ObservedSince
+// to label the young-tracking-window case rather than calling a skill unused.
+// It is rendered as null (not omitted) when no observation window exists.
+type skillUsageResponse struct {
+	ObservedSince *time.Time                `json:"observedSince"`
+	Skills        map[string]skillUsageStat `json:"skills"`
+}
+
+// handleSkillsUsage serves GET /api/skills/usage: per-skill cumulative
+// prompts/get counts and last-called timestamps from the metrics accumulator.
+// The data is seeded from disk on startup
+// (telemetry.MetricsFlusher.SeedPromptUsageFromFile) so it survives gateway
+// restarts when metrics persistence is enabled. Returns 503 when no
+// accumulator is wired, mirroring GET /api/tools/usage and GET /api/optimize.
+//
+// Skills is always a non-nil object so the JSON body is "{}" rather than null
+// when nothing has been served. Usage is joined to the registry list by name
+// on the frontend, so the registry list payload stays unchanged.
+func (s *Server) handleSkillsUsage(w http.ResponseWriter, _ *http.Request) {
+	if s.metricsAccumulator == nil {
+		writeJSONError(w, "metrics accumulator not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	resp := skillUsageResponse{Skills: map[string]skillUsageStat{}}
+	if started := s.metricsAccumulator.StartedAt(); !started.IsZero() {
+		t := started.UTC()
+		resp.ObservedSince = &t
+	}
+	for name, stat := range s.metricsAccumulator.PromptUsageSnapshot() {
+		entry := skillUsageStat{Calls: stat.Calls}
+		if !stat.LastCalledAt.IsZero() {
+			t := stat.LastCalledAt.UTC()
+			entry.LastCalledAt = &t
+		}
+		resp.Skills[name] = entry
+	}
+	writeJSON(w, resp)
+}

--- a/internal/api/skills_usage_test.go
+++ b/internal/api/skills_usage_test.go
@@ -78,8 +78,8 @@ func TestHandleSkillsUsage_NoAccumulatorReturns503(t *testing.T) {
 
 // TestHandleSkillsUsage_SurvivesRestoreSeed asserts the endpoint surfaces
 // usage that was restored from disk (the persistence path), not just usage
-// recorded live this process — i.e. the Skills Library reflects pre-restart
-// history.
+// recorded live this process (i.e. the Skills Library reflects pre-restart
+// history).
 func TestHandleSkillsUsage_SurvivesRestoreSeed(t *testing.T) {
 	srv := newTestServerWithMetrics(t)
 	last := time.Now().Add(-3 * time.Hour).Truncate(time.Second)

--- a/internal/api/skills_usage_test.go
+++ b/internal/api/skills_usage_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/metrics"
+)
+
+// decodeSkillUsage runs GET /api/skills/usage against srv and returns the
+// decoded response plus the HTTP status.
+func decodeSkillUsage(t *testing.T, srv *Server) (skillUsageResponse, int) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/skills/usage", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	var resp skillUsageResponse
+	if rec.Body.Len() > 0 {
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v (body=%s)", err, rec.Body.String())
+		}
+	}
+	return resp, rec.Code
+}
+
+func TestHandleSkillsUsage_ReportsPerSkillCounts(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	srv.metricsAccumulator.RecordPromptGet("code-review")
+	srv.metricsAccumulator.RecordPromptGet("code-review")
+	srv.metricsAccumulator.RecordPromptGet("summarize")
+
+	resp, code := decodeSkillUsage(t, srv)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if resp.Skills["code-review"].Calls != 2 {
+		t.Errorf("code-review calls = %d, want 2", resp.Skills["code-review"].Calls)
+	}
+	if resp.Skills["summarize"].Calls != 1 {
+		t.Errorf("summarize calls = %d, want 1", resp.Skills["summarize"].Calls)
+	}
+	if resp.Skills["code-review"].LastCalledAt == nil || resp.Skills["code-review"].LastCalledAt.IsZero() {
+		t.Error("code-review lastCalledAt should be set")
+	}
+	if resp.ObservedSince == nil || resp.ObservedSince.IsZero() {
+		t.Error("observedSince should be set when an accumulator is wired")
+	}
+}
+
+func TestHandleSkillsUsage_EmptyIsObjectNotNull(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	resp, code := decodeSkillUsage(t, srv)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if resp.Skills == nil {
+		t.Error("skills should be a non-nil object when nothing has been served")
+	}
+	if len(resp.Skills) != 0 {
+		t.Errorf("skills = %+v, want empty", resp.Skills)
+	}
+}
+
+func TestHandleSkillsUsage_NoAccumulatorReturns503(t *testing.T) {
+	srv := newTestServer(t) // no metrics accumulator wired
+	req := httptest.NewRequest(http.MethodGet, "/api/skills/usage", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+// TestHandleSkillsUsage_SurvivesRestoreSeed asserts the endpoint surfaces
+// usage that was restored from disk (the persistence path), not just usage
+// recorded live this process — i.e. the Skills Library reflects pre-restart
+// history.
+func TestHandleSkillsUsage_SurvivesRestoreSeed(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	last := time.Now().Add(-3 * time.Hour).Truncate(time.Second)
+	srv.metricsAccumulator.RestorePromptUsage(map[string]metrics.ToolStat{
+		"deep-research": {Calls: 7, LastCalledAt: last},
+	})
+
+	resp, code := decodeSkillUsage(t, srv)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	got := resp.Skills["deep-research"]
+	if got.Calls != 7 {
+		t.Errorf("restored deep-research calls = %d, want 7", got.Calls)
+	}
+	if got.LastCalledAt == nil || !got.LastCalledAt.Equal(last.UTC()) {
+		t.Errorf("restored lastCalledAt = %v, want %v", got.LastCalledAt, last.UTC())
+	}
+}

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -295,6 +295,15 @@ func (b *GatewayBuilder) seedMetricsFromDisk(handler slog.Handler) {
 			logger.Warn("telemetry: seed metrics failed", "server", srv.Name, "path", path, "error", err)
 		}
 	}
+
+	// Seed global prompt (skill) usage from the reserved namespace, persisted
+	// off the stack-global metrics toggle (the registry is not a stack server).
+	if b.stack.Telemetry != nil && b.stack.Telemetry.Persist.Metrics {
+		ppath := state.TelemetryServerPath(b.stack.Name, telemetry.PromptUsageNamespace, "metrics")
+		if err := b.telemetry.metricsFlusher.SeedPromptUsageFromFile(ppath, telemetrySeedLimit); err != nil {
+			logger.Warn("telemetry: seed prompt usage failed", "path", ppath, "error", err)
+		}
+	}
 }
 
 // Run starts the HTTP server, registers MCP servers, and blocks until shutdown.
@@ -475,6 +484,7 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 	accumulator := metrics.NewAccumulator(10000)
 	observer := metrics.NewObserver(counter, accumulator)
 	gateway.SetToolCallObserver(observer)
+	gateway.SetPromptGetObserver(observer)
 	gateway.SetTokenCounter(counter)
 	gateway.SetFormatSavingsRecorder(accumulator)
 	server.SetMetricsAccumulator(accumulator)
@@ -566,6 +576,26 @@ func (b *GatewayBuilder) applyTelemetryConfig(apiServer *api.Server, handler slo
 
 	logger := slog.New(handler)
 	stack := b.stack
+
+	// Prompt (skill) usage persists globally off the stack-global metrics
+	// toggle, independent of per-server opt-in: the skills registry is not a
+	// stack.MCPServers entry, so it has no per-server PersistMetrics switch.
+	// Run this before the early-return below so a stack that flips metrics off
+	// still tears the writer down on hot-reload.
+	if flusher := b.telemetry.metricsFlusher; flusher != nil {
+		if stack.Telemetry != nil && stack.Telemetry.Persist.Metrics {
+			if err := state.EnsureTelemetryServerDir(stack.Name, telemetry.PromptUsageNamespace); err != nil {
+				logger.Warn("telemetry: cannot ensure prompt-usage dir", "error", err)
+			} else {
+				path := state.TelemetryServerPath(stack.Name, telemetry.PromptUsageNamespace, "metrics")
+				if err := flusher.SetPromptUsageWriter(path, telemetryRotationOpts(stack)); err != nil {
+					logger.Warn("telemetry: prompt-usage writer install failed", "path", path, "error", err)
+				}
+			}
+		} else {
+			flusher.RemovePromptUsageWriter()
+		}
+	}
 
 	// Compute desired set per signal.
 	wantLogs := map[string]bool{}

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -33,27 +33,27 @@ var ErrReadyTimeout = errors.New("ready timeout")
 
 // MCPServerConfig contains configuration for connecting to an MCP server.
 type MCPServerConfig struct {
-	Name            string
-	Transport       Transport
-	Endpoint        string            // For HTTP/SSE transport
-	ContainerID     string            // For Docker Stdio transport
-	External        bool              // True for external URL servers (no container)
-	LocalProcess    bool              // True for local process servers (no container)
-	SSH             bool              // True for SSH servers (remote process over SSH)
-	OpenAPI         bool              // True for OpenAPI-based servers
-	Command         []string          // For local process or SSH transport
-	WorkDir         string            // For local process transport
-	Env             map[string]string // For local process or SSH transport
-	SSHHost            string            // SSH hostname (for SSH servers)
-	SSHUser            string            // SSH username (for SSH servers)
-	SSHPort            int               // SSH port (for SSH servers, 0 = default 22)
-	SSHIdentityFile    string            // SSH identity file path (for SSH servers)
-	SSHKnownHostsFile  string            // SSH known_hosts file path; enables StrictHostKeyChecking=yes
-	SSHJumpHost        string            // SSH jump/bastion host ([user@]host[:port])
-	OpenAPIConfig   *OpenAPIClientConfig // OpenAPI configuration (for OpenAPI servers)
-	Tools           []string          // Tool whitelist (empty = all tools)
-	OutputFormat    string            // Output format: "json", "toon", "csv", "text"
-	PinSchemas      *bool             // Override gateway schema pinning (nil = inherit gateway default)
+	Name              string
+	Transport         Transport
+	Endpoint          string               // For HTTP/SSE transport
+	ContainerID       string               // For Docker Stdio transport
+	External          bool                 // True for external URL servers (no container)
+	LocalProcess      bool                 // True for local process servers (no container)
+	SSH               bool                 // True for SSH servers (remote process over SSH)
+	OpenAPI           bool                 // True for OpenAPI-based servers
+	Command           []string             // For local process or SSH transport
+	WorkDir           string               // For local process transport
+	Env               map[string]string    // For local process or SSH transport
+	SSHHost           string               // SSH hostname (for SSH servers)
+	SSHUser           string               // SSH username (for SSH servers)
+	SSHPort           int                  // SSH port (for SSH servers, 0 = default 22)
+	SSHIdentityFile   string               // SSH identity file path (for SSH servers)
+	SSHKnownHostsFile string               // SSH known_hosts file path; enables StrictHostKeyChecking=yes
+	SSHJumpHost       string               // SSH jump/bastion host ([user@]host[:port])
+	OpenAPIConfig     *OpenAPIClientConfig // OpenAPI configuration (for OpenAPI servers)
+	Tools             []string             // Tool whitelist (empty = all tools)
+	OutputFormat      string               // Output format: "json", "toon", "csv", "text"
+	PinSchemas        *bool                // Override gateway schema pinning (nil = inherit gateway default)
 
 	// ReadyTimeout overrides the HTTP/SSE readiness wait. Zero uses DefaultReadyTimeout.
 	// Applies only to HTTP and SSE transports; stdio and other paths ignore it.
@@ -133,20 +133,21 @@ type Gateway struct {
 	health        map[string]*HealthStatus         // name -> rollup health (public API)
 	replicaHealth map[string]map[int]*HealthStatus // name -> replica_id -> health
 
-	toolCallObserver ToolCallObserver // optional observer for tool call metrics
+	toolCallObserver  ToolCallObserver  // optional observer for tool call metrics
+	promptGetObserver PromptGetObserver // optional observer for prompt-get (skill usage) metrics
 
-	defaultOutputFormat    string                // gateway-level default output format
-	tokenCounter          token.Counter          // token counter for format savings calculation
-	formatSavingsRecorder FormatSavingsRecorder  // optional recorder for format savings
+	defaultOutputFormat   string                // gateway-level default output format
+	tokenCounter          token.Counter         // token counter for format savings calculation
+	formatSavingsRecorder FormatSavingsRecorder // optional recorder for format savings
 
 	maxToolResultBytes int // maximum tool result size before truncation (0 = default 64KB)
 
 	toolCountWarned bool // whether the tool count hint has been logged
 
-	schemaVerifier SchemaVerifier   // optional TOFU schema verifier (pins.GatewayAdapter)
-	pinAction      string           // "warn" | "block" on drift (default "warn")
+	schemaVerifier SchemaVerifier // optional TOFU schema verifier (pins.GatewayAdapter)
+	pinAction      string         // "warn" | "block" on drift (default "warn")
 	blockedMu      sync.RWMutex
-	blockedServers map[string]bool  // servers blocked due to unacknowledged schema drift
+	blockedServers map[string]bool // servers blocked due to unacknowledged schema drift
 
 	autoMu      sync.RWMutex
 	autoscalers map[string]*Autoscaler // name -> scaler for autoscaled replica sets
@@ -189,6 +190,15 @@ func (g *Gateway) SetToolCallObserver(obs ToolCallObserver) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.toolCallObserver = obs
+}
+
+// SetPromptGetObserver sets an observer that is notified after every
+// successful prompts/get. Used to collect per-skill usage metrics without
+// coupling the gateway to a metrics package.
+func (g *Gateway) SetPromptGetObserver(obs PromptGetObserver) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.promptGetObserver = obs
 }
 
 // SetVersion sets the gateway version string.
@@ -1589,8 +1599,10 @@ func (g *Gateway) HandlePromptsList() (*PromptsListResult, error) {
 	return &PromptsListResult{Prompts: result}, nil
 }
 
-// HandlePromptsGet returns a specific prompt with argument substitution.
-func (g *Gateway) HandlePromptsGet(params PromptsGetParams) (*PromptsGetResult, error) {
+// HandlePromptsGet returns a specific prompt with argument substitution. The
+// ctx carries the originating client id (set on the streamable transport via
+// WithClientID) so the prompt-get observer can attribute usage per client.
+func (g *Gateway) HandlePromptsGet(ctx context.Context, params PromptsGetParams) (*PromptsGetResult, error) {
 	pp := g.promptProvider()
 	if pp == nil {
 		return nil, fmt.Errorf("registry not available")
@@ -1614,6 +1626,21 @@ func (g *Gateway) HandlePromptsGet(params PromptsGetParams) (*PromptsGetResult, 
 			}
 		}
 		content = strings.ReplaceAll(content, placeholder, value)
+	}
+
+	// Notify the prompt-get observer that this skill was served. Recording is
+	// advisory and must never block or fail prompt serving, so it runs on a
+	// separate goroutine and the observer swallows its own errors. Fired only
+	// on the success path, so a missing required argument does not count as a
+	// served skill. The prompt name equals the registry skill's Name.
+	g.mu.RLock()
+	pObs := g.promptGetObserver
+	g.mu.RUnlock()
+	if pObs != nil {
+		go pObs.ObservePromptGet(PromptGetObservation{
+			PromptName: params.Name,
+			ClientID:   ClientIDFromContext(ctx),
+		})
 	}
 
 	return &PromptsGetResult{
@@ -1696,20 +1723,20 @@ func (g *Gateway) RefreshAllTools(ctx context.Context) error {
 
 // MCPServerStatus returns status information about registered MCP servers.
 type MCPServerStatus struct {
-	Name         string    `json:"name"`
-	Transport    Transport `json:"transport"`
-	Endpoint     string    `json:"endpoint,omitempty"`
-	ContainerID  string    `json:"containerId,omitempty"`
-	Initialized  bool      `json:"initialized"`
-	ToolCount    int       `json:"toolCount"`
-	Tools        []string  `json:"tools"`
-	External     bool      `json:"external"`     // True for external URL servers
-	LocalProcess bool      `json:"localProcess"` // True for local process servers
-	SSH          bool      `json:"ssh"`          // True for SSH servers
-	SSHHost      string    `json:"sshHost,omitempty"` // SSH hostname
-	OpenAPI      bool      `json:"openapi"`      // True for OpenAPI servers
-	OpenAPISpec  string    `json:"openapiSpec,omitempty"` // OpenAPI spec location
-	OutputFormat string    `json:"outputFormat,omitempty"` // Configured output format (empty = json default)
+	Name         string     `json:"name"`
+	Transport    Transport  `json:"transport"`
+	Endpoint     string     `json:"endpoint,omitempty"`
+	ContainerID  string     `json:"containerId,omitempty"`
+	Initialized  bool       `json:"initialized"`
+	ToolCount    int        `json:"toolCount"`
+	Tools        []string   `json:"tools"`
+	External     bool       `json:"external"`               // True for external URL servers
+	LocalProcess bool       `json:"localProcess"`           // True for local process servers
+	SSH          bool       `json:"ssh"`                    // True for SSH servers
+	SSHHost      string     `json:"sshHost,omitempty"`      // SSH hostname
+	OpenAPI      bool       `json:"openapi"`                // True for OpenAPI servers
+	OpenAPISpec  string     `json:"openapiSpec,omitempty"`  // OpenAPI spec location
+	OutputFormat string     `json:"outputFormat,omitempty"` // Configured output format (empty = json default)
 	Healthy      *bool      `json:"healthy,omitempty"`      // Health check result (nil if not yet checked)
 	LastCheck    *time.Time `json:"lastCheck,omitempty"`    // When last health check ran
 	HealthError  string     `json:"healthError,omitempty"`  // Error message if unhealthy
@@ -1733,7 +1760,7 @@ type MCPServerStatus struct {
 // ReplicaSet. Uptime is derived from StartedAt at read time by the consumer.
 type ReplicaStatus struct {
 	ReplicaID       int        `json:"replicaId"`
-	State           string     `json:"state"`                     // "healthy" | "unhealthy" | "restarting"
+	State           string     `json:"state"` // "healthy" | "unhealthy" | "restarting"
 	Healthy         bool       `json:"healthy"`
 	InFlight        int64      `json:"inFlight"`
 	StartedAt       time.Time  `json:"startedAt,omitempty"`

--- a/pkg/mcp/gateway_test.go
+++ b/pkg/mcp/gateway_test.go
@@ -1303,7 +1303,7 @@ func TestGateway_HandlePromptsGet_ArgumentSubstitution(t *testing.T) {
 	g.Router().AddClient(client)
 
 	// Test with all arguments provided
-	result, err := g.HandlePromptsGet(PromptsGetParams{
+	result, err := g.HandlePromptsGet(context.Background(), PromptsGetParams{
 		Name:      "greet",
 		Arguments: map[string]string{"name": "Alice", "place": "Wonderland"},
 	})
@@ -1346,7 +1346,7 @@ func TestGateway_HandlePromptsGet_DefaultArguments(t *testing.T) {
 	g.Router().AddClient(client)
 
 	// Test with missing "place" argument — should use default
-	result, err := g.HandlePromptsGet(PromptsGetParams{
+	result, err := g.HandlePromptsGet(context.Background(), PromptsGetParams{
 		Name:      "greet",
 		Arguments: map[string]string{"name": "Bob"},
 	})
@@ -1370,7 +1370,7 @@ func TestGateway_HandlePromptsGet_NotFound(t *testing.T) {
 	}
 	g.Router().AddClient(client)
 
-	_, err := g.HandlePromptsGet(PromptsGetParams{Name: "nonexistent"})
+	_, err := g.HandlePromptsGet(context.Background(), PromptsGetParams{Name: "nonexistent"})
 	if err == nil {
 		t.Fatal("expected error for nonexistent prompt")
 	}
@@ -1379,7 +1379,7 @@ func TestGateway_HandlePromptsGet_NotFound(t *testing.T) {
 func TestGateway_HandlePromptsGet_NoRegistry(t *testing.T) {
 	g := NewGateway()
 
-	_, err := g.HandlePromptsGet(PromptsGetParams{Name: "anything"})
+	_, err := g.HandlePromptsGet(context.Background(), PromptsGetParams{Name: "anything"})
 	if err == nil {
 		t.Fatal("expected error when no registry")
 	}
@@ -1535,7 +1535,7 @@ func TestGateway_HandlePromptsGet_NilArguments(t *testing.T) {
 	g.Router().AddClient(client)
 
 	// nil arguments map should work for prompts without required args
-	result, err := g.HandlePromptsGet(PromptsGetParams{
+	result, err := g.HandlePromptsGet(context.Background(), PromptsGetParams{
 		Name:      "simple",
 		Arguments: nil,
 	})
@@ -1566,7 +1566,7 @@ func TestGateway_HandlePromptsGet_RequiredArgumentMissing(t *testing.T) {
 	}
 	g.Router().AddClient(client)
 
-	_, err := g.HandlePromptsGet(PromptsGetParams{
+	_, err := g.HandlePromptsGet(context.Background(), PromptsGetParams{
 		Name:      "greet",
 		Arguments: map[string]string{},
 	})

--- a/pkg/mcp/handler.go
+++ b/pkg/mcp/handler.go
@@ -119,7 +119,7 @@ func (h *Handler) handleMethod(r *http.Request, req *jsonrpc.Request) jsonrpc.Re
 	case "prompts/list":
 		resp = h.handlePromptsList(req)
 	case "prompts/get":
-		resp = h.handlePromptsGet(req)
+		resp = h.handlePromptsGet(r, req)
 	case "resources/list":
 		resp = h.handleResourcesList(req)
 	case "resources/read":
@@ -197,8 +197,10 @@ func (h *Handler) handlePromptsList(req *jsonrpc.Request) jsonrpc.Response {
 	return jsonrpc.NewSuccessResponse(req.ID, result)
 }
 
-// handlePromptsGet handles the prompts/get request.
-func (h *Handler) handlePromptsGet(req *jsonrpc.Request) jsonrpc.Response {
+// handlePromptsGet handles the prompts/get request. The request context
+// (created by handleMethod) is threaded into the gateway so the prompt-get
+// observer can attribute usage per client.
+func (h *Handler) handlePromptsGet(r *http.Request, req *jsonrpc.Request) jsonrpc.Response {
 	if req.Params == nil {
 		return jsonrpc.NewErrorResponse(req.ID, jsonrpc.InvalidParams, "params required for prompts/get")
 	}
@@ -206,7 +208,7 @@ func (h *Handler) handlePromptsGet(req *jsonrpc.Request) jsonrpc.Response {
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		return jsonrpc.NewErrorResponse(req.ID, jsonrpc.InvalidParams, "Invalid prompts/get params")
 	}
-	result, err := h.gateway.HandlePromptsGet(params)
+	result, err := h.gateway.HandlePromptsGet(r.Context(), params)
 	if err != nil {
 		return jsonrpc.NewErrorResponse(req.ID, jsonrpc.InternalError, err.Error())
 	}

--- a/pkg/mcp/handler_test.go
+++ b/pkg/mcp/handler_test.go
@@ -669,6 +669,52 @@ func TestHandler_PromptsGet(t *testing.T) {
 	}
 }
 
+func TestHandler_PromptsGet_FiresObserver(t *testing.T) {
+	h, g, _ := setupTestHandlerWithRegistry(t)
+	obs := newRecordingPromptGetObserver()
+	g.SetPromptGetObserver(obs)
+
+	body := makeJSONRPC(t, 1, "prompts/get", map[string]any{
+		"name":      "code-review",
+		"arguments": map[string]any{"language": "Go", "code": "func main() {}"},
+	})
+	w := postMCP(t, h, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	// Serving behavior is unchanged by the observer.
+	resp := decodeResponse(t, w)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: code=%d message=%s", resp.Error.Code, resp.Error.Message)
+	}
+
+	got := obs.waitForObservation(t)
+	if got.PromptName != "code-review" {
+		t.Errorf("observed prompt = %q, want code-review", got.PromptName)
+	}
+	// The stdio/HTTP handler path carries no per-client attribution.
+	if got.ClientID != "" {
+		t.Errorf("observed clientID = %q, want empty (anonymous)", got.ClientID)
+	}
+}
+
+func TestHandler_PromptsGet_NotFoundDoesNotFireObserver(t *testing.T) {
+	h, g, _ := setupTestHandlerWithRegistry(t)
+	obs := newRecordingPromptGetObserver()
+	g.SetPromptGetObserver(obs)
+
+	body := makeJSONRPC(t, 1, "prompts/get", map[string]any{"name": "nonexistent"})
+	w := postMCP(t, h, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (JSON-RPC error envelope), got %d", w.Code)
+	}
+	resp := decodeResponse(t, w)
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown prompt")
+	}
+	obs.expectNoObservation(t)
+}
+
 func TestHandler_PromptsGet_DefaultArguments(t *testing.T) {
 	h, _, _ := setupTestHandlerWithRegistry(t)
 

--- a/pkg/mcp/streamable.go
+++ b/pkg/mcp/streamable.go
@@ -27,7 +27,7 @@ type streamableEvent struct {
 type StreamableSession struct {
 	ID string
 
-	histMu sync.Mutex
+	histMu  sync.Mutex
 	history []*streamableEvent
 	nextID  atomic.Int64
 
@@ -355,7 +355,7 @@ func (s *StreamableHTTPServer) handleRequest(ctx context.Context, session *Strea
 	case "prompts/list":
 		return s.handlePromptsList(req)
 	case "prompts/get":
-		return s.handlePromptsGet(req)
+		return s.handlePromptsGet(ctx, req)
 	case "resources/list":
 		return s.handleResourcesList(req)
 	case "resources/read":
@@ -395,7 +395,7 @@ func (s *StreamableHTTPServer) handlePromptsList(req *jsonrpc.Request) jsonrpc.R
 	return jsonrpc.NewSuccessResponse(req.ID, result)
 }
 
-func (s *StreamableHTTPServer) handlePromptsGet(req *jsonrpc.Request) jsonrpc.Response {
+func (s *StreamableHTTPServer) handlePromptsGet(ctx context.Context, req *jsonrpc.Request) jsonrpc.Response {
 	if req.Params == nil {
 		return jsonrpc.NewErrorResponse(req.ID, jsonrpc.InvalidParams, "params required for prompts/get")
 	}
@@ -403,7 +403,7 @@ func (s *StreamableHTTPServer) handlePromptsGet(req *jsonrpc.Request) jsonrpc.Re
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		return jsonrpc.NewErrorResponse(req.ID, jsonrpc.InvalidParams, "Invalid prompts/get params")
 	}
-	result, err := s.gateway.HandlePromptsGet(params)
+	result, err := s.gateway.HandlePromptsGet(ctx, params)
 	if err != nil {
 		return jsonrpc.NewErrorResponse(req.ID, jsonrpc.InternalError, err.Error())
 	}

--- a/pkg/mcp/streamable_test.go
+++ b/pkg/mcp/streamable_test.go
@@ -704,6 +704,45 @@ func (p *streamableTestPromptProvider) GetPromptData(name string) (*PromptData, 
 	return nil, fmt.Errorf("prompt %q: not found", name)
 }
 
+// recordingPromptGetObserver captures ObservePromptGet calls for assertions.
+// The gateway fires the observer on a goroutine, so tests synchronize on the
+// channel rather than reading shared state. Shared by the handler and
+// streamable transport tests (both in package mcp).
+type recordingPromptGetObserver struct {
+	calls chan PromptGetObservation
+}
+
+func newRecordingPromptGetObserver() *recordingPromptGetObserver {
+	return &recordingPromptGetObserver{calls: make(chan PromptGetObservation, 8)}
+}
+
+func (o *recordingPromptGetObserver) ObservePromptGet(obs PromptGetObservation) {
+	o.calls <- obs
+}
+
+// waitForObservation returns the next observation or fails after a timeout.
+func (o *recordingPromptGetObserver) waitForObservation(t *testing.T) PromptGetObservation {
+	t.Helper()
+	select {
+	case obs := <-o.calls:
+		return obs
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for prompt-get observation")
+		return PromptGetObservation{}
+	}
+}
+
+// expectNoObservation asserts the observer does not fire within a short window.
+// Used to confirm a failed prompts/get records nothing.
+func (o *recordingPromptGetObserver) expectNoObservation(t *testing.T) {
+	t.Helper()
+	select {
+	case got := <-o.calls:
+		t.Fatalf("observer fired unexpectedly: %+v", got)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
 func setupStreamableWithRegistry(t *testing.T) (*StreamableHTTPServer, string) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
@@ -764,6 +803,49 @@ func TestStreamableHTTPServer_PromptsGet(t *testing.T) {
 	if result.Messages[0].Content.Text != expected {
 		t.Errorf("expected %q, got %q", expected, result.Messages[0].Content.Text)
 	}
+}
+
+func TestStreamableHTTPServer_PromptsGet_FiresObserver(t *testing.T) {
+	srv, sessionID := setupStreamableWithRegistry(t)
+	obs := newRecordingPromptGetObserver()
+	srv.gateway.SetPromptGetObserver(obs)
+
+	resp := streamablePost(t, srv, sessionID, "prompts/get", map[string]any{
+		"name":      "code-review",
+		"arguments": map[string]any{"language": "Go", "code": "func main() {}"},
+	})
+	// Serving behavior is unchanged by the observer.
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %s", resp.Error.Message)
+	}
+	var result PromptsGetResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatal(err)
+	}
+	if want := "Review this Go code: func main() {}"; result.Messages[0].Content.Text != want {
+		t.Errorf("content = %q, want %q", result.Messages[0].Content.Text, want)
+	}
+
+	got := obs.waitForObservation(t)
+	if got.PromptName != "code-review" {
+		t.Errorf("observed prompt = %q, want code-review", got.PromptName)
+	}
+	// The streamable transport attributes usage to the initializing client.
+	if got.ClientID != "test-client" {
+		t.Errorf("observed clientID = %q, want test-client", got.ClientID)
+	}
+}
+
+func TestStreamableHTTPServer_PromptsGet_NotFoundDoesNotFireObserver(t *testing.T) {
+	srv, sessionID := setupStreamableWithRegistry(t)
+	obs := newRecordingPromptGetObserver()
+	srv.gateway.SetPromptGetObserver(obs)
+
+	resp := streamablePost(t, srv, sessionID, "prompts/get", map[string]any{"name": "nonexistent"})
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown prompt")
+	}
+	obs.expectNoObservation(t)
 }
 
 func TestStreamableHTTPServer_PromptsGet_NilParams(t *testing.T) {

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -116,6 +116,30 @@ type ClientObserver interface {
 	ObserveToolCallWithClient(ctx context.Context, obs ToolCallObservation) ToolCallSummary
 }
 
+// PromptGetObserver receives notifications after a prompt (a registry skill)
+// is successfully served via prompts/get. Used by the metrics system to record
+// per-skill usage without coupling the gateway to the metrics package
+// directly. Kept separate from ToolCallObserver so prompt serving never shows
+// up in tool-call telemetry (Tools Audit Mode).
+type PromptGetObserver interface {
+	// ObservePromptGet is called after a prompt is successfully served. The
+	// gateway invokes it asynchronously, so implementations may be slow and
+	// must not assume any ordering relative to the request returning.
+	ObservePromptGet(obs PromptGetObservation)
+}
+
+// PromptGetObservation is the payload passed to a PromptGetObserver. New
+// optional fields can land here over time so the interface stays stable.
+type PromptGetObservation struct {
+	// PromptName is the served prompt name, which equals the registry
+	// skill's Name.
+	PromptName string
+	// ClientID is the normalized identifier of the originating MCP client
+	// (for example "claude-code", "cursor"). Empty when no session
+	// attribution was available; observers should treat that as anonymous.
+	ClientID string
+}
+
 // FormatSavingsRecorder receives format savings observations.
 // Used by the gateway to report token savings from format conversion
 // without coupling to the metrics package directly.
@@ -423,4 +447,3 @@ type ResourceContents struct {
 type ResourcesReadResult struct {
 	Contents []ResourceContents `json:"contents"`
 }
-

--- a/pkg/metrics/accumulator.go
+++ b/pkg/metrics/accumulator.go
@@ -251,6 +251,16 @@ type toolUsage struct {
 	lastCalledNanos atomic.Int64
 }
 
+// promptUsage holds per-skill atomic counters for prompts/get serving. Same
+// shape as toolUsage but keyed by a single skill (prompt) name in the
+// accumulator. Kept in a separate namespace from toolUsage so prompt serving
+// never appears in Tools Audit Mode. lastCalledNanos stores time.UnixNano so
+// the read path can produce a time.Time without taking a lock.
+type promptUsage struct {
+	calls           atomic.Int64
+	lastCalledNanos atomic.Int64
+}
+
 // Accumulator collects token usage metrics with thread-safe operations.
 // Session totals use atomic counters. Historical data is stored in a ring buffer
 // of pre-aggregated 1-minute time buckets.
@@ -302,6 +312,12 @@ type Accumulator struct {
 	toolUsageMu sync.RWMutex
 	toolUsage   map[string]map[string]*toolUsage
 
+	// Per-skill prompts/get call counters. Powers the Skills Library
+	// "Never used" facet. Kept in a separate namespace from toolUsage so
+	// prompt serving never pollutes Tools Audit Mode.
+	promptUsageMu sync.RWMutex
+	promptUsage   map[string]*promptUsage
+
 	// Format savings (atomic for lock-free reads)
 	savingsOriginal  atomic.Int64
 	savingsFormatted atomic.Int64
@@ -331,15 +347,16 @@ func NewAccumulator(maxDataPoints int) *Accumulator {
 		maxDataPoints = 10000
 	}
 	return &Accumulator{
-		startedAt:  time.Now(),
-		servers:    make(map[string]*serverCounters),
-		replicas:   make(map[string]map[int]*replicaCounters),
-		buckets:    make([]bucket, maxDataPoints),
-		maxSize:    maxDataPoints,
-		serverBufs: make(map[string]*serverBuffer),
-		clients:    make(map[string]*clientCounters),
-		clientBufs: make(map[string]*serverBuffer),
-		toolUsage:  make(map[string]map[string]*toolUsage),
+		startedAt:   time.Now(),
+		servers:     make(map[string]*serverCounters),
+		replicas:    make(map[string]map[int]*replicaCounters),
+		buckets:     make([]bucket, maxDataPoints),
+		maxSize:     maxDataPoints,
+		serverBufs:  make(map[string]*serverBuffer),
+		clients:     make(map[string]*clientCounters),
+		clientBufs:  make(map[string]*serverBuffer),
+		toolUsage:   make(map[string]map[string]*toolUsage),
+		promptUsage: make(map[string]*promptUsage),
 	}
 }
 
@@ -571,6 +588,93 @@ func (a *Accumulator) RestoreToolUsage(perServer map[string]map[string]ToolStat)
 				if nanos := stat.LastCalledAt.UnixNano(); nanos > tu.lastCalledNanos.Load() {
 					tu.lastCalledNanos.Store(nanos)
 				}
+			}
+		}
+	}
+}
+
+// RecordPromptGet increments the call counter for a single skill (prompt)
+// served via prompts/get and stamps the last-called timestamp. Powers the
+// Skills Library "Never used" facet. An empty name is a no-op so callers
+// without attribution can invoke unconditionally.
+//
+// Kept parallel to RecordToolCall rather than reusing it: routing prompt
+// serving through the tool-usage map would surface synthetic entries in
+// Tools Audit Mode.
+func (a *Accumulator) RecordPromptGet(name string) {
+	if name == "" {
+		return
+	}
+	pu := a.getOrCreatePromptUsage(name)
+	pu.calls.Add(1)
+	pu.lastCalledNanos.Store(time.Now().UnixNano())
+}
+
+func (a *Accumulator) getOrCreatePromptUsage(name string) *promptUsage {
+	a.promptUsageMu.RLock()
+	if pu, ok := a.promptUsage[name]; ok {
+		a.promptUsageMu.RUnlock()
+		return pu
+	}
+	a.promptUsageMu.RUnlock()
+
+	a.promptUsageMu.Lock()
+	defer a.promptUsageMu.Unlock()
+	pu, ok := a.promptUsage[name]
+	if !ok {
+		pu = &promptUsage{}
+		a.promptUsage[name] = pu
+	}
+	return pu
+}
+
+// PromptUsageSnapshot returns a deep copy of the per-skill prompts/get call
+// counters. Empty (nil) when no prompt has been served yet. Reuses the
+// ToolStat value shape so the persistence and API layers share one type.
+func (a *Accumulator) PromptUsageSnapshot() map[string]ToolStat {
+	a.promptUsageMu.RLock()
+	defer a.promptUsageMu.RUnlock()
+	if len(a.promptUsage) == 0 {
+		return nil
+	}
+	out := make(map[string]ToolStat, len(a.promptUsage))
+	for name, pu := range a.promptUsage {
+		calls := pu.calls.Load()
+		var lastCalled time.Time
+		if nanos := pu.lastCalledNanos.Load(); nanos > 0 {
+			lastCalled = time.Unix(0, nanos)
+		}
+		out[name] = ToolStat{Calls: calls, LastCalledAt: lastCalled}
+	}
+	return out
+}
+
+// RestorePromptUsage seeds per-skill prompts/get counters from a persisted
+// snapshot so usage history survives a gateway restart. Mirrors
+// RestoreToolUsage: max-wins per counter (an existing in-memory value is kept
+// when it already exceeds the restored one), entries with no recorded calls
+// are skipped, and an empty map is a no-op.
+func (a *Accumulator) RestorePromptUsage(perSkill map[string]ToolStat) {
+	if len(perSkill) == 0 {
+		return
+	}
+	a.promptUsageMu.Lock()
+	defer a.promptUsageMu.Unlock()
+	for name, stat := range perSkill {
+		if name == "" || stat.Calls <= 0 {
+			continue
+		}
+		pu, ok := a.promptUsage[name]
+		if !ok {
+			pu = &promptUsage{}
+			a.promptUsage[name] = pu
+		}
+		if stat.Calls > pu.calls.Load() {
+			pu.calls.Store(stat.Calls)
+		}
+		if !stat.LastCalledAt.IsZero() {
+			if nanos := stat.LastCalledAt.UnixNano(); nanos > pu.lastCalledNanos.Load() {
+				pu.lastCalledNanos.Store(nanos)
 			}
 		}
 	}
@@ -1444,6 +1548,10 @@ func (a *Accumulator) Clear() {
 	a.toolUsageMu.Lock()
 	a.toolUsage = make(map[string]map[string]*toolUsage)
 	a.toolUsageMu.Unlock()
+
+	a.promptUsageMu.Lock()
+	a.promptUsage = make(map[string]*promptUsage)
+	a.promptUsageMu.Unlock()
 
 	a.savingsOriginal.Store(0)
 	a.savingsFormatted.Store(0)

--- a/pkg/metrics/accumulator_test.go
+++ b/pkg/metrics/accumulator_test.go
@@ -822,6 +822,112 @@ func TestAccumulator_RestoreToolUsage(t *testing.T) {
 	})
 }
 
+func TestAccumulator_RecordPromptGet(t *testing.T) {
+	acc := NewAccumulator(100)
+
+	acc.RecordPromptGet("code-review")
+	acc.RecordPromptGet("code-review")
+	acc.RecordPromptGet("summarize")
+
+	snap := acc.PromptUsageSnapshot()
+	if got := snap["code-review"].Calls; got != 2 {
+		t.Errorf("code-review calls = %d, want 2", got)
+	}
+	if got := snap["summarize"].Calls; got != 1 {
+		t.Errorf("summarize calls = %d, want 1", got)
+	}
+	if snap["code-review"].LastCalledAt.IsZero() {
+		t.Error("code-review LastCalledAt should be non-zero")
+	}
+}
+
+func TestAccumulator_RecordPromptGet_EmptyNameIsNoOp(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordPromptGet("")
+	if snap := acc.PromptUsageSnapshot(); len(snap) != 0 {
+		t.Errorf("expected empty prompt usage; got %v", snap)
+	}
+}
+
+func TestAccumulator_PromptUsageSnapshot_EmptyAccumulator(t *testing.T) {
+	acc := NewAccumulator(100)
+	if snap := acc.PromptUsageSnapshot(); snap != nil {
+		t.Errorf("PromptUsageSnapshot on fresh accumulator should be nil; got %v", snap)
+	}
+}
+
+func TestAccumulator_PromptUsage_DoesNotTouchToolUsage(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordPromptGet("code-review")
+	if snap := acc.ToolUsageSnapshot(); snap != nil {
+		t.Errorf("prompt usage must not appear in tool usage (Audit Mode); got %v", snap)
+	}
+}
+
+func TestAccumulator_RestorePromptUsage(t *testing.T) {
+	t.Run("seeds counts and continues incrementing", func(t *testing.T) {
+		acc := NewAccumulator(100)
+		last := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+		acc.RestorePromptUsage(map[string]ToolStat{
+			"code-review": {Calls: 5, LastCalledAt: last},
+		})
+
+		snap := acc.PromptUsageSnapshot()
+		if got := snap["code-review"].Calls; got != 5 {
+			t.Fatalf("restored calls = %d, want 5", got)
+		}
+		if got := snap["code-review"].LastCalledAt; !got.Equal(last) {
+			t.Errorf("restored LastCalledAt = %v, want %v", got, last)
+		}
+
+		acc.RecordPromptGet("code-review")
+		if got := acc.PromptUsageSnapshot()["code-review"].Calls; got != 6 {
+			t.Errorf("calls after restore+record = %d, want 6", got)
+		}
+	})
+
+	t.Run("max-wins keeps a larger in-memory count", func(t *testing.T) {
+		acc := NewAccumulator(100)
+		acc.RecordPromptGet("code-review")
+		acc.RecordPromptGet("code-review")
+		acc.RecordPromptGet("code-review") // 3 live calls
+		acc.RestorePromptUsage(map[string]ToolStat{
+			"code-review": {Calls: 1, LastCalledAt: time.Now()},
+		})
+		if got := acc.PromptUsageSnapshot()["code-review"].Calls; got != 3 {
+			t.Errorf("calls = %d, want 3 (live count must win over smaller restore)", got)
+		}
+	})
+
+	t.Run("zero-call and empty entries are skipped", func(t *testing.T) {
+		acc := NewAccumulator(100)
+		acc.RestorePromptUsage(map[string]ToolStat{
+			"never": {Calls: 0},
+			"":      {Calls: 9},
+		})
+		if snap := acc.PromptUsageSnapshot(); snap != nil {
+			t.Errorf("expected no usage restored; got %v", snap)
+		}
+	})
+
+	t.Run("empty map is a no-op", func(t *testing.T) {
+		acc := NewAccumulator(100)
+		acc.RestorePromptUsage(nil)
+		if snap := acc.PromptUsageSnapshot(); snap != nil {
+			t.Errorf("nil restore should be no-op; got %v", snap)
+		}
+	})
+}
+
+func TestAccumulator_Clear_ResetsPromptUsage(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordPromptGet("code-review")
+	acc.Clear()
+	if snap := acc.PromptUsageSnapshot(); snap != nil {
+		t.Errorf("Clear should reset prompt usage; got %v", snap)
+	}
+}
+
 func TestAccumulator_Clear_ResetsPerClient(t *testing.T) {
 	acc := NewAccumulator(100)
 	acc.RecordReplicaWithClient("s", -1, "client-a", 10, 5)

--- a/pkg/metrics/observer.go
+++ b/pkg/metrics/observer.go
@@ -63,6 +63,14 @@ func (o *Observer) ObserveToolCallWithClient(_ context.Context, obs mcp.ToolCall
 	return o.observe(obs.ServerName, obs.ReplicaID, obs.ClientID, obs.ToolName, obs.Arguments, obs.Result)
 }
 
+// ObservePromptGet records that a registry skill was served via prompts/get,
+// incrementing its cumulative count and last-used timestamp in the parallel
+// prompt-usage namespace. The token/cost path does not apply: prompts are
+// static content, not tool calls.
+func (o *Observer) ObservePromptGet(obs mcp.PromptGetObservation) {
+	o.accumulator.RecordPromptGet(obs.PromptName)
+}
+
 // observe is the shared core of the legacy and client-aware observer entry
 // points. It returns the values needed to set OTel GenAI span attributes
 // for callers that pass the call through ObserveToolCallWithClient; the

--- a/pkg/metrics/observer_test.go
+++ b/pkg/metrics/observer_test.go
@@ -43,6 +43,28 @@ func TestObserver_ObserveToolCall(t *testing.T) {
 	}
 }
 
+func TestObserver_ObservePromptGet(t *testing.T) {
+	counter := token.NewHeuristicCounter(4)
+	acc := NewAccumulator(100)
+	obs := NewObserver(counter, acc)
+
+	obs.ObservePromptGet(mcp.PromptGetObservation{PromptName: "code-review", ClientID: "claude-code"})
+	obs.ObservePromptGet(mcp.PromptGetObservation{PromptName: "code-review"})
+
+	snap := acc.PromptUsageSnapshot()
+	if got := snap["code-review"].Calls; got != 2 {
+		t.Errorf("code-review calls = %d, want 2", got)
+	}
+	// Prompt serving must never appear in tool usage (Tools Audit Mode).
+	if tu := acc.ToolUsageSnapshot(); tu != nil {
+		t.Errorf("prompt get leaked into tool usage: %v", tu)
+	}
+	// And it must not record any token/cost usage.
+	if s := acc.Snapshot(); s.Session.TotalTokens != 0 {
+		t.Errorf("prompt get recorded tokens = %d, want 0", s.Session.TotalTokens)
+	}
+}
+
 func TestObserver_PerReplica(t *testing.T) {
 	counter := token.NewHeuristicCounter(4)
 	acc := NewAccumulator(100)

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -44,7 +44,20 @@ type MetricsSnapshotLine struct {
 	// takes the most recent non-nil ToolUsage per server (resetting on a
 	// token Reset) to rehydrate Audit Mode's usage history across restarts.
 	ToolUsage map[string]metrics.ToolStat `json:"tool_usage,omitempty"`
+	// PromptUsage carries *cumulative* per-skill prompts/get call counters
+	// (skillName -> calls + last-called) at flush time. Unlike ToolUsage it
+	// is global rather than per-server, so it is written only on lines for
+	// the reserved PromptUsageNamespace by the dedicated prompt-usage writer.
+	// omitempty keeps every per-server line byte-identical.
+	PromptUsage map[string]metrics.ToolStat `json:"prompt_usage,omitempty"`
 }
+
+// PromptUsageNamespace is the reserved flusher key under which global
+// per-skill prompts/get usage is persisted. It is not a real MCP server: the
+// skills registry is not a stack.MCPServers entry, so the gateway builder
+// registers a dedicated writer for it explicitly. The leading/trailing
+// underscores keep it from colliding with any user-defined server name.
+const PromptUsageNamespace = "__skills__"
 
 // MetricsFlusher periodically serializes per-server token counters from a
 // metrics.Accumulator and appends one NDJSON line per server with non-zero
@@ -62,6 +75,13 @@ type MetricsFlusher struct {
 	prevCost  map[string]metrics.CostMicroUSDCounts  // serverName -> last cost snapshot (parallel to prev)
 	prevTools map[string]map[string]metrics.ToolStat // serverName -> last per-tool snapshot (parallel to prev)
 
+	// Global prompt (skill) usage. The skills registry is not a per-server
+	// entry, so it gets a single dedicated writer rather than living in the
+	// per-server writers map. prevPrompts tracks the last flushed snapshot
+	// for change detection, mirroring prevTools.
+	promptWriter *lumberjack.Logger
+	prevPrompts  map[string]metrics.ToolStat
+
 	stop     chan struct{}
 	done     chan struct{}
 	started  bool
@@ -75,14 +95,15 @@ func NewMetricsFlusher(acc *metrics.Accumulator, interval time.Duration) *Metric
 		interval = DefaultMetricsFlushInterval
 	}
 	return &MetricsFlusher{
-		acc:       acc,
-		interval:  interval,
-		writers:   make(map[string]*lumberjack.Logger),
-		prev:      make(map[string]metrics.TokenCounts),
-		prevCost:  make(map[string]metrics.CostMicroUSDCounts),
-		prevTools: make(map[string]map[string]metrics.ToolStat),
-		stop:      make(chan struct{}),
-		done:      make(chan struct{}),
+		acc:         acc,
+		interval:    interval,
+		writers:     make(map[string]*lumberjack.Logger),
+		prev:        make(map[string]metrics.TokenCounts),
+		prevCost:    make(map[string]metrics.CostMicroUSDCounts),
+		prevTools:   make(map[string]map[string]metrics.ToolStat),
+		prevPrompts: make(map[string]metrics.ToolStat),
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
 	}
 }
 
@@ -150,6 +171,56 @@ func (f *MetricsFlusher) RemoveServer(name string) {
 	delete(f.prevTools, name)
 }
 
+// SetPromptUsageWriter installs (or replaces) the writer for the global
+// prompt-usage namespace. Unlike AddServer this is a single writer because
+// skill usage is not per-server; the gateway builder wires it explicitly off
+// the stack-global metrics toggle since the skills registry is not a
+// stack.MCPServers entry. Idempotent: re-installing closes the prior handle.
+func (f *MetricsFlusher) SetPromptUsageWriter(path string, opts LogOpts) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.promptWriter != nil {
+		_ = f.promptWriter.Close()
+	}
+
+	if opts.MaxSizeMB <= 0 {
+		opts.MaxSizeMB = 100
+	}
+	if opts.MaxBackups <= 0 {
+		opts.MaxBackups = 5
+	}
+	if opts.MaxAgeDays <= 0 {
+		opts.MaxAgeDays = 7
+	}
+
+	lj := &lumberjack.Logger{
+		Filename:   path,
+		MaxSize:    opts.MaxSizeMB,
+		MaxBackups: opts.MaxBackups,
+		MaxAge:     opts.MaxAgeDays,
+		Compress:   true,
+	}
+	if err := touchMode0600(path); err != nil {
+		return fmt.Errorf("telemetry prompt-usage writer: %w", err)
+	}
+	f.promptWriter = lj
+	return nil
+}
+
+// RemovePromptUsageWriter stops persisting prompt usage and closes its
+// writer. The previous-snapshot tracking is dropped so re-installing produces
+// a fresh cumulative line. Safe to call when no writer is configured.
+func (f *MetricsFlusher) RemovePromptUsageWriter() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.promptWriter != nil {
+		_ = f.promptWriter.Close()
+		f.promptWriter = nil
+	}
+	f.prevPrompts = make(map[string]metrics.ToolStat)
+}
+
 // ConfiguredServers returns the names currently persisting metrics.
 func (f *MetricsFlusher) ConfiguredServers() []string {
 	f.mu.Lock()
@@ -191,12 +262,16 @@ func (f *MetricsFlusher) Stop() {
 	f.stopOnce.Do(func() { close(f.stop) })
 	<-f.done
 
-	// Close all per-server writers after the final flush.
+	// Close all per-server writers and the prompt-usage writer after the
+	// final flush.
 	f.mu.Lock()
 	for _, lj := range f.writers {
 		if lj != nil {
 			_ = lj.Close()
 		}
+	}
+	if f.promptWriter != nil {
+		_ = f.promptWriter.Close()
 	}
 	f.mu.Unlock()
 }
@@ -232,6 +307,7 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 	snap := f.acc.Snapshot()
 	costSnap := f.acc.CostMicroSnapshot()
 	toolSnap := f.acc.ToolUsageSnapshot()
+	promptSnap := f.acc.PromptUsageSnapshot()
 
 	type planned struct {
 		writer *lumberjack.Logger
@@ -342,6 +418,23 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 		f.prev[name] = current
 		f.prevCost[name] = currentCost
 		f.prevTools[name] = currentTools
+	}
+
+	// Prompt (skill) usage is global cumulative state under a dedicated
+	// writer, not part of any per-server line. Emit one line whenever the
+	// counts advanced since the last flush; reuse toolUsageChanged since both
+	// are map[string]ToolStat. The line carries no token/cost diff, so it is
+	// never a reset line.
+	if f.promptWriter != nil && toolUsageChanged(f.prevPrompts, promptSnap) {
+		plan = append(plan, planned{
+			writer: f.promptWriter,
+			line: MetricsSnapshotLine{
+				Time:        now.UTC(),
+				Server:      PromptUsageNamespace,
+				PromptUsage: promptSnap,
+			},
+		})
+		f.prevPrompts = promptSnap
 	}
 	f.mu.Unlock()
 
@@ -572,6 +665,65 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 	for name, tools := range latestTools {
 		f.prevTools[name] = tools
 	}
+	f.mu.Unlock()
+	return nil
+}
+
+// SeedPromptUsageFromFile reads up to the last n NDJSON entries from path and
+// restores cumulative per-skill prompts/get counts via RestorePromptUsage so
+// skill usage survives a gateway restart. It seeds prevPrompts too so the
+// next flush computes a change against the restored baseline rather than
+// re-emitting it. Prompt usage is a cumulative snapshot (like ToolUsage), so
+// the most recent non-nil PromptUsage line wins.
+//
+// Missing or empty files return nil (expected on first run). Malformed lines
+// are skipped without aborting.
+func (f *MetricsFlusher) SeedPromptUsageFromFile(path string, n int) error {
+	if path == "" || f.acc == nil {
+		return nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("seed prompt usage from %q: %w", path, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("seed prompt usage scan %q: %w", path, err)
+	}
+	if n > 0 && len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+
+	var latest map[string]metrics.ToolStat
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec MetricsSnapshotLine
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec.PromptUsage != nil {
+			latest = rec.PromptUsage
+		}
+	}
+	if len(latest) == 0 {
+		return nil
+	}
+	f.acc.RestorePromptUsage(latest)
+	f.mu.Lock()
+	f.prevPrompts = latest
 	f.mu.Unlock()
 	return nil
 }

--- a/pkg/telemetry/seed_test.go
+++ b/pkg/telemetry/seed_test.go
@@ -525,6 +525,88 @@ func approxCostEq(a, b float64) bool {
 }
 
 // splitNonEmpty splits on '\n' and discards empty entries.
+// TestEndToEnd_PromptUsagePersistAndReseed is the prompt-usage analogue of
+// TestEndToEnd_MetricsPersistAndReseed: after a daemon restart, per-skill
+// prompts/get counts and last-used timestamps come back from disk so the
+// Skills Library "Never used" facet stays honest across restarts. This guards
+// the persistence-writer pitfall — without the dedicated prompt-usage writer
+// the counts would record in memory but never reach disk or seed.
+func TestEndToEnd_PromptUsagePersistAndReseed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.jsonl")
+
+	// === Daemon "instance 1" ===
+	acc1 := metrics.NewAccumulator(100)
+	f1 := NewMetricsFlusher(acc1, time.Hour)
+	if err := f1.SetPromptUsageWriter(path, LogOpts{}); err != nil {
+		t.Fatalf("SetPromptUsageWriter: %v", err)
+	}
+	acc1.RecordPromptGet("code-review")
+	acc1.RecordPromptGet("code-review")
+	acc1.RecordPromptGet("summarize")
+	f1.flushOnce(time.Now())
+
+	// "Restart": close instance 1's writer so the file is fully flushed.
+	f1.mu.Lock()
+	if f1.promptWriter != nil {
+		_ = f1.promptWriter.Close()
+	}
+	f1.mu.Unlock()
+
+	// === Daemon "instance 2" ===
+	acc2 := metrics.NewAccumulator(100)
+	f2 := NewMetricsFlusher(acc2, time.Hour)
+	if err := f2.SetPromptUsageWriter(path, LogOpts{}); err != nil {
+		t.Fatalf("SetPromptUsageWriter: %v", err)
+	}
+	if err := f2.SeedPromptUsageFromFile(path, 100); err != nil {
+		t.Fatalf("SeedPromptUsageFromFile: %v", err)
+	}
+
+	// Pre-restart counts are visible immediately via the snapshot.
+	snap := acc2.PromptUsageSnapshot()
+	if got := snap["code-review"].Calls; got != 2 {
+		t.Errorf("seeded code-review calls = %d, want 2", got)
+	}
+	if got := snap["summarize"].Calls; got != 1 {
+		t.Errorf("seeded summarize calls = %d, want 1", got)
+	}
+	if snap["code-review"].LastCalledAt.IsZero() {
+		t.Error("seeded code-review LastCalledAt should be non-zero")
+	}
+
+	// A live call after restart continues from the restored count, and a flush
+	// emits the new cumulative snapshot (3 for code-review).
+	acc2.RecordPromptGet("code-review")
+	f2.flushOnce(time.Now())
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	lines := splitNonEmpty(string(data))
+	var last MetricsSnapshotLine
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &last); err != nil {
+		t.Fatalf("unmarshal last line: %v", err)
+	}
+	if last.Server != PromptUsageNamespace {
+		t.Errorf("last line server = %q, want %q", last.Server, PromptUsageNamespace)
+	}
+	if got := last.PromptUsage["code-review"].Calls; got != 3 {
+		t.Errorf("post-seed code-review calls = %d, want 3 (2 seeded + 1 live)", got)
+	}
+}
+
+// TestMetricsFlusher_PromptUsageMissingFileNoError confirms seeding from an
+// absent prompt-usage file is a clean no-op (expected on first run).
+func TestMetricsFlusher_PromptUsageMissingFileNoError(t *testing.T) {
+	acc := metrics.NewAccumulator(100)
+	f := NewMetricsFlusher(acc, time.Hour)
+	if err := f.SeedPromptUsageFromFile(filepath.Join(t.TempDir(), "missing.jsonl"), 100); err != nil {
+		t.Errorf("missing file should be a no-op, got %v", err)
+	}
+}
+
 func splitNonEmpty(s string) []string {
 	var out []string
 	for _, l := range strings.Split(s, "\n") {

--- a/pkg/telemetry/seed_test.go
+++ b/pkg/telemetry/seed_test.go
@@ -524,13 +524,12 @@ func approxCostEq(a, b float64) bool {
 	return d < eps
 }
 
-// splitNonEmpty splits on '\n' and discards empty entries.
 // TestEndToEnd_PromptUsagePersistAndReseed is the prompt-usage analogue of
 // TestEndToEnd_MetricsPersistAndReseed: after a daemon restart, per-skill
 // prompts/get counts and last-used timestamps come back from disk so the
 // Skills Library "Never used" facet stays honest across restarts. This guards
-// the persistence-writer pitfall — without the dedicated prompt-usage writer
-// the counts would record in memory but never reach disk or seed.
+// the persistence-writer pitfall (without the dedicated prompt-usage writer
+// the counts would record in memory but never reach disk or seed).
 func TestEndToEnd_PromptUsagePersistAndReseed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "metrics.jsonl")
@@ -607,6 +606,7 @@ func TestMetricsFlusher_PromptUsageMissingFileNoError(t *testing.T) {
 	}
 }
 
+// splitNonEmpty splits on '\n' and discards empty entries.
 func splitNonEmpty(s string) []string {
 	var out []string
 	for _, l := range strings.Split(s, "\n") {


### PR DESCRIPTION
## Description

Backend for Skill Usage Analytics (1 of 2 PRs): record, persist, and serve per-skill `prompts/get` usage so the Skills Library can surface never-used active skills. The frontend (table column, inspector strip, "Never used" KPI + facet) follows in a second PR.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- Add a `PromptGetObserver` mirroring `ToolCallObserver`, fired asynchronously after a successful `prompts/get` so recording never blocks or fails prompt serving. Thread `context.Context` through `HandlePromptsGet` and both transports (`handler.go`, `streamable.go`) for per-client attribution.
- Add a parallel persisted prompt-usage store: `RecordPromptGet` / `PromptUsageSnapshot` / `RestorePromptUsage` on the metrics accumulator (reusing the `ToolStat` shape), persisted by a dedicated `MetricsFlusher` writer under the reserved `__skills__` namespace with flush + seed. Wired in the gateway builder off the stack-global metrics toggle, since the registry is not a stack server.
- Keep prompt usage in a separate namespace from tool usage so Tools Audit Mode and `/api/tools/usage` are unaffected.
- Add `GET /api/skills/usage` returning `{ observedSince, skills: { <name>: { calls, lastCalledAt } } }`, degrading to 503 when no accumulator is wired. The registry list payload and `AgentSkill` type are unchanged; the frontend joins usage by name.

## Testing

- Observer fires (and does not fire on not-found) on both transports; metrics accumulator record/snapshot/restore + Clear; telemetry write-then-restart-then-seed round-trip; endpoint counts/empty-object/503/restore-seed.
- `go test ./...`, `go vet` (touched packages), and `make build` all pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #731