### PR TITLE
feat: skills sync backend (state-preservation fix, aggregate endpoint, sync alias)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,33 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Bulk skill sync.** `POST /api/skills/sources/update` syncs every imported
+  skill source in parallel (cap 3), returning a `SourceSyncSummary` with
+  per-source results plus aggregate counters (`syncedSources`,
+  `updatedSkills`, `failedSources`, `pinnedSources`). Pinned sources (refs
+  shaped like `v1.0.0` or full commit SHAs) are silently skipped to avoid
+  bulk operations bumping intentionally-fixed versions. `GET /api/skills/sources`
+  now populates the `updateAvailable` flag by reading the background-checker
+  cache, so the existing per-source "Update" pill in the Library surfaces
+  reliably.
+- **`gridctl skill sync` CLI alias** for `gridctl skill update`, matching
+  the verb used in the web UI. `gridctl skill update` (no name) now prints
+  a final summary line (`Synced N source(s), M skill(s) updated, K failed,
+  L pinned`) and refuses by default when any imported skill's on-disk
+  `SKILL.md` has been locally edited; pass `--force` to overwrite.
+
 - **Grok Build client support.** `gridctl link grok` / `gridctl unlink grok`
   now manage the gateway entry in xAI Grok Build's `~/.grok/config.toml`,
   writing an `[mcp_servers.<name>]` table over native streamable HTTP. It is
   auto-detected by the interactive `link` and `--all` flows and appears in the
   web UI client list. This is gridctl's first TOML-based client provisioner.
+
+### Fixed
+
+- **Skill state preserved across sync.** `Importer.Update` no longer
+  silently re-activates skills that the user disabled. The fix threads a
+  new `PreserveState` flag through `ImportOptions` so re-imports inherit
+  the existing skill's `state`. The legacy `skill add` path is unchanged.
 
 ### Removed
 

--- a/cmd/gridctl/skill.go
+++ b/cmd/gridctl/skill.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -70,10 +73,18 @@ var skillListCmd = &cobra.Command{
 }
 
 var skillUpdateCmd = &cobra.Command{
-	Use:   "update [name]",
-	Short: "Update imported skills",
-	Long:  "Fetch latest from source repositories and apply updates.",
-	Args:  cobra.MaximumNArgs(1),
+	Use:     "update [name]",
+	Aliases: []string{"sync"},
+	Short:   "Update imported skills (alias: sync)",
+	Long: `Fetch latest from source repositories and apply updates.
+
+With no name, every imported skill is checked. By default, skills whose
+on-disk SKILL.md has been locally modified since the last import are
+refused; pass --force to overwrite them anyway.
+
+This command is also available as 'gridctl skill sync' for parity with the
+"Sync sources" affordance in the web UI Library.`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := ""
 		if len(args) > 0 {
@@ -391,6 +402,36 @@ func runSkillList() error {
 	return nil
 }
 
+// driftedSkills returns the names of skills with local edits to their on-disk
+// SKILL.md. When skillName is non-empty, only that skill is inspected (so
+// `gridctl skill update foo` doesn't pay to hash every installed skill).
+func driftedSkills(store *registry.Store, skillName string) ([]string, error) {
+	if skillName != "" {
+		sk, err := store.GetSkill(skillName)
+		if err != nil {
+			return nil, nil // skill not found — let imp.Update produce the real error
+		}
+		dir := sk.Dir
+		if dir == "" {
+			dir = sk.Name
+		}
+		skillDir := filepath.Join(registryDir(), "skills", dir)
+		origin, err := skills.ReadOrigin(skillDir)
+		if err != nil || origin.InstalledHash == "" {
+			return nil, nil
+		}
+		current, err := skills.ContentHashFile(filepath.Join(skillDir, "SKILL.md"))
+		if err != nil {
+			return nil, nil
+		}
+		if current != origin.InstalledHash {
+			return []string{skillName}, nil
+		}
+		return nil, nil
+	}
+	return skills.DetectDrift(context.Background(), store, skills.LockFilePath(), "")
+}
+
 func runSkillUpdate(name string) error {
 	store, err := loadRegistry()
 	if err != nil {
@@ -399,6 +440,23 @@ func runSkillUpdate(name string) error {
 
 	imp := newImporter(store)
 	printer := output.New()
+
+	// Drift check (unless --force or --dry-run). Refuse rather than silently
+	// overwrite local edits to imported SKILL.md files.
+	if !skillUpdateForce && !skillUpdateDryRun {
+		drifted, err := driftedSkills(store, name)
+		if err != nil {
+			return fmt.Errorf("checking drift: %w", err)
+		}
+		if len(drifted) > 0 {
+			fmt.Fprintln(os.Stderr, "The following skills have local edits that would be overwritten:")
+			for _, d := range drifted {
+				fmt.Fprintf(os.Stderr, "  - %s\n", d)
+			}
+			fmt.Fprintln(os.Stderr, "\nRe-run with --force to overwrite, or revert local changes first.")
+			return fmt.Errorf("refusing to overwrite locally-edited skills")
+		}
+	}
 
 	if name != "" {
 		result, err := imp.Update(name, skillUpdateDryRun, skillUpdateForce)
@@ -414,18 +472,47 @@ func runSkillUpdate(name string) error {
 		return nil
 	}
 
-	// Update all remote skills
+	// Update all remote skills, grouped by source so we can honor pins and
+	// print an aggregate summary at the end.
 	allSkills := store.ListSkills()
-	updated := 0
+	type skillRef struct {
+		sk     *registry.AgentSkill
+		ref    string
+		source string
+	}
+	var remoteSkills []skillRef
+	sourcesSeen := map[string]string{} // source name → ref (one is enough for pin check)
 	for _, sk := range allSkills {
 		skillDir := skillDirPath(sk)
 		if !skills.HasOrigin(skillDir) {
 			continue
 		}
-
-		result, err := imp.Update(sk.Name, skillUpdateDryRun, skillUpdateForce)
+		origin, err := skills.ReadOrigin(skillDir)
 		if err != nil {
-			printer.Warn("Failed to update", "skill", sk.Name, "error", err)
+			continue
+		}
+		sourceName := skills.RepoToName(origin.Repo)
+		sourcesSeen[sourceName] = origin.Ref
+		remoteSkills = append(remoteSkills, skillRef{sk: sk, ref: origin.Ref, source: sourceName})
+	}
+
+	var (
+		updatedSkills int
+		failedSources = map[string]bool{}
+		syncedSources = map[string]bool{}
+		pinnedSources = map[string]bool{}
+	)
+
+	for _, sr := range remoteSkills {
+		if skills.IsPinnedRef(sr.ref) {
+			pinnedSources[sr.source] = true
+			continue
+		}
+
+		result, err := imp.Update(sr.sk.Name, skillUpdateDryRun, skillUpdateForce)
+		if err != nil {
+			printer.Warn("Failed to update", "skill", sr.sk.Name, "error", err)
+			failedSources[sr.source] = true
 			continue
 		}
 		for _, w := range result.Warnings {
@@ -433,16 +520,39 @@ func runSkillUpdate(name string) error {
 		}
 		for _, imported := range result.Imported {
 			printer.Info("Updated skill", "name", imported.Name)
-			updated++
+			updatedSkills++
+		}
+		if !failedSources[sr.source] {
+			syncedSources[sr.source] = true
 		}
 	}
 
-	if updated == 0 && !skillUpdateDryRun {
-		fmt.Println("All skills are up to date")
+	// Sources can show up in both syncedSources and failedSources; the
+	// failed-skill loop sets failedSources but doesn't unset syncedSources.
+	// Reconcile so a source with any failure counts as failed.
+	for src := range failedSources {
+		delete(syncedSources, src)
 	}
+
+	if skillUpdateDryRun {
+		return nil
+	}
+
+	if len(pinnedSources) > 0 {
+		names := make([]string, 0, len(pinnedSources))
+		for n := range pinnedSources {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		fmt.Printf("Skipped pinned sources: %s (use 'gridctl skill update <name>' to force)\n", strings.Join(names, ", "))
+	}
+
+	fmt.Printf("Synced %d source(s), %d skill(s) updated, %d failed, %d pinned\n",
+		len(syncedSources), updatedSkills, len(failedSources), len(pinnedSources))
 
 	return nil
 }
+
 
 func runSkillRemove(name string) error {
 	store, err := loadRegistry()

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -55,7 +55,7 @@ The same operations are exposed as CLI subcommands. Use these when scripting or 
 | Activate a draft skill | `gridctl activate <name>` |
 | Validate a skill's frontmatter | `gridctl skill validate <name>` |
 | Import skills from a git repo | `gridctl skill add <repo-url>` |
-| Update an imported skill | `gridctl skill update [name]` |
+| Update imported skills (alias `sync`) | `gridctl skill update [name]` |
 | Pin an imported skill to a ref | `gridctl skill pin <name> <ref>` |
 | Remove a skill | `gridctl skill remove <name>` |
 
@@ -63,7 +63,7 @@ See [`docs/cli-reference.md`](./cli-reference.md) for the full flag set.
 
 ## Git-imported skills
 
-Skills don't have to be authored locally. `gridctl skill add <repo-url>` clones a remote repository, walks it for `SKILL.md` files, and pulls each one into the local registry. Pin to a ref with `gridctl skill pin`; refresh with `gridctl skill update`.
+Skills don't have to be authored locally. `gridctl skill add <repo-url>` clones a remote repository, walks it for `SKILL.md` files, and pulls each one into the local registry. Pin to a ref with `gridctl skill pin`; refresh with `gridctl skill update` (also available as `gridctl skill sync` for parity with the Library page's "Sync sources" action). With no name argument, every imported skill is checked; pinned sources (tags like `v1.0.0` or full commit SHAs) are skipped unless updated explicitly. Sync preserves each skill's enable/disable state and refuses to overwrite locally-edited SKILL.md files unless `--force` is passed.
 
 Supported auth flows for private repos:
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -62,10 +62,12 @@ type Server struct {
 	probeLimiter *probeLimiter
 
 	// Skill source paths. Empty values fall back to the global defaults
-	// (skills.LockFilePath / skills.SkillsConfigPath) so production code is
-	// unchanged; tests inject temp paths to stay isolated from $HOME.
-	skillLockPath    string
-	skillsConfigPath string
+	// (skills.LockFilePath / skills.SkillsConfigPath / skills.UpdateCachePath)
+	// so production code is unchanged; tests inject temp paths to stay
+	// isolated from $HOME.
+	skillLockPath        string
+	skillsConfigPath     string
+	skillUpdateCachePath string
 }
 
 // NewServer creates a new API server.
@@ -188,6 +190,12 @@ func (s *Server) SetSkillSourcePaths(lockPath, configPath string) {
 	s.skillsConfigPath = configPath
 }
 
+// SetSkillUpdateCachePath overrides the skill update cache path. Empty keeps
+// the global default. Tests use this to isolate from $HOME/.gridctl/cache.
+func (s *Server) SetSkillUpdateCachePath(path string) {
+	s.skillUpdateCachePath = path
+}
+
 // RegistryServer returns the registry server.
 func (s *Server) RegistryServer() *registry.Server {
 	return s.registryServer
@@ -299,6 +307,7 @@ func (s *Server) Handler() http.Handler {
 	// Skills endpoints (remote skill import)
 	mux.HandleFunc("GET /api/skills/sources", s.handleSkillSourcesList)
 	mux.HandleFunc("POST /api/skills/sources", s.handleSkillSourceAdd)
+	mux.HandleFunc("POST /api/skills/sources/update", s.handleSkillSourcesSyncAll)
 	mux.HandleFunc("GET /api/skills/updates", s.handleSkillUpdates)
 	mux.HandleFunc("DELETE /api/skills/sources/{name}", s.handleSkillSourceRemove)
 	mux.HandleFunc("POST /api/skills/sources/{name}/check", s.handleSkillSourceCheck)

--- a/internal/api/registry_test.go
+++ b/internal/api/registry_test.go
@@ -31,6 +31,7 @@ func setupRegistryTestServer(t *testing.T) (*Server, *registry.Server) {
 		filepath.Join(dir, "skills.lock.yaml"),
 		filepath.Join(dir, "skills.yaml"),
 	)
+	apiServer.SetSkillUpdateCachePath(filepath.Join(dir, "skill-updates.yaml"))
 	return apiServer, regServer
 }
 

--- a/internal/api/skills.go
+++ b/internal/api/skills.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
+	"sync"
 
 	"github.com/gridctl/gridctl/pkg/config"
 	gitpkg "github.com/gridctl/gridctl/pkg/git"
@@ -30,6 +32,16 @@ func (s *Server) configFilePath() string {
 		return s.skillsConfigPath
 	}
 	return skills.SkillsConfigPath()
+}
+
+// updateCachePath returns the configured skill-updates cache path, falling
+// back to the global default. Tests inject a temp path via
+// SetSkillUpdateCachePath.
+func (s *Server) updateCachePath() string {
+	if s.skillUpdateCachePath != "" {
+		return s.skillUpdateCachePath
+	}
+	return skills.UpdateCachePath()
 }
 
 // SkillSourceStatus represents a skill source with its update status.
@@ -198,6 +210,11 @@ func (s *Server) handleSkillSourcesList(w http.ResponseWriter, _ *http.Request) 
 		cfg = skills.DefaultSkillsConfig()
 	}
 
+	// Read the background-checker cache so we can mark sources with pending
+	// updates without forcing a live git fetch on every page load. Fail
+	// open: a missing/unreadable cache leaves UpdateAvail=false.
+	updateStatus, _ := skills.ReadUpdateCacheAt(s.updateCachePath())
+
 	var sources []SkillSourceStatus
 
 	// Build sources from lock file (which records what's actually imported)
@@ -234,6 +251,14 @@ func (s *Server) handleSkillSourcesList(w http.ResponseWriter, _ *http.Request) 
 				entry.State = string(sk.State)
 			}
 			src.Skills = append(src.Skills, entry)
+
+			// The cache is keyed by skill name; if any skill in this source
+			// has a pending update, surface it at the source level.
+			if updateStatus != nil {
+				if _, ok := updateStatus.Updates[skillName]; ok {
+					src.UpdateAvail = true
+				}
+			}
 		}
 
 		sources = append(sources, src)
@@ -575,6 +600,149 @@ func (s *Server) handleSkillSourcePreview(w http.ResponseWriter, r *http.Request
 		"commitSha": result.CommitSHA,
 		"skills":    previews,
 	})
+}
+
+// SourceSyncSummary is the aggregate response from a bulk sync.
+type SourceSyncSummary struct {
+	Sources       []SourceSyncResult `json:"sources"`
+	SyncedSources int                `json:"syncedSources"`
+	UpdatedSkills int                `json:"updatedSkills"`
+	FailedSources int                `json:"failedSources"`
+	PinnedSources int                `json:"pinnedSources"`
+}
+
+// SourceSyncResult is the per-source outcome of a bulk sync.
+type SourceSyncResult struct {
+	Name   string            `json:"name"`
+	Repo   string            `json:"repo"`
+	Pinned bool              `json:"pinned,omitempty"`
+	Skills []SkillSyncResult `json:"skills,omitempty"`
+	Error  string            `json:"error,omitempty"`
+}
+
+// SkillSyncResult is the per-skill outcome within a sync.
+type SkillSyncResult struct {
+	Skill    string   `json:"skill"`
+	Imported int      `json:"imported,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+	Error    string   `json:"error,omitempty"`
+}
+
+// syncAllConcurrency caps the number of sources synced in parallel. Matches
+// the background-checker's bound to keep behavior consistent and to avoid
+// saturating shared git hosts under bulk operations.
+const syncAllConcurrency = 3
+
+// handleSkillSourcesSyncAll syncs every imported source in parallel, honoring
+// pins. Mirrors the per-source semantics of handleSkillSourceUpdate.
+// POST /api/skills/sources/update
+func (s *Server) handleSkillSourcesSyncAll(w http.ResponseWriter, r *http.Request) {
+	if s.registryServer == nil {
+		writeJSONError(w, "Registry not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx := r.Context()
+	lockPath := s.lockFilePath()
+	lf, err := skills.ReadLockFile(lockPath)
+	if err != nil {
+		writeJSONError(w, "Failed to read lock file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	store := s.registryServer.Store()
+	registryDir := store.Dir()
+	logger := slog.Default()
+	imp := skills.NewImporter(store, registryDir, lockPath, logger)
+	imp.SetCredentialResolver(s.credentialResolver())
+
+	// Pre-sort source names for deterministic output.
+	names := make([]string, 0, len(lf.Sources))
+	for name := range lf.Sources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	results := make([]SourceSyncResult, len(names))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, syncAllConcurrency)
+
+	for i, name := range names {
+		src := lf.Sources[name]
+		results[i] = SourceSyncResult{Name: name, Repo: src.Repo}
+
+		if skills.IsPinnedRef(src.Ref) {
+			results[i].Pinned = true
+			continue
+		}
+
+		wg.Add(1)
+		go func(idx int, sourceName string, source skills.LockedSource) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			// Skill names sorted so per-skill output order is stable too.
+			skillNames := make([]string, 0, len(source.Skills))
+			for sn := range source.Skills {
+				skillNames = append(skillNames, sn)
+			}
+			sort.Strings(skillNames)
+
+			for _, skillName := range skillNames {
+				// Stop processing further skills in this source if the
+				// client disconnected. In-flight Update calls still complete
+				// (Importer.Update doesn't accept ctx today) but no new
+				// fetches are kicked off.
+				if ctx.Err() != nil {
+					results[idx].Skills = append(results[idx].Skills, SkillSyncResult{
+						Skill: skillName,
+						Error: "canceled",
+					})
+					continue
+				}
+				entry := SkillSyncResult{Skill: skillName}
+				result, updErr := imp.Update(skillName, false, false)
+				if updErr != nil {
+					entry.Error = gitpkg.RedactError(updErr).Error()
+				} else {
+					entry.Imported = len(result.Imported)
+					entry.Warnings = result.Warnings
+				}
+				results[idx].Skills = append(results[idx].Skills, entry)
+			}
+		}(i, name, src)
+	}
+
+	wg.Wait()
+
+	summary := SourceSyncSummary{Sources: results}
+	for _, r := range results {
+		switch {
+		case r.Pinned:
+			summary.PinnedSources++
+		case r.Error != "":
+			summary.FailedSources++
+		default:
+			// Source had at least one skill error → counts as failed.
+			sourceFailed := false
+			for _, sk := range r.Skills {
+				if sk.Error != "" {
+					sourceFailed = true
+				}
+				summary.UpdatedSkills += sk.Imported
+			}
+			if sourceFailed {
+				summary.FailedSources++
+			} else {
+				summary.SyncedSources++
+			}
+		}
+	}
+
+	s.refreshRegistryRouter()
+
+	writeJSON(w, summary)
 }
 
 // handleSkillUpdates returns pending update summary across all sources.

--- a/internal/api/skills_test.go
+++ b/internal/api/skills_test.go
@@ -6,12 +6,98 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gridctl/gridctl/pkg/mcp"
 	"github.com/gridctl/gridctl/pkg/registry"
+	"github.com/gridctl/gridctl/pkg/skills"
 )
 
 // --- Skills Sources Endpoints ---
+
+// seedSkillSource writes a minimal lock-file entry so handlers can iterate a
+// source without going through the importer (which would clone a real repo).
+func seedSkillSource(t *testing.T, srv *Server, sourceName, repo string, skillNames ...string) {
+	t.Helper()
+	lf := &skills.LockFile{Sources: map[string]skills.LockedSource{}}
+	locked := skills.LockedSource{
+		Repo:      repo,
+		Ref:       "main",
+		CommitSHA: "abc1234567890abc1234567890abc1234567890a",
+		FetchedAt: time.Now().UTC(),
+		Skills:    map[string]skills.LockedSkill{},
+	}
+	for _, name := range skillNames {
+		locked.Skills[name] = skills.LockedSkill{Path: name, ContentHash: "h"}
+	}
+	lf.Sources[sourceName] = locked
+	if err := skills.WriteLockFile(srv.lockFilePath(), lf); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+}
+
+func TestHandleSkills_SourcesList_PopulatesUpdateAvailFromCache(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkill(t, regServer, "skill-a", registry.StateActive)
+	seedSkillSource(t, srv, "my-source", "https://github.com/org/repo", "skill-a")
+
+	// Seed the update cache: skill-a has a pending update.
+	status := &skills.UpdateStatus{
+		CheckedAt: time.Now().UTC(),
+		Updates: map[string]skills.SkillUpdate{
+			"skill-a": {CurrentSHA: "old", LatestSHA: "new", Repo: "https://github.com/org/repo", Ref: "main"},
+		},
+	}
+	if err := skills.WriteUpdateCacheAt(srv.updateCachePath(), status); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	handler := srv.Handler()
+	req := httptest.NewRequest(http.MethodGet, "/api/skills/sources", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var result []SkillSourceStatus
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 source, got %d", len(result))
+	}
+	if !result[0].UpdateAvail {
+		t.Errorf("expected updateAvailable=true for source with pending skill update")
+	}
+}
+
+func TestHandleSkills_SourcesList_MissingCacheFailsOpen(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkill(t, regServer, "skill-a", registry.StateActive)
+	seedSkillSource(t, srv, "my-source", "https://github.com/org/repo", "skill-a")
+	// No cache file written.
+
+	handler := srv.Handler()
+	req := httptest.NewRequest(http.MethodGet, "/api/skills/sources", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var result []SkillSourceStatus
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 source, got %d", len(result))
+	}
+	if result[0].UpdateAvail {
+		t.Errorf("expected updateAvailable=false with missing cache")
+	}
+}
 
 func TestHandleSkills_SourcesList_Empty(t *testing.T) {
 	srv, _ := setupRegistryTestServer(t)
@@ -119,6 +205,98 @@ func TestHandleSkills_SourceCheck_NotFound(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleSkills_SyncAll_HonorsPinsAndCountsFailures(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkill(t, regServer, "pinned-skill", registry.StateActive)
+	seedSkill(t, regServer, "floating-skill", registry.StateActive)
+
+	// Seed a pinned source (Ref looks like a semver tag) and an unpinned
+	// source pointing at a non-existent repo so its Update will error.
+	// Exercises error accounting without needing a live git fixture.
+	lf := &skills.LockFile{Sources: map[string]skills.LockedSource{
+		"pinned-source": {
+			Repo:      "https://github.com/example/pinned",
+			Ref:       "v1.0.0",
+			CommitSHA: "abc1234567890abc1234567890abc1234567890a",
+			Skills:    map[string]skills.LockedSkill{"pinned-skill": {Path: "pinned-skill"}},
+		},
+		"floating-source": {
+			Repo:      "/nonexistent/path/to/repo",
+			Ref:       "main",
+			CommitSHA: "def1234567890def1234567890def1234567890d",
+			Skills:    map[string]skills.LockedSkill{"floating-skill": {Path: "floating-skill"}},
+		},
+	}}
+	if err := skills.WriteLockFile(srv.lockFilePath(), lf); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+
+	handler := srv.Handler()
+	req := httptest.NewRequest(http.MethodPost, "/api/skills/sources/update", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var summary SourceSyncSummary
+	if err := json.NewDecoder(rec.Body).Decode(&summary); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if summary.PinnedSources != 1 {
+		t.Errorf("expected 1 pinned source, got %d", summary.PinnedSources)
+	}
+	if summary.FailedSources != 1 {
+		t.Errorf("expected 1 failed source, got %d", summary.FailedSources)
+	}
+	if summary.SyncedSources != 0 {
+		t.Errorf("expected 0 cleanly-synced sources, got %d", summary.SyncedSources)
+	}
+	if summary.UpdatedSkills != 0 {
+		t.Errorf("expected 0 updated skills, got %d", summary.UpdatedSkills)
+	}
+	if len(summary.Sources) != 2 {
+		t.Fatalf("expected 2 source results, got %d", len(summary.Sources))
+	}
+
+	// Sources are returned in deterministic alphabetical order.
+	if summary.Sources[0].Name != "floating-source" {
+		t.Errorf("expected floating-source first, got %s", summary.Sources[0].Name)
+	}
+	if !summary.Sources[1].Pinned {
+		t.Errorf("expected pinned-source to be marked pinned")
+	}
+	if summary.Sources[1].Skills != nil {
+		t.Errorf("expected pinned-source to have no skills attempted")
+	}
+}
+
+func TestHandleSkills_SyncAll_EmptyLockFile(t *testing.T) {
+	srv, _ := setupRegistryTestServer(t)
+
+	handler := srv.Handler()
+	req := httptest.NewRequest(http.MethodPost, "/api/skills/sources/update", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var summary SourceSyncSummary
+	if err := json.NewDecoder(rec.Body).Decode(&summary); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(summary.Sources) != 0 {
+		t.Errorf("expected empty sources, got %d", len(summary.Sources))
+	}
+	if summary.SyncedSources != 0 || summary.UpdatedSkills != 0 ||
+		summary.FailedSources != 0 || summary.PinnedSources != 0 {
+		t.Errorf("expected zero counters on empty lock file, got %+v", summary)
 	}
 }
 

--- a/pkg/skills/config.go
+++ b/pkg/skills/config.go
@@ -112,7 +112,7 @@ func LoadSkillsConfig(path string) (*SkillsConfig, error) {
 			return nil, fmt.Errorf("source %d: repo is required", i)
 		}
 		if src.Name == "" {
-			cfg.Sources[i].Name = repoToName(src.Repo)
+			cfg.Sources[i].Name = RepoToName(src.Repo)
 		}
 	}
 
@@ -123,6 +123,49 @@ func LoadSkillsConfig(path string) (*SkillsConfig, error) {
 func SkillsConfigPath() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".gridctl", "skills.yaml")
+}
+
+// IsPinnedRef returns true when ref looks like an immutable pin (a specific
+// version tag containing a ".", or a full 40-character commit SHA). Bare
+// branch names and empty refs return false so they are treated as floating.
+//
+// This is a heuristic, not a guarantee: a tag like "release-2026" with no dot
+// will read as unpinned, and a branch named "feature.x" will read as pinned.
+// Used by aggregate sync to skip pins by default so a bulk operation does
+// not silently bump a user's intentionally-fixed version.
+func IsPinnedRef(ref string) bool {
+	if ref == "" {
+		return false
+	}
+	if isFullSHA(ref) {
+		return true
+	}
+	if IsSemVerConstraint(ref) {
+		return false
+	}
+	for _, r := range ref {
+		if r == '.' {
+			return true
+		}
+	}
+	return false
+}
+
+// isFullSHA reports whether s is exactly 40 lowercase or uppercase hex chars.
+func isFullSHA(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // IsSemVerConstraint returns true if the ref looks like a semver constraint.
@@ -170,10 +213,11 @@ func ResolveSemVerConstraint(constraintStr string, tags []string) (string, error
 	return bestTag, nil
 }
 
-// repoToName extracts a short name from a repo URL.
-func repoToName(repo string) string {
+// RepoToName extracts a short name from a repo URL (the last path segment
+// with any ".git" suffix stripped). Exported so callers like the CLI can
+// match the source names this package uses without duplicating the logic.
+func RepoToName(repo string) string {
 	base := filepath.Base(repo)
-	// Remove .git suffix
 	if ext := filepath.Ext(base); ext == ".git" {
 		base = base[:len(base)-len(ext)]
 	}

--- a/pkg/skills/config_test.go
+++ b/pkg/skills/config_test.go
@@ -180,6 +180,34 @@ func TestResolveSemVerConstraint(t *testing.T) {
 	}
 }
 
+func TestIsPinnedRef(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"", false},
+		{"main", false},
+		{"master", false},
+		{"develop", false},
+		{"v1.2.3", true},
+		{"1.0.0", true},
+		{"release-2026", false},
+		{"^1.0", false},
+		{"~1.2", false},
+		{"abc1234567890abc1234567890abc1234567890a", true}, // 40-char hex SHA
+		{"abc1234", false},                                 // short SHA, not pinned
+		{"ABC1234567890ABC1234567890ABC1234567890A", true}, // uppercase hex
+		{"feature.x", true},                                // dot heuristic catches false positive
+		{"not-hex-but-40-chars-long-1234567890123zz", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsPinnedRef(tt.ref))
+		})
+	}
+}
+
 func TestRepoToName(t *testing.T) {
 	tests := []struct {
 		repo string
@@ -192,7 +220,7 @@ func TestRepoToName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.repo, func(t *testing.T) {
-			assert.Equal(t, tt.want, repoToName(tt.repo))
+			assert.Equal(t, tt.want, RepoToName(tt.repo))
 		})
 	}
 }

--- a/pkg/skills/drift.go
+++ b/pkg/skills/drift.go
@@ -1,0 +1,96 @@
+package skills
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/gridctl/gridctl/pkg/registry"
+)
+
+// DetectDrift returns the names of imported skills in sourceName whose on-disk
+// SKILL.md has been edited since the last import or sync. Drift is detected by
+// comparing the current file hash against the InstalledHash snapshot written
+// when the skill was last installed.
+//
+// Skills imported before InstalledHash was tracked (empty value) are treated
+// as not drifted — DetectDrift fails open rather than reporting noise.
+// Skills with no Origin (purely local) are not considered.
+//
+// Pass an empty sourceName to scan every imported skill in the registry.
+func DetectDrift(ctx context.Context, store *registry.Store, lockPath, sourceName string) ([]string, error) {
+	if store == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+
+	skillNames, err := skillNamesForSource(store, lockPath, sourceName)
+	if err != nil {
+		return nil, err
+	}
+
+	registryDir := store.Dir()
+	var drifted []string
+
+	for _, name := range skillNames {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		sk, err := store.GetSkill(name)
+		if err != nil {
+			continue
+		}
+		dirName := sk.Dir
+		if dirName == "" {
+			dirName = sk.Name
+		}
+		skillDir := filepath.Join(registryDir, "skills", dirName)
+
+		origin, err := ReadOrigin(skillDir)
+		if err != nil || origin.InstalledHash == "" {
+			// Local skill, or imported before InstalledHash existed — fail open.
+			continue
+		}
+
+		currentHash, err := ContentHashFile(filepath.Join(skillDir, "SKILL.md"))
+		if err != nil {
+			continue
+		}
+
+		if currentHash != origin.InstalledHash {
+			drifted = append(drifted, name)
+		}
+	}
+
+	sort.Strings(drifted)
+	return drifted, nil
+}
+
+// skillNamesForSource returns the skill names to scan. When sourceName is
+// empty, every skill in the store is returned; otherwise only the skills
+// recorded under that source in the lock file.
+func skillNamesForSource(store *registry.Store, lockPath, sourceName string) ([]string, error) {
+	if sourceName == "" {
+		all := store.ListSkills()
+		names := make([]string, 0, len(all))
+		for _, sk := range all {
+			names = append(names, sk.Name)
+		}
+		return names, nil
+	}
+
+	lf, err := ReadLockFile(lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading lock file: %w", err)
+	}
+	src, ok := lf.Sources[sourceName]
+	if !ok {
+		return nil, fmt.Errorf("source %q not found in lock file", sourceName)
+	}
+	names := make([]string, 0, len(src.Skills))
+	for name := range src.Skills {
+		names = append(names, name)
+	}
+	return names, nil
+}

--- a/pkg/skills/drift_test.go
+++ b/pkg/skills/drift_test.go
@@ -1,0 +1,103 @@
+package skills
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectDrift_NoDriftAfterImport(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	repoDir, _ := initSkillRepo(t, "# Test\n\nBody.\n")
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Trust: true})
+	require.NoError(t, err)
+
+	drifted, err := DetectDrift(context.Background(), store, lockPath, "")
+	require.NoError(t, err)
+	assert.Empty(t, drifted, "fresh import should report no drift")
+}
+
+func TestDetectDrift_DetectsEditedSkill(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	repoDir, _ := initSkillRepo(t, "# Test\n\nBody.\n")
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Trust: true})
+	require.NoError(t, err)
+
+	// Tamper with the installed SKILL.md.
+	skillFile := filepath.Join(regDir, "skills", "test-skill", "SKILL.md")
+	current, err := os.ReadFile(skillFile)
+	require.NoError(t, err)
+	tampered := append(current, []byte("\n\n<!-- local edit -->\n")...)
+	require.NoError(t, os.WriteFile(skillFile, tampered, 0644))
+
+	drifted, err := DetectDrift(context.Background(), store, lockPath, "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test-skill"}, drifted)
+}
+
+func TestDetectDrift_FailsOpenWithoutInstalledHash(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	// Seed a skill the legacy way: no InstalledHash in origin.
+	createTestSkill(t, store, "legacy-skill")
+	skillDir := filepath.Join(regDir, "skills", "legacy-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("body"), 0644))
+	require.NoError(t, WriteOrigin(skillDir, &Origin{
+		Repo:        "https://github.com/org/repo",
+		Ref:         "main",
+		CommitSHA:   "abc123",
+		ContentHash: "old-upstream-hash",
+		// InstalledHash intentionally empty.
+	}))
+
+	drifted, err := DetectDrift(context.Background(), store, lockPath, "")
+	require.NoError(t, err)
+	assert.Empty(t, drifted, "missing InstalledHash should not be reported as drift")
+}
+
+func TestDetectDrift_PerSource(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	repoDir, _ := initSkillRepo(t, "# Test\n\nBody.\n")
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Trust: true})
+	require.NoError(t, err)
+
+	// Tamper.
+	skillFile := filepath.Join(regDir, "skills", "test-skill", "SKILL.md")
+	require.NoError(t, os.WriteFile(skillFile, []byte("tampered"), 0644))
+
+	srcName := filepath.Base(repoDir)
+	drifted, err := DetectDrift(context.Background(), store, lockPath, srcName)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test-skill"}, drifted)
+
+	// Unknown source name → error.
+	_, err = DetectDrift(context.Background(), store, lockPath, "no-such-source")
+	assert.Error(t, err)
+}

--- a/pkg/skills/importer.go
+++ b/pkg/skills/importer.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	gitpkg "github.com/gridctl/gridctl/pkg/git"
@@ -83,6 +84,10 @@ type ImportOptions struct {
 	Rename     string   // Rename the skill on import
 	Selected   []string // Only import skills with these names (empty = import all)
 	Auth       AuthConfig
+	// PreserveState carries over the existing skill's State (draft/active/
+	// disabled) instead of resetting it. Used by Update so that re-syncing
+	// a source does not silently re-activate skills the user disabled.
+	PreserveState bool
 }
 
 // ImportResult contains the results of an import operation.
@@ -113,6 +118,11 @@ type Importer struct {
 	lockPath           string
 	logger             *slog.Logger
 	credentialResolver CredentialResolver
+	// lockfileMu serializes read-modify-write windows on skills.lock.yaml.
+	// Held only across the file RMW, not the surrounding git work, so
+	// concurrent callers (e.g. handleSkillSourcesSyncAll's bounded fan-out)
+	// still parallelize their clones.
+	lockfileMu sync.Mutex
 }
 
 // NewImporter creates a new skill importer.
@@ -156,10 +166,6 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 	imp.logger.Info("discovered skills", "count", len(result.Skills))
 
 	importResult := &ImportResult{}
-	lf, err := ReadLockFile(imp.lockPath)
-	if err != nil {
-		return nil, fmt.Errorf("reading lock file: %w", err)
-	}
 
 	// Build selection set for O(1) lookup (empty = import all)
 	selectedSet := make(map[string]bool, len(opts.Selected))
@@ -217,13 +223,20 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 			continue
 		}
 
-		// Set state
+		// Set state. PreserveState carries over the existing skill's State
+		// across a re-import (used by Update); otherwise NoActivate decides
+		// between draft and active.
 		discovered.Skill.Name = skillName
+		state := registry.StateActive
 		if opts.NoActivate {
-			discovered.Skill.State = registry.StateDraft
-		} else {
-			discovered.Skill.State = registry.StateActive
+			state = registry.StateDraft
 		}
+		if opts.PreserveState {
+			if existing, err := imp.store.GetSkill(skillName); err == nil && existing.State != "" {
+				state = existing.State
+			}
+		}
+		discovered.Skill.State = state
 
 		// Save to registry
 		if err := imp.store.SaveSkill(discovered.Skill); err != nil {
@@ -234,6 +247,12 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 		// Compute fingerprint
 		fp := ComputeFingerprint(discovered.Skill)
 
+		// Snapshot the just-written SKILL.md hash so DetectDrift can later
+		// distinguish user edits from upstream changes. ContentHash records
+		// the upstream file as fetched; InstalledHash records what we wrote.
+		skillDir := imp.skillDir(skillName)
+		installedHash, _ := ContentHashFile(filepath.Join(skillDir, "SKILL.md"))
+
 		// Write origin sidecar. CredentialRef (if any) is persisted as an
 		// opaque reference string — the raw token is never written to disk.
 		origin := &Origin{
@@ -243,11 +262,11 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 			CommitSHA:     result.CommitSHA,
 			ImportedAt:    time.Now().UTC(),
 			ContentHash:   discovered.ContentHash,
+			InstalledHash: installedHash,
 			Fingerprint:   fp,
 			CredentialRef: opts.Auth.CredentialRef,
 		}
 
-		skillDir := imp.skillDir(skillName)
 		if err := WriteOrigin(skillDir, origin); err != nil {
 			importResult.Warnings = append(importResult.Warnings, fmt.Sprintf("failed to write origin for %s: %v", skillName, err))
 		}
@@ -271,9 +290,19 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 		imp.logger.Info("imported skill", "name", skillName)
 	}
 
-	// Update lock file
+	// Update lock file. Re-read inside the critical section so concurrent
+	// Import calls (e.g. from handleSkillSourcesSyncAll's bounded fan-out)
+	// observe each other's writes instead of clobbering them.
 	if len(lockedSkills) > 0 {
-		sourceName := repoToName(opts.Repo)
+		imp.lockfileMu.Lock()
+		defer imp.lockfileMu.Unlock()
+
+		lf, err := ReadLockFile(imp.lockPath)
+		if err != nil {
+			return importResult, fmt.Errorf("reading lock file: %w", err)
+		}
+
+		sourceName := RepoToName(opts.Repo)
 		lf.SetSource(sourceName, LockedSource{
 			Repo:          opts.Repo,
 			Ref:           opts.Ref,
@@ -356,12 +385,13 @@ func (imp *Importer) Update(skillName string, dryRun, force bool) (*ImportResult
 	oldFingerprint := origin.Fingerprint
 
 	result, err := imp.Import(ImportOptions{
-		Repo:  origin.Repo,
-		Ref:   origin.Ref,
-		Path:  origin.Path,
-		Trust: true,
-		Force: true,
-		Auth:  auth,
+		Repo:          origin.Repo,
+		Ref:           origin.Ref,
+		Path:          origin.Path,
+		Trust:         true,
+		Force:         true,
+		Auth:          auth,
+		PreserveState: true,
 	})
 	if err != nil {
 		return result, err

--- a/pkg/skills/importer_test.go
+++ b/pkg/skills/importer_test.go
@@ -4,7 +4,11 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/gridctl/gridctl/pkg/registry"
 	"github.com/stretchr/testify/assert"
@@ -167,6 +171,248 @@ func TestSafeRepoPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+// initSkillRepo creates a local git repo with a SKILL.md and returns its path
+// plus the worktree handle so the test can commit further changes.
+func initSkillRepo(t *testing.T, body string) (string, *git.Repository) {
+	t.Helper()
+
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+
+	skillContent := `---
+name: test-skill
+description: A test skill for state preservation
+state: active
+---
+
+` + body
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillContent), 0644))
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("SKILL.md")
+	require.NoError(t, err)
+	_, err = wt.Commit("initial", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com"},
+	})
+	require.NoError(t, err)
+
+	return dir, repo
+}
+
+// commitChange writes new SKILL.md content and creates a follow-up commit so
+// that FetchAndCompare reports an available update.
+func commitChange(t *testing.T, repo *git.Repository, dir, body string) {
+	t.Helper()
+
+	skillContent := `---
+name: test-skill
+description: A test skill for state preservation (v2)
+state: active
+---
+
+` + body
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillContent), 0644))
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("SKILL.md")
+	require.NoError(t, err)
+	_, err = wt.Commit("update", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com"},
+	})
+	require.NoError(t, err)
+}
+
+// TestImporter_Update_PreservesState verifies that re-syncing a source does
+// not silently re-activate a skill the user disabled. Regression test for
+// the bug where Importer.Update called Import(Force: true) which clobbered
+// the user-set State.
+func TestImporter_Update_PreservesState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	repoDir, repo := initSkillRepo(t, "# Test\n\nFirst version.\n")
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+
+	// Initial import → skill should be active. Pin to "master" (go-git's
+	// default branch) so FetchAndCompare can resolve via origin/master after
+	// a subsequent fetch.
+	result, err := imp.Import(ImportOptions{Repo: repoDir, Ref: "master", Trust: true})
+	require.NoError(t, err)
+	require.Len(t, result.Imported, 1)
+
+	sk, err := store.GetSkill("test-skill")
+	require.NoError(t, err)
+	assert.Equal(t, registry.StateActive, sk.State)
+
+	// User disables the skill.
+	sk.State = registry.StateDisabled
+	require.NoError(t, store.SaveSkill(sk))
+
+	// Push a new upstream commit so Update will re-import (rather than
+	// short-circuit on "already up to date").
+	commitChange(t, repo, repoDir, "# Test\n\nSecond version.\n")
+
+	// Sync. The bug under test would reset State to active here.
+	updateResult, err := imp.Update("test-skill", false, false)
+	require.NoError(t, err)
+	require.Len(t, updateResult.Imported, 1, "expected a re-import after upstream change")
+
+	sk, err = store.GetSkill("test-skill")
+	require.NoError(t, err)
+	assert.Equal(t, registry.StateDisabled, sk.State,
+		"disabled skill should remain disabled after sync")
+}
+
+// TestImporter_Import_NoPreserveStateResetsState confirms that the default
+// Import path (PreserveState=false, used by `gridctl skill add`) still
+// (re)sets state to active. Sanity check that the preservation flag is
+// scoped to Update.
+func TestImporter_Import_NoPreserveStateResetsState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	repoDir, _ := initSkillRepo(t, "# Test\n\nBody.\n")
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+
+	// Initial import.
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Trust: true})
+	require.NoError(t, err)
+
+	sk, err := store.GetSkill("test-skill")
+	require.NoError(t, err)
+	sk.State = registry.StateDisabled
+	require.NoError(t, store.SaveSkill(sk))
+
+	// Re-import without PreserveState: state should be reset to active.
+	_, err = imp.Import(ImportOptions{Repo: repoDir, Trust: true, Force: true})
+	require.NoError(t, err)
+
+	sk, err = store.GetSkill("test-skill")
+	require.NoError(t, err)
+	assert.Equal(t, registry.StateActive, sk.State)
+}
+
+// TestImporter_Import_PreserveStateNewSkillDefaultsActive verifies that when
+// PreserveState=true is passed but the skill doesn't yet exist, the default
+// (StateActive / StateDraft) still applies. Preservation only kicks in when
+// there is existing state to preserve.
+func TestImporter_Import_PreserveStateNewSkillDefaultsActive(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	repoDir, _ := initSkillRepo(t, "# Test\n\nBody.\n")
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+
+	// First-time import with PreserveState. No existing skill to preserve.
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Trust: true, PreserveState: true})
+	require.NoError(t, err)
+
+	sk, err := store.GetSkill("test-skill")
+	require.NoError(t, err)
+	assert.Equal(t, registry.StateActive, sk.State)
+}
+
+// TestImporter_Update_ConcurrentSourcesPreserveLockfile verifies that
+// concurrent Update calls against different sources both land in the lock
+// file. Pre-fix, the read-modify-write window was unguarded and the last
+// writer would silently drop the other source's entries. Run under -race.
+func TestImporter_Update_ConcurrentSourcesPreserveLockfile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	// Two independent local repos with distinct skill names so they don't
+	// clobber each other in the registry.
+	repoA := initSkillRepoNamed(t, "skill-a", "# A\n\nv1.\n")
+	repoB := initSkillRepoNamed(t, "skill-b", "# B\n\nv1.\n")
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+
+	// Initial imports so both sources exist in the lock file.
+	_, err := imp.Import(ImportOptions{Repo: repoA.dir, Ref: "master", Trust: true})
+	require.NoError(t, err)
+	_, err = imp.Import(ImportOptions{Repo: repoB.dir, Ref: "master", Trust: true})
+	require.NoError(t, err)
+
+	// Push new commits to both so Update will re-import them.
+	commitChangeNamed(t, repoA, "skill-a", "# A\n\nv2.\n")
+	commitChangeNamed(t, repoB, "skill-b", "# B\n\nv2.\n")
+
+	// Concurrent updates.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = imp.Update("skill-a", false, false)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = imp.Update("skill-b", false, false)
+	}()
+	wg.Wait()
+
+	lf, err := ReadLockFile(lockPath)
+	require.NoError(t, err)
+	assert.Len(t, lf.Sources, 2, "both sources must survive concurrent Update")
+	for srcName, src := range lf.Sources {
+		assert.NotEmpty(t, src.Skills, "source %q lost its skills under concurrent Update", srcName)
+	}
+}
+
+// initSkillRepoNamed is initSkillRepo with a configurable skill name.
+type testRepo struct {
+	dir  string
+	repo *git.Repository
+}
+
+func initSkillRepoNamed(t *testing.T, skillName, body string) testRepo {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+
+	content := "---\nname: " + skillName + "\ndescription: test\nstate: active\n---\n\n" + body
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0644))
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("SKILL.md")
+	require.NoError(t, err)
+	_, err = wt.Commit("initial", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com"},
+	})
+	require.NoError(t, err)
+
+	return testRepo{dir: dir, repo: repo}
+}
+
+func commitChangeNamed(t *testing.T, r testRepo, skillName, body string) {
+	t.Helper()
+	content := "---\nname: " + skillName + "\ndescription: test v2\nstate: active\n---\n\n" + body
+	require.NoError(t, os.WriteFile(filepath.Join(r.dir, "SKILL.md"), []byte(content), 0644))
+	wt, err := r.repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("SKILL.md")
+	require.NoError(t, err)
+	_, err = wt.Commit("update", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com"},
+	})
+	require.NoError(t, err)
 }
 
 func TestContentHashFile(t *testing.T) {

--- a/pkg/skills/origin.go
+++ b/pkg/skills/origin.go
@@ -11,13 +11,20 @@ import (
 // Origin tracks the remote source of an imported skill.
 // Stored as .origin.json alongside the SKILL.md file.
 type Origin struct {
-	Repo        string       `json:"repo"`
-	Ref         string       `json:"ref"`
-	Path        string       `json:"path,omitempty"`
-	CommitSHA   string       `json:"commitSha"`
-	ImportedAt  time.Time    `json:"importedAt"`
-	ContentHash string       `json:"contentHash"`
-	Fingerprint *Fingerprint `json:"fingerprint,omitempty"`
+	Repo        string    `json:"repo"`
+	Ref         string    `json:"ref"`
+	Path        string    `json:"path,omitempty"`
+	CommitSHA   string    `json:"commitSha"`
+	ImportedAt  time.Time `json:"importedAt"`
+	ContentHash string    `json:"contentHash"`
+	// InstalledHash is the SHA-256 of the SKILL.md as written to disk
+	// immediately after the last import. DetectDrift compares the current
+	// on-disk hash against this to surface local user edits. Distinct from
+	// ContentHash, which records the upstream file as fetched (and which
+	// diverges from the installed file because of frontmatter render
+	// normalization and state injection).
+	InstalledHash string       `json:"installedHash,omitempty"`
+	Fingerprint   *Fingerprint `json:"fingerprint,omitempty"`
 	// CredentialRef is an opaque reference like "${vault:GIT_TOKEN}" used to
 	// re-resolve credentials on skill update. Raw token values are never
 	// persisted — only the reference string.

--- a/pkg/skills/updater.go
+++ b/pkg/skills/updater.go
@@ -32,9 +32,14 @@ func UpdateCachePath() string {
 	return filepath.Join(home, ".gridctl", "cache", "skill-updates.yaml")
 }
 
-// ReadUpdateCache reads the cached update status.
+// ReadUpdateCache reads the cached update status from the default path.
 func ReadUpdateCache() (*UpdateStatus, error) {
-	path := UpdateCachePath()
+	return ReadUpdateCacheAt(UpdateCachePath())
+}
+
+// ReadUpdateCacheAt reads the cached update status from an explicit path.
+// Returns (nil, nil) when the file does not exist so callers can fail open.
+func ReadUpdateCacheAt(path string) (*UpdateStatus, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -50,9 +55,13 @@ func ReadUpdateCache() (*UpdateStatus, error) {
 	return &status, nil
 }
 
-// WriteUpdateCache writes the update status to cache.
+// WriteUpdateCache writes the update status to the default cache path.
 func WriteUpdateCache(status *UpdateStatus) error {
-	path := UpdateCachePath()
+	return WriteUpdateCacheAt(UpdateCachePath(), status)
+}
+
+// WriteUpdateCacheAt writes the update status to an explicit path.
+func WriteUpdateCacheAt(path string, status *UpdateStatus) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Backend half of the skills sync surface: fixes a correctness bug where `Importer.Update` silently re-activated disabled skills on every sync, adds an aggregate `POST /api/skills/sources/update` endpoint with bounded concurrency, surfaces the existing per-source \"Update\" pill by populating the missing `updateAvailable` flag, and adds a `gridctl skill sync` CLI alias with drift refusal. Frontend (workspace-level Sync button, drift modal, toast feedback) is a separate PR.

Part of #735.

## Type of Change

- [x] Bug fix
- [x] New feature

## Changes Made

- **`Importer.Update` state preservation.** New `PreserveState` on `ImportOptions`. `Import` carries over the existing skill's `state` when set, defaulting to `StateActive` only for new skills. `Update` always sets it. Legacy `skill add` path unchanged.
- **Concurrent-safe lock file.** New `lockfileMu` on `Importer` guards the read-modify-write window around `skills.lock.yaml`. Held only across the file RMW (not the surrounding git fetch) so the new aggregate handler still parallelizes clones. Regression test runs under `-race`.
- **`POST /api/skills/sources/update`.** New aggregate handler fans out per source with cap 3, honors pins (refs shaped like `v1.0.0` or 40-char SHAs are silently skipped), respects request cancellation between skills, returns `SourceSyncSummary` with `SyncedSources` / `UpdatedSkills` / `FailedSources` / `PinnedSources` counters.
- **`updateAvailable` populated.** `handleSkillSourcesList` now reads `~/.gridctl/cache/skill-updates.yaml` via a new `ReadUpdateCacheAt(path)` helper, fails open on missing cache. New `SetSkillUpdateCachePath` on Server for test isolation.
- **`pkg/skills.DetectDrift`.** Rehashes on-disk SKILL.md against a new `Origin.InstalledHash` snapshot. Fails open for pre-existing imports without InstalledHash. Per-source or whole-registry scan.
- **CLI sync alias and drift gate.** `gridctl skill sync` aliases `update`. Drift check refuses with a non-zero exit and a per-skill list unless `--force`. Pin-aware bulk loop. Final summary line: `Synced N source(s), M skill(s) updated, K failed, L pinned`.
- **`docs/skills.md` and `CHANGELOG.md`** updated.

## Testing

\`\`\`
make build
go test -race ./pkg/skills/... ./internal/api/... ./cmd/gridctl/...
golangci-lint run --new-from-rev=main
\`\`\`

All green, lint clean. New tests: `TestImporter_Update_PreservesState`, `TestImporter_Update_ConcurrentSourcesPreserveLockfile`, `TestImporter_Import_{NoPreserveStateResetsState,PreserveStateNewSkillDefaultsActive}`, `TestDetectDrift_{NoDriftAfterImport,DetectsEditedSkill,FailsOpenWithoutInstalledHash,PerSource}`, `TestIsPinnedRef` (14 cases), `TestHandleSkills_SourcesList_{PopulatesUpdateAvailFromCache,MissingCacheFailsOpen}`, `TestHandleSkills_SyncAll_{HonorsPinsAndCountsFailures,EmptyLockFile}`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed