### PR TITLE
feat: tool fan-out in topology view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to gridctl will be documented in this file.
   locally so expanding never reflows the three-column backbone. Server -> tool
   edges are non-highlightable, so they stay out of the client-reach highlight.
   Expansion state lives in the stack store and survives polling refreshes.
+  When multiple servers are expanded, each gets its own horizontal lane so
+  their tool columns never overlap. A focused client's reachable servers carry
+  their highlight onto their fanned-out tools, so expanding a reachable server
+  while a client is selected shows its tools at full opacity (tools of
+  out-of-scope servers stay dimmed). Selecting a client zooms the view to fit
+  its reachable subgraph, re-fitting as servers are expanded; clicking empty
+  canvas zooms back out to the whole graph.
 
 - **Multi-hop client path highlight in the Topology view.** Clicking a client
   node now lights up its full transitive reach (client → gateway → the servers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Tool fan-out in the Topology view.** Each MCP server node now has an
+  expand chevron; clicking it fans that server's tools out as nodes in a local
+  column to the server's right, and clicking again collapses them. Fan-out is
+  an explicit per-server action independent of the client path highlight, and
+  multiple servers can be expanded at once. The fan-out is capped at 10 tool
+  nodes; a server with more collapses the remainder into a single "+N more"
+  node whose in-node popover lists the hidden tools, so an 80-tool server never
+  starbursts the canvas. Tool nodes are sourced from the existing server tool
+  data (no new backend endpoint), slide in when mounted, and are laid out
+  locally so expanding never reflows the three-column backbone. Server -> tool
+  edges are non-highlightable, so they stay out of the client-reach highlight.
+  Expansion state lives in the stack store and survives polling refreshes.
+
 - **Multi-hop client path highlight in the Topology view.** Clicking a client
   node now lights up its full transitive reach (client → gateway → the servers
   it can reach) and fades everything outside that path (resources, skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,20 @@ All notable changes to gridctl will be documented in this file.
   node whose in-node popover lists the hidden tools, so an 80-tool server never
   starbursts the canvas. Tool nodes are sourced from the existing server tool
   data (no new backend endpoint), slide in when mounted, and are laid out
-  locally so expanding never reflows the three-column backbone. Server -> tool
-  edges are non-highlightable, so they stay out of the client-reach highlight.
-  Expansion state lives in the stack store and survives polling refreshes.
-  When multiple servers are expanded, each gets its own horizontal lane so
-  their tool columns never overlap. A focused client's reachable servers carry
-  their highlight onto their fanned-out tools, so expanding a reachable server
-  while a client is selected shows its tools at full opacity (tools of
-  out-of-scope servers stay dimmed). Selecting a client zooms the view to fit
-  its reachable subgraph, re-fitting as servers are expanded; clicking empty
-  canvas zooms back out to the whole graph.
+  locally so expanding never reflows the three-column backbone. Tool pills use
+  the neutral linked-client theme (not the violet server theme), so tools read
+  as a distinct tier from the servers they belong to, and long tool names
+  truncate with the full name in a tooltip. Server -> tool edges are
+  non-highlightable, so they stay out of the client-reach highlight. Expansion
+  state lives in the stack store and survives polling refreshes. When multiple
+  servers are expanded, their tools share one column and each server's tools
+  form a vertical band stacked in server order, so the per-server edge bundles
+  do not cross. A focused client's reachable servers carry their highlight onto
+  their fanned-out tools, so expanding a reachable server while a client is
+  selected shows its tools at full opacity (tools of out-of-scope servers stay
+  dimmed). Selecting a client zooms the view to fit its reachable subgraph,
+  re-fitting as servers are expanded; clicking empty canvas zooms back out to
+  the whole graph.
 
 - **Multi-hop client path highlight in the Topology view.** Clicking a client
   node now lights up its full transitive reach (client → gateway → the servers

--- a/web/src/__tests__/expandedServers.test.ts
+++ b/web/src/__tests__/expandedServers.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useStackStore } from '../stores/useStackStore';
+import { TOOL_FANOUT_CAP } from '../lib/graph/toolFanout';
+import type { GatewayStatus, MCPServerStatus } from '../types';
+
+function makeServer(name: string, toolCount: number): MCPServerStatus {
+  return {
+    name,
+    transport: 'http',
+    initialized: true,
+    toolCount,
+    tools: Array.from({ length: toolCount }, (_, i) => `${name}-tool-${i}`),
+  };
+}
+
+function status(servers: MCPServerStatus[]): GatewayStatus {
+  return {
+    gateway: { name: 'gw', version: '0.0.0' },
+    'mcp-servers': servers,
+  };
+}
+
+function toolNodeCountFor(serverNodeId: string): number {
+  return useStackStore
+    .getState()
+    .nodes.filter((n) => {
+      const d = n.data as { type?: string; serverNodeId?: string };
+      return (d.type === 'tool' || d.type === 'tool-overflow') && d.serverNodeId === serverNodeId;
+    }).length;
+}
+
+describe('useStackStore tool expansion', () => {
+  beforeEach(() => {
+    // Reset expansion and seed two servers: github (3 tools), jira (15 tools).
+    useStackStore.setState({ expandedServers: new Set() });
+    useStackStore.getState().setGatewayStatus(
+      status([makeServer('github', 3), makeServer('jira', TOOL_FANOUT_CAP + 5)])
+    );
+  });
+
+  it('starts with no servers expanded and no tool nodes', () => {
+    expect(useStackStore.getState().expandedServers.size).toBe(0);
+    expect(toolNodeCountFor('mcp-github')).toBe(0);
+  });
+
+  it('toggles a server expanded and back collapsed', () => {
+    const { toggleServerExpanded } = useStackStore.getState();
+
+    toggleServerExpanded('mcp-github');
+    expect(useStackStore.getState().expandedServers.has('mcp-github')).toBe(true);
+    expect(toolNodeCountFor('mcp-github')).toBe(3);
+
+    toggleServerExpanded('mcp-github');
+    expect(useStackStore.getState().expandedServers.has('mcp-github')).toBe(false);
+    expect(toolNodeCountFor('mcp-github')).toBe(0);
+  });
+
+  it('expandServer / collapseServer are idempotent', () => {
+    const { expandServer, collapseServer } = useStackStore.getState();
+
+    expandServer('mcp-github');
+    expandServer('mcp-github');
+    expect(useStackStore.getState().expandedServers.size).toBe(1);
+    expect(toolNodeCountFor('mcp-github')).toBe(3);
+
+    collapseServer('mcp-github');
+    collapseServer('mcp-github');
+    expect(useStackStore.getState().expandedServers.size).toBe(0);
+  });
+
+  it('expands multiple servers independently', () => {
+    const { expandServer } = useStackStore.getState();
+    expandServer('mcp-github');
+    expandServer('mcp-jira');
+
+    expect(toolNodeCountFor('mcp-github')).toBe(3);
+    // jira has 15 tools -> capped 10 tool nodes + 1 overflow node = 11.
+    expect(toolNodeCountFor('mcp-jira')).toBe(TOOL_FANOUT_CAP + 1);
+  });
+
+  it('caps fan-out and adds a single overflow node for a large server', () => {
+    useStackStore.getState().expandServer('mcp-jira');
+    const overflow = useStackStore
+      .getState()
+      .nodes.filter((n) => n.type === 'toolOverflow');
+    expect(overflow).toHaveLength(1);
+    const data = overflow[0].data as { overflowCount: number };
+    expect(data.overflowCount).toBe(5);
+  });
+
+  it('keeps expansion across a polling refresh (setGatewayStatus)', () => {
+    useStackStore.getState().expandServer('mcp-github');
+    expect(toolNodeCountFor('mcp-github')).toBe(3);
+
+    // Simulate the next poll delivering the same status.
+    useStackStore.getState().setGatewayStatus(
+      status([makeServer('github', 3), makeServer('jira', TOOL_FANOUT_CAP + 5)])
+    );
+
+    expect(useStackStore.getState().expandedServers.has('mcp-github')).toBe(true);
+    expect(toolNodeCountFor('mcp-github')).toBe(3);
+  });
+});

--- a/web/src/__tests__/toolFanout.test.ts
+++ b/web/src/__tests__/toolFanout.test.ts
@@ -184,4 +184,20 @@ describe('appendToolFanout', () => {
     );
     expect(result.nodes.filter((n) => n.type === 'tool')).toHaveLength(0);
   });
+
+  it('places each expanded server in its own horizontal lane', () => {
+    // Both servers sit at the same X; lanes must separate their columns.
+    const sameXNodes: Node[] = [
+      makeServerNode('a', ['a1'], 800, 0),
+      makeServerNode('b', ['b1'], 800, 300),
+    ];
+    const result = appendToolFanout(sameXNodes, [], new Set(['mcp-a', 'mcp-b']));
+
+    const aTool = result.nodes.find((n) => n.id === toolNodeId('mcp-a', 'a1'));
+    const bTool = result.nodes.find((n) => n.id === toolNodeId('mcp-b', 'b1'));
+
+    // Lane 0 vs lane 1 -> distinct X columns, so the fans never overlap.
+    expect(aTool?.position.x).not.toBe(bTool?.position.x);
+    expect(bTool!.position.x).toBeGreaterThan(aTool!.position.x);
+  });
 });

--- a/web/src/__tests__/toolFanout.test.ts
+++ b/web/src/__tests__/toolFanout.test.ts
@@ -185,19 +185,27 @@ describe('appendToolFanout', () => {
     expect(result.nodes.filter((n) => n.type === 'tool')).toHaveLength(0);
   });
 
-  it('places each expanded server in its own horizontal lane', () => {
-    // Both servers sit at the same X; lanes must separate their columns.
+  it('stacks expanded servers as non-overlapping vertical bands in one column', () => {
+    // Two servers at the same X; bands must share a column and tile vertically.
     const sameXNodes: Node[] = [
-      makeServerNode('a', ['a1'], 800, 0),
+      makeServerNode('a', ['a1', 'a2'], 800, 0),
       makeServerNode('b', ['b1'], 800, 300),
     ];
     const result = appendToolFanout(sameXNodes, [], new Set(['mcp-a', 'mcp-b']));
 
-    const aTool = result.nodes.find((n) => n.id === toolNodeId('mcp-a', 'a1'));
-    const bTool = result.nodes.find((n) => n.id === toolNodeId('mcp-b', 'b1'));
+    const toolNodes = result.nodes.filter((n) => n.type === 'tool');
+    // All tools share a single column X.
+    expect(new Set(toolNodes.map((n) => n.position.x)).size).toBe(1);
 
-    // Lane 0 vs lane 1 -> distinct X columns, so the fans never overlap.
-    expect(aTool?.position.x).not.toBe(bTool?.position.x);
-    expect(bTool!.position.x).toBeGreaterThan(aTool!.position.x);
+    const aTools = result.nodes.filter(
+      (n) => (n.data as { serverNodeId?: string }).serverNodeId === 'mcp-a'
+    );
+    const bTools = result.nodes.filter(
+      (n) => (n.data as { serverNodeId?: string }).serverNodeId === 'mcp-b'
+    );
+    // Server a is above server b, so a's band sits entirely above b's band.
+    const aMaxY = Math.max(...aTools.map((n) => n.position.y));
+    const bMinY = Math.min(...bTools.map((n) => n.position.y));
+    expect(bMinY).toBeGreaterThan(aMaxY);
   });
 });

--- a/web/src/__tests__/toolFanout.test.ts
+++ b/web/src/__tests__/toolFanout.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import type { Node, Edge } from '@xyflow/react';
+
+import {
+  TOOL_FANOUT_CAP,
+  computeToolFanout,
+  createToolFanout,
+  appendToolFanout,
+  toolNodeId,
+  overflowNodeId,
+} from '../lib/graph/toolFanout';
+import { LAYOUT } from '../lib/constants';
+
+function makeServerNode(name: string, tools: string[], x = 800, y = 0): Node {
+  return {
+    id: `mcp-${name}`,
+    type: 'mcpServer',
+    position: { x, y },
+    data: { type: 'mcp-server', name, tools, toolCount: tools.length },
+  };
+}
+
+function names(n: number): string[] {
+  return Array.from({ length: n }, (_, i) => `tool-${i}`);
+}
+
+describe('computeToolFanout (cap logic)', () => {
+  it('returns nothing for an empty tool list', () => {
+    expect(computeToolFanout([])).toEqual({ visible: [], overflow: [] });
+  });
+
+  it('shows every tool with no overflow when below the cap', () => {
+    const { visible, overflow } = computeToolFanout(names(5));
+    expect(visible).toHaveLength(5);
+    expect(overflow).toHaveLength(0);
+  });
+
+  it('shows exactly the cap with no overflow node at the boundary', () => {
+    const { visible, overflow } = computeToolFanout(names(TOOL_FANOUT_CAP));
+    expect(visible).toHaveLength(TOOL_FANOUT_CAP);
+    expect(overflow).toHaveLength(0);
+  });
+
+  it('caps the visible set and overflows the remainder past the cap', () => {
+    const { visible, overflow } = computeToolFanout(names(TOOL_FANOUT_CAP + 2));
+    expect(visible).toHaveLength(TOOL_FANOUT_CAP);
+    expect(overflow).toHaveLength(2);
+    // No tool is both visible and overflowed.
+    expect(new Set([...visible, ...overflow]).size).toBe(TOOL_FANOUT_CAP + 2);
+  });
+
+  it('honors a custom cap', () => {
+    const { visible, overflow } = computeToolFanout(names(4), 2);
+    expect(visible).toEqual(['tool-0', 'tool-1']);
+    expect(overflow).toEqual(['tool-2', 'tool-3']);
+  });
+});
+
+describe('createToolFanout', () => {
+  it('returns nothing for a server with no tools', () => {
+    const result = createToolFanout(makeServerNode('empty', []));
+    expect(result.nodes).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it('builds one tool node and one non-highlightable edge per tool', () => {
+    const server = makeServerNode('github', ['search', 'create-pr', 'merge']);
+    const { nodes, edges } = createToolFanout(server);
+
+    expect(nodes).toHaveLength(3);
+    expect(edges).toHaveLength(3);
+
+    for (const node of nodes) {
+      expect(node.type).toBe('tool');
+      expect(node.selectable).toBe(false);
+      const data = node.data as { type: string; serverNodeId: string };
+      expect(data.type).toBe('tool');
+      expect(data.serverNodeId).toBe('mcp-github');
+    }
+
+    for (const edge of edges) {
+      expect(edge.source).toBe('mcp-github');
+      expect(edge.sourceHandle).toBe('output');
+      expect(edge.targetHandle).toBe('input');
+      const meta = edge.data as { relationType: string; isHighlightable: boolean };
+      expect(meta.relationType).toBe('server-to-tool');
+      // Must stay out of PR 1's client-reach highlight walk.
+      expect(meta.isHighlightable).toBe(false);
+    }
+  });
+
+  it('positions tool nodes in a column to the right of the server', () => {
+    const server = makeServerNode('svc', ['a', 'b'], 800, 0);
+    const { nodes } = createToolFanout(server);
+    const expectedX = 800 + LAYOUT.NODE_WIDTH + LAYOUT.TOOL_OFFSET_X;
+
+    for (const node of nodes) {
+      expect(node.position.x).toBe(expectedX);
+      expect(node.position.x).toBeGreaterThan(server.position.x);
+    }
+    // Stacked vertically (distinct y per node).
+    expect(nodes[0].position.y).not.toBe(nodes[1].position.y);
+  });
+
+  it('caps tool nodes and emits a single overflow node carrying the remainder', () => {
+    const tools = names(TOOL_FANOUT_CAP + 5); // 15 tools
+    const server = makeServerNode('big', tools);
+    const { nodes, edges } = createToolFanout(server);
+
+    const toolNodes = nodes.filter((n) => n.type === 'tool');
+    const overflowNodes = nodes.filter((n) => n.type === 'toolOverflow');
+
+    expect(toolNodes).toHaveLength(TOOL_FANOUT_CAP);
+    expect(overflowNodes).toHaveLength(1);
+    // One edge per mounted node (tools + the overflow node).
+    expect(edges).toHaveLength(TOOL_FANOUT_CAP + 1);
+
+    const overflow = overflowNodes[0];
+    expect(overflow.id).toBe(overflowNodeId('mcp-big'));
+    const data = overflow.data as { overflowCount: number; hiddenTools: string[] };
+    expect(data.overflowCount).toBe(5);
+    expect(data.hiddenTools).toEqual(tools.slice(TOOL_FANOUT_CAP));
+  });
+
+  it('preserves dragged positions for tool nodes', () => {
+    const server = makeServerNode('svc', ['a']);
+    const id = toolNodeId('mcp-svc', 'a');
+    const draggedPositions = new Map([[id, { x: 1234, y: 567 }]]);
+    const { nodes } = createToolFanout(server, { draggedPositions });
+    expect(nodes[0].position).toEqual({ x: 1234, y: 567 });
+  });
+});
+
+describe('appendToolFanout', () => {
+  const backboneNodes: Node[] = [
+    makeServerNode('a', ['a1', 'a2']),
+    makeServerNode('b', ['b1']),
+    { id: 'gateway', type: 'gateway', position: { x: 400, y: 0 }, data: { type: 'gateway' } },
+  ];
+  const backboneEdges: Edge[] = [
+    { id: 'edge-gateway-mcp-a', source: 'gateway', target: 'mcp-a' },
+  ];
+
+  it('returns the backbone unchanged when nothing is expanded', () => {
+    const result = appendToolFanout(backboneNodes, backboneEdges, new Set());
+    expect(result.nodes).toBe(backboneNodes);
+    expect(result.edges).toBe(backboneEdges);
+  });
+
+  it('appends fan-out only for expanded servers, leaving the backbone intact', () => {
+    const result = appendToolFanout(
+      backboneNodes,
+      backboneEdges,
+      new Set(['mcp-a'])
+    );
+
+    // Original backbone nodes/edges are still present.
+    expect(result.nodes.slice(0, backboneNodes.length)).toEqual(backboneNodes);
+    expect(result.edges.slice(0, backboneEdges.length)).toEqual(backboneEdges);
+
+    // Only server a fanned out (2 tools), server b did not.
+    const added = result.nodes.filter((n) => n.type === 'tool');
+    expect(added.map((n) => n.id).sort()).toEqual([
+      toolNodeId('mcp-a', 'a1'),
+      toolNodeId('mcp-a', 'a2'),
+    ]);
+  });
+
+  it('expands multiple servers independently', () => {
+    const result = appendToolFanout(
+      backboneNodes,
+      backboneEdges,
+      new Set(['mcp-a', 'mcp-b'])
+    );
+    const added = result.nodes.filter((n) => n.type === 'tool');
+    expect(added).toHaveLength(3); // 2 from a + 1 from b
+  });
+
+  it('ignores expanded ids with no matching server node', () => {
+    const result = appendToolFanout(
+      backboneNodes,
+      backboneEdges,
+      new Set(['mcp-ghost'])
+    );
+    expect(result.nodes.filter((n) => n.type === 'tool')).toHaveLength(0);
+  });
+});

--- a/web/src/__tests__/usePathHighlight.test.ts
+++ b/web/src/__tests__/usePathHighlight.test.ts
@@ -156,6 +156,46 @@ describe('computeHighlightState', () => {
   });
 });
 
+describe('computeHighlightState with expanded tool fan-out', () => {
+  // Graph where client-a reaches mcp-x (expanded, 1 tool) but not mcp-z.
+  // mcp-z is also expanded but off the client's path.
+  function makeGraphWithTools(): { nodes: Node[]; edges: Edge[] } {
+    const { nodes, edges } = makeGraph();
+    nodes.push(
+      { id: 'mcp-z', position: { x: 0, y: 0 }, data: { type: 'mcp-server' } },
+      { id: 'tool-mcp-x-search', position: { x: 0, y: 0 }, data: { type: 'tool', serverNodeId: 'mcp-x' } },
+      { id: 'tool-overflow-mcp-x', position: { x: 0, y: 0 }, data: { type: 'tool-overflow', serverNodeId: 'mcp-x' } },
+      { id: 'tool-mcp-z-secret', position: { x: 0, y: 0 }, data: { type: 'tool', serverNodeId: 'mcp-z' } }
+    );
+    edges.push(
+      { id: 'edge-tool-mcp-x-search', source: 'mcp-x', target: 'tool-mcp-x-search', data: { relationType: 'server-to-tool', isHighlightable: false } },
+      { id: 'edge-tool-overflow-mcp-x', source: 'mcp-x', target: 'tool-overflow-mcp-x', data: { relationType: 'server-to-tool', isHighlightable: false } },
+      { id: 'edge-tool-mcp-z-secret', source: 'mcp-z', target: 'tool-mcp-z-secret', data: { relationType: 'server-to-tool', isHighlightable: false } }
+    );
+    return { nodes, edges };
+  }
+
+  it('highlights the tools (and overflow) of a reachable, expanded server', () => {
+    const { nodes, edges } = makeGraphWithTools();
+    const state = computeHighlightState(nodes, edges, 'client-a');
+
+    expect(state.highlightedNodeIds.has('tool-mcp-x-search')).toBe(true);
+    expect(state.highlightedNodeIds.has('tool-overflow-mcp-x')).toBe(true);
+    expect(state.highlightedEdgeIds.has('edge-tool-mcp-x-search')).toBe(true);
+    expect(state.highlightedEdgeIds.has('edge-tool-overflow-mcp-x')).toBe(true);
+  });
+
+  it('does not highlight tools of a server outside the client path', () => {
+    const { nodes, edges } = makeGraphWithTools();
+    const state = computeHighlightState(nodes, edges, 'client-a');
+
+    // mcp-z is not reachable from client-a, so its tools stay dimmed.
+    expect(state.highlightedNodeIds.has('mcp-z')).toBe(false);
+    expect(state.highlightedNodeIds.has('tool-mcp-z-secret')).toBe(false);
+    expect(state.highlightedEdgeIds.has('edge-tool-mcp-z-secret')).toBe(false);
+  });
+});
+
 describe('isNodeDimmed / isEdgeDimmed', () => {
   it('dims nothing when there is no selection', () => {
     const state = computeHighlightState([], [], null);

--- a/web/src/components/graph/Canvas.tsx
+++ b/web/src/components/graph/Canvas.tsx
@@ -106,8 +106,12 @@ export function Canvas() {
     });
   }, [edges, highlightState]);
 
-  // Handle node selection
-  const onNodeClick = useCallback((_: React.MouseEvent, node: { id: string }) => {
+  // Handle node selection. Tool fan-out nodes are read-only affordances: a
+  // click should not select them or open the sidebar (the "+N more" node
+  // handles its own popover internally).
+  const onNodeClick = useCallback((_: React.MouseEvent, node: { id: string; data?: { type?: string } }) => {
+    const nodeType = node.data?.type;
+    if (nodeType === 'tool' || nodeType === 'tool-overflow') return;
     selectNode(node.id);
     setSidebarOpen(true);
   }, [selectNode, setSidebarOpen]);

--- a/web/src/components/graph/Canvas.tsx
+++ b/web/src/components/graph/Canvas.tsx
@@ -64,6 +64,26 @@ export function Canvas() {
   // Path highlighting for selected agents
   const highlightState = usePathHighlight(nodes, edges, selectedNodeId);
 
+  // Auto-fit the view to a focused client's reachable subgraph. The fit key
+  // captures the highlighted node set, so the view re-fits whenever that set
+  // changes - including expanding a reachable server while the client stays
+  // focused, which brings the newly-fanned-out tools into frame.
+  const selectedNode = nodes.find((n) => n.id === selectedNodeId);
+  const isClientSelected =
+    (selectedNode?.data as { type?: string } | undefined)?.type === 'client';
+  const fitKey = isClientSelected
+    ? [...highlightState.highlightedNodeIds].sort().join(',')
+    : '';
+  useEffect(() => {
+    if (!fitKey) return;
+    const ids = fitKey.split(',').map((id) => ({ id }));
+    // Defer one frame so React Flow has mounted/measured any new tool nodes.
+    const raf = requestAnimationFrame(() => {
+      fitView({ nodes: ids, padding: 0.25, duration: 400, maxZoom: 1.5 });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [fitKey, fitView]);
+
   // Evolvable grid - main lines at 100px, sub-grid dots at 20px fade in at >0.8x
   const showSubGrid = zoom > 0.8;
   const subGridOpacity = Math.min((zoom - 0.8) * 2.5, 1); // Fade from 0.8 to 1.2
@@ -116,11 +136,13 @@ export function Canvas() {
     setSidebarOpen(true);
   }, [selectNode, setSidebarOpen]);
 
-  // Handle pane click (deselect)
+  // Handle pane click (deselect). Reset focus and zoom back out to frame the
+  // whole graph, complementing the zoom-to-fit on client selection.
   const onPaneClick = useCallback(() => {
     selectNode(null);
     setSidebarOpen(false);
-  }, [selectNode, setSidebarOpen]);
+    fitView({ padding: 0.2, duration: 400 });
+  }, [selectNode, setSidebarOpen, fitView]);
 
   // No-op connect handler (wiring mode no longer supports agent connections)
   const onConnect = useCallback((_connection: Connection) => {}, []);

--- a/web/src/components/graph/CustomNode.tsx
+++ b/web/src/components/graph/CustomNode.tsx
@@ -1,11 +1,12 @@
 import { memo } from 'react';
 import { Handle, Position } from '@xyflow/react';
-import { Terminal, Box, Hash, Globe, Wifi, Server, Cpu, KeyRound, HeartPulse, FileJson, FileOutput, Filter, LockOpen, Lock } from 'lucide-react';
+import { Terminal, Box, Hash, Globe, Wifi, Server, Cpu, KeyRound, HeartPulse, FileJson, FileOutput, Filter, LockOpen, Lock, ChevronRight, ChevronDown } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { Badge } from '../ui/Badge';
 import { StatusDot } from '../ui/StatusDot';
 import { getTransportIcon, getTransportColorClasses } from '../../lib/transport';
 import { useUIStore } from '../../stores/useUIStore';
+import { useStackStore } from '../../stores/useStackStore';
 import { useTokenHeat } from '../../hooks/useTokenHeat';
 import { LAYOUT } from '../../lib/constants';
 import { TelemetryNodeDot } from '../telemetry/TelemetryNodeDot';
@@ -22,6 +23,14 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
   const isCompact = useUIStore((s) => s.compactCards);
   const isServer = data.type === 'mcp-server';
   const heatIntensity = useTokenHeat(isServer ? data.name : '');
+
+  // Tool fan-out expand/collapse (servers only). The node id matches the
+  // convention in lib/graph/nodes.ts (`mcp-<name>`).
+  const serverNodeId = `mcp-${data.name}`;
+  const isExpanded = useStackStore((s) => s.expandedServers.has(serverNodeId));
+  const toggleServerExpanded = useStackStore((s) => s.toggleServerExpanded);
+  const serverToolCount = isServer ? (data as MCPServerNodeData).toolCount : 0;
+  const canExpand = isServer && (serverToolCount ?? 0) > 0;
   const isExternal = isServer && (data as MCPServerNodeData).external;
   const isLocalProcess = isServer && (data as MCPServerNodeData).localProcess;
   const isSSH = isServer && (data as MCPServerNodeData).ssh;
@@ -146,6 +155,28 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
             <span className="text-[10px] text-text-muted font-mono">
               {toolCount}t
             </span>
+          )}
+          {/* Tool fan-out toggle. Stops propagation so it expands tools
+              without also selecting the node / opening the sidebar. */}
+          {canExpand && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleServerExpanded(serverNodeId);
+              }}
+              aria-expanded={isExpanded}
+              aria-label={isExpanded ? `Collapse ${data.name} tools` : `Expand ${data.name} tools`}
+              title={isExpanded ? 'Collapse tools' : 'Expand tools'}
+              className={cn(
+                'flex items-center justify-center w-5 h-5 rounded-md border transition-colors duration-200',
+                isExpanded
+                  ? 'border-violet-500/40 bg-violet-500/15 text-violet-300'
+                  : 'border-border/50 text-text-muted hover:border-violet-400/50 hover:text-violet-300'
+              )}
+            >
+              {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+            </button>
           )}
           <StatusDot status={data.status} pulse={!isCompact} />
         </div>

--- a/web/src/components/graph/ToolNode.tsx
+++ b/web/src/components/graph/ToolNode.tsx
@@ -11,9 +11,10 @@ interface ToolNodeProps {
 
 /**
  * A single tool fanned out from an expanded MCP server. Renders as a compact
- * violet pill (tools inherit the server's violet theme) and slides in from the
- * left when mounted, so expanding a server reads as the tools flowing out of
- * it. Not selectable - it is a read-only affordance for PR 2.
+ * neutral pill that matches the linked-client theme (surface gradient, neutral
+ * border, monochrome accents) rather than the violet server theme, so "tools"
+ * read as a distinct layer from the MCP servers they belong to. Slides in from
+ * the left when mounted. Not selectable - it is a read-only affordance for PR 2.
  */
 const ToolNode = memo(({ data }: ToolNodeProps) => {
   return (
@@ -21,17 +22,21 @@ const ToolNode = memo(({ data }: ToolNodeProps) => {
       className={cn(
         'animate-slide-in-right',
         'flex items-center gap-2 px-2.5 rounded-lg relative',
-        'border border-violet-500/25 bg-gradient-to-r from-surface/95 to-violet-500/[0.05]',
+        'border border-border bg-gradient-to-b from-surface/95 via-surface/90 to-surface/80',
         'backdrop-blur-xl shadow-bevel',
-        'transition-colors duration-200 hover:border-violet-400/50'
+        'transition-colors duration-200 hover:shadow-node-hover hover:border-text-secondary/40'
       )}
       style={{ width: LAYOUT.TOOL_WIDTH, height: LAYOUT.TOOL_HEIGHT }}
       title={`${data.serverName} · ${data.name}`}
     >
-      <Wrench size={11} className="text-violet-400 flex-shrink-0" />
-      {/* min-w-0 lets the flex item shrink so truncate actually clips long
-          tool names instead of overflowing the pill. */}
-      <span className="min-w-0 flex-1 font-mono text-[11px] text-text-secondary truncate tracking-tight">
+      {/* Top accent line, matching the client nodes. */}
+      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+
+      <Wrench size={11} className="text-text-secondary flex-shrink-0" />
+      {/* min-w-0 lets the flex item shrink; tool-label re-asserts
+          overflow:hidden (see index.css) so truncate clips long tool names
+          instead of overflowing the pill. */}
+      <span className="tool-label min-w-0 flex-1 font-mono text-[11px] text-text-secondary truncate tracking-tight">
         {data.name}
       </span>
 
@@ -39,7 +44,7 @@ const ToolNode = memo(({ data }: ToolNodeProps) => {
         type="target"
         position={Position.Left}
         className={cn(
-          '!w-2 !h-2 !bg-violet-500 !border-2 !border-background !rounded-full',
+          '!w-2 !h-2 !bg-text-secondary !border-2 !border-background !rounded-full',
           'transition-all duration-200'
         )}
         id="input"

--- a/web/src/components/graph/ToolNode.tsx
+++ b/web/src/components/graph/ToolNode.tsx
@@ -1,0 +1,51 @@
+import { memo } from 'react';
+import { Handle, Position } from '@xyflow/react';
+import { Wrench } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { LAYOUT } from '../../lib/constants';
+import type { ToolNodeData } from '../../types';
+
+interface ToolNodeProps {
+  data: ToolNodeData;
+}
+
+/**
+ * A single tool fanned out from an expanded MCP server. Renders as a compact
+ * violet pill (tools inherit the server's violet theme) and slides in from the
+ * left when mounted, so expanding a server reads as the tools flowing out of
+ * it. Not selectable - it is a read-only affordance for PR 2.
+ */
+const ToolNode = memo(({ data }: ToolNodeProps) => {
+  return (
+    <div
+      className={cn(
+        'animate-slide-in-right',
+        'flex items-center gap-2 px-2.5 rounded-lg relative',
+        'border border-violet-500/25 bg-gradient-to-r from-surface/95 to-violet-500/[0.05]',
+        'backdrop-blur-xl shadow-bevel',
+        'transition-colors duration-200 hover:border-violet-400/50'
+      )}
+      style={{ width: LAYOUT.TOOL_WIDTH, height: LAYOUT.TOOL_HEIGHT }}
+      title={`${data.serverName} · ${data.name}`}
+    >
+      <Wrench size={11} className="text-violet-400 flex-shrink-0" />
+      <span className="font-mono text-[11px] text-text-secondary truncate tracking-tight">
+        {data.name}
+      </span>
+
+      <Handle
+        type="target"
+        position={Position.Left}
+        className={cn(
+          '!w-2 !h-2 !bg-violet-500 !border-2 !border-background !rounded-full',
+          'transition-all duration-200'
+        )}
+        id="input"
+      />
+    </div>
+  );
+});
+
+ToolNode.displayName = 'ToolNode';
+
+export default ToolNode;

--- a/web/src/components/graph/ToolNode.tsx
+++ b/web/src/components/graph/ToolNode.tsx
@@ -29,7 +29,9 @@ const ToolNode = memo(({ data }: ToolNodeProps) => {
       title={`${data.serverName} · ${data.name}`}
     >
       <Wrench size={11} className="text-violet-400 flex-shrink-0" />
-      <span className="font-mono text-[11px] text-text-secondary truncate tracking-tight">
+      {/* min-w-0 lets the flex item shrink so truncate actually clips long
+          tool names instead of overflowing the pill. */}
+      <span className="min-w-0 flex-1 font-mono text-[11px] text-text-secondary truncate tracking-tight">
         {data.name}
       </span>
 

--- a/web/src/components/graph/ToolOverflowNode.tsx
+++ b/web/src/components/graph/ToolOverflowNode.tsx
@@ -35,14 +35,14 @@ const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
         className={cn(
           'animate-slide-in-right',
           'w-full flex items-center gap-2 px-2.5 rounded-lg',
-          'border border-dashed border-violet-500/40 bg-violet-500/[0.06]',
+          'border border-dashed border-text-secondary/40 bg-white/[0.03]',
           'backdrop-blur-xl text-left',
-          'transition-colors duration-200 hover:border-violet-400/70 hover:bg-violet-500/10'
+          'transition-colors duration-200 hover:border-text-secondary/70 hover:bg-white/[0.06]'
         )}
         style={{ height: LAYOUT.TOOL_HEIGHT }}
       >
-        <MoreHorizontal size={12} className="text-violet-300 flex-shrink-0" />
-        <span className="font-mono text-[11px] text-violet-200/90 tracking-tight">
+        <MoreHorizontal size={12} className="text-text-secondary flex-shrink-0" />
+        <span className="font-mono text-[11px] text-text-secondary tracking-tight">
           +{data.overflowCount} more
         </span>
       </button>
@@ -51,7 +51,7 @@ const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
         <div
           className={cn(
             'absolute left-0 top-full mt-1.5 z-50 w-full',
-            'rounded-lg border border-violet-500/25 bg-surface-elevated/95',
+            'rounded-lg border border-border bg-surface-elevated/95',
             'backdrop-blur-xl shadow-bevel p-1.5',
             'max-h-48 overflow-y-auto animate-fade-in-scale'
           )}
@@ -63,10 +63,10 @@ const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
             {data.hiddenTools.map((tool) => (
               <li
                 key={tool}
-                className="flex items-center gap-1.5 px-1.5 py-1 rounded-md hover:bg-violet-500/10"
+                className="flex items-center gap-1.5 px-1.5 py-1 rounded-md hover:bg-white/[0.06]"
               >
-                <Wrench size={10} className="text-violet-400/80 flex-shrink-0" />
-                <span className="min-w-0 flex-1 font-mono text-[11px] text-text-secondary truncate" title={tool}>
+                <Wrench size={10} className="text-text-secondary/80 flex-shrink-0" />
+                <span className="tool-label min-w-0 flex-1 font-mono text-[11px] text-text-secondary truncate" title={tool}>
                   {tool}
                 </span>
               </li>
@@ -79,7 +79,7 @@ const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
         type="target"
         position={Position.Left}
         className={cn(
-          '!w-2 !h-2 !bg-violet-500 !border-2 !border-background !rounded-full',
+          '!w-2 !h-2 !bg-text-secondary !border-2 !border-background !rounded-full',
           'transition-all duration-200'
         )}
         id="input"

--- a/web/src/components/graph/ToolOverflowNode.tsx
+++ b/web/src/components/graph/ToolOverflowNode.tsx
@@ -1,0 +1,93 @@
+import { memo, useState, useCallback } from 'react';
+import { Handle, Position } from '@xyflow/react';
+import { MoreHorizontal, Wrench } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { LAYOUT } from '../../lib/constants';
+import type { ToolOverflowNodeData } from '../../types';
+
+interface ToolOverflowNodeProps {
+  data: ToolOverflowNodeData;
+}
+
+/**
+ * The "+N more" aggregate node shown when an expanded server has more tools
+ * than the fan-out cap. Clicking it opens an in-node popover listing the
+ * remaining tools rather than mounting more canvas nodes, so a large server
+ * stays legible. The popover lives inside this single node, anchored to it,
+ * so it pans and zooms with the canvas.
+ */
+const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
+  const [open, setOpen] = useState(false);
+
+  const toggle = useCallback((event: React.MouseEvent) => {
+    // Keep the click from bubbling to the canvas node-selection handler.
+    event.stopPropagation();
+    setOpen((prev) => !prev);
+  }, []);
+
+  return (
+    <div className="relative nodrag" style={{ width: LAYOUT.TOOL_WIDTH }}>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        aria-label={`Show ${data.overflowCount} more ${data.serverName} tools`}
+        className={cn(
+          'animate-slide-in-right',
+          'w-full flex items-center gap-2 px-2.5 rounded-lg',
+          'border border-dashed border-violet-500/40 bg-violet-500/[0.06]',
+          'backdrop-blur-xl text-left',
+          'transition-colors duration-200 hover:border-violet-400/70 hover:bg-violet-500/10'
+        )}
+        style={{ height: LAYOUT.TOOL_HEIGHT }}
+      >
+        <MoreHorizontal size={12} className="text-violet-300 flex-shrink-0" />
+        <span className="font-mono text-[11px] text-violet-200/90 tracking-tight">
+          +{data.overflowCount} more
+        </span>
+      </button>
+
+      {open && (
+        <div
+          className={cn(
+            'absolute left-0 top-full mt-1.5 z-50 w-full',
+            'rounded-lg border border-violet-500/25 bg-surface-elevated/95',
+            'backdrop-blur-xl shadow-bevel p-1.5',
+            'max-h-48 overflow-y-auto animate-fade-in-scale'
+          )}
+        >
+          <div className="px-1.5 py-1 text-[9px] uppercase tracking-widest text-text-muted">
+            {data.serverName} · {data.overflowCount} more
+          </div>
+          <ul className="space-y-0.5">
+            {data.hiddenTools.map((tool) => (
+              <li
+                key={tool}
+                className="flex items-center gap-1.5 px-1.5 py-1 rounded-md hover:bg-violet-500/10"
+              >
+                <Wrench size={10} className="text-violet-400/80 flex-shrink-0" />
+                <span className="font-mono text-[11px] text-text-secondary truncate" title={tool}>
+                  {tool}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <Handle
+        type="target"
+        position={Position.Left}
+        className={cn(
+          '!w-2 !h-2 !bg-violet-500 !border-2 !border-background !rounded-full',
+          'transition-all duration-200'
+        )}
+        id="input"
+      />
+    </div>
+  );
+});
+
+ToolOverflowNode.displayName = 'ToolOverflowNode';
+
+export default ToolOverflowNode;

--- a/web/src/components/graph/ToolOverflowNode.tsx
+++ b/web/src/components/graph/ToolOverflowNode.tsx
@@ -66,7 +66,7 @@ const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
                 className="flex items-center gap-1.5 px-1.5 py-1 rounded-md hover:bg-violet-500/10"
               >
                 <Wrench size={10} className="text-violet-400/80 flex-shrink-0" />
-                <span className="font-mono text-[11px] text-text-secondary truncate" title={tool}>
+                <span className="min-w-0 flex-1 font-mono text-[11px] text-text-secondary truncate" title={tool}>
                   {tool}
                 </span>
               </li>

--- a/web/src/components/graph/nodeTypes.ts
+++ b/web/src/components/graph/nodeTypes.ts
@@ -4,6 +4,8 @@ import GatewayNode from './GatewayNode';
 import ClientNode from './ClientNode';
 import SkillNode from './SkillNode';
 import SkillGroupNode from './SkillGroupNode';
+import ToolNode from './ToolNode';
+import ToolOverflowNode from './ToolOverflowNode';
 
 // Use 'any' to bypass React Flow's strict typing
 // The components receive props correctly at runtime
@@ -14,4 +16,6 @@ export const nodeTypes: Record<string, ComponentType<any>> = {
   client: ClientNode,
   skill: SkillNode,
   skillGroup: SkillGroupNode,
+  tool: ToolNode,
+  toolOverflow: ToolOverflowNode,
 };

--- a/web/src/hooks/usePathHighlight.ts
+++ b/web/src/hooks/usePathHighlight.ts
@@ -81,11 +81,48 @@ function traceReachablePath(
 }
 
 /**
+ * Fold the fanned-out tools of already-highlighted servers into the highlight
+ * sets, in place. A tool (or "+N more") node inherits its parent server's
+ * highlight state via its `serverNodeId`, and the server -> tool edge follows.
+ *
+ * This is what lets a client stay focused while you expand one of its
+ * reachable servers: the new tool nodes light up in scope instead of being
+ * dimmed with everything off the path. Tools of an out-of-scope server keep
+ * their dimmed state because that server is not in the highlighted set.
+ */
+function includeHighlightedServerTools(
+  highlightedNodeIds: Set<string>,
+  highlightedEdgeIds: Set<string>,
+  nodes: Node[],
+  edges: Edge[]
+): void {
+  for (const node of nodes) {
+    const data = node.data as { type?: string; serverNodeId?: string };
+    if (
+      (data.type === 'tool' || data.type === 'tool-overflow') &&
+      data.serverNodeId &&
+      highlightedNodeIds.has(data.serverNodeId)
+    ) {
+      highlightedNodeIds.add(node.id);
+    }
+  }
+
+  for (const edge of edges) {
+    const meta = edge.data as EdgeMetadata | undefined;
+    if (meta?.relationType === 'server-to-tool' && highlightedNodeIds.has(edge.source)) {
+      highlightedEdgeIds.add(edge.id);
+    }
+  }
+}
+
+/**
  * Compute path highlighting based on the selected node.
  *
  * When a client is selected: highlight the transitive client -> gateway ->
  * reachable-servers path. For other node types: highlight only the selected
- * node. Pure function so it can be unit-tested without React.
+ * node. In every case, the fanned-out tools of a highlighted server are
+ * highlighted too, so expanding a reachable server in focus mode keeps its
+ * tools at full opacity. Pure function so it can be unit-tested without React.
  *
  * @param nodes - All nodes in the graph
  * @param edges - All edges in the graph
@@ -115,20 +152,18 @@ export function computeHighlightState(
   const nodeData = selectedNode.data as Record<string, unknown>;
 
   // Client nodes: highlight the transitive client -> gateway -> servers path.
-  if (nodeData?.type === 'client') {
-    const { highlightedNodeIds, highlightedEdgeIds } = traceReachablePath(
-      selectedNodeId,
-      edges
-    );
-    return { highlightedNodeIds, highlightedEdgeIds, hasSelection: true };
-  }
+  // Other node types: just highlight the selected node.
+  const { highlightedNodeIds, highlightedEdgeIds } =
+    nodeData?.type === 'client'
+      ? traceReachablePath(selectedNodeId, edges)
+      : {
+          highlightedNodeIds: new Set([selectedNodeId]),
+          highlightedEdgeIds: new Set<string>(),
+        };
 
-  // For all other node types, just highlight the selected node.
-  return {
-    highlightedNodeIds: new Set([selectedNodeId]),
-    highlightedEdgeIds: new Set<string>(),
-    hasSelection: true,
-  };
+  includeHighlightedServerTools(highlightedNodeIds, highlightedEdgeIds, nodes, edges);
+
+  return { highlightedNodeIds, highlightedEdgeIds, hasSelection: true };
 }
 
 /**

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -634,6 +634,15 @@ body::before {
   overflow: visible !important;
 }
 
+/* Re-assert clipping for truncated tool fan-out labels. The rule above forces
+   overflow:visible on every node descendant, which otherwise defeats the
+   `truncate` utility (it needs overflow:hidden) and lets long tool names spill
+   past the pill. Higher specificity + !important wins it back, scoped to the
+   label so badges/handles/dots still overflow freely. */
+.react-flow__node .tool-label {
+  overflow: hidden !important;
+}
+
 .react-flow__edge.animated .react-flow__edge-path {
   transform: translateZ(0);
   backface-visibility: hidden;

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -14,7 +14,7 @@ export const LAYOUT = {
   TOOL_HEIGHT: 34,     // Tool fan-out pill height
   TOOL_GAP: 14,        // Vertical gap between fanned-out tool nodes
   TOOL_OFFSET_X: 72,   // Horizontal gap from server right edge to tool column
-  TOOL_LANE_GAP: 64,   // Horizontal gap between adjacent expanded servers' tool lanes
+  TOOL_BAND_GAP: 48,   // Vertical gap between adjacent expanded servers' tool bands
   // Dagre layout spacing
   NODE_SPACING: 60,    // Vertical spacing between nodes in same rank
   RANK_SPACING: 120,   // Horizontal spacing between tiers (gateway -> servers -> etc)

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -10,10 +10,11 @@ export const LAYOUT = {
   CLIENT_WIDTH: 160,   // Linked client node width
   CLIENT_HEIGHT: 120,  // Linked client node height
   CLIENT_HEIGHT_COMPACT: 48,  // Client compact mode height
-  TOOL_WIDTH: 180,     // Tool fan-out pill width
+  TOOL_WIDTH: 200,     // Tool fan-out pill width
   TOOL_HEIGHT: 34,     // Tool fan-out pill height
   TOOL_GAP: 14,        // Vertical gap between fanned-out tool nodes
   TOOL_OFFSET_X: 72,   // Horizontal gap from server right edge to tool column
+  TOOL_LANE_GAP: 64,   // Horizontal gap between adjacent expanded servers' tool lanes
   // Dagre layout spacing
   NODE_SPACING: 60,    // Vertical spacing between nodes in same rank
   RANK_SPACING: 120,   // Horizontal spacing between tiers (gateway -> servers -> etc)

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -10,6 +10,10 @@ export const LAYOUT = {
   CLIENT_WIDTH: 160,   // Linked client node width
   CLIENT_HEIGHT: 120,  // Linked client node height
   CLIENT_HEIGHT_COMPACT: 48,  // Client compact mode height
+  TOOL_WIDTH: 180,     // Tool fan-out pill width
+  TOOL_HEIGHT: 34,     // Tool fan-out pill height
+  TOOL_GAP: 14,        // Vertical gap between fanned-out tool nodes
+  TOOL_OFFSET_X: 72,   // Horizontal gap from server right edge to tool column
   // Dagre layout spacing
   NODE_SPACING: 60,    // Vertical spacing between nodes in same rank
   RANK_SPACING: 120,   // Horizontal spacing between tiers (gateway -> servers -> etc)
@@ -87,6 +91,8 @@ export const NODE_TYPES = {
   CLIENT: 'client',
   SKILL: 'skill',
   SKILL_GROUP: 'skillGroup',
+  TOOL: 'tool',
+  TOOL_OVERFLOW: 'toolOverflow',
 } as const;
 
 // Edge type identifiers

--- a/web/src/lib/graph/toolFanout.ts
+++ b/web/src/lib/graph/toolFanout.ts
@@ -60,25 +60,37 @@ interface FanoutOptions {
   /** User-dragged positions to preserve (keyed by node id). */
   draggedPositions?: Map<string, { x: number; y: number }>;
   /**
-   * Lane index for this server among the currently-expanded servers. Servers
-   * all share the same X (the "servers" column), so without a lane offset
-   * every expanded server's tools would stack in the same place. Each lane
-   * steps the tool column further right so columns never overlap.
+   * Shared X for the tool column. All expanded servers fan into one column to
+   * the right of the servers zone; appendToolFanout computes this so every
+   * server's band lines up. Defaults to just right of this server.
    */
-  laneIndex?: number;
+  columnX?: number;
+  /**
+   * Top Y of this server's band. appendToolFanout tiles bands top-to-bottom so
+   * they do not overlap. Defaults to centering the band on the server.
+   */
+  startY?: number;
+}
+
+/** Height of a server's tool band given how many nodes it mounts. */
+export function fanoutBandHeight(tools: string[]): number {
+  const { visible, overflow } = computeToolFanout(tools);
+  const count = visible.length + (overflow.length > 0 ? 1 : 0);
+  if (count === 0) return 0;
+  return count * LAYOUT.TOOL_HEIGHT + (count - 1) * LAYOUT.TOOL_GAP;
 }
 
 /**
  * Build the tool + overflow nodes and server -> tool edges for a single
- * expanded server, positioned in a local vertical column to the server's
- * right and centered on the server's vertical midpoint. `laneIndex` offsets
- * the column horizontally so multiple expanded servers do not collide.
+ * expanded server as a vertical band. `columnX` sets the shared column and
+ * `startY` the band's top; both default to a stand-alone column centered on
+ * the server (used when fanning out a single server).
  */
 export function createToolFanout(
   serverNode: Node,
   options: FanoutOptions = {}
 ): { nodes: Node[]; edges: Edge[] } {
-  const { compact = false, draggedPositions, laneIndex = 0 } = options;
+  const { compact = false, draggedPositions, columnX, startY } = options;
   const data = serverNode.data as { name?: string; tools?: string[] };
   const tools = data.tools ?? [];
   if (tools.length === 0) {
@@ -93,17 +105,12 @@ export function createToolFanout(
     serverNode,
     compact
   );
-  const laneStride = LAYOUT.TOOL_WIDTH + LAYOUT.TOOL_LANE_GAP;
-  const columnX =
-    serverNode.position.x + serverWidth + LAYOUT.TOOL_OFFSET_X + laneIndex * laneStride;
-  const serverCenterY = serverNode.position.y + serverHeight / 2;
-
-  const itemCount = visible.length + (overflow.length > 0 ? 1 : 0);
-  const stackHeight =
-    itemCount * LAYOUT.TOOL_HEIGHT + (itemCount - 1) * LAYOUT.TOOL_GAP;
-  const startY = serverCenterY - stackHeight / 2;
+  const colX =
+    columnX ?? serverNode.position.x + serverWidth + LAYOUT.TOOL_OFFSET_X;
+  const bandHeight = fanoutBandHeight(tools);
+  const top = startY ?? serverNode.position.y + serverHeight / 2 - bandHeight / 2;
   const rowY = (index: number) =>
-    startY + index * (LAYOUT.TOOL_HEIGHT + LAYOUT.TOOL_GAP);
+    top + index * (LAYOUT.TOOL_HEIGHT + LAYOUT.TOOL_GAP);
 
   const nodes: Node[] = [];
   const edges: Edge[] = [];
@@ -119,7 +126,7 @@ export function createToolFanout(
     nodes.push({
       id,
       type: NODE_TYPES.TOOL,
-      position: draggedPositions?.get(id) ?? { x: columnX, y: rowY(index) },
+      position: draggedPositions?.get(id) ?? { x: colX, y: rowY(index) },
       data: nodeData,
       draggable: true,
       selectable: false,
@@ -146,7 +153,7 @@ export function createToolFanout(
     nodes.push({
       id,
       type: NODE_TYPES.TOOL_OVERFLOW,
-      position: draggedPositions?.get(id) ?? { x: columnX, y: rowY(visible.length) },
+      position: draggedPositions?.get(id) ?? { x: colX, y: rowY(visible.length) },
       data: overflowData,
       draggable: true,
       selectable: false,
@@ -169,6 +176,12 @@ export function createToolFanout(
  * an already-laid-out backbone. Returns new arrays; inputs are not mutated.
  * Servers in `expandedServers` that are not present in `nodes` (e.g. removed
  * from the stack) are silently skipped, so stale expansion state is harmless.
+ *
+ * All expanded servers fan into ONE shared column to the right of the servers
+ * zone. Each server's tools form a vertical band; bands are tiled top-to-bottom
+ * in the servers' own vertical order and the whole stack is centered on the
+ * servers' midpoint. Because band order matches server order, each server's
+ * edge bundle fans to a contiguous, aligned block and the bundles do not cross.
  */
 export function appendToolFanout(
   nodes: Node[],
@@ -180,22 +193,57 @@ export function appendToolFanout(
     return { nodes, edges };
   }
 
+  const { compact = false } = options;
+
+  // Expanded servers that actually have tools, ordered top-to-bottom so their
+  // bands tile in the same order they appear on the canvas.
+  const servers = nodes
+    .filter((node) => {
+      const data = node.data as { type?: string; tools?: string[] };
+      return (
+        data.type === 'mcp-server' &&
+        expandedServers.has(node.id) &&
+        (data.tools?.length ?? 0) > 0
+      );
+    })
+    .sort((a, b) => a.position.y - b.position.y);
+
+  if (servers.length === 0) {
+    return { nodes, edges };
+  }
+
+  // Single shared column, just right of the rightmost server edge.
+  const columnX =
+    Math.max(
+      ...servers.map(
+        (s) => s.position.x + getNodeDimensions(s, compact).width
+      )
+    ) + LAYOUT.TOOL_OFFSET_X;
+
+  // Total height of all bands plus the gaps between them, centered on the
+  // vertical midpoint of the expanded servers.
+  const bandHeights = servers.map((s) =>
+    fanoutBandHeight((s.data as { tools?: string[] }).tools ?? [])
+  );
+  const totalHeight =
+    bandHeights.reduce((sum, h) => sum + h, 0) +
+    (servers.length - 1) * LAYOUT.TOOL_BAND_GAP;
+  const centerY =
+    servers.reduce(
+      (sum, s) => sum + s.position.y + getNodeDimensions(s, compact).height / 2,
+      0
+    ) / servers.length;
+
   const extraNodes: Node[] = [];
   const extraEdges: Edge[] = [];
 
-  // Assign each expanded server its own lane in the order servers appear
-  // (top to bottom), so their tool columns are separated horizontally.
-  let laneIndex = 0;
-  for (const node of nodes) {
-    const nodeData = node.data as { type?: string };
-    if (nodeData.type !== 'mcp-server' || !expandedServers.has(node.id)) {
-      continue;
-    }
-    const fanout = createToolFanout(node, { ...options, laneIndex });
-    laneIndex += 1;
+  let cursorY = centerY - totalHeight / 2;
+  servers.forEach((server, i) => {
+    const fanout = createToolFanout(server, { ...options, columnX, startY: cursorY });
     extraNodes.push(...fanout.nodes);
     extraEdges.push(...fanout.edges);
-  }
+    cursorY += bandHeights[i] + LAYOUT.TOOL_BAND_GAP;
+  });
 
   return {
     nodes: [...nodes, ...extraNodes],

--- a/web/src/lib/graph/toolFanout.ts
+++ b/web/src/lib/graph/toolFanout.ts
@@ -1,0 +1,190 @@
+/**
+ * Tool fan-out derivation for the topology canvas.
+ *
+ * When an MCP server node is expanded, its tools fan out as nodes to the
+ * right of the server. These helpers are pure: given the laid-out backbone
+ * nodes and the set of expanded server ids, they derive the extra tool nodes
+ * and server -> tool edges, positioned LOCALLY relative to each server. The
+ * backbone is never re-laid-out, so expanding a server does not shift it.
+ *
+ * The per-server fan-out is capped: at most TOOL_FANOUT_CAP tool nodes are
+ * mounted. Any remainder collapses into a single "+N more" aggregate node that
+ * carries the hidden tool names for an in-node popover, so a server with 80
+ * tools never starbursts the canvas.
+ */
+
+import type { Node, Edge } from '@xyflow/react';
+import type { ToolNodeData, ToolOverflowNodeData } from '../../types';
+import { LAYOUT, NODE_TYPES } from '../constants';
+import { getNodeDimensions } from './utils';
+
+/** Maximum number of tool nodes mounted per expanded server. */
+export const TOOL_FANOUT_CAP = 10;
+
+/** Stable id for a tool fan-out node. */
+export function toolNodeId(serverNodeId: string, toolName: string): string {
+  return `tool-${serverNodeId}-${toolName}`;
+}
+
+/** Stable id for a server's "+N more" overflow node. */
+export function overflowNodeId(serverNodeId: string): string {
+  return `tool-overflow-${serverNodeId}`;
+}
+
+/** Stable id for a server -> tool edge. */
+export function toolEdgeId(serverNodeId: string, targetId: string): string {
+  return `edge-tool-${serverNodeId}-${targetId}`;
+}
+
+/**
+ * Split a server's tools into the visible set (rendered as nodes) and the
+ * overflow set (collapsed into a "+N more" node).
+ *
+ * - tools.length <= cap  -> all visible, no overflow.
+ * - tools.length  > cap  -> first `cap` visible, the rest overflow.
+ *
+ * Pure and side-effect free; the unit of the cap logic.
+ */
+export function computeToolFanout(
+  tools: string[],
+  cap: number = TOOL_FANOUT_CAP
+): { visible: string[]; overflow: string[] } {
+  if (tools.length <= cap) {
+    return { visible: [...tools], overflow: [] };
+  }
+  return { visible: tools.slice(0, cap), overflow: tools.slice(cap) };
+}
+
+interface FanoutOptions {
+  compact?: boolean;
+  /** User-dragged positions to preserve (keyed by node id). */
+  draggedPositions?: Map<string, { x: number; y: number }>;
+}
+
+/**
+ * Build the tool + overflow nodes and server -> tool edges for a single
+ * expanded server, positioned in a local vertical column to the server's
+ * right and centered on the server's vertical midpoint.
+ */
+export function createToolFanout(
+  serverNode: Node,
+  options: FanoutOptions = {}
+): { nodes: Node[]; edges: Edge[] } {
+  const { compact = false, draggedPositions } = options;
+  const data = serverNode.data as { name?: string; tools?: string[] };
+  const tools = data.tools ?? [];
+  if (tools.length === 0) {
+    return { nodes: [], edges: [] };
+  }
+
+  const serverNodeId = serverNode.id;
+  const serverName = data.name ?? serverNodeId;
+  const { visible, overflow } = computeToolFanout(tools);
+
+  const { width: serverWidth, height: serverHeight } = getNodeDimensions(
+    serverNode,
+    compact
+  );
+  const columnX = serverNode.position.x + serverWidth + LAYOUT.TOOL_OFFSET_X;
+  const serverCenterY = serverNode.position.y + serverHeight / 2;
+
+  const itemCount = visible.length + (overflow.length > 0 ? 1 : 0);
+  const stackHeight =
+    itemCount * LAYOUT.TOOL_HEIGHT + (itemCount - 1) * LAYOUT.TOOL_GAP;
+  const startY = serverCenterY - stackHeight / 2;
+  const rowY = (index: number) =>
+    startY + index * (LAYOUT.TOOL_HEIGHT + LAYOUT.TOOL_GAP);
+
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  visible.forEach((toolName, index) => {
+    const id = toolNodeId(serverNodeId, toolName);
+    const nodeData: ToolNodeData = {
+      type: 'tool',
+      name: toolName,
+      serverName,
+      serverNodeId,
+    };
+    nodes.push({
+      id,
+      type: NODE_TYPES.TOOL,
+      position: draggedPositions?.get(id) ?? { x: columnX, y: rowY(index) },
+      data: nodeData,
+      draggable: true,
+      selectable: false,
+    });
+    edges.push({
+      id: toolEdgeId(serverNodeId, id),
+      source: serverNodeId,
+      sourceHandle: 'output',
+      target: id,
+      targetHandle: 'input',
+      data: { relationType: 'server-to-tool', isHighlightable: false },
+    });
+  });
+
+  if (overflow.length > 0) {
+    const id = overflowNodeId(serverNodeId);
+    const overflowData: ToolOverflowNodeData = {
+      type: 'tool-overflow',
+      serverName,
+      serverNodeId,
+      overflowCount: overflow.length,
+      hiddenTools: overflow,
+    };
+    nodes.push({
+      id,
+      type: NODE_TYPES.TOOL_OVERFLOW,
+      position: draggedPositions?.get(id) ?? { x: columnX, y: rowY(visible.length) },
+      data: overflowData,
+      draggable: true,
+      selectable: false,
+    });
+    edges.push({
+      id: toolEdgeId(serverNodeId, id),
+      source: serverNodeId,
+      sourceHandle: 'output',
+      target: id,
+      targetHandle: 'input',
+      data: { relationType: 'server-to-tool', isHighlightable: false },
+    });
+  }
+
+  return { nodes, edges };
+}
+
+/**
+ * Append tool fan-out nodes and edges for every currently-expanded server to
+ * an already-laid-out backbone. Returns new arrays; inputs are not mutated.
+ * Servers in `expandedServers` that are not present in `nodes` (e.g. removed
+ * from the stack) are silently skipped, so stale expansion state is harmless.
+ */
+export function appendToolFanout(
+  nodes: Node[],
+  edges: Edge[],
+  expandedServers: Set<string>,
+  options: FanoutOptions = {}
+): { nodes: Node[]; edges: Edge[] } {
+  if (expandedServers.size === 0) {
+    return { nodes, edges };
+  }
+
+  const extraNodes: Node[] = [];
+  const extraEdges: Edge[] = [];
+
+  for (const node of nodes) {
+    const nodeData = node.data as { type?: string };
+    if (nodeData.type !== 'mcp-server' || !expandedServers.has(node.id)) {
+      continue;
+    }
+    const fanout = createToolFanout(node, options);
+    extraNodes.push(...fanout.nodes);
+    extraEdges.push(...fanout.edges);
+  }
+
+  return {
+    nodes: [...nodes, ...extraNodes],
+    edges: [...edges, ...extraEdges],
+  };
+}

--- a/web/src/lib/graph/toolFanout.ts
+++ b/web/src/lib/graph/toolFanout.ts
@@ -59,18 +59,26 @@ interface FanoutOptions {
   compact?: boolean;
   /** User-dragged positions to preserve (keyed by node id). */
   draggedPositions?: Map<string, { x: number; y: number }>;
+  /**
+   * Lane index for this server among the currently-expanded servers. Servers
+   * all share the same X (the "servers" column), so without a lane offset
+   * every expanded server's tools would stack in the same place. Each lane
+   * steps the tool column further right so columns never overlap.
+   */
+  laneIndex?: number;
 }
 
 /**
  * Build the tool + overflow nodes and server -> tool edges for a single
  * expanded server, positioned in a local vertical column to the server's
- * right and centered on the server's vertical midpoint.
+ * right and centered on the server's vertical midpoint. `laneIndex` offsets
+ * the column horizontally so multiple expanded servers do not collide.
  */
 export function createToolFanout(
   serverNode: Node,
   options: FanoutOptions = {}
 ): { nodes: Node[]; edges: Edge[] } {
-  const { compact = false, draggedPositions } = options;
+  const { compact = false, draggedPositions, laneIndex = 0 } = options;
   const data = serverNode.data as { name?: string; tools?: string[] };
   const tools = data.tools ?? [];
   if (tools.length === 0) {
@@ -85,7 +93,9 @@ export function createToolFanout(
     serverNode,
     compact
   );
-  const columnX = serverNode.position.x + serverWidth + LAYOUT.TOOL_OFFSET_X;
+  const laneStride = LAYOUT.TOOL_WIDTH + LAYOUT.TOOL_LANE_GAP;
+  const columnX =
+    serverNode.position.x + serverWidth + LAYOUT.TOOL_OFFSET_X + laneIndex * laneStride;
   const serverCenterY = serverNode.position.y + serverHeight / 2;
 
   const itemCount = visible.length + (overflow.length > 0 ? 1 : 0);
@@ -173,12 +183,16 @@ export function appendToolFanout(
   const extraNodes: Node[] = [];
   const extraEdges: Edge[] = [];
 
+  // Assign each expanded server its own lane in the order servers appear
+  // (top to bottom), so their tool columns are separated horizontally.
+  let laneIndex = 0;
   for (const node of nodes) {
     const nodeData = node.data as { type?: string };
     if (nodeData.type !== 'mcp-server' || !expandedServers.has(node.id)) {
       continue;
     }
-    const fanout = createToolFanout(node, options);
+    const fanout = createToolFanout(node, { ...options, laneIndex });
+    laneIndex += 1;
     extraNodes.push(...fanout.nodes);
     extraEdges.push(...fanout.edges);
   }

--- a/web/src/lib/graph/types.ts
+++ b/web/src/lib/graph/types.ts
@@ -87,6 +87,7 @@ export type EdgeRelationType =
   | 'gateway-to-resource'     // Gateway manages resource
   | 'gateway-to-skill'        // Gateway serves a registered skill
   | 'gateway-to-skill-group'  // Gateway serves a skill directory group
+  | 'server-to-tool'          // MCP server fans out to one of its tools
   | 'agent-uses-server'       // Agent uses specific MCP server (via uses field)
   | 'agent-uses-agent';       // Agent delegates to another agent (A2A)
 

--- a/web/src/stores/useStackStore.ts
+++ b/web/src/stores/useStackStore.ts
@@ -15,6 +15,7 @@ import type {
   AutoscaleDecisionKind,
 } from '../types';
 import { transformToNodesAndEdges } from '../lib/transform';
+import { appendToolFanout } from '../lib/graph/toolFanout';
 import { useRegistryStore } from './useRegistryStore';
 import { useUIStore } from './useUIStore';
 import { usePinsStore } from './usePinsStore';
@@ -74,6 +75,10 @@ interface StackState {
 
   // === UI State ===
   selectedNodeId: string | null;
+  // Server node ids (e.g. "mcp-github") whose tools are fanned out on the
+  // canvas. Independent per server and preserved across polling refreshes so
+  // an expanded server stays expanded when the graph data refetches.
+  expandedServers: Set<string>;
   connectionStatus: ConnectionStatus;
   lastUpdated: Date | null;
   isLoading: boolean;
@@ -88,6 +93,9 @@ interface StackState {
   setLoading: (loading: boolean) => void;
   setConnectionStatus: (status: ConnectionStatus) => void;
   selectNode: (nodeId: string | null) => void;
+  toggleServerExpanded: (serverId: string) => void;
+  expandServer: (serverId: string) => void;
+  collapseServer: (serverId: string) => void;
   refreshNodesAndEdges: () => void;
   resetLayout: () => void;
 
@@ -117,6 +125,7 @@ export const useStackStore = create<StackState>()(
     autoscaleDecisions: {},
     autoscaleLastSeen: {},
     selectedNodeId: null,
+    expandedServers: new Set<string>(),
     connectionStatus: 'disconnected',
     lastUpdated: null,
     isLoading: true,
@@ -174,6 +183,33 @@ export const useStackStore = create<StackState>()(
 
     selectNode: (nodeId) => set({ selectedNodeId: nodeId }),
 
+    toggleServerExpanded: (serverId) => {
+      const next = new Set(get().expandedServers);
+      if (next.has(serverId)) {
+        next.delete(serverId);
+      } else {
+        next.add(serverId);
+      }
+      set({ expandedServers: next });
+      get().refreshNodesAndEdges();
+    },
+
+    expandServer: (serverId) => {
+      if (get().expandedServers.has(serverId)) return;
+      const next = new Set(get().expandedServers);
+      next.add(serverId);
+      set({ expandedServers: next });
+      get().refreshNodesAndEdges();
+    },
+
+    collapseServer: (serverId) => {
+      if (!get().expandedServers.has(serverId)) return;
+      const next = new Set(get().expandedServers);
+      next.delete(serverId);
+      set({ expandedServers: next });
+      get().refreshNodesAndEdges();
+    },
+
     refreshNodesAndEdges: () => {
       const { gatewayInfo, mcpServers, resources, clients, sessions, codeMode, draggedPositions } = get();
       if (!gatewayInfo) return;
@@ -209,7 +245,15 @@ export const useStackStore = create<StackState>()(
         }
       }
 
-      set({ nodes, edges });
+      // Append tool fan-out for any expanded servers AFTER backbone layout so
+      // expanding never reflows the three-column backbone (tool nodes are laid
+      // out locally relative to their server, not through the zone engine).
+      const fanned = appendToolFanout(nodes, edges, get().expandedServers, {
+        compact: isCompact,
+        draggedPositions: draggedPositions.size > 0 ? draggedPositions : undefined,
+      });
+
+      set({ nodes: fanned.nodes, edges: fanned.edges });
     },
 
     resetLayout: () => {
@@ -231,7 +275,12 @@ export const useStackStore = create<StackState>()(
         codeMode,
         isCompact,
       );
-      set({ nodes, edges, draggedPositions: new Map() });
+      // Re-derive tool fan-out from scratch too (positions are local to the
+      // freshly-laid-out servers; no dragged positions survive a reset).
+      const fanned = appendToolFanout(nodes, edges, get().expandedServers, {
+        compact: isCompact,
+      });
+      set({ nodes: fanned.nodes, edges: fanned.edges, draggedPositions: new Map() });
     },
 
     onNodesChange: (changes) => {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -395,7 +395,26 @@ export interface SkillGroupNodeData extends NodeDataBase {
   untestedSkills: number;
 }
 
-export type NodeData = GatewayNodeData | MCPServerNodeData | ResourceNodeData | ClientNodeData | SkillNodeData | SkillGroupNodeData;
+// Tool fan-out node data — one node per visible tool of an expanded server.
+export interface ToolNodeData extends NodeDataBase {
+  type: 'tool';
+  name: string;          // Unprefixed tool name (e.g. "search-repos")
+  serverName: string;    // Owning MCP server name
+  serverNodeId: string;  // Parent server node id (e.g. "mcp-github")
+}
+
+// Aggregate "+N more" node shown when an expanded server exceeds the fan-out
+// cap. Carries the hidden tool names so the node can list them in a popover
+// rather than mounting more canvas nodes.
+export interface ToolOverflowNodeData extends NodeDataBase {
+  type: 'tool-overflow';
+  serverName: string;
+  serverNodeId: string;
+  overflowCount: number; // Number of tools beyond the cap (the N in "+N more")
+  hiddenTools: string[]; // The unprefixed names of the capped-out tools
+}
+
+export type NodeData = GatewayNodeData | MCPServerNodeData | ResourceNodeData | ClientNodeData | SkillNodeData | SkillGroupNodeData | ToolNodeData | ToolOverflowNodeData;
 
 // Connection status for real-time updates
 export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected' | 'error';


### PR DESCRIPTION
## Description

Adds an explicit per-server expand affordance in the Topology view: clicking a server's chevron fans its tools out as nodes to the server's right, capped with a "+N more" aggregate node for large servers. This is PR 2 of a staggered series; it is frontend-only and reuses existing data.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- New `lib/graph/toolFanout.ts` pure helpers: `computeToolFanout` (cap logic), `createToolFanout` (positioned nodes + edges for one server), and `appendToolFanout` (orchestrates over expanded servers).
- New `ToolNode` (tool pill, slides in on mount) and `ToolOverflowNode` ("+N more" with an in-node popover listing hidden tools); registered in `nodeTypes`.
- Server nodes get an expand/collapse chevron (`CustomNode`), stopping propagation so toggling does not select the node.
- Store gains `expandedServers` plus `toggleServerExpanded`/`expandServer`/`collapseServer`; fan-out is appended after backbone layout in `refreshNodesAndEdges` and `resetLayout`, so it survives polling refresh and never reflows the backbone.
- Fan-out capped at 10 nodes; server -> tool edges are non-highlightable so PR 1's client-reach highlight ignores them. Canvas ignores clicks on tool/overflow nodes.

## Testing

- `web/src/__tests__/toolFanout.test.ts`: cap logic (below/at/above cap, custom cap), node/edge derivation, right-of-server positioning, overflow node contents, dragged-position preservation, and `appendToolFanout` selectivity.
- `web/src/__tests__/expandedServers.test.ts`: toggle/expand/collapse (idempotent), independent multi-server expansion, cap + single overflow node, and expansion surviving a `setGatewayStatus` poll.
- `make build` passes; full frontend suite 845/845 passes (including PR 1's highlight tests); lint clean on changed code.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #742