### PR TITLE
feat: Library Sync sources button with failures details modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ All notable changes to gridctl will be documented in this file.
   a final summary line (`Synced N source(s), M skill(s) updated, K failed,
   L pinned`) and refuses by default when any imported skill's on-disk
   `SKILL.md` has been locally edited; pass `--force` to overwrite.
+- **"Sync sources" button on the Library workspace.** Pulls every imported
+  skill source in one click. Hidden when no sources are imported. When the
+  background checker has flagged updates, the button morphs to a labeled
+  amber pill `Sync sources (N updates)`; otherwise it sits as a quiet
+  icon-only affordance. Success and mixed-result toasts; a Details overlay
+  lists per-source failures with the backend's error message. The Library
+  header's existing "Refresh" icon swapped to `RotateCw` so the two
+  affordances no longer share the same circular-arrow glyph. Per-source
+  pill in the source group header reworded from "Update" to "Sync" for
+  verb consistency.
 
 - **Grok Build client support.** `gridctl link grok` / `gridctl unlink grok`
   now manage the gateway entry in xAI Grok Build's `~/.grok/config.toml`,

--- a/web/src/__tests__/LibraryWorkspace.test.tsx
+++ b/web/src/__tests__/LibraryWorkspace.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { LibraryWorkspace } from '../components/workspaces/LibraryWorkspace';
 import { useRegistryStore } from '../stores/useRegistryStore';
-import { setRegistrySkillsBatch, fetchSkillUsage } from '../lib/api';
+import { setRegistrySkillsBatch, fetchSkillUsage, syncAllSources } from '../lib/api';
 import { showToast } from '../components/ui/Toast';
 import { CommandRegistryProvider } from '../hooks/useCommandRegistry';
 import type { AgentSkill, SkillSourceStatus } from '../types';
@@ -19,6 +19,13 @@ vi.mock('../lib/api', () => ({
   fetchRegistrySkills: vi.fn().mockResolvedValue([]),
   fetchSkillSources: vi.fn().mockResolvedValue([]),
   updateSkillSource: vi.fn().mockResolvedValue({ source: 'acme-skills', results: [] }),
+  syncAllSources: vi.fn().mockResolvedValue({
+    sources: [],
+    syncedSources: 0,
+    updatedSkills: 0,
+    failedSources: 0,
+    pinnedSources: 0,
+  }),
   activateRegistrySkill: vi.fn().mockResolvedValue(undefined),
   disableRegistrySkill: vi.fn().mockResolvedValue(undefined),
   deleteRegistrySkill: vi.fn().mockResolvedValue(undefined),
@@ -495,6 +502,92 @@ describe('LibraryWorkspace', () => {
       expect(await screen.findByRole('button', { name: 'Active (2)' })).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /never used/i })).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /last used/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('sync sources button', () => {
+    it('is hidden when no sources are imported', () => {
+      useRegistryStore.setState({ skills: SAMPLE_SKILLS, sources: [] });
+      renderAt('/library');
+      expect(screen.queryByRole('button', { name: /sync sources/i })).not.toBeInTheDocument();
+    });
+
+    it('renders as a low-emphasis icon button when sources have no pending updates', () => {
+      useRegistryStore.setState({ skills: SAMPLE_SKILLS, sources: SAMPLE_SOURCES });
+      renderAt('/library');
+      const btn = screen.getByRole('button', { name: /sync sources from git/i });
+      expect(btn).toBeInTheDocument();
+      // Quiet variant has no update-count label in its accessible name.
+      expect(btn.textContent).not.toMatch(/\d+\s+update/i);
+    });
+
+    it('morphs to "Sync sources (N updates)" when sources have updateAvailable', () => {
+      const sourcesWithUpdates: SkillSourceStatus[] = [
+        { ...SAMPLE_SOURCES[0], updateAvailable: true },
+        {
+          name: 'other',
+          repo: 'https://github.com/other/skills',
+          autoUpdate: false,
+          updateInterval: '',
+          updateAvailable: true,
+          skills: [],
+        },
+      ];
+      useRegistryStore.setState({ skills: SAMPLE_SKILLS, sources: sourcesWithUpdates });
+      renderAt('/library');
+      expect(screen.getByRole('button', { name: /sync sources, 2 updates available/i })).toBeInTheDocument();
+      expect(screen.getByText('Sync sources (2 updates)')).toBeInTheDocument();
+    });
+
+    it('calls syncAllSources on click and toasts the no-change summary', async () => {
+      useRegistryStore.setState({ skills: SAMPLE_SKILLS, sources: SAMPLE_SOURCES });
+      renderAt('/library');
+      fireEvent.click(screen.getByRole('button', { name: /sync sources from git/i }));
+      await waitFor(() => expect(syncAllSources).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(showToast).toHaveBeenCalledWith('success', 'All sources up to date'),
+      );
+    });
+
+    it('toasts the happy-path summary when skills were updated', async () => {
+      vi.mocked(syncAllSources).mockResolvedValueOnce({
+        sources: [
+          { name: 'acme-skills', repo: 'https://github.com/acme/skills', skills: [{ skill: 'draft-summarizer', imported: 1 }] },
+        ],
+        syncedSources: 1,
+        updatedSkills: 1,
+        failedSources: 0,
+        pinnedSources: 0,
+      });
+      useRegistryStore.setState({ skills: SAMPLE_SKILLS, sources: SAMPLE_SOURCES });
+      renderAt('/library');
+      fireEvent.click(screen.getByRole('button', { name: /sync sources from git/i }));
+      await waitFor(() =>
+        expect(showToast).toHaveBeenCalledWith('success', 'Synced 1 source, 1 skill updated'),
+      );
+    });
+
+    it('warns and exposes a Details action when any source failed', async () => {
+      vi.mocked(syncAllSources).mockResolvedValueOnce({
+        sources: [
+          { name: 'acme-skills', repo: 'https://github.com/acme/skills', skills: [{ skill: 'draft-summarizer', imported: 1 }] },
+          { name: 'broken', repo: 'https://github.com/broken/repo', error: 'authentication required' },
+        ],
+        syncedSources: 1,
+        updatedSkills: 1,
+        failedSources: 1,
+        pinnedSources: 0,
+      });
+      useRegistryStore.setState({ skills: SAMPLE_SKILLS, sources: SAMPLE_SOURCES });
+      renderAt('/library');
+      fireEvent.click(screen.getByRole('button', { name: /sync sources from git/i }));
+      await waitFor(() =>
+        expect(showToast).toHaveBeenCalledWith(
+          'warning',
+          'Synced 1 of 2 sources. 1 failed',
+          expect.objectContaining({ action: expect.objectContaining({ label: 'Details' }) }),
+        ),
+      );
     });
   });
 });

--- a/web/src/components/registry/SourceGroupHeader.tsx
+++ b/web/src/components/registry/SourceGroupHeader.tsx
@@ -47,10 +47,10 @@ export function SourceGroupHeader({
     setUpdating(true);
     try {
       await updateSkillSource(source.name);
-      showToast('success', `Updated "${source.name}"`);
+      showToast('success', `Synced "${source.name}"`);
       onUpdated?.();
     } catch (err) {
-      showToast('error', err instanceof Error ? err.message : 'Update failed');
+      showToast('error', err instanceof Error ? err.message : 'Sync failed');
     } finally {
       setUpdating(false);
     }
@@ -103,11 +103,11 @@ export function SourceGroupHeader({
             <button
               onClick={handleUpdate}
               disabled={updating}
-              title="Update available — pull latest"
+              title="Update available, pull latest"
               className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full border border-amber-400/30 bg-amber-400/10 text-amber-300 hover:bg-amber-400/20 transition-colors disabled:opacity-60 flex-shrink-0"
             >
               <RefreshCw size={10} className={updating ? 'animate-spin' : undefined} />
-              {updating ? 'Updating…' : 'Update'}
+              {updating ? 'Syncing…' : 'Sync'}
             </button>
           )}
         </div>

--- a/web/src/components/workspaces/LibraryWorkspace.tsx
+++ b/web/src/components/workspaces/LibraryWorkspace.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import {
   AlignJustify,
   BookOpen,
+  CloudDownload,
   LayoutGrid,
   List,
   Plus,
@@ -23,6 +24,7 @@ import { LibraryGrid, type GroupMode } from '../registry/LibraryGrid';
 import { LibraryTable } from '../registry/LibraryTable';
 import { SkillDetailPanel } from '../registry/SkillDetailPanel';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
+import { Modal } from '../ui/Modal';
 import { showToast } from '../ui/Toast';
 import { useFuzzySearch } from '../../hooks/useFuzzySearch';
 import { useSkillUsage } from '../../hooks/useSkillUsage';
@@ -38,10 +40,11 @@ import {
   fetchRegistryStatus,
   fetchSkillSources,
   setRegistrySkillsBatch,
+  syncAllSources,
 } from '../../lib/api';
 import { extractRepoInfo } from '../../lib/repo';
 import { WorkspaceShell } from '../layout/WorkspaceShell';
-import type { AgentSkill, ItemState, SkillSourceStatus, SkillUsageStat } from '../../types';
+import type { AgentSkill, ItemState, SkillSourceStatus, SkillUsageStat, SourceSyncResult } from '../../types';
 
 type FilterTab = 'all' | ItemState;
 type SortMode = 'name' | 'state' | 'files' | 'usage';
@@ -292,6 +295,11 @@ export function LibraryWorkspace() {
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
 
+  // Sync sources state. `syncing` disables the workspace-level button; the
+  // failure list is captured for the Details overlay opened from the toast.
+  const [syncing, setSyncing] = useState(false);
+  const [syncFailures, setSyncFailures] = useState<SourceSyncResult[] | null>(null);
+
   // Multi-select state. Names only (not skill objects) so the selection
   // survives filter, sort, group, and refresh; stale names are pruned at the
   // point of use against the live skill set.
@@ -384,6 +392,41 @@ export function LibraryWorkspace() {
       // Sources unavailable — progressive disclosure.
     }
   }, [refreshRegistry]);
+
+  // Bulk sync every imported source via the aggregate backend endpoint.
+  // Surfaces an aggregated toast; failures expose a Details action that
+  // opens an overlay listing the per-source error messages.
+  const handleSyncAll = useCallback(async () => {
+    if (syncing) return;
+    setSyncing(true);
+    try {
+      const summary = await syncAllSources();
+      await refreshAll();
+      const failures = summary.sources.filter((s) => s.error || s.skills?.some((k) => k.error));
+      if (failures.length === 0) {
+        if (summary.updatedSkills === 0) {
+          showToast('success', 'All sources up to date');
+        } else {
+          showToast(
+            'success',
+            `Synced ${summary.syncedSources} source${summary.syncedSources === 1 ? '' : 's'}, ${summary.updatedSkills} skill${summary.updatedSkills === 1 ? '' : 's'} updated`,
+          );
+        }
+      } else {
+        const okCount = summary.syncedSources;
+        const failCount = failures.length;
+        showToast(
+          'warning',
+          `Synced ${okCount} of ${okCount + failCount} sources. ${failCount} failed`,
+          { action: { label: 'Details', onClick: () => setSyncFailures(failures) }, duration: 6000 },
+        );
+      }
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'Sync failed');
+    } finally {
+      setSyncing(false);
+    }
+  }, [syncing, refreshAll]);
 
   const handleEnable = useCallback(async (skill: AgentSkill) => {
     try {
@@ -621,6 +664,9 @@ export function LibraryWorkspace() {
           <LibraryHeader
             onNewSkill={handleNewSkill}
             onRefresh={refreshRegistry}
+            onSync={handleSyncAll}
+            sources={sources ?? []}
+            syncing={syncing}
             onPopout={handlePopout}
             counts={tabCounts}
             activeTab={activeTab}
@@ -839,6 +885,13 @@ export function LibraryWorkspace() {
         onSaved={refreshRegistry}
         skill={editingSkill}
       />
+
+      {syncFailures && (
+        <SyncFailuresDialog
+          failures={syncFailures}
+          onClose={() => setSyncFailures(null)}
+        />
+      )}
     </div>
   );
 }
@@ -1092,6 +1145,9 @@ const KPI_METRICS: { key: FilterTab; label: string; dot: ItemState | null }[] = 
 interface LibraryHeaderProps {
   onNewSkill: () => void;
   onRefresh: () => void;
+  onSync: () => void;
+  sources: SkillSourceStatus[];
+  syncing: boolean;
   onPopout: () => void;
   counts: Record<FilterTab, number>;
   activeTab: FilterTab;
@@ -1104,8 +1160,10 @@ interface LibraryHeaderProps {
   compact: boolean;
 }
 
-function LibraryHeader({ onNewSkill, onRefresh, onPopout, counts, activeTab, onSelectFilter, neverUsedCount, usageFilterActive, onToggleNeverUsed, compact }: LibraryHeaderProps) {
+function LibraryHeader({ onNewSkill, onRefresh, onSync, sources, syncing, onPopout, counts, activeTab, onSelectFilter, neverUsedCount, usageFilterActive, onToggleNeverUsed, compact }: LibraryHeaderProps) {
   const registryDetached = useUIStore((s) => s.registryDetached);
+  const hasSources = sources.length > 0;
+  const updateCount = sources.filter((s) => s.updateAvailable).length;
   return (
     <header className={cn(
       'flex-shrink-0 bg-surface/30 backdrop-blur-sm border-b border-border-subtle px-6 flex flex-col gap-2',
@@ -1122,6 +1180,12 @@ function LibraryHeader({ onNewSkill, onRefresh, onPopout, counts, activeTab, onS
           >
             <Plus size={12} /> New Skill
           </button>
+          <SyncSourcesButton
+            hasSources={hasSources}
+            updateCount={updateCount}
+            syncing={syncing}
+            onClick={onSync}
+          />
           <IconButton icon={RefreshCw} onClick={onRefresh} tooltip="Refresh" size="sm" variant="ghost" />
           <PopoutButton onClick={onPopout} disabled={registryDetached} tooltip="Open in new window" />
         </div>
@@ -1202,6 +1266,113 @@ function KpiCard({ label, count, dot, active, compact, onClick }: KpiCardProps) 
         {count}
       </span>
     </button>
+  );
+}
+
+interface SyncSourcesButtonProps {
+  hasSources: boolean;
+  updateCount: number;
+  syncing: boolean;
+  onClick: () => void;
+}
+
+/**
+ * Workspace-level "Sync sources" affordance. Three states:
+ * - hidden when no imported sources exist (feature is dormant)
+ * - amber pill "Sync sources (N updates)" when any source has updateAvailable
+ * - low-emphasis IconButton otherwise (lets users force a sync anyway)
+ *
+ * During sync the button disables and the label morphs inside an aria-live
+ * region so screen readers announce the in-flight state. `CloudDownload`
+ * differentiates the sync action from the local Refresh button (which uses
+ * `RefreshCw`, matching the global Header convention).
+ */
+function SyncSourcesButton({ hasSources, updateCount, syncing, onClick }: SyncSourcesButtonProps) {
+  if (!hasSources) return null;
+
+  const hasUpdates = updateCount > 0;
+  const ariaLabel = syncing
+    ? 'Syncing skill sources'
+    : hasUpdates
+      ? `Sync sources, ${updateCount} ${updateCount === 1 ? 'update' : 'updates'} available`
+      : 'Sync sources from git';
+
+  if (hasUpdates) {
+    // Pill mirrors the per-source amber pill in SourceGroupHeader so the two
+    // affordances read as the same family.
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={syncing}
+        aria-label={ariaLabel}
+        aria-busy={syncing}
+        title={ariaLabel}
+        className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg border border-amber-400/30 bg-amber-400/10 text-amber-300 hover:bg-amber-400/20 transition-colors disabled:opacity-60"
+      >
+        <CloudDownload size={12} aria-hidden="true" className={syncing ? 'animate-pulse' : undefined} />
+        <span aria-live="polite">
+          {syncing ? 'Syncing…' : `Sync sources (${updateCount} update${updateCount === 1 ? '' : 's'})`}
+        </span>
+      </button>
+    );
+  }
+
+  // No pending updates: a quiet IconButton lets users force a sync without
+  // the chrome implying anything is wrong. The aria-label morph carries the
+  // in-flight announcement; no separate live region is needed.
+  return (
+    <IconButton
+      icon={CloudDownload}
+      onClick={onClick}
+      disabled={syncing}
+      tooltip={ariaLabel}
+      size="sm"
+      variant="ghost"
+      className={syncing ? 'animate-pulse' : undefined}
+    />
+  );
+}
+
+interface SyncFailuresDialogProps {
+  failures: SourceSyncResult[];
+  onClose: () => void;
+}
+
+/**
+ * Listing of per-source failures from a bulk sync, opened from the toast's
+ * "Details" action. Wraps the shared Modal so focus trap, Escape, and panel
+ * chrome stay consistent with every other dialog in the app. The backend's
+ * error message is rendered verbatim so users can act on auth failures,
+ * missing repos, etc.
+ */
+function SyncFailuresDialog({ failures, onClose }: SyncFailuresDialogProps) {
+  return (
+    <Modal isOpen onClose={onClose} title="Sync failures">
+      <ul className="space-y-3">
+        {failures.map((src) => {
+          const skillErrors = (src.skills ?? []).filter((k) => k.error);
+          return (
+            <li key={src.name} className="border border-border/30 rounded-md p-3">
+              <div className="text-xs font-mono text-text-secondary mb-1.5">{src.name}</div>
+              {src.error && (
+                <div className="text-xs text-status-error whitespace-pre-wrap">{src.error}</div>
+              )}
+              {skillErrors.length > 0 && (
+                <ul className="space-y-1 mt-1">
+                  {skillErrors.map((sk) => (
+                    <li key={sk.skill} className="text-xs">
+                      <span className="text-text-muted">{sk.skill}:</span>{' '}
+                      <span className="text-status-error whitespace-pre-wrap">{sk.error}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </Modal>
   );
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, SkillUsageResponse, RegistryStatus, AgentSkill, ItemState, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
+import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, SkillUsageResponse, RegistryStatus, AgentSkill, ItemState, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SourceSyncSummary, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
 
 // Base URL for API calls - empty for same origin
 const API_BASE = '';
@@ -1056,6 +1056,17 @@ export async function updateSkillSource(name: string): Promise<{ source: string;
     `/api/skills/sources/${encodeURIComponent(name)}/update`,
     'POST',
   );
+}
+
+/**
+ * Sync every imported source in one server-side fan-out. Pinned sources
+ * (refs shaped like v1.0.0 or full commit SHAs) are silently skipped. The
+ * response carries per-source results plus aggregate counters.
+ *
+ * POST /api/skills/sources/update
+ */
+export async function syncAllSources(): Promise<SourceSyncSummary> {
+  return mutateJSON<SourceSyncSummary>('/api/skills/sources/update', 'POST');
 }
 
 /**

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -546,6 +546,29 @@ export interface UpdateSummary {
   sources: SourceUpdateSummary[];
 }
 
+export interface SkillSyncResult {
+  skill: string;
+  imported?: number;
+  warnings?: string[];
+  error?: string;
+}
+
+export interface SourceSyncResult {
+  name: string;
+  repo: string;
+  pinned?: boolean;
+  skills?: SkillSyncResult[];
+  error?: string;
+}
+
+export interface SourceSyncSummary {
+  sources: SourceSyncResult[];
+  syncedSources: number;
+  updatedSkills: number;
+  failedSources: number;
+  pinnedSources: number;
+}
+
 // --- Telemetry Persistence Types (Phase 4) ---
 
 // Three signal types persisted to disk. Lower-case wire shape matches the


### PR DESCRIPTION
## Description

Frontend half of the skills sync surface. Adds a workspace-level \"Sync sources\" button to the Library page that pulls every imported git source via the backend's new aggregate endpoint (shipped in #736), with aggregated toast feedback and a failures details modal. Per-source pill in the source group header reworded from \"Update\" to \"Sync\" for verb consistency with the new top-level button and the `gridctl skill sync` CLI alias.

Closes #735.

## Type of Change

- [x] New feature

## Changes Made

- **`SyncSourcesButton` in `LibraryHeader`.** Hidden when no sources are imported. When the background checker has flagged any source as behind, the button morphs to a labeled amber pill `Sync sources (N updates)` matching the per-source pill in `SourceGroupHeader`. Otherwise it sits as a quiet ghost `IconButton`. Uses `CloudDownload` (distinct from the existing `RefreshCw` Refresh button) so the two affordances read as different actions.
- **`SyncFailuresDialog` opened from the toast's `Details` action.** Wraps the shared `Modal` primitive so focus trap, Escape-to-close, and panel chrome stay consistent. Lists per-source backend errors verbatim.
- **`handleSyncAll` handler** with three toast branches: `'All sources up to date'`, `'Synced N sources, M skills updated'` (success), and `'Synced X of N sources. Y failed'` with a `Details` action (mixed).
- **`syncAllSources()` API client** + matching TypeScript types (`SourceSyncSummary`, `SourceSyncResult`, `SkillSyncResult`) in `web/src/lib/api.ts` and `web/src/types/index.ts`.
- **Per-source pill verb rename** from `Update` / `Updating…` to `Sync` / `Syncing…` in `SourceGroupHeader.tsx`. Toast copy updated to match.
- **CHANGELOG entry** under `[Unreleased] > Added`.

## Testing

\`\`\`
cd web && npm test
cd web && npx eslint src/components/workspaces/LibraryWorkspace.tsx src/components/registry/SourceGroupHeader.tsx src/lib/api.ts src/types/index.ts src/__tests__/LibraryWorkspace.test.tsx
make build
\`\`\`

All 815 vitest tests pass. Lint on changed files is clean except a pre-existing `react-hooks/set-state-in-effect` error at `LibraryWorkspace.tsx:334` that exists on `main` (verified via `git stash`). `make build` is clean.

New tests (6) under `describe('sync sources button', ...)`: hidden-when-no-sources, low-emphasis-when-no-updates, label-morph-when-updates-pending, calls-syncAllSources-and-toasts-no-change, happy-path-toast, mixed-with-Details-action.

## Out of Scope

- Client-side drift probe + confirm modal before sync. Backend doesn't yet expose a drift-probe endpoint separate from the CLI's `DetectDrift`; toast surfaces backend failures and users can re-run via the CLI with `--force` for now. Adding `GET /api/skills/sources/drift` is a follow-up.
- Streaming sync progress (single POST returns single response).
- Per-skill sync in the table view (sync is per-source by design).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed