### PR TITLE
feat: skill usage analytics (frontend)

### DIFF
--- a/web/src/__tests__/LibraryWorkspace.test.tsx
+++ b/web/src/__tests__/LibraryWorkspace.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { LibraryWorkspace } from '../components/workspaces/LibraryWorkspace';
 import { useRegistryStore } from '../stores/useRegistryStore';
-import { setRegistrySkillsBatch } from '../lib/api';
+import { setRegistrySkillsBatch, fetchSkillUsage } from '../lib/api';
 import { showToast } from '../components/ui/Toast';
 import { CommandRegistryProvider } from '../hooks/useCommandRegistry';
 import type { AgentSkill, SkillSourceStatus } from '../types';
@@ -23,6 +23,9 @@ vi.mock('../lib/api', () => ({
   disableRegistrySkill: vi.fn().mockResolvedValue(undefined),
   deleteRegistrySkill: vi.fn().mockResolvedValue(undefined),
   setRegistrySkillsBatch: vi.fn().mockResolvedValue({ skills: [] }),
+  // Usage overlay (joined by name). Defaults to "available, no calls yet";
+  // tests that exercise usage UI override it with mockResolvedValueOnce.
+  fetchSkillUsage: vi.fn().mockResolvedValue({ observedSince: null, skills: {} }),
   // Used by SkillFileTree (mounted only on the inspector's Files tab).
   fetchSkillFiles: vi.fn().mockResolvedValue([]),
 }));
@@ -422,6 +425,76 @@ describe('LibraryWorkspace', () => {
       expect(await screen.findByText('1 selected')).toBeInTheDocument();
       fireEvent.click(screen.getByRole('button', { name: /clear selection/i }));
       await waitFor(() => expect(screen.queryByRole('region', { name: 'Bulk actions' })).not.toBeInTheDocument());
+    });
+  });
+
+  describe('usage analytics', () => {
+    // Two active skills (one used, one never used), plus a draft. The "Never
+    // used" KPI counts active + zero-call skills, so it should report 1.
+    const USAGE_SKILLS: AgentSkill[] = [
+      // @ts-expect-error partial AgentSkill is fine for the test
+      { name: 'used-skill', description: 'used', state: 'active', dir: 'ops', fileCount: 1 },
+      // @ts-expect-error partial AgentSkill is fine for the test
+      { name: 'unused-skill', description: 'never run', state: 'active', dir: 'ops', fileCount: 1 },
+      // @ts-expect-error partial AgentSkill is fine for the test
+      { name: 'draft-one', description: 'draft', state: 'draft', dir: 'tools', fileCount: 1 },
+    ];
+
+    const seedUsage = () => {
+      useRegistryStore.setState({ skills: USAGE_SKILLS });
+      vi.mocked(fetchSkillUsage).mockResolvedValueOnce({
+        observedSince: '2026-05-01T00:00:00Z',
+        skills: { 'used-skill': { calls: 5, lastCalledAt: '2026-05-26T00:00:00Z' } },
+      });
+    };
+
+    it('shows a "Never used" KPI counting active zero-call skills', async () => {
+      seedUsage();
+      renderAt('/library');
+      // used-skill has calls; unused-skill is active with none → count 1.
+      expect(await screen.findByRole('button', { name: 'Never used (1)' })).toBeInTheDocument();
+    });
+
+    it('applies ?usage=unused and filters to unused active skills on KPI click', async () => {
+      seedUsage();
+      let currentSearch = '';
+      renderAt('/library', (s) => { currentSearch = s; });
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Never used (1)' }));
+      await waitFor(() => expect(currentSearch).toContain('usage=unused'));
+      // Only the unused active skill remains; the used one is filtered out.
+      expect(screen.getByText('unused-skill')).toBeInTheDocument();
+      expect(screen.queryByText('used-skill')).not.toBeInTheDocument();
+      // The draft is not active, so it is excluded too.
+      expect(screen.queryByText('draft-one')).not.toBeInTheDocument();
+    });
+
+    it('shows a removable usage chip that clears ?usage', async () => {
+      seedUsage();
+      let currentSearch = '?usage=unused';
+      renderAt('/library?usage=unused', (s) => { currentSearch = s; });
+
+      fireEvent.click(await screen.findByRole('button', { name: /clear usage filter/i }));
+      await waitFor(() => expect(currentSearch).not.toContain('usage='));
+    });
+
+    it('renders a sortable "Last used" column in the table when usage exists', async () => {
+      seedUsage();
+      renderAt('/library?view=table');
+      // Scope to the column header (a "Last used" sort button also appears in
+      // the SortControl, so an unscoped button query would match two elements).
+      expect(await screen.findByRole('columnheader', { name: /last used/i })).toBeInTheDocument();
+    });
+
+    it('hides all usage UI when the usage endpoint is unavailable', async () => {
+      useRegistryStore.setState({ skills: USAGE_SKILLS });
+      vi.mocked(fetchSkillUsage).mockRejectedValueOnce(new Error('no accumulator'));
+      renderAt('/library?view=table');
+
+      // The state KPIs still render, but the usage KPI and column never appear.
+      expect(await screen.findByRole('button', { name: 'Active (2)' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /never used/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /last used/i })).not.toBeInTheDocument();
     });
   });
 });

--- a/web/src/components/registry/LibraryTable.tsx
+++ b/web/src/components/registry/LibraryTable.tsx
@@ -3,19 +3,23 @@ import { cn } from '../../lib/cn';
 import { StateBadge } from './StateBadge';
 import { SkillActions } from './SkillActions';
 import { skillCategory } from '../../lib/skillMeta';
+import { formatLastUsed } from '../../lib/toolAudit';
 import { toTitleCase } from '../../lib/text';
-import type { AgentSkill, SkillSourceStatus } from '../../types';
+import type { AgentSkill, SkillSourceStatus, SkillUsageStat } from '../../types';
 
 // The sortable column keys. Declared locally (rather than imported from the
 // workspace) so the table has no dependency cycle with its parent; the union
-// matches the workspace's SortMode for the sortable axes.
-export type LibraryTableSort = 'name' | 'state' | 'files';
+// matches the workspace's SortMode for the sortable axes. 'usage' is only an
+// option when a usageMap is supplied (the Last used column is then rendered).
+export type LibraryTableSort = 'name' | 'state' | 'files' | 'usage';
 
-const SORT_COLUMNS: { key: LibraryTableSort; label: string }[] = [
+const BASE_SORT_COLUMNS: { key: LibraryTableSort; label: string }[] = [
   { key: 'state', label: 'State' },
   { key: 'name', label: 'Name' },
   { key: 'files', label: 'Files' },
 ];
+
+const USAGE_SORT_COLUMN: { key: LibraryTableSort; label: string } = { key: 'usage', label: 'Last used' };
 
 export interface LibraryTableProps {
   skills: AgentSkill[];
@@ -30,6 +34,11 @@ export interface LibraryTableProps {
   onSelect: (skill: AgentSkill) => void;
   activeSkillName: string | null;
   sourceMap?: Map<string, SkillSourceStatus>;
+  // Per-skill usage, joined by name. When supplied, a sortable "Last used"
+  // column is rendered; when absent the column is omitted entirely (the usage
+  // endpoint is unavailable), keeping DetachedRegistryPage and prior callers
+  // unchanged.
+  usageMap?: Map<string, SkillUsageStat>;
   onEnable: (skill: AgentSkill) => void;
   onDisable: (skill: AgentSkill) => void;
   onEdit: (skill: AgentSkill) => void;
@@ -56,6 +65,7 @@ export function LibraryTable({
   onSelect,
   activeSkillName,
   sourceMap,
+  usageMap,
   onEnable,
   onDisable,
   onEdit,
@@ -65,6 +75,8 @@ export function LibraryTable({
   const handleToggle = (s: AgentSkill) => (s.state === 'active' ? onDisable(s) : onEnable(s));
   const cellPad = compact ? 'py-1.5' : 'py-2.5';
   const selectAllChecked = allSelected ? 'true' : someSelected ? 'mixed' : 'false';
+  const showUsage = usageMap !== undefined;
+  const sortColumns = showUsage ? [...BASE_SORT_COLUMNS, USAGE_SORT_COLUMN] : BASE_SORT_COLUMNS;
 
   return (
     <div className="p-4">
@@ -92,7 +104,7 @@ export function LibraryTable({
                 ) : null}
               </button>
             </th>
-            {SORT_COLUMNS.map((col) => (
+            {sortColumns.map((col) => (
               <th key={col.key} scope="col" className="px-2 py-2 text-left">
                 <button
                   type="button"
@@ -121,6 +133,8 @@ export function LibraryTable({
             const isSel = selectedNames.has(skill.name);
             const src = sourceMap?.get(skill.name);
             const category = skillCategory(skill.dir);
+            const usage = usageMap?.get(skill.name);
+            const lastUsed = usage?.lastCalledAt ? formatLastUsed(usage.lastCalledAt) : '–';
             return (
               <tr
                 key={skill.name}
@@ -166,10 +180,13 @@ export function LibraryTable({
                     )}
                   </button>
                 </td>
+                <td className={cn('px-2 text-xs font-mono text-text-muted', cellPad)}>{skill.fileCount}</td>
+                {showUsage && (
+                  <td className={cn('px-2 text-xs text-text-muted whitespace-nowrap', cellPad)}>{lastUsed}</td>
+                )}
                 <td className={cn('px-2 text-xs text-text-muted', cellPad)}>
                   {category ? toTitleCase(category) : '–'}
                 </td>
-                <td className={cn('px-2 text-xs font-mono text-text-muted', cellPad)}>{skill.fileCount}</td>
                 <td className={cn('px-2 text-right', cellPad)}>
                   <div className="inline-flex justify-end">
                     <SkillActions skill={skill} onToggle={handleToggle} onEdit={onEdit} onDelete={onDelete} />

--- a/web/src/components/registry/SkillDetailPanel.tsx
+++ b/web/src/components/registry/SkillDetailPanel.tsx
@@ -4,12 +4,13 @@ import { cn } from '../../lib/cn';
 import { extractRepoInfo } from '../../lib/repo';
 import { toTitleCase } from '../../lib/text';
 import { parseAcceptanceCriterion } from '../../lib/skillCriteria';
+import { formatLastUsed } from '../../lib/toolAudit';
 import { InspectorHeader, InspectorTabList, InspectorTabButton } from '../inspector';
 import { IconButton } from '../ui/IconButton';
 import { StateBadge } from './StateBadge';
 import { MarkdownPreview } from './MarkdownPreview';
 import { SkillFileTree } from './SkillFileTree';
-import type { AgentSkill, SkillSourceStatus } from '../../types';
+import type { AgentSkill, SkillSourceStatus, SkillUsageStat } from '../../types';
 
 type SkillTab = 'overview' | 'instructions' | 'files';
 
@@ -29,6 +30,16 @@ export interface SkillDetailPanelProps {
   source?: SkillSourceStatus;
   /** Other skills in the same top-level category, for the "Related" list. */
   relatedSkills?: AgentSkill[];
+  /**
+   * Whether the usage endpoint is available. When false, the Usage section is
+   * omitted entirely (no column/KPI/strip on graceful degradation). When true,
+   * a skill with no `usage` entry is shown as "no recorded calls".
+   */
+  usageTracked?: boolean;
+  /** This skill's usage, joined by name. Undefined means zero recorded calls. */
+  usage?: SkillUsageStat;
+  /** When the gateway began recording usage, to label the young-window case. */
+  observedSince?: string | null;
   onClose: () => void;
   onEdit: (skill: AgentSkill) => void;
   onToggle: (skill: AgentSkill) => void;
@@ -46,6 +57,9 @@ export function SkillDetailPanel({
   skill,
   source,
   relatedSkills = [],
+  usageTracked = false,
+  usage,
+  observedSince,
   onClose,
   onEdit,
   onToggle,
@@ -164,6 +178,9 @@ export function SkillDetailPanel({
             <SkillOverview
               skill={skill}
               relatedSkills={relatedSkills}
+              usageTracked={usageTracked}
+              usage={usage}
+              observedSince={observedSince}
               onSelectRelated={onSelectRelated}
             />
           )}
@@ -204,16 +221,23 @@ export function SkillDetailPanel({
 function SkillOverview({
   skill,
   relatedSkills,
+  usageTracked,
+  usage,
+  observedSince,
   onSelectRelated,
 }: {
   skill: AgentSkill;
   relatedSkills: AgentSkill[];
+  usageTracked: boolean;
+  usage?: SkillUsageStat;
+  observedSince?: string | null;
   onSelectRelated?: (name: string) => void;
 }) {
   const category = skill.dir ? toTitleCase(skill.dir.split('/')[0]) : null;
   const tools = (skill.allowedTools ?? '').split(/\s+/).filter(Boolean);
   const metadataEntries = Object.entries(skill.metadata ?? {});
   const criteria = skill.acceptanceCriteria ?? [];
+  const calls = usage?.calls ?? 0;
 
   return (
     <>
@@ -226,6 +250,22 @@ function SkillOverview({
           <p className="text-[11px] text-text-muted/70 italic">No description.</p>
         )}
       </Section>
+
+      {usageTracked && (
+        <Section title="Usage">
+          {calls > 0 ? (
+            <p className="text-xs text-text-secondary">
+              Last used {usage?.lastCalledAt ? formatLastUsed(usage.lastCalledAt) : 'recently'} ·{' '}
+              {calls} {calls === 1 ? 'call' : 'calls'}
+            </p>
+          ) : (
+            <p className="text-[11px] text-text-muted/80 leading-relaxed">
+              No recorded calls{observedSince ? `, tracking since ${formatLastUsed(observedSince)}` : ''}.
+              Counts are cumulative across served clients, so a zero may mean the skill predates tracking.
+            </p>
+          )}
+        </Section>
+      )}
 
       <Section title="Details">
         <dl className="space-y-1.5">

--- a/web/src/components/workspaces/LibraryWorkspace.tsx
+++ b/web/src/components/workspaces/LibraryWorkspace.tsx
@@ -25,6 +25,7 @@ import { SkillDetailPanel } from '../registry/SkillDetailPanel';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { showToast } from '../ui/Toast';
 import { useFuzzySearch } from '../../hooks/useFuzzySearch';
+import { useSkillUsage } from '../../hooks/useSkillUsage';
 import { useWindowManager } from '../../hooks/useWindowManager';
 import { useRegistryStore } from '../../stores/useRegistryStore';
 import { useUIStore } from '../../stores/useUIStore';
@@ -40,10 +41,10 @@ import {
 } from '../../lib/api';
 import { extractRepoInfo } from '../../lib/repo';
 import { WorkspaceShell } from '../layout/WorkspaceShell';
-import type { AgentSkill, ItemState, SkillSourceStatus } from '../../types';
+import type { AgentSkill, ItemState, SkillSourceStatus, SkillUsageStat } from '../../types';
 
 type FilterTab = 'all' | ItemState;
-type SortMode = 'name' | 'state' | 'files';
+type SortMode = 'name' | 'state' | 'files' | 'usage';
 
 function isGroupMode(value: string | null): value is GroupMode {
   return value === 'source' || value === 'category' || value === 'none';
@@ -54,7 +55,7 @@ function isFilterTab(value: string | null): value is FilterTab {
 }
 
 function isSortMode(value: string | null): value is SortMode {
-  return value === 'name' || value === 'state' || value === 'files';
+  return value === 'name' || value === 'state' || value === 'files' || value === 'usage';
 }
 
 /**
@@ -73,6 +74,30 @@ export function LibraryWorkspace() {
   // the store instead of starting a second polling loop here.
   const skills = useRegistryStore((s) => s.skills);
   const sources = useRegistryStore((s) => s.sources);
+
+  // Per-skill usage, fetched separately and joined by name (mirroring the
+  // provenance source join) so the registry list payload stays untouched. When
+  // the endpoint is unavailable (no metrics accumulator wired) usage stays null
+  // and every usage surface (column, KPI, inspector line) is omitted.
+  const { usage } = useSkillUsage();
+  const usageAvailable = usage !== null;
+  const observedSince = usage?.observedSince ?? null;
+  const usageMap = useMemo(() => {
+    if (!usage) return null;
+    const map = new Map<string, SkillUsageStat>();
+    for (const [name, stat] of Object.entries(usage.skills)) map.set(name, stat);
+    return map;
+  }, [usage]);
+
+  // A skill is "unused" when usage data exists and it has zero recorded calls
+  // (no entry, or an entry with calls === 0).
+  const isUnused = useCallback(
+    (name: string) => {
+      const u = usageMap?.get(name);
+      return !u || u.calls === 0;
+    },
+    [usageMap],
+  );
 
   // null means "not loaded yet"; the deep-link error toast must wait for a
   // resolved fetch so a transient mid-fetch render doesn't false-positive.
@@ -208,6 +233,42 @@ export function LibraryWorkspace() {
     );
   }, [setSearchParams]);
 
+  // Usage facet: a new axis beyond the state filter, URL-synced as
+  // ?usage=unused (the only value today) and omitted otherwise. Threaded like
+  // the source isolate. Effective only when usage data is available.
+  const usageParam = searchParams.get('usage');
+  const usageFilter: 'unused' | null = usageParam === 'unused' ? 'unused' : null;
+  const usageFilterActive = usageFilter === 'unused' && usageAvailable;
+  const setUsageFilter = useCallback((filter: 'unused' | null) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (filter === 'unused') next.set('usage', 'unused');
+        else next.delete('usage');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+  // Enabling "Never used" also clears any state tab: the facet is active-only,
+  // so a draft/disabled tab would contradict it and yield an empty list while
+  // the (search-aware, tab-independent) KPI count still reads non-zero.
+  const toggleNeverUsed = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (usageFilter === 'unused') {
+          next.delete('usage');
+        } else {
+          next.set('usage', 'unused');
+          next.delete('filter');
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  }, [usageFilter, setSearchParams]);
+
   // Clear every removable facet in one update. Grouping (?group) is a view axis,
   // not a facet, so it is intentionally left untouched.
   const clearAllFacets = useCallback(() => {
@@ -218,6 +279,7 @@ export function LibraryWorkspace() {
         next.delete('filter');
         next.delete('source');
         next.delete('sort');
+        next.delete('usage');
         return next;
       },
       { replace: true },
@@ -411,15 +473,24 @@ export function LibraryWorkspace() {
     return searchResults.filter((s) => s.state === activeTab);
   }, [searchResults, activeTab]);
 
-  // Apply the provenance isolate on top of search + tab filtering, so empty
-  // states and the grid see a coherent set.
+  // Apply the provenance isolate and the usage facet on top of search + tab
+  // filtering, so empty states and the grid see a coherent set. The usage
+  // facet keeps only active skills with zero recorded calls, and applies only
+  // when usage data is available (a stale ?usage on an unavailable endpoint is
+  // inert rather than hiding everything).
   const visibleSkills = useMemo(() => {
-    if (groupMode !== 'source' || !activeSource) return displayedSkills;
-    return displayedSkills.filter((s) => {
-      const src = sourceMap.get(s.name);
-      return activeSource === 'local' ? !src : src?.name === activeSource;
-    });
-  }, [displayedSkills, groupMode, activeSource, sourceMap]);
+    let result = displayedSkills;
+    if (groupMode === 'source' && activeSource) {
+      result = result.filter((s) => {
+        const src = sourceMap.get(s.name);
+        return activeSource === 'local' ? !src : src?.name === activeSource;
+      });
+    }
+    if (usageFilterActive) {
+      result = result.filter((s) => s.state === 'active' && isUnused(s.name));
+    }
+    return result;
+  }, [displayedSkills, groupMode, activeSource, sourceMap, usageFilterActive, isUnused]);
 
   // Sort a copy of the visible set (never mutate the source). LibraryGrid
   // buckets in array order, so sorting here also orders within each group;
@@ -434,8 +505,29 @@ export function LibraryWorkspace() {
     if (sortMode === 'files') {
       return copy.sort((a, b) => b.fileCount - a.fileCount || byName(a, b));
     }
+    if (sortMode === 'usage') {
+      // Most recently used first, then by call count, then by name. A missing
+      // timestamp or count sorts as zero, so never-used skills sink to the end.
+      const lastMs = (name: string) => {
+        const t = usageMap?.get(name)?.lastCalledAt;
+        const ms = t ? Date.parse(t) : 0;
+        return Number.isNaN(ms) ? 0 : ms;
+      };
+      const calls = (name: string) => usageMap?.get(name)?.calls ?? 0;
+      return copy.sort(
+        (a, b) => lastMs(b.name) - lastMs(a.name) || calls(b.name) - calls(a.name) || byName(a, b),
+      );
+    }
     return copy.sort(byName);
-  }, [visibleSkills, sortMode]);
+  }, [visibleSkills, sortMode, usageMap]);
+
+  // "Never used" KPI count: active skills with zero recorded calls, computed
+  // within the search results (search-aware, like the state KPIs) and only
+  // when usage data exists. null hides the KPI entirely (no zero-state noise).
+  const neverUsedCount = useMemo(() => {
+    if (!usageAvailable) return null;
+    return searchResults.filter((s) => s.state === 'active' && isUnused(s.name)).length;
+  }, [usageAvailable, searchResults, isUnused]);
 
   // Reconcile the selection against the live skill set so a skill deleted out
   // from under the selection never lands in a bulk request (which would reject
@@ -506,6 +598,9 @@ export function LibraryWorkspace() {
       skill={selectedSkillObj}
       source={selectedSkillObj ? sourceMap.get(selectedSkillObj.name) : undefined}
       relatedSkills={relatedSkills}
+      usageTracked={usageAvailable}
+      usage={selectedSkillObj ? usageMap?.get(selectedSkillObj.name) : undefined}
+      observedSince={observedSince}
       onClose={() => setSelectedName(null)}
       onEdit={(s) => { setEditingSkill(s); setShowEditor(true); }}
       onToggle={(s) => (s.state === 'active' ? handleDisable(s) : handleEnable(s))}
@@ -530,6 +625,9 @@ export function LibraryWorkspace() {
             counts={tabCounts}
             activeTab={activeTab}
             onSelectFilter={setActiveTab}
+            neverUsedCount={neverUsedCount}
+            usageFilterActive={usageFilterActive}
+            onToggleNeverUsed={toggleNeverUsed}
             compact={compact}
           />
 
@@ -558,7 +656,7 @@ export function LibraryWorkspace() {
             {/* Controls row: sort axis (always), then view controls, plus the
                 grouping axis in cards view when sources exist. */}
             <div className="flex items-center justify-between gap-2 flex-wrap">
-              <SortControl mode={sortMode} onChange={setSortMode} />
+              <SortControl mode={sortMode} onChange={setSortMode} usageAvailable={usageAvailable} />
               <div className="flex items-center gap-2 flex-wrap">
                 {hasSources && viewMode === 'cards' && (
                   <GroupByControl mode={groupMode} onChange={setGroupMode} />
@@ -579,10 +677,12 @@ export function LibraryWorkspace() {
               activeTab={activeTab}
               sortMode={sortMode}
               sourceLabel={groupMode === 'source' ? activeSourceLabel : null}
+              usageUnused={usageFilterActive}
               onClearSearch={() => setSearchQuery('')}
               onClearState={() => setActiveTab('all')}
               onClearSource={() => setActiveSource(null)}
               onClearSort={() => setSortMode('name')}
+              onClearUsage={() => setUsageFilter(null)}
               onClearAll={clearAllFacets}
             />
           </div>
@@ -678,6 +778,7 @@ export function LibraryWorkspace() {
                 onSelect={(s) => setSelectedName(s.name)}
                 activeSkillName={selectedName}
                 sourceMap={sourceMap}
+                usageMap={usageMap ?? undefined}
                 onEnable={handleEnable}
                 onDisable={handleDisable}
                 onEdit={(s) => { setEditingSkill(s); setShowEditor(true); }}
@@ -778,14 +879,18 @@ const SORT_OPTIONS: { key: SortMode; label: string }[] = [
   { key: 'files', label: 'Files' },
 ];
 
-const SORT_LABEL: Record<SortMode, string> = { name: 'Name', state: 'State', files: 'Files' };
+// "Last used" sorts by usage; only offered when usage data is available.
+const USAGE_SORT_OPTION: { key: SortMode; label: string } = { key: 'usage', label: 'Last used' };
+
+const SORT_LABEL: Record<SortMode, string> = { name: 'Name', state: 'State', files: 'Files', usage: 'Last used' };
 
 /** Segmented control to switch the Library's sort axis. */
-function SortControl({ mode, onChange }: { mode: SortMode; onChange: (m: SortMode) => void }) {
+function SortControl({ mode, onChange, usageAvailable }: { mode: SortMode; onChange: (m: SortMode) => void; usageAvailable: boolean }) {
+  const options = usageAvailable ? [...SORT_OPTIONS, USAGE_SORT_OPTION] : SORT_OPTIONS;
   return (
     <div className="flex items-center gap-1" role="group" aria-label="Sort skills by">
       <span className="text-[10px] uppercase tracking-wider text-text-muted/60 mr-0.5">Sort</span>
-      {SORT_OPTIONS.map((opt) => (
+      {options.map((opt) => (
         <button
           key={opt.key}
           onClick={() => onChange(opt.key)}
@@ -809,10 +914,12 @@ interface FacetChipsProps {
   activeTab: FilterTab;
   sortMode: SortMode;
   sourceLabel: string | null;
+  usageUnused: boolean;
   onClearSearch: () => void;
   onClearState: () => void;
   onClearSource: () => void;
   onClearSort: () => void;
+  onClearUsage: () => void;
   onClearAll: () => void;
 }
 
@@ -827,16 +934,19 @@ function FacetChips({
   activeTab,
   sortMode,
   sourceLabel,
+  usageUnused,
   onClearSearch,
   onClearState,
   onClearSource,
   onClearSort,
+  onClearUsage,
   onClearAll,
 }: FacetChipsProps) {
   const chips: { key: string; label: string; value: string; onClear: () => void }[] = [];
   if (searchQuery.trim()) chips.push({ key: 'search', label: 'Search', value: searchQuery.trim(), onClear: onClearSearch });
   if (activeTab !== 'all') chips.push({ key: 'state', label: 'State', value: activeTab, onClear: onClearState });
   if (sourceLabel) chips.push({ key: 'source', label: 'Source', value: sourceLabel, onClear: onClearSource });
+  if (usageUnused) chips.push({ key: 'usage', label: 'Usage', value: 'Never used', onClear: onClearUsage });
   if (sortMode !== 'name') chips.push({ key: 'sort', label: 'Sort', value: SORT_LABEL[sortMode], onClear: onClearSort });
 
   if (chips.length === 0) return null;
@@ -969,8 +1079,9 @@ const STATE_DOT: Record<ItemState, string> = {
 
 // KPI cards double as the state filter: clicking one applies that ?filter, and
 // "Total" clears it. Counts are search-aware (they come from tabCounts),
-// matching the tab strip these cards replaced. Appending a metric here (e.g.
-// failing validation, once that data exists) extends the row without churn.
+// matching the tab strip these cards replaced. The "Never used" KPI is a
+// separate usage axis (?usage) appended after this row in LibraryHeader, and
+// only when usage data exists.
 const KPI_METRICS: { key: FilterTab; label: string; dot: ItemState | null }[] = [
   { key: 'all', label: 'Total', dot: null },
   { key: 'active', label: 'Active', dot: 'active' },
@@ -985,10 +1096,15 @@ interface LibraryHeaderProps {
   counts: Record<FilterTab, number>;
   activeTab: FilterTab;
   onSelectFilter: (tab: FilterTab) => void;
+  // "Never used" is a usage-data KPI on a separate axis from the state filter.
+  // null hides it (usage unavailable), so the row carries no zero-state noise.
+  neverUsedCount: number | null;
+  usageFilterActive: boolean;
+  onToggleNeverUsed: () => void;
   compact: boolean;
 }
 
-function LibraryHeader({ onNewSkill, onRefresh, onPopout, counts, activeTab, onSelectFilter, compact }: LibraryHeaderProps) {
+function LibraryHeader({ onNewSkill, onRefresh, onPopout, counts, activeTab, onSelectFilter, neverUsedCount, usageFilterActive, onToggleNeverUsed, compact }: LibraryHeaderProps) {
   const registryDetached = useUIStore((s) => s.registryDetached);
   return (
     <header className={cn(
@@ -1014,7 +1130,7 @@ function LibraryHeader({ onNewSkill, onRefresh, onPopout, counts, activeTab, onS
       {/* KPI summary cards — the first-class dashboard signal, and the primary
           state filter. They replace the old tab strip, so the URL contract
           (?filter) and selected-state live in exactly one place. */}
-      <div className="flex items-center gap-1.5 flex-wrap" role="group" aria-label="Filter skills by state">
+      <div className="flex items-center gap-1.5 flex-wrap" role="group" aria-label="Filter skills by state and usage">
         {KPI_METRICS.map((metric) => (
           <KpiCard
             key={metric.key}
@@ -1026,6 +1142,18 @@ function LibraryHeader({ onNewSkill, onRefresh, onPopout, counts, activeTab, onS
             onClick={() => onSelectFilter(metric.key)}
           />
         ))}
+        {/* "Never used" is a reserved slot that renders only when usage data
+            exists. It toggles the ?usage=unused facet rather than ?filter. */}
+        {neverUsedCount !== null && (
+          <KpiCard
+            label="Never used"
+            count={neverUsedCount}
+            dot={null}
+            active={usageFilterActive}
+            compact={compact}
+            onClick={onToggleNeverUsed}
+          />
+        )}
       </div>
     </header>
   );

--- a/web/src/hooks/useSkillUsage.ts
+++ b/web/src/hooks/useSkillUsage.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { fetchSkillUsage } from '../lib/api';
+import type { SkillUsageResponse } from '../types';
+
+// Poll cadence for skill usage. Usage shifts over hours/days, so a slow loop
+// matches useToolUsage and keeps the join memo stable between renders.
+const USAGE_POLL_MS = 15000;
+
+export interface SkillUsageState {
+  // null until the first successful load, and stays null when the endpoint is
+  // unavailable (e.g. 503 when no metrics accumulator is wired) so the Library
+  // degrades to no column / KPI / strip rather than erroring.
+  usage: SkillUsageResponse | null;
+}
+
+// useSkillUsage fetches GET /api/skills/usage and refreshes it on an interval.
+// Usage is a best-effort overlay joined to skills by name; a fetch failure is
+// swallowed and the last good snapshot is retained (progressive disclosure,
+// like the sources fetch in the Library). State writes happen only inside the
+// async loader after an await tick, never synchronously in the effect body, so
+// a refetch cannot cascade an extra synchronous render.
+export function useSkillUsage(): SkillUsageState {
+  const [usage, setUsage] = useState<SkillUsageResponse | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      try {
+        const data = await fetchSkillUsage();
+        if (!active) return;
+        setUsage(data);
+      } catch {
+        // Usage unavailable: keep the last snapshot (or null on first load)
+        // so the Library shows no usage UI rather than an error.
+      }
+    };
+
+    void load();
+    const id = setInterval(load, USAGE_POLL_MS);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  return { usage };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, RegistryStatus, AgentSkill, ItemState, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
+import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, SkillUsageResponse, RegistryStatus, AgentSkill, ItemState, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
 
 // Base URL for API calls - empty for same origin
 const API_BASE = '';
@@ -539,6 +539,18 @@ export async function fetchRegistryStatus(): Promise<RegistryStatus> {
 
 export async function fetchRegistrySkills(): Promise<AgentSkill[]> {
   return fetchJSON<AgentSkill[]>('/api/registry/skills');
+}
+
+/**
+ * Per-skill prompts/get usage: cumulative call counts plus last-called
+ * timestamps, keyed by skill name. Powers the Library "Last used" column,
+ * the inspector usage line, and the "Never used" facet. Joined to skills by
+ * name, so the registry list payload stays unchanged. Survives gateway
+ * restarts when metrics persistence is enabled.
+ * GET /api/skills/usage
+ */
+export async function fetchSkillUsage(): Promise<SkillUsageResponse> {
+  return fetchJSON<SkillUsageResponse>('/api/skills/usage');
 }
 
 export async function fetchRegistrySkill(name: string): Promise<AgentSkill> {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -243,6 +243,25 @@ export interface ToolUsageResponse {
   servers: Record<string, Record<string, ToolUsageStat>>;
 }
 
+// One skill's observed usage from GET /api/skills/usage. lastCalledAt is
+// explicitly null (not omitted) when a skill has a count but no recorded
+// timestamp, matching the endpoint's documented shape.
+export interface SkillUsageStat {
+  calls: number;
+  lastCalledAt: string | null;
+}
+
+// GET /api/skills/usage: per-skill prompts/get call counts + last-called
+// times, keyed by skill name. Joined to the registry list by name on the
+// frontend (the registry payload is unchanged). observedSince is when this
+// gateway process began recording; with metrics persistence enabled the
+// restored counts may predate it, so a skill missing from `skills` means
+// "no recorded calls", not a guaranteed longer disuse window.
+export interface SkillUsageResponse {
+  observedSince: string | null;
+  skills: Record<string, SkillUsageStat>;
+}
+
 // Node status for UI display
 export type NodeStatus = 'running' | 'stopped' | 'error' | 'initializing' | 'idle';
 


### PR DESCRIPTION
## Description

Frontend for Skill Usage Analytics (2 of 2 PRs), building on the backend in #732. Surfaces per-skill `prompts/get` usage in the Skills Library so an operator can find never-used active skills and bulk-disable them. Usage is joined by name as a side overlay; the registry list payload and `AgentSkill` type are unchanged.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- Add `fetchSkillUsage()` + `SkillUsageStat`/`SkillUsageResponse` types and a `useSkillUsage` hook (mirroring `useToolUsage`), polling `GET /api/skills/usage` and degrading gracefully when it is unavailable (no column/KPI/strip rather than an error).
- Join usage to skills by name in `LibraryWorkspace` (mirroring the provenance source join), with a new `usage` sort axis.
- Add a sortable "Last used" column to the table (also fixing a pre-existing Files/Category header/body column-order mismatch) and a usage line in the inspector Overview that labels the young-tracking-window case.
- Add a "Never used" KPI counting active zero-call skills; clicking it applies a `?usage=unused` facet (removable chip, URL-synced, default omitted) that filters to unused active skills feeding the existing multi-select + bulk Disable loop.

## Testing

- `npx tsc -b`, `npx vitest run` (809 web tests), and `make build` all pass. New tests cover the KPI count, the `?usage=unused` round-trip and filtering, the chip clear, the table column, and graceful degradation when the endpoint is down.
- Lint on changed files is clean apart from two pre-existing `set-state-in-effect` errors in untouched effects.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #731