### PR TITLE
feat: multi-hop client path highlight in topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Multi-hop client path highlight in the Topology view.** Clicking a client
+  node now lights up its full transitive reach (client → gateway → the servers
+  it can reach) and fades everything outside that path (resources, skill
+  groups, and sibling clients) rather than only the client → gateway hop. The
+  highlight walks outgoing highlightable edges, so it follows whatever the
+  gateway exposes today and will narrow automatically once per-client scoping
+  lands. Faded nodes and edges stay visible (dimmed, not hidden); clicking
+  empty canvas resets focus. Highlighting is opacity/emphasis only - the
+  backbone layout does not reflow, and edges keep their neutral color.
+
 - **Per-client brand icons in the Topology view.** Each client node now renders
   its product brand mark (Claude, Cursor, Windsurf, Gemini, OpenCode, Grok,
   Cline, Roo Code, Goose) instead of a generic monitor glyph, selected by the

--- a/web/src/__tests__/usePathHighlight.test.ts
+++ b/web/src/__tests__/usePathHighlight.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import type { Node, Edge } from '@xyflow/react';
+
+import {
+  computeHighlightState,
+  isNodeDimmed,
+  isEdgeDimmed,
+} from '../hooks/usePathHighlight';
+
+/**
+ * Build a small butterfly-shaped graph:
+ *
+ *   client-a ─┐
+ *             ├─> gateway ─> mcp-x   (highlightable)
+ *   client-b ─┘           ─> mcp-y   (highlightable)
+ *                         ─> resource-r   (not highlightable)
+ *                         ─> skill-group-s (not highlightable)
+ */
+function makeGraph(): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = [
+    { id: 'client-a', position: { x: 0, y: 0 }, data: { type: 'client' } },
+    { id: 'client-b', position: { x: 0, y: 0 }, data: { type: 'client' } },
+    { id: 'gateway', position: { x: 0, y: 0 }, data: { type: 'gateway' } },
+    { id: 'mcp-x', position: { x: 0, y: 0 }, data: { type: 'mcp-server' } },
+    { id: 'mcp-y', position: { x: 0, y: 0 }, data: { type: 'mcp-server' } },
+    { id: 'resource-r', position: { x: 0, y: 0 }, data: { type: 'resource' } },
+    { id: 'skill-group-s', position: { x: 0, y: 0 }, data: { type: 'skill-group' } },
+  ];
+
+  const edges: Edge[] = [
+    {
+      id: 'edge-client-gateway-a',
+      source: 'client-a',
+      target: 'gateway',
+      data: { relationType: 'client-to-gateway', isHighlightable: true },
+    },
+    {
+      id: 'edge-client-gateway-b',
+      source: 'client-b',
+      target: 'gateway',
+      data: { relationType: 'client-to-gateway', isHighlightable: true },
+    },
+    {
+      id: 'edge-gateway-mcp-x',
+      source: 'gateway',
+      target: 'mcp-x',
+      data: { relationType: 'gateway-to-server', isHighlightable: true },
+    },
+    {
+      id: 'edge-gateway-mcp-y',
+      source: 'gateway',
+      target: 'mcp-y',
+      data: { relationType: 'gateway-to-server', isHighlightable: true },
+    },
+    {
+      id: 'edge-gateway-resource-r',
+      source: 'gateway',
+      target: 'resource-r',
+      data: { relationType: 'gateway-to-resource', isHighlightable: false },
+    },
+    {
+      id: 'edge-gateway-skill-group-s',
+      source: 'gateway',
+      target: 'skill-group-s',
+      data: { relationType: 'gateway-to-skill-group', isHighlightable: false },
+    },
+  ];
+
+  return { nodes, edges };
+}
+
+describe('computeHighlightState', () => {
+  it('returns no highlight and no selection when nothing is selected', () => {
+    const { nodes, edges } = makeGraph();
+    const state = computeHighlightState(nodes, edges, null);
+
+    expect(state.hasSelection).toBe(false);
+    expect(state.highlightedNodeIds.size).toBe(0);
+    expect(state.highlightedEdgeIds.size).toBe(0);
+  });
+
+  it('highlights the transitive client -> gateway -> reachable-servers path', () => {
+    const { nodes, edges } = makeGraph();
+    const state = computeHighlightState(nodes, edges, 'client-a');
+
+    expect(state.hasSelection).toBe(true);
+    expect([...state.highlightedNodeIds].sort()).toEqual([
+      'client-a',
+      'gateway',
+      'mcp-x',
+      'mcp-y',
+    ]);
+    expect([...state.highlightedEdgeIds].sort()).toEqual([
+      'edge-client-gateway-a',
+      'edge-gateway-mcp-x',
+      'edge-gateway-mcp-y',
+    ]);
+  });
+
+  it('does not highlight non-highlightable neighbors (resources, skill groups)', () => {
+    const { nodes, edges } = makeGraph();
+    const state = computeHighlightState(nodes, edges, 'client-a');
+
+    expect(state.highlightedNodeIds.has('resource-r')).toBe(false);
+    expect(state.highlightedNodeIds.has('skill-group-s')).toBe(false);
+    expect(state.highlightedEdgeIds.has('edge-gateway-resource-r')).toBe(false);
+    expect(state.highlightedEdgeIds.has('edge-gateway-skill-group-s')).toBe(false);
+  });
+
+  it('does not highlight a sibling client sharing the gateway', () => {
+    const { nodes, edges } = makeGraph();
+    const state = computeHighlightState(nodes, edges, 'client-a');
+
+    expect(state.highlightedNodeIds.has('client-b')).toBe(false);
+    expect(state.highlightedEdgeIds.has('edge-client-gateway-b')).toBe(false);
+  });
+
+  it('honors scoping when a server edge is dropped from the graph', () => {
+    // Simulates a future per-client scope where mcp-y is not reachable:
+    // removing the gateway -> mcp-y edge narrows the highlight automatically.
+    const { nodes, edges } = makeGraph();
+    const scoped = edges.filter((e) => e.id !== 'edge-gateway-mcp-y');
+    const state = computeHighlightState(nodes, scoped, 'client-a');
+
+    expect(state.highlightedNodeIds.has('mcp-x')).toBe(true);
+    expect(state.highlightedNodeIds.has('mcp-y')).toBe(false);
+  });
+
+  it('highlights only the selected node for non-client node types', () => {
+    const { nodes, edges } = makeGraph();
+    const state = computeHighlightState(nodes, edges, 'mcp-x');
+
+    expect(state.hasSelection).toBe(true);
+    expect([...state.highlightedNodeIds]).toEqual(['mcp-x']);
+    expect(state.highlightedEdgeIds.size).toBe(0);
+  });
+
+  it('highlights just the id when the selected node is missing', () => {
+    const { edges } = makeGraph();
+    const state = computeHighlightState([], edges, 'ghost');
+
+    expect(state.hasSelection).toBe(true);
+    expect([...state.highlightedNodeIds]).toEqual(['ghost']);
+    expect(state.highlightedEdgeIds.size).toBe(0);
+  });
+
+  it('treats reselecting null as a reset that clears all highlighting', () => {
+    const { nodes, edges } = makeGraph();
+    const selected = computeHighlightState(nodes, edges, 'client-a');
+    expect(selected.hasSelection).toBe(true);
+
+    const reset = computeHighlightState(nodes, edges, null);
+    expect(reset.hasSelection).toBe(false);
+    expect(reset.highlightedNodeIds.size).toBe(0);
+    expect(reset.highlightedEdgeIds.size).toBe(0);
+  });
+});
+
+describe('isNodeDimmed / isEdgeDimmed', () => {
+  it('dims nothing when there is no selection', () => {
+    const state = computeHighlightState([], [], null);
+    expect(isNodeDimmed('client-a', state)).toBe(false);
+    expect(isEdgeDimmed('edge-client-gateway-a', state)).toBe(false);
+  });
+
+  it('dims nodes and edges outside the highlighted path', () => {
+    const { nodes, edges } = makeGraph();
+    const state = computeHighlightState(nodes, edges, 'client-a');
+
+    // On the path -> not dimmed.
+    expect(isNodeDimmed('mcp-x', state)).toBe(false);
+    expect(isEdgeDimmed('edge-gateway-mcp-x', state)).toBe(false);
+
+    // Off the path -> dimmed (faded, not hidden).
+    expect(isNodeDimmed('resource-r', state)).toBe(true);
+    expect(isNodeDimmed('client-b', state)).toBe(true);
+    expect(isEdgeDimmed('edge-gateway-resource-r', state)).toBe(true);
+  });
+});

--- a/web/src/hooks/usePathHighlight.ts
+++ b/web/src/hooks/usePathHighlight.ts
@@ -1,12 +1,14 @@
 /**
  * Path highlighting hook for butterfly layout
  *
- * Computes which nodes and edges should be highlighted based on
- * the selected node. For clients, traces the path: Client -> Gateway.
+ * Computes which nodes and edges should be highlighted based on the
+ * selected node. For clients, traces the full transitive reachable path:
+ * Client -> Gateway -> the servers that client can reach.
  */
 
 import { useMemo } from 'react';
 import type { Node, Edge } from '@xyflow/react';
+import type { EdgeMetadata } from '../lib/graph/types';
 
 /**
  * Highlight state returned by the hook
@@ -20,11 +22,120 @@ export interface HighlightState {
   hasSelection: boolean;
 }
 
+/** Empty highlight state - nothing selected, nothing dimmed. */
+function emptyHighlight(): HighlightState {
+  return {
+    highlightedNodeIds: new Set<string>(),
+    highlightedEdgeIds: new Set<string>(),
+    hasSelection: false,
+  };
+}
+
+/**
+ * Trace the transitive reachable path outward from a node.
+ *
+ * Performs a breadth-first walk following only outgoing highlightable edges
+ * (source -> target). Edge metadata's `isHighlightable` flag gates traversal,
+ * so a client reaches the gateway and the servers behind it, but not the
+ * resources or skill groups the gateway also manages (those edges are not
+ * highlightable). When per-client scoping lands, the scoped-out gateway ->
+ * server edges drop out of this walk and the highlight narrows automatically.
+ *
+ * @param startId - Node to start the walk from
+ * @param edges - All edges in the graph
+ * @returns Highlighted node and edge ID sets, including the start node
+ */
+function traceReachablePath(
+  startId: string,
+  edges: Edge[]
+): { highlightedNodeIds: Set<string>; highlightedEdgeIds: Set<string> } {
+  const highlightedNodeIds = new Set<string>([startId]);
+  const highlightedEdgeIds = new Set<string>();
+
+  // Index outgoing highlightable edges by source for an O(1) frontier expand.
+  const outgoing = new Map<string, Edge[]>();
+  for (const edge of edges) {
+    const meta = edge.data as EdgeMetadata | undefined;
+    if (!meta?.isHighlightable) continue;
+    const bucket = outgoing.get(edge.source);
+    if (bucket) {
+      bucket.push(edge);
+    } else {
+      outgoing.set(edge.source, [edge]);
+    }
+  }
+
+  const queue = [startId];
+  while (queue.length > 0) {
+    const current = queue.shift() as string;
+    for (const edge of outgoing.get(current) ?? []) {
+      highlightedEdgeIds.add(edge.id);
+      if (!highlightedNodeIds.has(edge.target)) {
+        highlightedNodeIds.add(edge.target);
+        queue.push(edge.target);
+      }
+    }
+  }
+
+  return { highlightedNodeIds, highlightedEdgeIds };
+}
+
+/**
+ * Compute path highlighting based on the selected node.
+ *
+ * When a client is selected: highlight the transitive client -> gateway ->
+ * reachable-servers path. For other node types: highlight only the selected
+ * node. Pure function so it can be unit-tested without React.
+ *
+ * @param nodes - All nodes in the graph
+ * @param edges - All edges in the graph
+ * @param selectedNodeId - Currently selected node ID, or null
+ * @returns Highlight state with sets of node/edge IDs
+ */
+export function computeHighlightState(
+  nodes: Node[],
+  edges: Edge[],
+  selectedNodeId: string | null
+): HighlightState {
+  // No selection = no highlighting
+  if (!selectedNodeId) {
+    return emptyHighlight();
+  }
+
+  // Find the selected node
+  const selectedNode = nodes.find((n) => n.id === selectedNodeId);
+  if (!selectedNode) {
+    return {
+      highlightedNodeIds: new Set([selectedNodeId]),
+      highlightedEdgeIds: new Set<string>(),
+      hasSelection: true,
+    };
+  }
+
+  const nodeData = selectedNode.data as Record<string, unknown>;
+
+  // Client nodes: highlight the transitive client -> gateway -> servers path.
+  if (nodeData?.type === 'client') {
+    const { highlightedNodeIds, highlightedEdgeIds } = traceReachablePath(
+      selectedNodeId,
+      edges
+    );
+    return { highlightedNodeIds, highlightedEdgeIds, hasSelection: true };
+  }
+
+  // For all other node types, just highlight the selected node.
+  return {
+    highlightedNodeIds: new Set([selectedNodeId]),
+    highlightedEdgeIds: new Set<string>(),
+    hasSelection: true,
+  };
+}
+
 /**
  * Compute path highlighting based on selected node
  *
- * When a client is selected: highlight client -> gateway path.
- * For other node types: just highlight the selected node.
+ * When a client is selected: highlight client -> gateway -> reachable-servers
+ * path. For other node types: just highlight the selected node.
  *
  * @param nodes - All nodes in the graph
  * @param edges - All edges in the graph
@@ -36,51 +147,10 @@ export function usePathHighlight(
   edges: Edge[],
   selectedNodeId: string | null
 ): HighlightState {
-  return useMemo(() => {
-    // No selection = no highlighting
-    if (!selectedNodeId) {
-      return {
-        highlightedNodeIds: new Set<string>(),
-        highlightedEdgeIds: new Set<string>(),
-        hasSelection: false,
-      };
-    }
-
-    // Find the selected node
-    const selectedNode = nodes.find((n) => n.id === selectedNodeId);
-    if (!selectedNode) {
-      return {
-        highlightedNodeIds: new Set([selectedNodeId]),
-        highlightedEdgeIds: new Set<string>(),
-        hasSelection: true,
-      };
-    }
-
-    const nodeData = selectedNode.data as Record<string, unknown>;
-
-    // Client nodes: highlight client -> gateway path
-    if (nodeData?.type === 'client') {
-      const highlightedNodeIds = new Set<string>([selectedNodeId]);
-      const highlightedEdgeIds = new Set<string>();
-
-      for (const edge of edges) {
-        if (edge.source === selectedNodeId && edge.target === 'gateway') {
-          highlightedEdgeIds.add(edge.id);
-          highlightedNodeIds.add('gateway');
-          break;
-        }
-      }
-
-      return { highlightedNodeIds, highlightedEdgeIds, hasSelection: true };
-    }
-
-    // For all other node types, just highlight the selected node
-    return {
-      highlightedNodeIds: new Set([selectedNodeId]),
-      highlightedEdgeIds: new Set<string>(),
-      hasSelection: true,
-    };
-  }, [nodes, edges, selectedNodeId]);
+  return useMemo(
+    () => computeHighlightState(nodes, edges, selectedNodeId),
+    [nodes, edges, selectedNodeId]
+  );
 }
 
 /**


### PR DESCRIPTION
## Description

Clicking a client node in the Topology view now lights up its full transitive reach (client → gateway → the servers it can reach) and fades everything outside that path, instead of only the client → gateway hop. This is PR 1 of a staggered series; it is frontend-only and reuses existing data.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- Extend `usePathHighlight` from a single hop to a transitive BFS that walks outgoing highlightable edges, yielding `client → gateway → reachable servers`.
- Extract a pure `computeHighlightState` (and `traceReachablePath` walker) so the reachability logic is unit-testable without React.
- Exclude resources, skill groups, and sibling clients from the highlight automatically (their edges carry `isHighlightable: false`); a scoped-out server edge drops from the walk, so this narrows automatically once per-client scoping lands.
- Fade-don't-hide and empty-canvas reset already exist in `Canvas.tsx`; highlighting stays class-only so the backbone layout does not reflow and edges keep their neutral color.

## Testing

- `web/src/__tests__/usePathHighlight.test.ts`: 10 Vitest cases (no-selection, transitive path, non-highlightable exclusion, sibling-client exclusion, scoped-edge-dropped, non-client node types, missing node, reset-to-null, dim helpers).
- `make build` passes; full frontend suite 825/825 passes; lint clean on changed files.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #742