### PR TITLE
fix: clean lock file on UI skill delete and self-heal ghost entries during sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ All notable changes to gridctl will be documented in this file.
 
 ### Fixed
 
+- **Sync no longer reports ghost-skill failures for deleted skills.** Deleting a
+  skill from the Library UI (`DELETE /api/registry/skills/{name}`) now also
+  scrubs it from `skills.lock.yaml`, matching the CLI path (`gridctl skill rm`).
+  Previously the UI delete left an orphaned lock entry, so the next bulk sync
+  tried to update the now-deleted skill and surfaced a spurious
+  `has no origin (not an imported skill)` failure for each one. Bulk sync is
+  also self-healing: a lock entry whose skill is no longer in the registry is
+  skipped and pruned from the lock file instead of failing the source, which
+  clears lock files that already accumulated orphaned entries. Skills still
+  present in the registry whose update genuinely fails are unaffected — they are
+  still reported and retained.
+
 - **Skill state preserved across sync.** `Importer.Update` no longer
   silently re-activates skills that the user disabled. The fix threads a
   new `PreserveState` flag through `ImportOptions` so re-imports inherit

--- a/internal/api/registry.go
+++ b/internal/api/registry.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
 	"github.com/gridctl/gridctl/pkg/registry"
+	"github.com/gridctl/gridctl/pkg/skills"
 )
 
 // handleRegistryStatus returns registry summary counts.
@@ -123,6 +125,22 @@ func (s *Server) handleRegistrySkillDelete(w http.ResponseWriter, r *http.Reques
 		writeJSONError(w, "Failed to delete skill: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// Scrub the skill from the lock file so a later sync doesn't try to update
+	// a now-deleted skill (which no longer has an origin sidecar) and report it
+	// as a failure. Mirrors the CLI path (skills.Importer.Remove). The registry
+	// deletion above is authoritative; lock cleanup is best-effort and a failure
+	// here is logged, not surfaced to the caller.
+	lockPath := s.lockFilePath()
+	if lf, err := skills.ReadLockFile(lockPath); err != nil {
+		slog.Default().Warn("delete skill: failed to read lock file for cleanup", "skill", name, "error", err)
+	} else if _, _, found := lf.FindSkillSource(name); found {
+		lf.RemoveSkill(name)
+		if err := skills.WriteLockFile(lockPath, lf); err != nil {
+			slog.Default().Warn("delete skill: failed to write lock file after cleanup", "skill", name, "error", err)
+		}
+	}
+
 	s.refreshRegistryRouter()
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/api/registry_test.go
+++ b/internal/api/registry_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gridctl/gridctl/pkg/mcp"
 	"github.com/gridctl/gridctl/pkg/registry"
+	"github.com/gridctl/gridctl/pkg/skills"
 )
 
 // setupRegistryTestServer creates a Server with a temp registry store for testing.
@@ -284,6 +285,58 @@ func TestHandleRegistry_DeleteSkill(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected 404 after delete, got %d", rec.Code)
+	}
+}
+
+// TestHandleRegistry_DeleteSkill_CleansLockFile verifies that deleting a skill
+// via the HTTP/UI path also scrubs it from skills.lock.yaml, so a later sync
+// doesn't try to update a now-deleted skill. Regression for ghost-skill sync
+// failures.
+func TestHandleRegistry_DeleteSkill_CleansLockFile(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkill(t, regServer, "skill-a", registry.StateActive)
+	seedSkill(t, regServer, "skill-b", registry.StateActive)
+	seedSkillSource(t, srv, "my-source", "https://github.com/org/repo", "skill-a", "skill-b")
+
+	handler := srv.Handler()
+
+	// Delete the first skill: it should leave the source intact with skill-b.
+	req := httptest.NewRequest(http.MethodDelete, "/api/registry/skills/skill-a", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	lf, err := skills.ReadLockFile(srv.lockFilePath())
+	if err != nil {
+		t.Fatalf("read lock: %v", err)
+	}
+	src, ok := lf.Sources["my-source"]
+	if !ok {
+		t.Fatalf("expected my-source to remain after deleting one of two skills")
+	}
+	if _, present := src.Skills["skill-a"]; present {
+		t.Errorf("expected skill-a removed from lock file, still present")
+	}
+	if _, present := src.Skills["skill-b"]; !present {
+		t.Errorf("expected skill-b to remain in lock file")
+	}
+
+	// Delete the second skill: the now-empty source should be dropped.
+	req = httptest.NewRequest(http.MethodDelete, "/api/registry/skills/skill-b", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	lf, err = skills.ReadLockFile(srv.lockFilePath())
+	if err != nil {
+		t.Fatalf("read lock: %v", err)
+	}
+	if _, ok := lf.Sources["my-source"]; ok {
+		t.Errorf("expected empty source dropped from lock file, still present")
 	}
 }
 

--- a/internal/api/skills.go
+++ b/internal/api/skills.go
@@ -664,6 +664,11 @@ func (s *Server) handleSkillSourcesSyncAll(w http.ResponseWriter, r *http.Reques
 	sort.Strings(names)
 
 	results := make([]SourceSyncResult, len(names))
+	// ghostsBySource collects, per source index, the names of skills that are
+	// recorded in the lock file but no longer present in the registry (e.g.
+	// deleted via the UI). Each goroutine writes only its own index, so the
+	// slice is race-free without a mutex. Pruned once after the fan-out.
+	ghostsBySource := make([][]string, len(names))
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, syncAllConcurrency)
 
@@ -702,6 +707,21 @@ func (s *Server) handleSkillSourcesSyncAll(w http.ResponseWriter, r *http.Reques
 					continue
 				}
 				entry := SkillSyncResult{Skill: skillName}
+
+				// The skill is in the lock file but no longer in the registry
+				// (deleted out from under the lock file, e.g. via the UI).
+				// Updating it would fail reading the missing origin sidecar and
+				// surface as a spurious failure. Record it for pruning and skip.
+				// We gate on registry presence rather than the Update error so a
+				// present skill whose update merely failed (transient/auth) is
+				// still reported and retained.
+				if _, err := store.GetSkill(skillName); err != nil {
+					ghostsBySource[idx] = append(ghostsBySource[idx], skillName)
+					entry.Warnings = []string{"skill no longer in registry; removed stale lock entry"}
+					results[idx].Skills = append(results[idx].Skills, entry)
+					continue
+				}
+
 				result, updErr := imp.Update(skillName, false, false)
 				if updErr != nil {
 					entry.Error = gitpkg.RedactError(updErr).Error()
@@ -715,6 +735,27 @@ func (s *Server) handleSkillSourcesSyncAll(w http.ResponseWriter, r *http.Reques
 	}
 
 	wg.Wait()
+
+	// Prune stale lock entries for skills that were deleted from the registry.
+	// Done on the main goroutine after the fan-out so the lock-file write can't
+	// race the in-flight Update calls (which may write the lock file via the
+	// importer). Re-read first to pick up any writes those updates made.
+	var ghosts []string
+	for _, g := range ghostsBySource {
+		ghosts = append(ghosts, g...)
+	}
+	if len(ghosts) > 0 {
+		if lf2, err := skills.ReadLockFile(lockPath); err != nil {
+			logger.Warn("sync: failed to read lock file to prune stale skills", "error", err)
+		} else {
+			for _, skillName := range ghosts {
+				lf2.RemoveSkill(skillName)
+			}
+			if err := skills.WriteLockFile(lockPath, lf2); err != nil {
+				logger.Warn("sync: failed to write lock file after pruning stale skills", "error", err)
+			}
+		}
+	}
 
 	summary := SourceSyncSummary{Sources: results}
 	for _, r := range results {

--- a/internal/api/skills_test.go
+++ b/internal/api/skills_test.go
@@ -276,6 +276,93 @@ func TestHandleSkills_SyncAll_HonorsPinsAndCountsFailures(t *testing.T) {
 	}
 }
 
+// TestHandleSkills_SyncAll_PrunesGhostSkill verifies that a lock entry whose
+// skill no longer exists in the registry is skipped (not reported as a failure)
+// and pruned from the lock file. Regression for ghost-skill sync failures: the
+// skill was deleted from the registry but its lock entry lingered.
+func TestHandleSkills_SyncAll_PrunesGhostSkill(t *testing.T) {
+	srv, _ := setupRegistryTestServer(t)
+	// Note: the ghost skill is NOT seeded into the registry — only into the
+	// lock file, simulating a skill deleted out from under the lock entry.
+	seedSkillSource(t, srv, "ghost-source", "https://github.com/org/repo", "ghost-skill")
+
+	handler := srv.Handler()
+	req := httptest.NewRequest(http.MethodPost, "/api/skills/sources/update", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var summary SourceSyncSummary
+	if err := json.NewDecoder(rec.Body).Decode(&summary); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if summary.FailedSources != 0 {
+		t.Errorf("expected ghost not to fail the source, got FailedSources=%d", summary.FailedSources)
+	}
+	if len(summary.Sources) != 1 || len(summary.Sources[0].Skills) != 1 {
+		t.Fatalf("expected 1 source with 1 skill result, got %+v", summary.Sources)
+	}
+	if got := summary.Sources[0].Skills[0]; got.Error != "" {
+		t.Errorf("expected no error for ghost skill, got %q", got.Error)
+	}
+
+	// The stale entry should be pruned; the now-empty source dropped.
+	lf, err := skills.ReadLockFile(srv.lockFilePath())
+	if err != nil {
+		t.Fatalf("read lock: %v", err)
+	}
+	if _, _, found := lf.FindSkillSource("ghost-skill"); found {
+		t.Errorf("expected ghost-skill pruned from lock file, still present")
+	}
+}
+
+// TestHandleSkills_SyncAll_RetainsPresentSkillOnUpdateError verifies that a
+// skill still present in the registry whose update fails (e.g. transient/repo
+// error) is reported as a failure and is NOT pruned from the lock file. Guards
+// against the ghost-prune logic over-pruning live skills.
+func TestHandleSkills_SyncAll_RetainsPresentSkillOnUpdateError(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedSkill(t, regServer, "live-skill", registry.StateActive)
+	// Source points at a non-existent repo so Update errors, but the skill is
+	// present in the registry, so it must not be treated as a ghost.
+	seedSkillSource(t, srv, "live-source", "/nonexistent/path/to/repo", "live-skill")
+
+	handler := srv.Handler()
+	req := httptest.NewRequest(http.MethodPost, "/api/skills/sources/update", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var summary SourceSyncSummary
+	if err := json.NewDecoder(rec.Body).Decode(&summary); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if summary.FailedSources != 1 {
+		t.Errorf("expected the update error to fail the source, got FailedSources=%d", summary.FailedSources)
+	}
+	if len(summary.Sources) != 1 || len(summary.Sources[0].Skills) != 1 {
+		t.Fatalf("expected 1 source with 1 skill result, got %+v", summary.Sources)
+	}
+	if summary.Sources[0].Skills[0].Error == "" {
+		t.Errorf("expected an error reported for the present-but-failing skill")
+	}
+
+	// The live skill's lock entry must be retained.
+	lf, err := skills.ReadLockFile(srv.lockFilePath())
+	if err != nil {
+		t.Fatalf("read lock: %v", err)
+	}
+	if _, _, found := lf.FindSkillSource("live-skill"); !found {
+		t.Errorf("expected live-skill retained in lock file, was pruned")
+	}
+}
+
 func TestHandleSkills_SyncAll_EmptyLockFile(t *testing.T) {
 	srv, _ := setupRegistryTestServer(t)
 


### PR DESCRIPTION
## Description

Deleting a skill from the Library UI left an orphaned entry in `skills.lock.yaml`, so the next bulk sync tried to update the now-deleted skill and reported a spurious `has no origin (not an imported skill)` failure for each one. This fixes the delete path and makes sync self-healing.

## Type of Change

- [x] Bug fix

## Changes Made

- `handleRegistrySkillDelete` now scrubs the skill from `skills.lock.yaml` after the registry delete, matching the CLI path (`Importer.Remove`). Registry deletion stays authoritative; lock cleanup is best-effort (logged, never 500s) and only writes when the skill was actually present.
- `handleSkillSourcesSyncAll` detects a lock entry whose skill is no longer in the registry (gated on registry presence, not the update error), skips it with a benign warning instead of a failure, and prunes it from the lock file once after the fan-out (race-safe). This drains lock files that already accumulated orphaned entries.
- Skills still present in the registry whose update genuinely fails are reported and retained, unchanged.

## Testing

- New unit tests: delete-cleans-lockfile (source retained, then dropped when empty), sync-prunes-ghost-skill, sync-retains-present-skill-on-update-error.
- `go test ./...` passes; targeted tests pass under `-race`; `golangci-lint run ./internal/api/...` reports 0 issues.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #740