### PR TITLE
feat: per-client access scoping (backend access model)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Per-client access scoping (`clients:` block).** A new optional top-level
+  `clients:` block in `stack.yaml` lets an operator restrict which servers and
+  tools each connecting client can reach, following Kubernetes NetworkPolicy
+  semantics: omitting the block preserves today's behavior (every client sees
+  every tool), while adding it opts into least-privilege — a client matching a
+  profile is limited to that profile's `servers:`/`tools:` allow-list, and a
+  client matching no profile is governed by `default:` (`deny` unless set to
+  `allow`). The filter is applied at a single chokepoint that every exposure
+  path funnels through — `tools/list`, `tools/call` rejection, and the code-mode
+  search/execute tool universe — so a scoped client cannot reach a denied tool
+  via code mode. Enforcement keys on a stable client identifier reconciled
+  across the wire, configuration, and the UI: `gridctl link --client-id <id>`
+  embeds the identifier as the `client` query parameter on the gateway URL (the
+  `X-Gridctl-Client-Id` header also works), profiles may declare `aliases:` for
+  divergent wire names, and the normalized `clientInfo.name` is the fallback.
+  Unknown server or tool references in a profile fail config validation. A
+  `clients:` change applies on hot-reload to all subsequent `tools/list` and
+  `tools/call` requests, including existing sessions. The `/api/clients`
+  response now carries each client's backend-computed effective scope. Scope
+  coverage for v1 is tools only: skills (served as MCP prompts) and resources
+  remain globally visible.
+
 - **Tool fan-out in the Topology view.** Each MCP server node now has an
   expand chevron; clicking it fans that server's tools out as nodes in a local
   column to the server's right, and clicking again collapses them. Fan-out is

--- a/cmd/gridctl/link.go
+++ b/cmd/gridctl/link.go
@@ -15,11 +15,12 @@ import (
 )
 
 var (
-	linkPort   int
-	linkAll    bool
-	linkName   string
-	linkDryRun bool
-	linkForce  bool
+	linkPort     int
+	linkAll      bool
+	linkName     string
+	linkClientID string
+	linkDryRun   bool
+	linkForce    bool
 )
 
 var linkCmd = &cobra.Command{
@@ -45,6 +46,7 @@ func init() {
 	linkCmd.Flags().IntVarP(&linkPort, "port", "p", 0, "Gateway port (default: auto-detect from running stack, else 8180)")
 	linkCmd.Flags().BoolVarP(&linkAll, "all", "a", false, "Link all detected clients at once")
 	linkCmd.Flags().StringVarP(&linkName, "name", "n", "gridctl", "Server name in client config")
+	linkCmd.Flags().StringVar(&linkClientID, "client-id", "", "Stable client identifier for per-client access scoping (matches a stack.yaml clients: profile)")
 	linkCmd.Flags().BoolVar(&linkDryRun, "dry-run", false, "Show what would change without modifying files")
 	linkCmd.Flags().BoolVar(&linkForce, "force", false, "Overwrite existing gridctl entry even if present")
 }
@@ -54,12 +56,16 @@ func runLink(client string) error {
 	registry := provisioner.NewRegistry()
 
 	port := resolveGatewayPort(linkPort)
-	gatewayURL := provisioner.GatewayURL(port)
+	// Embed the stable client identifier (when set) on the gateway URL so the
+	// gateway resolves the connecting client's access scope from the wire rather
+	// than from the clientInfo.name normalization heuristic alone.
+	gatewayURL := provisioner.AppendClientParam(provisioner.GatewayURL(port), linkClientID)
 
 	opts := provisioner.LinkOptions{
 		GatewayURL: gatewayURL,
 		Port:       port,
 		ServerName: linkName,
+		ClientID:   linkClientID,
 		Force:      linkForce,
 		DryRun:     linkDryRun,
 	}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -34,7 +34,7 @@ Commands are grouped by domain. Run `gridctl <command> --help` for the full flag
 
 | Command | Purpose |
 |---|---|
-| `gridctl link [client]` | Connect an LLM client to the gateway; `--all` for every detected client, `--dry-run` to preview. |
+| `gridctl link [client]` | Connect an LLM client to the gateway; `--all` for every detected client, `--dry-run` to preview, `--client-id <id>` to bind the link to a `clients:` access profile. |
 | `gridctl unlink [client]` | Remove gridctl from an LLM client's config. |
 
 ## Skills

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -617,6 +617,87 @@ resources:
 
 ---
 
+## Clients (per-client access scoping)
+
+The optional top-level `clients:` block restricts which servers and tools each
+connecting client can reach. It follows Kubernetes NetworkPolicy semantics:
+
+- **No `clients:` block** → every client sees every tool (the default, and the
+  behavior of every stack written before this feature existed).
+- **Block present** → a client matching a profile is limited to that profile's
+  allow-list; a client matching no profile is governed by `default:`.
+
+```yaml
+clients:
+  default: deny          # policy for unlisted clients: deny (default) or allow
+  profiles:
+    cursor:              # stable client identifier (see "Client identity" below)
+      servers:           # allow-list of server names; empty = all servers
+        - github
+    claude-code:
+      tools:             # allow-list of prefixed tool names; empty = all tools
+        - github__search-repos
+        - gitlab__list-issues
+    team-bot:
+      aliases:           # wire clientInfo.name values that map to this profile
+        - "Custom Agent"
+      servers:
+        - github
+```
+
+### Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `default` | string | No | `deny` | Policy for clients matching no profile: `deny` or `allow` |
+| `profiles` | map | No | - | Map of stable client identifier → allow-list |
+| `profiles.<id>.servers` | []string | No | - | Allowed server names. Empty means all servers |
+| `profiles.<id>.tools` | []string | No | - | Allowed prefixed tool names (`server__tool`). Empty means all tools within the allowed servers |
+| `profiles.<id>.aliases` | []string | No | - | Raw `clientInfo.name` values that resolve to this profile |
+
+A profile's effective scope is the intersection of its `servers:` and `tools:`
+allow-lists with each server's own `tools:` whitelist. A profile with neither
+`servers:` nor `tools:` is listed but unrestricted (sees everything). Unknown
+server references — directly or via a tool prefix — fail config validation.
+
+### Client identity
+
+Enforcement keys on a **stable client identifier** that reconciles the wire
+identity with the configuration and UI identity. It is resolved per session, in
+priority order:
+
+1. The `client` query parameter on the gateway URL, or the
+   `X-Gridctl-Client-Id` header. `gridctl link --client-id <id>` embeds the
+   query parameter into the URL it writes, so the identifier assigned at link
+   time is exactly the one enforced and displayed.
+2. A profile `aliases:` entry matching the connecting client's
+   `clientInfo.name`.
+3. The normalized `clientInfo.name` (the fallback heuristic).
+
+All identifiers are normalized (lowercased, hyphenated) so configuration, the
+wire, and the UI reconcile on one canonical form.
+
+The identifier is self-declared by the connecting client (it sets its own
+`client` parameter, header, or `clientInfo.name`). Per-client scoping is
+therefore a least-privilege guardrail for cooperating clients, not an
+authentication boundary against a hostile client that can choose its own
+identity. Identity-based access control (IdP / OAuth / JWT) is out of scope.
+
+### Scope coverage (v1)
+
+Scoping covers **tools only**. Skills (served as MCP prompts) and resources
+remain globally visible to every client. Extending scope to prompts and
+resources is deferred.
+
+### Reload semantics
+
+The gateway re-resolves each client's scope from the live configuration on every
+`tools/list` and `tools/call`. A `clients:` change applied via hot-reload (file
+watch or `POST /api/reload`) therefore takes effect on the next request,
+including for already-established sessions — no restart required.
+
+---
+
 ## Skill Sources
 
 Skill sources are declared in `~/.gridctl/skills.yaml`. Each source points at a git repository that gridctl clones to discover `SKILL.md` files. Sources may be public or authenticated.

--- a/examples/access-control/README.md
+++ b/examples/access-control/README.md
@@ -1,12 +1,13 @@
 # 🔐 Access Control
 
-Examples demonstrating tool filtering for least-privilege access.
+Examples demonstrating tool filtering and per-client scoping for least-privilege access.
 
 ## 📄 Examples
 
 | File | Description |
 |------|-------------|
-| `tool-filtering.yaml` | Server-level tool filtering |
+| `tool-filtering.yaml` | Server-level tool filtering (applies to all clients) |
+| `per-client-scoping.yaml` | Per-client allow-lists via the `clients:` block |
 
 ## 💡 Concepts
 
@@ -24,8 +25,32 @@ mcp-servers:
 
 This is the primary mechanism for reducing context window consumption and preventing tool confusion.
 
+### Per-Client Scoping
+
+The top-level `clients:` block restricts which servers and tools each *connecting client* can reach, independent of the global server-level filter. It follows Kubernetes NetworkPolicy semantics: omitting the block keeps today's behavior (every client sees everything), while adding it opts into least-privilege per client.
+
+```yaml
+clients:
+  default: deny            # unlisted clients see nothing (or set "allow")
+  profiles:
+    cursor:
+      servers: [github]    # cursor reaches only the github server
+    claude-code:
+      tools:               # claude-code reaches only these prefixed tools
+        - github__search-repos
+```
+
+The scope is enforced on `tools/list`, `tools/call`, and the code-mode search/execute surface. Bind a linked client to a profile with a stable identifier:
+
+```bash
+gridctl link cursor --client-id cursor
+```
+
+See [docs/config-schema.md](../../docs/config-schema.md#clients-per-client-access-scoping) for the full reference, including client-identity reconciliation and reload semantics.
+
 ## 💻 Usage
 
 ```bash
 gridctl apply examples/access-control/tool-filtering.yaml
+gridctl apply examples/access-control/per-client-scoping.yaml
 ```

--- a/examples/access-control/per-client-scoping.yaml
+++ b/examples/access-control/per-client-scoping.yaml
@@ -1,0 +1,61 @@
+# Per-Client Access Scoping Example
+#
+# Demonstrates the top-level `clients:` block, which restricts which servers and
+# tools each connecting client can reach (least-privilege per client).
+#
+# Semantics (Kubernetes NetworkPolicy style):
+#   - No `clients:` block at all  -> every client sees every tool (legacy).
+#   - Block present + client in a profile -> limited to that profile's allow-list.
+#   - Block present + client not in any profile -> governed by `default:`
+#     (`deny` unless set to `allow`).
+#
+# Scope coverage is tools only; skills (MCP prompts) and resources stay global.
+#
+# Bind a linked client to a profile so enforcement uses a stable identifier:
+#   gridctl link cursor --client-id cursor
+#
+# Usage:
+#   gridctl apply examples/access-control/per-client-scoping.yaml
+#
+version: "1"
+name: per-client-scoping-demo
+
+network:
+  name: per-client-scoping-net
+
+mcp-servers:
+  - name: github
+    image: alpine:latest
+    port: 8080
+    command: ["sh", "-c", "while true; do sleep 3600; done"]
+
+  - name: gitlab
+    image: alpine:latest
+    port: 8081
+    command: ["sh", "-c", "while true; do sleep 3600; done"]
+
+# Per-client access scoping.
+clients:
+  # Unlisted clients are denied entirely. Set to "allow" to instead let
+  # unlisted clients see everything (looser, opt-out posture).
+  default: deny
+
+  profiles:
+    # Server-level allow-list: cursor reaches every tool on github, nothing else.
+    cursor:
+      servers:
+        - github
+
+    # Tool-level allow-list: claude-code reaches only these two prefixed tools.
+    claude-code:
+      tools:
+        - github__search-repos
+        - gitlab__list-issues
+
+    # Alias reconciliation: a client whose clientInfo.name is "Custom Agent"
+    # maps to this profile without relying on the built-in normalization.
+    team-bot:
+      aliases:
+        - "Custom Agent"
+      servers:
+        - gitlab

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -451,7 +451,7 @@ func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, _ := s.gateway.HandleToolsList()
+	result, _ := s.gateway.HandleToolsListUnscoped()
 	writeJSON(w, result)
 }
 
@@ -987,6 +987,11 @@ type ClientStatus struct {
 	Linked     bool   `json:"linked"`
 	Transport  string `json:"transport"`
 	ConfigPath string `json:"configPath,omitempty"`
+	// EffectiveScope is the backend-computed per-client tool access scope when a
+	// `clients:` block is configured: the servers and prefixed tools this client
+	// can reach. nil when no access scoping is in effect, so the frontend can
+	// distinguish "unscoped (legacy)" from "scoped to nothing".
+	EffectiveScope *mcp.ClientScopeResult `json:"effectiveScope,omitempty"`
 }
 
 // handleClients returns detected LLM clients and their link status.
@@ -1007,17 +1012,27 @@ func (s *Server) handleClients(w http.ResponseWriter, r *http.Request) {
 		serverName = "gridctl"
 	}
 
+	scopingOn := s.gateway != nil && s.gateway.ClientAccessConfigured()
+
 	infos := s.provisioners.AllClientInfo(serverName)
 	statuses := make([]ClientStatus, 0, len(infos))
 	for _, info := range infos {
-		statuses = append(statuses, ClientStatus{
+		status := ClientStatus{
 			Name:       info.Name,
 			Slug:       info.Slug,
 			Detected:   info.Detected,
 			Linked:     info.Linked,
 			Transport:  info.Transport,
 			ConfigPath: info.ConfigPath,
-		})
+		}
+		// Surface the backend-computed effective scope keyed on the client's
+		// stable identifier (its slug, which is what `gridctl link` assigns and
+		// what stack.yaml profiles are keyed on).
+		if scopingOn {
+			scope := s.gateway.ClientScope(info.Slug)
+			status.EffectiveScope = &scope
+		}
+		statuses = append(statuses, status)
 	}
 
 	writeJSON(w, statuses)

--- a/internal/api/optimize.go
+++ b/internal/api/optimize.go
@@ -126,7 +126,7 @@ func computeSchemaTokens(gateway *mcp.Gateway) map[string]optimize.PinStat {
 	if gateway == nil {
 		return nil
 	}
-	result, err := gateway.HandleToolsList()
+	result, err := gateway.HandleToolsListUnscoped()
 	if err != nil || result == nil || len(result.Tools) == 0 {
 		return nil
 	}

--- a/pkg/config/clients_test.go
+++ b/pkg/config/clients_test.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestValidate_Clients(t *testing.T) {
+	base := func(clients *ClientsConfig) *Stack {
+		return &Stack{
+			Name:    "test",
+			Network: Network{Name: "net"},
+			MCPServers: []MCPServer{
+				{Name: "github", Image: "alpine", Port: 3000},
+				{Name: "gitlab", Image: "alpine", Port: 3001},
+			},
+			Clients: clients,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		clients *ClientsConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "no clients block is valid (back-compat)",
+			clients: nil,
+			wantErr: false,
+		},
+		{
+			name: "valid server allow-list",
+			clients: &ClientsConfig{
+				Default:  "deny",
+				Profiles: map[string]ClientProfile{"cursor": {Servers: []string{"github"}}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid tool allow-list",
+			clients: &ClientsConfig{
+				Profiles: map[string]ClientProfile{"cursor": {Tools: []string{"github__search-repos"}}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid default allow",
+			clients: &ClientsConfig{
+				Default:  "allow",
+				Profiles: map[string]ClientProfile{"cursor": {}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid default value",
+			clients: &ClientsConfig{
+				Default:  "permit",
+				Profiles: map[string]ClientProfile{"cursor": {}},
+			},
+			wantErr: true,
+			errMsg:  "clients.default",
+		},
+		{
+			name: "unknown server reference",
+			clients: &ClientsConfig{
+				Profiles: map[string]ClientProfile{"cursor": {Servers: []string{"nonexistent"}}},
+			},
+			wantErr: true,
+			errMsg:  "unknown MCP server 'nonexistent'",
+		},
+		{
+			name: "tool not prefixed",
+			clients: &ClientsConfig{
+				Profiles: map[string]ClientProfile{"cursor": {Tools: []string{"search-repos"}}},
+			},
+			wantErr: true,
+			errMsg:  "must be a prefixed name",
+		},
+		{
+			name: "tool references unknown server",
+			clients: &ClientsConfig{
+				Profiles: map[string]ClientProfile{"cursor": {Tools: []string{"slack__post"}}},
+			},
+			wantErr: true,
+			errMsg:  "references unknown MCP server 'slack'",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(base(tc.clients))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errMsg != "" && !strings.Contains(err.Error(), tc.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tc.errMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestClientsConfig_RoundTrip asserts the clients block survives a load/save
+// cycle without dropping or reordering its fields (Article IX back-compat).
+func TestClientsConfig_RoundTrip(t *testing.T) {
+	src := `version: "1"
+name: test
+network:
+  name: net
+mcp-servers:
+  - name: github
+    image: alpine
+    port: 3000
+clients:
+  default: deny
+  profiles:
+    cursor:
+      servers:
+        - github
+      tools:
+        - github__search-repos
+    team-bot:
+      aliases:
+        - Claude Code
+      servers:
+        - github
+`
+	var stack Stack
+	if err := yaml.Unmarshal([]byte(src), &stack); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stack.Clients == nil {
+		t.Fatal("clients block dropped on unmarshal")
+	}
+	if stack.Clients.Default != "deny" {
+		t.Errorf("default = %q, want deny", stack.Clients.Default)
+	}
+	if got := stack.Clients.Profiles["cursor"].Servers; len(got) != 1 || got[0] != "github" {
+		t.Errorf("cursor.servers = %v", got)
+	}
+	if got := stack.Clients.Profiles["team-bot"].Aliases; len(got) != 1 || got[0] != "Claude Code" {
+		t.Errorf("team-bot.aliases = %v", got)
+	}
+
+	// Marshal back and re-parse: the block must survive intact.
+	out, err := yaml.Marshal(&stack)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var reparsed Stack
+	if err := yaml.Unmarshal(out, &reparsed); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if reparsed.Clients == nil || len(reparsed.Clients.Profiles) != 2 {
+		t.Fatalf("round-trip lost profiles: %+v", reparsed.Clients)
+	}
+	if reparsed.Clients.Profiles["cursor"].Tools[0] != "github__search-repos" {
+		t.Errorf("round-trip lost tool: %+v", reparsed.Clients.Profiles["cursor"])
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -18,12 +18,55 @@ type Stack struct {
 	Networks   []Network        `yaml:"networks,omitempty"`  // Multiple networks (advanced mode)
 	MCPServers []MCPServer      `yaml:"mcp-servers"`
 	Resources  []Resource       `yaml:"resources,omitempty"`
+	Clients    *ClientsConfig   `yaml:"clients,omitempty"` // Optional per-client access scoping (NetworkPolicy semantics)
 
 	// References is the variable-usage index, derived during expandStackVars:
 	// which consumers reference each ${var:KEY}/${vault:KEY} key. It is computed
 	// from the stack, not persisted with it — the yaml/json "-" tags keep it out
 	// of every existing serialization path. Nil until a stack is loaded/expanded.
 	References ReferenceIndex `yaml:"-" json:"-"`
+}
+
+// ClientsConfig is the optional top-level per-client access scoping block.
+// Its presence opts a stack into NetworkPolicy semantics:
+//
+//   - Omitting the entire `clients:` block preserves legacy behavior — every
+//     connecting client sees every tool (Article IX back-compat).
+//   - With the block present, a connecting client that matches a profile is
+//     restricted to that profile's allow-list; a client matching no profile is
+//     governed by Default ("deny" unless set to "allow").
+//
+// The map key in Profiles is the stable client identifier assigned at
+// `gridctl link` time, which is also the identifier shown in the UI and carried
+// on the wire (the `client` query parameter / X-Gridctl-Client-Id header). It is
+// reconciled with the connecting client's normalized identity, so the same
+// string keys configuration, enforcement, and the topology view.
+//
+// Scope coverage for v1 is tools only: skills (served as MCP prompts) and
+// resources remain globally visible. This is an explicit, documented decision;
+// extending scope to prompts/resources is deferred.
+type ClientsConfig struct {
+	// Default is the policy for clients that match no profile: "deny" (the
+	// default when empty) or "allow".
+	Default string `yaml:"default,omitempty"`
+	// Profiles maps a stable client identifier to its access allow-list.
+	Profiles map[string]ClientProfile `yaml:"profiles,omitempty"`
+}
+
+// ClientProfile is one client's tool access allow-list. Servers and Tools are
+// both allow-lists; an empty Servers list means "all servers" and an empty
+// Tools list means "all tools within the allowed servers". Tools are matched
+// against the router's prefixed names (e.g. "github__search-repos").
+type ClientProfile struct {
+	// Aliases are raw clientInfo.name values that should resolve to this
+	// profile, for reconciling a wire identity that differs from the profile
+	// key without relying on the built-in normalization heuristic.
+	Aliases []string `yaml:"aliases,omitempty"`
+	// Servers is an allow-list of MCP server names. Empty means all servers.
+	Servers []string `yaml:"servers,omitempty"`
+	// Tools is an allow-list of prefixed tool names. Empty means all tools
+	// within the allowed servers.
+	Tools []string `yaml:"tools,omitempty"`
 }
 
 // LoggingConfig configures log file output with automatic rotation.

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -452,10 +452,85 @@ func Validate(s *Stack) error {
 		// In simple mode, resource.Network is ignored (per design decision)
 	}
 
+	// Per-client access scoping validation
+	errs = append(errs, validateClients(s, serverNames)...)
+
 	if len(errs) > 0 {
 		return errs
 	}
 	return nil
+}
+
+// validateClients checks the optional `clients:` access block. It fails when
+// the default policy is invalid or a profile references an unknown server —
+// directly or via a tool prefix — so a misconfigured allow-list surfaces as a
+// clear error rather than silently granting or denying access. serverNames is
+// the set of declared MCP server names.
+//
+// Tool references are validated structurally: each must be a prefixed
+// "server__tool" name whose server is declared. The existence of the specific
+// tool cannot be checked at load time (downstream tools are only known once
+// servers are running), so an unknown tool on a known server is not a load-time
+// error; it simply never appears in the client's effective scope.
+func validateClients(s *Stack, serverNames map[string]bool) ValidationErrors {
+	var errs ValidationErrors
+	if s.Clients == nil {
+		return errs
+	}
+
+	switch s.Clients.Default {
+	case "", "deny", "allow":
+		// valid
+	default:
+		errs = append(errs, ValidationError{"clients.default", "must be 'allow' or 'deny'"})
+	}
+
+	for name, profile := range s.Clients.Profiles {
+		prefix := fmt.Sprintf("clients.profiles[%s]", name)
+		if name == "" {
+			errs = append(errs, ValidationError{"clients.profiles", "profile name must not be empty"})
+		}
+		for i, server := range profile.Servers {
+			if !serverNames[server] {
+				errs = append(errs, ValidationError{
+					fmt.Sprintf("%s.servers[%d]", prefix, i),
+					fmt.Sprintf("references unknown MCP server '%s'", server),
+				})
+			}
+		}
+		for i, tool := range profile.Tools {
+			server, _, ok := splitPrefixedToolName(tool)
+			if !ok {
+				errs = append(errs, ValidationError{
+					fmt.Sprintf("%s.tools[%d]", prefix, i),
+					fmt.Sprintf("tool '%s' must be a prefixed name (server__tool)", tool),
+				})
+				continue
+			}
+			if !serverNames[server] {
+				errs = append(errs, ValidationError{
+					fmt.Sprintf("%s.tools[%d]", prefix, i),
+					fmt.Sprintf("tool '%s' references unknown MCP server '%s'", tool, server),
+				})
+			}
+		}
+	}
+	return errs
+}
+
+// splitPrefixedToolName splits a "server__tool" name into its server and tool
+// parts without importing pkg/mcp (which would create an import cycle). It is
+// intentionally stricter than mcp.ParsePrefixedTool — it also rejects an empty
+// server or tool half — so config validation rejects malformed names that the
+// looser runtime parser would otherwise accept. Returns ok=false when the name
+// is not a well-formed prefixed name.
+func splitPrefixedToolName(prefixed string) (server, tool string, ok bool) {
+	const delim = "__"
+	idx := strings.Index(prefixed, delim)
+	if idx <= 0 || idx+len(delim) >= len(prefixed) {
+		return "", "", false
+	}
+	return prefixed[:idx], prefixed[idx+len(delim):], true
 }
 
 // validateAutoscale validates the autoscale block on one MCP server. prefix is

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -167,6 +167,10 @@ func (b *GatewayBuilder) Build(verbose bool) (*GatewayInstance, error) {
 		inst.Gateway.SetMaxToolResultBytes(b.stack.Gateway.MaxToolResultBytes)
 	}
 
+	// Phase 1a4: Install the per-client access policy (nil when no clients:
+	// block is configured, preserving legacy "everyone sees everything").
+	inst.Gateway.SetClientAccessPolicy(mcp.NewClientAccessPolicy(clientAccessSpec(b.stack)))
+
 	// Phase 1b: Create registry server (internal MCP server)
 	regDir := filepath.Join(state.BaseDir(), "registry")
 	if b.registryDir != "" {
@@ -564,6 +568,27 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 }
 
 // applyTelemetryConfig walks the stack's MCP servers and registers per-
+// clientAccessSpec translates the stack's optional `clients:` block into the
+// config-agnostic spec the gateway consumes. Returns nil when no block is
+// configured, which the gateway treats as "every client sees every tool".
+func clientAccessSpec(stack *config.Stack) *mcp.ClientAccessSpec {
+	if stack == nil || stack.Clients == nil {
+		return nil
+	}
+	spec := &mcp.ClientAccessSpec{
+		Default:  stack.Clients.Default,
+		Profiles: make(map[string]mcp.ClientProfileSpec, len(stack.Clients.Profiles)),
+	}
+	for name, profile := range stack.Clients.Profiles {
+		spec.Profiles[name] = mcp.ClientProfileSpec{
+			Aliases: profile.Aliases,
+			Servers: profile.Servers,
+			Tools:   profile.Tools,
+		}
+	}
+	return spec
+}
+
 // server file writers for every signal a server opts into. Idempotent:
 // re-running with a changed stack adds new writers and removes ones that
 // flipped to off. Used both at initial Build time and from the hot-reload
@@ -813,6 +838,9 @@ func (b *GatewayBuilder) setupHotReload(ctx context.Context, inst *GatewayInstan
 	// callback fires under reload.Handler.mu — keep it allocation-light.
 	reloadHandler.SetOnConfigApplied(func(newCfg *config.Stack) {
 		b.stack = newCfg
+		// Re-resolve the per-client access policy from the reloaded config so a
+		// `clients:` change takes effect on the next tools/list and tools/call.
+		inst.Gateway.SetClientAccessPolicy(mcp.NewClientAccessPolicy(clientAccessSpec(newCfg)))
 		b.applyTelemetryConfig(inst.APIServer, handler)
 	})
 	inst.APIServer.SetReloadHandler(reloadHandler)

--- a/pkg/mcp/clientid.go
+++ b/pkg/mcp/clientid.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"unicode"
 )
@@ -10,6 +11,14 @@ import (
 // normalized client ID through the tool-call path. Tool-call observers
 // read the value via ClientIDFromContext to attribute calls per client.
 type clientIDKey struct{}
+
+// clientAccessIDKey is the context key under which the gateway propagates the
+// connecting client's stable access identifier (see Session.AccessID). The
+// per-client access filter reads it via ClientAccessIDFromContext to scope the
+// exposed tool surface. It is kept distinct from clientIDKey: ClientID is the
+// telemetry attribution dimension, while AccessID is the enforcement key the
+// operator configures under stack.yaml `clients:`.
+type clientAccessIDKey struct{}
 
 // WithClientID returns a child context carrying the given normalized client ID.
 // An empty id leaves the context unchanged so callers do not have to pre-check.
@@ -25,6 +34,44 @@ func WithClientID(ctx context.Context, id string) context.Context {
 func ClientIDFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(clientIDKey{}).(string)
 	return v
+}
+
+// WithClientAccessID returns a child context carrying the connecting client's
+// stable access identifier. An empty id leaves the context unchanged.
+func WithClientAccessID(ctx context.Context, id string) context.Context {
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, clientAccessIDKey{}, id)
+}
+
+// ClientAccessIDFromContext returns the access identifier previously stored on
+// ctx via WithClientAccessID, or "" when none is available.
+func ClientAccessIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(clientAccessIDKey{}).(string)
+	return v
+}
+
+// ClientAccessIDHeader is the HTTP header an upstream client may set to declare
+// its stable access identifier explicitly, bypassing the clientInfo.name
+// normalization heuristic. `gridctl link --client-id` embeds the same value as
+// the `client` query parameter on the gateway URL it writes.
+const ClientAccessIDHeader = "X-Gridctl-Client-Id"
+
+// clientAccessIDFromRequest extracts the explicit, link-time-assigned client
+// identifier from a request: the `client` query parameter takes precedence,
+// then the X-Gridctl-Client-Id header. Returns "" when neither is present, in
+// which case the gateway falls back to NormalizeClientID(clientInfo.name).
+func clientAccessIDFromRequest(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if r.URL != nil {
+		if v := strings.TrimSpace(r.URL.Query().Get("client")); v != "" {
+			return v
+		}
+	}
+	return strings.TrimSpace(r.Header.Get(ClientAccessIDHeader))
 }
 
 // clientNameAliases maps the noisy `clientInfo.name` strings emitted by

--- a/pkg/mcp/clientidentity_test.go
+++ b/pkg/mcp/clientidentity_test.go
@@ -1,0 +1,104 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientAccessIDContext(t *testing.T) {
+	ctx := context.Background()
+	if got := ClientAccessIDFromContext(ctx); got != "" {
+		t.Errorf("empty context should return \"\", got %q", got)
+	}
+	// Empty id is a no-op (does not store).
+	if got := ClientAccessIDFromContext(WithClientAccessID(ctx, "")); got != "" {
+		t.Errorf("WithClientAccessID(\"\") should be a no-op, got %q", got)
+	}
+	ctx = WithClientAccessID(ctx, "cursor")
+	if got := ClientAccessIDFromContext(ctx); got != "cursor" {
+		t.Errorf("got %q, want cursor", got)
+	}
+	// Access id and telemetry client id are independent dimensions.
+	ctx = WithClientID(ctx, "claude-desktop")
+	if got := ClientAccessIDFromContext(ctx); got != "cursor" {
+		t.Errorf("access id should be unaffected by WithClientID, got %q", got)
+	}
+	if got := ClientIDFromContext(ctx); got != "claude-desktop" {
+		t.Errorf("client id = %q, want claude-desktop", got)
+	}
+}
+
+func TestClientAccessIDFromRequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		header string
+		want   string
+	}{
+		{"query param", "http://x/mcp?client=team-bot", "", "team-bot"},
+		{"header fallback", "http://x/mcp", "team-bot", "team-bot"},
+		{"query wins over header", "http://x/mcp?client=from-query", "from-header", "from-query"},
+		{"neither present", "http://x/mcp", "", ""},
+		{"blank query falls through to header", "http://x/mcp?client=", "from-header", "from-header"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, tt.url, nil)
+			if tt.header != "" {
+				r.Header.Set(ClientAccessIDHeader, tt.header)
+			}
+			if got := clientAccessIDFromRequest(r); got != tt.want {
+				t.Errorf("clientAccessIDFromRequest() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSessionAccessIDReconciliation covers the wire-vs-config identity
+// reconciliation: the explicit link-time identifier wins, otherwise the
+// normalized clientInfo.name is used, and both are normalized to a single form.
+func TestSessionAccessIDReconciliation(t *testing.T) {
+	tests := []struct {
+		name         string
+		clientName   string
+		explicitID   string
+		wantClientID string
+		wantAccessID string
+	}{
+		{
+			name:         "no explicit id falls back to normalized client name",
+			clientName:   "Claude Code",
+			explicitID:   "",
+			wantClientID: "claude-code",
+			wantAccessID: "claude-code",
+		},
+		{
+			name:         "explicit id overrides the wire name",
+			clientName:   "Claude Code",
+			explicitID:   "team-bot",
+			wantClientID: "claude-code",
+			wantAccessID: "team-bot",
+		},
+		{
+			name:         "explicit id is normalized",
+			clientName:   "Cursor",
+			explicitID:   "Team Bot",
+			wantClientID: "cursor",
+			wantAccessID: "team-bot",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewSessionManager()
+			sess := m.Create(ClientInfo{Name: tt.clientName}, tt.explicitID)
+			if sess.ClientID != tt.wantClientID {
+				t.Errorf("ClientID = %q, want %q", sess.ClientID, tt.wantClientID)
+			}
+			if sess.AccessID != tt.wantAccessID {
+				t.Errorf("AccessID = %q, want %q", sess.AccessID, tt.wantAccessID)
+			}
+		})
+	}
+}

--- a/pkg/mcp/clientscope.go
+++ b/pkg/mcp/clientscope.go
@@ -1,0 +1,196 @@
+package mcp
+
+import "sort"
+
+// ClientProfileSpec is the config-agnostic description of one client's
+// allow-list. The controller builds these from the stack.yaml `clients:` block
+// without pkg/mcp needing to import pkg/config.
+//
+// Servers and Tools are allow-lists. An empty Servers list means "all servers";
+// an empty Tools list means "all tools within the allowed servers". Tools are
+// matched against the router's prefixed names (e.g. "github__search-repos").
+// Aliases are raw clientInfo.name values that should resolve to this profile,
+// letting an operator reconcile a wire identity that differs from the profile
+// key without depending on the built-in NormalizeClientID alias table.
+type ClientProfileSpec struct {
+	Aliases []string
+	Servers []string
+	Tools   []string
+}
+
+// ClientAccessSpec is the config-agnostic description of the whole `clients:`
+// block. Default is the policy applied to clients that match no profile:
+// "allow" exposes everything, any other value (including the empty string)
+// denies. A nil *ClientAccessSpec means no block was configured at all.
+type ClientAccessSpec struct {
+	Default  string
+	Profiles map[string]ClientProfileSpec
+}
+
+// clientProfile is the resolved, read-optimized form of a ClientProfileSpec.
+type clientProfile struct {
+	servers map[string]bool // allowed server names; empty = all servers
+	tools   map[string]bool // allowed prefixed tool names; empty = all tools within servers
+}
+
+// allowsTool reports whether the given prefixed tool name is permitted by this
+// profile. An unparseable name is denied: a profiled client only reaches tools
+// that route to a known server.
+func (p clientProfile) allowsTool(prefixedName string) bool {
+	server, _, err := ParsePrefixedTool(prefixedName)
+	if err != nil {
+		return false
+	}
+	if len(p.servers) > 0 && !p.servers[server] {
+		return false
+	}
+	if len(p.tools) > 0 && !p.tools[prefixedName] {
+		return false
+	}
+	return true
+}
+
+// ClientAccessPolicy is the resolved per-client tool access filter applied at
+// every gateway exposure path (tools/list, tools/call, and the code-mode tool
+// universe). It is a read-time filter modeled on the per-server tool whitelist
+// in client_base.go, keyed on the connecting client's stable access identifier.
+//
+// A nil *ClientAccessPolicy means no `clients:` block was configured: every
+// client sees every tool (legacy behavior, Article IX). A non-nil policy
+// applies NetworkPolicy semantics — a client matching no profile is governed by
+// the default (deny unless `default: allow`).
+type ClientAccessPolicy struct {
+	defaultAllow bool
+	profiles     map[string]clientProfile // keyed by normalized access id
+	aliasIndex   map[string]string        // normalized alias -> profile key
+}
+
+// NewClientAccessPolicy builds a policy from a spec. A nil spec returns a nil
+// policy (legacy "everyone sees everything"). Profile keys and aliases are
+// normalized via NormalizeClientID so the configured identifier, the wire
+// identity, and the UI identifier reconcile on a single canonical form.
+func NewClientAccessPolicy(spec *ClientAccessSpec) *ClientAccessPolicy {
+	if spec == nil {
+		return nil
+	}
+	p := &ClientAccessPolicy{
+		defaultAllow: spec.Default == "allow",
+		profiles:     make(map[string]clientProfile, len(spec.Profiles)),
+		aliasIndex:   make(map[string]string),
+	}
+	for name, prof := range spec.Profiles {
+		key := NormalizeClientID(name)
+		cp := clientProfile{
+			servers: make(map[string]bool, len(prof.Servers)),
+			tools:   make(map[string]bool, len(prof.Tools)),
+		}
+		for _, s := range prof.Servers {
+			cp.servers[s] = true
+		}
+		for _, t := range prof.Tools {
+			cp.tools[t] = true
+		}
+		p.profiles[key] = cp
+		for _, alias := range prof.Aliases {
+			if na := NormalizeClientID(alias); na != "" {
+				p.aliasIndex[na] = key
+			}
+		}
+	}
+	return p
+}
+
+// resolveKey maps an access identifier to a profile key. It returns the key and
+// whether an explicit profile exists for the client. Resolution order: direct
+// profile match, then a configured alias, then the normalized id itself (which
+// will not be listed and so falls to the default policy).
+func (p *ClientAccessPolicy) resolveKey(accessID string) (key string, listed bool) {
+	n := NormalizeClientID(accessID)
+	if _, ok := p.profiles[n]; ok {
+		return n, true
+	}
+	if k, ok := p.aliasIndex[n]; ok {
+		return k, true
+	}
+	return n, false
+}
+
+// Allows reports whether the client identified by accessID may call the given
+// prefixed tool. A nil policy allows everything.
+func (p *ClientAccessPolicy) Allows(accessID, prefixedName string) bool {
+	if p == nil {
+		return true
+	}
+	key, listed := p.resolveKey(accessID)
+	if !listed {
+		return p.defaultAllow
+	}
+	return p.profiles[key].allowsTool(prefixedName)
+}
+
+// Filter returns the subset of tools visible to the client identified by
+// accessID. A nil policy returns the tools unchanged.
+func (p *ClientAccessPolicy) Filter(accessID string, tools []Tool) []Tool {
+	if p == nil {
+		return tools
+	}
+	key, listed := p.resolveKey(accessID)
+	if !listed {
+		if p.defaultAllow {
+			return tools
+		}
+		return nil
+	}
+	prof := p.profiles[key]
+	filtered := make([]Tool, 0, len(tools))
+	for _, t := range tools {
+		if prof.allowsTool(t.Name) {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}
+
+// ClientScopeResult reports a client's backend-computed effective scope: the
+// servers and prefixed tool names it can actually reach after intersecting its
+// allow-list with the live tool surface. It backs the per-client scope the
+// topology/clients API surfaces.
+type ClientScopeResult struct {
+	// Configured reports whether a `clients:` block exists at all.
+	Configured bool `json:"configured"`
+	// Unscoped reports that the client reaches the full tool surface (no block,
+	// or default-allow for an unlisted client, or a profile with no restriction).
+	Unscoped bool `json:"unscoped"`
+	// Servers are the reachable server names, sorted.
+	Servers []string `json:"servers"`
+	// Tools are the reachable prefixed tool names, sorted.
+	Tools []string `json:"tools"`
+}
+
+// scopeResult computes the effective scope for accessID against a fully-known
+// tool surface. allTools is the global (unscoped) catalog of prefixed tools.
+func (p *ClientAccessPolicy) scopeResult(accessID string, allTools []Tool) ClientScopeResult {
+	res := ClientScopeResult{Configured: p != nil}
+	visible := p.Filter(accessID, allTools)
+
+	// Unscoped when the policy did not narrow the surface.
+	res.Unscoped = p == nil || len(visible) == len(allTools)
+
+	serverSet := make(map[string]bool, len(visible))
+	tools := make([]string, 0, len(visible))
+	for _, t := range visible {
+		tools = append(tools, t.Name)
+		if server, _, err := ParsePrefixedTool(t.Name); err == nil {
+			serverSet[server] = true
+		}
+	}
+	servers := make([]string, 0, len(serverSet))
+	for s := range serverSet {
+		servers = append(servers, s)
+	}
+	sort.Strings(servers)
+	sort.Strings(tools)
+	res.Servers = servers
+	res.Tools = tools
+	return res
+}

--- a/pkg/mcp/clientscope_test.go
+++ b/pkg/mcp/clientscope_test.go
@@ -1,0 +1,201 @@
+package mcp
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// toolNames is a small helper to extract sorted names from a tool slice.
+func toolNames(tools []Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, t := range tools {
+		names = append(names, t.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// sampleTools is the global (unscoped) surface used across the policy tests:
+// two servers, two tools each, with the router's prefixed-name convention.
+func sampleTools() []Tool {
+	return []Tool{
+		{Name: "github__search-repos"},
+		{Name: "github__create-issue"},
+		{Name: "gitlab__list-issues"},
+		{Name: "gitlab__merge-request"},
+	}
+}
+
+func TestClientAccessPolicy_Filter(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     *ClientAccessSpec
+		accessID string
+		want     []string // expected visible prefixed tool names (sorted)
+	}{
+		{
+			name:     "no block: every client sees everything",
+			spec:     nil,
+			accessID: "anyone",
+			want:     []string{"github__create-issue", "github__search-repos", "gitlab__list-issues", "gitlab__merge-request"},
+		},
+		{
+			name:     "default deny: unlisted client sees nothing",
+			spec:     &ClientAccessSpec{Default: "deny", Profiles: map[string]ClientProfileSpec{"cursor": {Servers: []string{"github"}}}},
+			accessID: "windsurf",
+			want:     nil,
+		},
+		{
+			name:     "default empty is deny: unlisted client sees nothing",
+			spec:     &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {Servers: []string{"github"}}}},
+			accessID: "windsurf",
+			want:     nil,
+		},
+		{
+			name:     "default allow: unlisted client sees everything",
+			spec:     &ClientAccessSpec{Default: "allow", Profiles: map[string]ClientProfileSpec{"cursor": {Servers: []string{"github"}}}},
+			accessID: "windsurf",
+			want:     []string{"github__create-issue", "github__search-repos", "gitlab__list-issues", "gitlab__merge-request"},
+		},
+		{
+			name:     "server-level allow-list",
+			spec:     &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {Servers: []string{"github"}}}},
+			accessID: "cursor",
+			want:     []string{"github__create-issue", "github__search-repos"},
+		},
+		{
+			name:     "tool-level allow-list",
+			spec:     &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {Tools: []string{"github__search-repos", "gitlab__list-issues"}}}},
+			accessID: "cursor",
+			want:     []string{"github__search-repos", "gitlab__list-issues"},
+		},
+		{
+			name: "server and tool allow-list intersect",
+			spec: &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {
+				Servers: []string{"github"},
+				Tools:   []string{"github__search-repos", "gitlab__list-issues"},
+			}}},
+			accessID: "cursor",
+			want:     []string{"github__search-repos"},
+		},
+		{
+			name:     "listed client with empty profile sees everything",
+			spec:     &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {}}},
+			accessID: "cursor",
+			want:     []string{"github__create-issue", "github__search-repos", "gitlab__list-issues", "gitlab__merge-request"},
+		},
+		{
+			name:     "unknown server reference filters to nothing for that profile",
+			spec:     &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {Servers: []string{"nonexistent"}}}},
+			accessID: "cursor",
+			want:     nil,
+		},
+		{
+			name: "alias resolves a divergent wire name to a profile",
+			spec: &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"team-bot": {
+				Aliases: []string{"Claude Code"},
+				Servers: []string{"gitlab"},
+			}}},
+			accessID: "claude-code", // normalized form of "Claude Code"
+			want:     []string{"gitlab__list-issues", "gitlab__merge-request"},
+		},
+		{
+			name: "profile key matched case-insensitively via normalization",
+			spec: &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"Claude-Code": {
+				Servers: []string{"github"},
+			}}},
+			accessID: "claude-code",
+			want:     []string{"github__create-issue", "github__search-repos"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := NewClientAccessPolicy(tt.spec)
+			got := toolNames(policy.Filter(tt.accessID, sampleTools()))
+			if len(got) == 0 {
+				got = nil
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Filter(%q) = %v, want %v", tt.accessID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientAccessPolicy_Allows(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     *ClientAccessSpec
+		accessID string
+		tool     string
+		want     bool
+	}{
+		{"no block allows any tool", nil, "anyone", "github__search-repos", true},
+		{"default deny rejects unlisted client", &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {}}}, "windsurf", "github__search-repos", false},
+		{"default allow accepts unlisted client", &ClientAccessSpec{Default: "allow", Profiles: map[string]ClientProfileSpec{"cursor": {}}}, "windsurf", "github__search-repos", true},
+		{"server allow-list accepts in-scope tool", &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {Servers: []string{"github"}}}}, "cursor", "github__search-repos", true},
+		{"server allow-list rejects out-of-scope tool", &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {Servers: []string{"github"}}}}, "cursor", "gitlab__list-issues", false},
+		{"tool allow-list accepts listed tool", &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {Tools: []string{"github__search-repos"}}}}, "cursor", "github__search-repos", true},
+		{"tool allow-list rejects unlisted tool", &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {Tools: []string{"github__search-repos"}}}}, "cursor", "github__create-issue", false},
+		{"unparseable tool name denied under a profile", &ClientAccessSpec{Profiles: map[string]ClientProfileSpec{"cursor": {}}}, "cursor", "no-prefix", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := NewClientAccessPolicy(tt.spec)
+			if got := policy.Allows(tt.accessID, tt.tool); got != tt.want {
+				t.Errorf("Allows(%q, %q) = %v, want %v", tt.accessID, tt.tool, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientAccessPolicy_ScopeResult(t *testing.T) {
+	t.Run("nil policy is unscoped and lists everything", func(t *testing.T) {
+		var policy *ClientAccessPolicy
+		res := policy.scopeResult("anyone", sampleTools())
+		if res.Configured {
+			t.Error("Configured should be false for nil policy")
+		}
+		if !res.Unscoped {
+			t.Error("Unscoped should be true for nil policy")
+		}
+		if len(res.Tools) != 4 || len(res.Servers) != 2 {
+			t.Errorf("expected 4 tools/2 servers, got %d/%d", len(res.Tools), len(res.Servers))
+		}
+	})
+
+	t.Run("scoped client reports effective servers and tools", func(t *testing.T) {
+		policy := NewClientAccessPolicy(&ClientAccessSpec{
+			Profiles: map[string]ClientProfileSpec{"cursor": {Servers: []string{"github"}}},
+		})
+		res := policy.scopeResult("cursor", sampleTools())
+		if !res.Configured {
+			t.Error("Configured should be true")
+		}
+		if res.Unscoped {
+			t.Error("Unscoped should be false for a narrowed client")
+		}
+		if !reflect.DeepEqual(res.Servers, []string{"github"}) {
+			t.Errorf("servers = %v, want [github]", res.Servers)
+		}
+		if !reflect.DeepEqual(res.Tools, []string{"github__create-issue", "github__search-repos"}) {
+			t.Errorf("tools = %v", res.Tools)
+		}
+	})
+
+	t.Run("default-deny unlisted client reports empty scope", func(t *testing.T) {
+		policy := NewClientAccessPolicy(&ClientAccessSpec{
+			Profiles: map[string]ClientProfileSpec{"cursor": {}},
+		})
+		res := policy.scopeResult("windsurf", sampleTools())
+		if res.Unscoped {
+			t.Error("Unscoped should be false for a denied client")
+		}
+		if len(res.Tools) != 0 || len(res.Servers) != 0 {
+			t.Errorf("expected empty scope, got tools=%v servers=%v", res.Tools, res.Servers)
+		}
+	})
+}

--- a/pkg/mcp/codemode_test.go
+++ b/pkg/mcp/codemode_test.go
@@ -395,7 +395,7 @@ func TestGateway_CodeMode_ToolsList(t *testing.T) {
 	gw := NewGateway()
 	gw.SetCodeMode(30 * time.Second)
 
-	result, err := gw.HandleToolsList()
+	result, err := gw.HandleToolsList(context.Background())
 	if err != nil {
 		t.Fatalf("HandleToolsList failed: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestGateway_CodeMode_Off(t *testing.T) {
 	gw := NewGateway()
 	// Code mode not enabled — should return aggregated tools as usual
 
-	result, err := gw.HandleToolsList()
+	result, err := gw.HandleToolsList(context.Background())
 	if err != nil {
 		t.Fatalf("HandleToolsList failed: %v", err)
 	}

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -151,6 +151,12 @@ type Gateway struct {
 
 	autoMu      sync.RWMutex
 	autoscalers map[string]*Autoscaler // name -> scaler for autoscaled replica sets
+
+	// clientPolicy is the per-client tool access filter resolved from the
+	// stack.yaml `clients:` block. nil means no block was configured and every
+	// client sees every tool (legacy behavior). Guarded by mu; replaced
+	// wholesale on apply and hot-reload.
+	clientPolicy *ClientAccessPolicy
 }
 
 // NewGateway creates a new MCP gateway.
@@ -217,6 +223,58 @@ func (g *Gateway) SetCodeMode(timeout time.Duration) {
 	cm.SetLogger(g.logger)
 	g.codeMode = cm
 	g.codeModeStr = "on"
+}
+
+// SetClientAccessPolicy installs the per-client tool access filter. Passing nil
+// disables scoping (every client sees every tool). The gateway re-resolves
+// scope from the live policy on every tools/list and tools/call, so a hot
+// reload that swaps the policy takes effect on the next request — including for
+// already-established sessions.
+func (g *Gateway) SetClientAccessPolicy(policy *ClientAccessPolicy) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.clientPolicy = policy
+}
+
+// clientAccessPolicy returns the current policy under a read lock.
+func (g *Gateway) clientAccessPolicy() *ClientAccessPolicy {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.clientPolicy
+}
+
+// scopeToolsForContext narrows tools to those the connecting client (resolved
+// from ctx) is allowed to see. It is the single chokepoint every tool-exposure
+// path funnels through so the code-mode universe cannot bypass the filter.
+func (g *Gateway) scopeToolsForContext(ctx context.Context, tools []Tool) []Tool {
+	policy := g.clientAccessPolicy()
+	if policy == nil {
+		return tools
+	}
+	return policy.Filter(ClientAccessIDFromContext(ctx), tools)
+}
+
+// clientAllowsToolCall reports whether the connecting client (resolved from
+// ctx) may invoke the given prefixed tool. Always true when no policy is set.
+func (g *Gateway) clientAllowsToolCall(ctx context.Context, prefixedName string) bool {
+	policy := g.clientAccessPolicy()
+	if policy == nil {
+		return true
+	}
+	return policy.Allows(ClientAccessIDFromContext(ctx), prefixedName)
+}
+
+// ClientAccessConfigured reports whether a `clients:` access block is in effect.
+func (g *Gateway) ClientAccessConfigured() bool {
+	return g.clientAccessPolicy() != nil
+}
+
+// ClientScope returns the backend-computed effective scope for the given access
+// identifier: the servers and prefixed tools it can reach after intersecting
+// its allow-list with the live tool surface. Used by the topology/clients API
+// so the frontend renders the real per-client subgraph.
+func (g *Gateway) ClientScope(accessID string) ClientScopeResult {
+	return g.clientAccessPolicy().scopeResult(NormalizeClientID(accessID), g.router.CatalogTools())
 }
 
 // SetDefaultOutputFormat sets the gateway-level default output format.
@@ -1200,8 +1258,13 @@ func (g *Gateway) buildInstructions() string {
 
 // HandleInitialize handles the initialize request. It creates a new session and
 // returns both the result and the session so callers can use the session ID.
-func (g *Gateway) HandleInitialize(params InitializeParams) (*InitializeResult, *Session, error) {
-	session := g.sessions.Create(params.ClientInfo)
+//
+// accessID is the explicit, link-time-assigned client identifier resolved from
+// the connection (the `client` query parameter or X-Gridctl-Client-Id header);
+// pass "" when the client declared none so the gateway falls back to the
+// normalized clientInfo.name for access scoping.
+func (g *Gateway) HandleInitialize(params InitializeParams, accessID string) (*InitializeResult, *Session, error) {
+	session := g.sessions.Create(params.ClientInfo, accessID)
 
 	caps := Capabilities{
 		Tools: &ToolsCapability{
@@ -1227,9 +1290,11 @@ func (g *Gateway) HandleInitialize(params InitializeParams) (*InitializeResult, 
 	}, session, nil
 }
 
-// HandleToolsList returns all aggregated tools.
-// When code mode is active, returns the two meta-tools instead.
-func (g *Gateway) HandleToolsList() (*ToolsListResult, error) {
+// HandleToolsList returns all aggregated tools, scoped to what the connecting
+// client (resolved from ctx) is allowed to see. When code mode is active,
+// returns the two meta-tools instead (the scoped universe is applied to the
+// code-mode search/execute path in HandleToolsCall).
+func (g *Gateway) HandleToolsList(ctx context.Context) (*ToolsListResult, error) {
 	g.mu.RLock()
 	cm := g.codeMode
 	g.mu.RUnlock()
@@ -1238,9 +1303,25 @@ func (g *Gateway) HandleToolsList() (*ToolsListResult, error) {
 		return cm.ToolsList(), nil
 	}
 
-	tools := g.router.AggregatedTools()
+	tools := g.scopeToolsForContext(ctx, g.router.AggregatedTools())
 	g.logToolCountHint(len(tools))
 	return &ToolsListResult{Tools: tools}, nil
+}
+
+// HandleToolsListUnscoped returns the full aggregated tool surface, ignoring
+// any per-client access scope. It backs operator-facing, informational paths
+// (the web console tool list and the optimize schema-token measurement) that
+// must see every tool regardless of client scoping. Like HandleToolsList it
+// returns the code-mode meta-tools when code mode is active.
+func (g *Gateway) HandleToolsListUnscoped() (*ToolsListResult, error) {
+	g.mu.RLock()
+	cm := g.codeMode
+	g.mu.RUnlock()
+
+	if cm != nil {
+		return cm.ToolsList(), nil
+	}
+	return &ToolsListResult{Tools: g.router.AggregatedTools()}, nil
 }
 
 // HandleToolsCatalog returns the full downstream tool inventory with each
@@ -1260,8 +1341,23 @@ func (g *Gateway) HandleToolsCall(ctx context.Context, params ToolCallParams) (*
 	g.mu.RUnlock()
 
 	if cm != nil && cm.IsMetaTool(params.Name) {
-		allTools := g.router.AggregatedTools()
+		// Scope the code-mode tool universe to the connecting client. Code mode
+		// sources its search/execute surface from the same aggregated tool set
+		// as the direct path, so without this filter a scoped client could
+		// discover and call denied tools via code mode.
+		allTools := g.scopeToolsForContext(ctx, g.router.AggregatedTools())
 		return cm.HandleCall(ctx, params, g, allTools)
+	}
+
+	// Enforce the per-client access scope on the direct tools/call path. A
+	// denied call is rejected before routing; denials are logged at debug.
+	if !g.clientAllowsToolCall(ctx, params.Name) {
+		g.logger.Debug("tool call denied by client access policy",
+			"client", ClientAccessIDFromContext(ctx), "tool", params.Name)
+		return &ToolCallResult{
+			Content: []Content{NewTextContent(fmt.Sprintf("Error: tool %q is not in this client's access scope", params.Name))},
+			IsError: true,
+		}, nil
 	}
 
 	// Child span: routing decision.

--- a/pkg/mcp/gateway_clientscope_test.go
+++ b/pkg/mcp/gateway_clientscope_test.go
@@ -1,0 +1,170 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+)
+
+// newScopeTestGateway builds a gateway with two servers (github, gitlab), each
+// advertising two tools, ready for per-client scope assertions.
+func newScopeTestGateway(t *testing.T) *Gateway {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+	g.Router().AddClient(setupMockAgentClient(ctrl, "github", []Tool{
+		{Name: "search-repos"}, {Name: "create-issue"},
+	}))
+	g.Router().AddClient(setupMockAgentClient(ctrl, "gitlab", []Tool{
+		{Name: "list-issues"}, {Name: "merge-request"},
+	}))
+	g.Router().RefreshTools()
+	return g
+}
+
+func ctxWithAccess(id string) context.Context {
+	return WithClientAccessID(context.Background(), id)
+}
+
+func TestGateway_ToolsList_ScopedPerClient(t *testing.T) {
+	g := newScopeTestGateway(t)
+	g.SetClientAccessPolicy(NewClientAccessPolicy(&ClientAccessSpec{
+		Profiles: map[string]ClientProfileSpec{
+			"cursor": {Servers: []string{"github"}},
+		},
+	}))
+
+	// Scoped client sees only github tools.
+	res, err := g.HandleToolsList(ctxWithAccess("cursor"))
+	if err != nil {
+		t.Fatalf("HandleToolsList: %v", err)
+	}
+	got := toolNames(res.Tools)
+	want := []string{"github__create-issue", "github__search-repos"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("scoped tools/list = %v, want %v", got, want)
+	}
+
+	// Unlisted client under default-deny sees nothing.
+	res, err = g.HandleToolsList(ctxWithAccess("windsurf"))
+	if err != nil {
+		t.Fatalf("HandleToolsList: %v", err)
+	}
+	if len(res.Tools) != 0 {
+		t.Errorf("unlisted client should see no tools, got %v", toolNames(res.Tools))
+	}
+
+	// Unscoped (no policy) sees all four.
+	g.SetClientAccessPolicy(nil)
+	res, _ = g.HandleToolsList(ctxWithAccess("cursor"))
+	if len(res.Tools) != 4 {
+		t.Errorf("no policy should expose all 4 tools, got %d", len(res.Tools))
+	}
+}
+
+// TestGateway_ToolsListUnscoped_BypassesPolicy locks the operator-facing
+// guarantee: the web console and optimize paths see the full tool surface even
+// under a deny-all policy that would hide everything from a scoped MCP client.
+func TestGateway_ToolsListUnscoped_BypassesPolicy(t *testing.T) {
+	g := newScopeTestGateway(t)
+	g.SetClientAccessPolicy(NewClientAccessPolicy(&ClientAccessSpec{
+		Default: "deny", // no profiles: every MCP client is denied
+	}))
+
+	// A scoped MCP client sees nothing.
+	scoped, err := g.HandleToolsList(ctxWithAccess("windsurf"))
+	if err != nil {
+		t.Fatalf("HandleToolsList: %v", err)
+	}
+	if len(scoped.Tools) != 0 {
+		t.Errorf("deny-all policy should hide all tools from MCP client, got %d", len(scoped.Tools))
+	}
+
+	// The operator-facing unscoped view still sees the full surface.
+	full, err := g.HandleToolsListUnscoped()
+	if err != nil {
+		t.Fatalf("HandleToolsListUnscoped: %v", err)
+	}
+	if len(full.Tools) != 4 {
+		t.Errorf("unscoped view should expose all 4 tools regardless of policy, got %d", len(full.Tools))
+	}
+}
+
+func TestGateway_ToolsCall_DeniedByScope(t *testing.T) {
+	g := newScopeTestGateway(t)
+	g.SetClientAccessPolicy(NewClientAccessPolicy(&ClientAccessSpec{
+		Profiles: map[string]ClientProfileSpec{
+			"cursor": {Servers: []string{"github"}},
+		},
+	}))
+
+	// A gitlab tool is out of scope for cursor: rejected before routing.
+	res, err := g.HandleToolsCall(ctxWithAccess("cursor"), ToolCallParams{Name: "gitlab__list-issues"})
+	if err != nil {
+		t.Fatalf("HandleToolsCall: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected denied call to return an error result")
+	}
+	if !strings.Contains(res.Content[0].Text, "access scope") {
+		t.Errorf("expected access-scope denial message, got %q", res.Content[0].Text)
+	}
+}
+
+// TestGateway_CodeMode_UniverseScoped asserts the code-mode search surface only
+// exposes the connecting client's allowed tools — the bypass the design guards
+// against. With code mode on, search must not reveal a denied tool.
+func TestGateway_CodeMode_UniverseScoped(t *testing.T) {
+	g := newScopeTestGateway(t)
+	g.SetCodeMode(5 * time.Second)
+	g.SetClientAccessPolicy(NewClientAccessPolicy(&ClientAccessSpec{
+		Profiles: map[string]ClientProfileSpec{
+			"cursor": {Servers: []string{"github"}},
+		},
+	}))
+
+	res, err := g.HandleToolsCall(ctxWithAccess("cursor"), ToolCallParams{
+		Name:      MetaToolSearch,
+		Arguments: map[string]any{"query": ""},
+	})
+	if err != nil {
+		t.Fatalf("code-mode search: %v", err)
+	}
+	text := res.Content[0].Text
+	if strings.Contains(text, "gitlab__") {
+		t.Errorf("code-mode search leaked out-of-scope tools: %q", text)
+	}
+	if !strings.Contains(text, "github__search-repos") {
+		t.Errorf("code-mode search should include in-scope tools: %q", text)
+	}
+}
+
+func TestGateway_ClientScope_API(t *testing.T) {
+	g := newScopeTestGateway(t)
+
+	// No policy: not configured, unscoped, full surface.
+	if g.ClientAccessConfigured() {
+		t.Error("ClientAccessConfigured should be false without a policy")
+	}
+	scope := g.ClientScope("cursor")
+	if scope.Configured || !scope.Unscoped || len(scope.Tools) != 4 {
+		t.Errorf("unscoped result unexpected: %+v", scope)
+	}
+
+	g.SetClientAccessPolicy(NewClientAccessPolicy(&ClientAccessSpec{
+		Profiles: map[string]ClientProfileSpec{"cursor": {Servers: []string{"gitlab"}}},
+	}))
+	if !g.ClientAccessConfigured() {
+		t.Error("ClientAccessConfigured should be true with a policy")
+	}
+	scope = g.ClientScope("cursor")
+	if !scope.Configured || scope.Unscoped {
+		t.Errorf("expected configured+scoped, got %+v", scope)
+	}
+	if len(scope.Servers) != 1 || scope.Servers[0] != "gitlab" {
+		t.Errorf("servers = %v, want [gitlab]", scope.Servers)
+	}
+}

--- a/pkg/mcp/gateway_test.go
+++ b/pkg/mcp/gateway_test.go
@@ -58,7 +58,7 @@ func TestGateway_HandleInitialize(t *testing.T) {
 		Capabilities:    Capabilities{},
 	}
 
-	result, _, err := g.HandleInitialize(params)
+	result, _, err := g.HandleInitialize(params, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestGateway_HandleToolsList(t *testing.T) {
 	g.Router().AddClient(client)
 	g.Router().RefreshTools()
 
-	result, err := g.HandleToolsList()
+	result, err := g.HandleToolsList(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -417,7 +417,7 @@ func TestGateway_SessionCount(t *testing.T) {
 	_, _, err := g.HandleInitialize(InitializeParams{
 		ProtocolVersion: "2024-11-05",
 		ClientInfo:      ClientInfo{Name: "client1", Version: "1.0"},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1164,7 +1164,7 @@ func TestGateway_HandleInitialize_WithRegistry(t *testing.T) {
 		ClientInfo:      ClientInfo{Name: "test-client", Version: "1.0"},
 	}
 
-	result, _, err := g.HandleInitialize(params)
+	result, _, err := g.HandleInitialize(params, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1194,7 +1194,7 @@ func TestGateway_HandleInitialize_WithoutRegistry(t *testing.T) {
 		ClientInfo:      ClientInfo{Name: "test-client", Version: "1.0"},
 	}
 
-	result, _, err := g.HandleInitialize(params)
+	result, _, err := g.HandleInitialize(params, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1624,7 +1624,7 @@ func TestGateway_HandleToolsList_CodeMode(t *testing.T) {
 	g := NewGateway()
 	g.SetCodeMode(30 * time.Second)
 
-	result, err := g.HandleToolsList()
+	result, err := g.HandleToolsList(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1655,7 +1655,7 @@ func TestGateway_HandleToolsCatalog_CodeMode(t *testing.T) {
 	g.SetCodeMode(30 * time.Second)
 
 	// tools/list still hides downstream tools behind the meta-tools.
-	list, err := g.HandleToolsList()
+	list, err := g.HandleToolsList(context.Background())
 	if err != nil {
 		t.Fatalf("HandleToolsList: %v", err)
 	}
@@ -1735,7 +1735,7 @@ func TestGateway_HandleToolsList_LogsHint(t *testing.T) {
 	g.Router().AddClient(client)
 	g.Router().RefreshTools()
 
-	result, err := g.HandleToolsList()
+	result, err := g.HandleToolsList(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2791,7 +2791,7 @@ func TestGateway_HandleInitialize_Instructions(t *testing.T) {
 	result, _, err := g.HandleInitialize(InitializeParams{
 		ProtocolVersion: "2024-11-05",
 		ClientInfo:      ClientInfo{Name: "test-client", Version: "1.0"},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2828,7 +2828,7 @@ func TestGateway_HandleInitialize_InstructionsCodeMode(t *testing.T) {
 	result, _, err := g.HandleInitialize(InitializeParams{
 		ProtocolVersion: "2024-11-05",
 		ClientInfo:      ClientInfo{Name: "test-client", Version: "1.0"},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2847,7 +2847,7 @@ func TestGateway_HandleInitialize_InstructionsNoServers(t *testing.T) {
 	result, _, err := g.HandleInitialize(InitializeParams{
 		ProtocolVersion: "2024-11-05",
 		ClientInfo:      ClientInfo{Name: "test-client", Version: "1.0"},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2886,7 +2886,7 @@ func TestGateway_HandleInitialize_InstructionsFiltersNonMCP(t *testing.T) {
 	result, _, err := g.HandleInitialize(InitializeParams{
 		ProtocolVersion: "2024-11-05",
 		ClientInfo:      ClientInfo{Name: "test-client", Version: "1.0"},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -3493,7 +3493,7 @@ func TestGateway_HandleInitialize_NormalizesClientID(t *testing.T) {
 	_, sess, err := g.HandleInitialize(InitializeParams{
 		ProtocolVersion: MCPProtocolVersion,
 		ClientInfo:      ClientInfo{Name: "Claude Code", Version: "1.0"},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("HandleInitialize: %v", err)
 	}

--- a/pkg/mcp/handler.go
+++ b/pkg/mcp/handler.go
@@ -79,8 +79,9 @@ func (h *Handler) handlePost(w http.ResponseWriter, r *http.Request) {
 	// initialize request itself has no session yet — its ClientID lands on
 	// the spawned session and applies to subsequent calls.
 	if sid := r.Header.Get("Mcp-Session-Id"); sid != "" {
-		if sess := h.gateway.sessions.Get(sid); sess != nil && sess.ClientID != "" {
+		if sess := h.gateway.sessions.Get(sid); sess != nil {
 			ctx = WithClientID(ctx, sess.ClientID)
+			ctx = WithClientAccessID(ctx, sess.AccessID)
 		}
 	}
 	r = r.WithContext(ctx)
@@ -109,7 +110,7 @@ func (h *Handler) handleMethod(r *http.Request, req *jsonrpc.Request) jsonrpc.Re
 	var resp jsonrpc.Response
 	switch req.Method {
 	case "initialize":
-		resp = h.handleInitialize(req)
+		resp = h.handleInitialize(r, req)
 	case "notifications/initialized":
 		resp = jsonrpc.NewSuccessResponse(req.ID, nil)
 	case "tools/list":
@@ -136,8 +137,10 @@ func (h *Handler) handleMethod(r *http.Request, req *jsonrpc.Request) jsonrpc.Re
 	return resp
 }
 
-// handleInitialize handles the initialize request.
-func (h *Handler) handleInitialize(req *jsonrpc.Request) jsonrpc.Response {
+// handleInitialize handles the initialize request. The connecting client's
+// explicit access identifier (query parameter or header) is resolved here and
+// stored on the spawned session for per-client scope enforcement.
+func (h *Handler) handleInitialize(r *http.Request, req *jsonrpc.Request) jsonrpc.Response {
 	var params InitializeParams
 	if req.Params != nil {
 		if err := json.Unmarshal(req.Params, &params); err != nil {
@@ -145,7 +148,7 @@ func (h *Handler) handleInitialize(req *jsonrpc.Request) jsonrpc.Response {
 		}
 	}
 
-	result, _, err := h.gateway.HandleInitialize(params)
+	result, _, err := h.gateway.HandleInitialize(params, clientAccessIDFromRequest(r))
 	if err != nil {
 		return jsonrpc.NewErrorResponse(req.ID, jsonrpc.InternalError, err.Error())
 	}
@@ -155,7 +158,7 @@ func (h *Handler) handleInitialize(req *jsonrpc.Request) jsonrpc.Response {
 
 // handleToolsList handles the tools/list request.
 func (h *Handler) handleToolsList(r *http.Request, req *jsonrpc.Request) jsonrpc.Response {
-	result, err := h.gateway.HandleToolsList()
+	result, err := h.gateway.HandleToolsList(r.Context())
 	if err != nil {
 		return jsonrpc.NewErrorResponse(req.ID, jsonrpc.InternalError, err.Error())
 	}

--- a/pkg/mcp/session.go
+++ b/pkg/mcp/session.go
@@ -12,12 +12,18 @@ const maxSessions = 1000
 
 // Session represents an MCP client session.
 type Session struct {
-	ID          string
-	ClientInfo  ClientInfo
+	ID         string
+	ClientInfo ClientInfo
 	// ClientID is the normalized form of ClientInfo.Name (see NormalizeClientID).
 	// It is the stable attribution dimension threaded through tool-call observers
 	// so cost and token aggregates can be grouped per originating client.
-	ClientID    string
+	ClientID string
+	// AccessID is the stable identifier used to scope this client's tool access
+	// (the key under stack.yaml `clients:`). It is the explicit link-time
+	// identifier when the client declares one (the `client` query parameter or
+	// X-Gridctl-Client-Id header), otherwise it falls back to ClientID. Both are
+	// normalized so configuration, the wire, and the UI reconcile on one form.
+	AccessID    string
 	Initialized bool
 	CreatedAt   time.Time
 	LastSeen    time.Time
@@ -38,7 +44,12 @@ func NewSessionManager() *SessionManager {
 
 // Create creates a new session. If the session count exceeds maxSessions,
 // the oldest session (by LastSeen) is evicted.
-func (m *SessionManager) Create(clientInfo ClientInfo) *Session {
+//
+// accessID is the explicit, link-time-assigned client identifier resolved from
+// the connection (query parameter or header); pass "" when the client declared
+// none, in which case the normalized clientInfo.name becomes the access id.
+// Both forms are normalized so enforcement, config, and UI reconcile.
+func (m *SessionManager) Create(clientInfo ClientInfo, accessID string) *Session {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -46,11 +57,18 @@ func (m *SessionManager) Create(clientInfo ClientInfo) *Session {
 		m.evictOldest()
 	}
 
+	normalized := NormalizeClientID(clientInfo.Name)
+	resolvedAccess := NormalizeClientID(accessID)
+	if resolvedAccess == "" {
+		resolvedAccess = normalized
+	}
+
 	id := generateSessionID()
 	session := &Session{
 		ID:          id,
 		ClientInfo:  clientInfo,
-		ClientID:    NormalizeClientID(clientInfo.Name),
+		ClientID:    normalized,
+		AccessID:    resolvedAccess,
 		Initialized: true,
 		CreatedAt:   time.Now(),
 		LastSeen:    time.Now(),

--- a/pkg/mcp/session_test.go
+++ b/pkg/mcp/session_test.go
@@ -20,7 +20,7 @@ func TestSessionManager_Create(t *testing.T) {
 	m := NewSessionManager()
 	clientInfo := ClientInfo{Name: "test-client", Version: "1.0"}
 
-	session := m.Create(clientInfo)
+	session := m.Create(clientInfo, "")
 
 	if session == nil {
 		t.Fatal("Create returned nil session")
@@ -48,7 +48,7 @@ func TestSessionManager_Create_UniqueIDs(t *testing.T) {
 
 	ids := make(map[string]bool)
 	for i := 0; i < 100; i++ {
-		session := m.Create(clientInfo)
+		session := m.Create(clientInfo, "")
 		if ids[session.ID] {
 			t.Fatalf("duplicate session ID generated: %s", session.ID)
 		}
@@ -60,7 +60,7 @@ func TestSessionManager_Get(t *testing.T) {
 	m := NewSessionManager()
 	clientInfo := ClientInfo{Name: "test-client", Version: "1.0"}
 
-	created := m.Create(clientInfo)
+	created := m.Create(clientInfo, "")
 	retrieved := m.Get(created.ID)
 
 	if retrieved == nil {
@@ -84,7 +84,7 @@ func TestSessionManager_Touch(t *testing.T) {
 	m := NewSessionManager()
 	clientInfo := ClientInfo{Name: "test-client", Version: "1.0"}
 
-	session := m.Create(clientInfo)
+	session := m.Create(clientInfo, "")
 	originalLastSeen := session.LastSeen
 
 	// Wait a bit to ensure time difference
@@ -109,7 +109,7 @@ func TestSessionManager_Delete(t *testing.T) {
 	m := NewSessionManager()
 	clientInfo := ClientInfo{Name: "test-client", Version: "1.0"}
 
-	session := m.Create(clientInfo)
+	session := m.Create(clientInfo, "")
 	m.Delete(session.ID)
 
 	if m.Get(session.ID) != nil {
@@ -121,9 +121,9 @@ func TestSessionManager_List(t *testing.T) {
 	m := NewSessionManager()
 	clientInfo := ClientInfo{Name: "client", Version: "1.0"}
 
-	m.Create(clientInfo)
-	m.Create(clientInfo)
-	m.Create(clientInfo)
+	m.Create(clientInfo, "")
+	m.Create(clientInfo, "")
+	m.Create(clientInfo, "")
 
 	sessions := m.List()
 	if len(sessions) != 3 {
@@ -136,7 +136,7 @@ func TestSessionManager_Cleanup(t *testing.T) {
 	clientInfo := ClientInfo{Name: "client", Version: "1.0"}
 
 	// Create a session
-	session := m.Create(clientInfo)
+	session := m.Create(clientInfo, "")
 
 	// Manually set LastSeen to the past
 	m.mu.Lock()
@@ -159,7 +159,7 @@ func TestSessionManager_Cleanup_KeepsRecent(t *testing.T) {
 	clientInfo := ClientInfo{Name: "client", Version: "1.0"}
 
 	// Create a fresh session
-	session := m.Create(clientInfo)
+	session := m.Create(clientInfo, "")
 
 	// Cleanup sessions older than 1 hour (this session is recent)
 	removed := m.Cleanup(1 * time.Hour)
@@ -180,8 +180,8 @@ func TestSessionManager_Count(t *testing.T) {
 		t.Errorf("expected 0, got %d", m.Count())
 	}
 
-	m.Create(clientInfo)
-	m.Create(clientInfo)
+	m.Create(clientInfo, "")
+	m.Create(clientInfo, "")
 
 	if m.Count() != 2 {
 		t.Errorf("expected 2, got %d", m.Count())
@@ -194,7 +194,7 @@ func TestSessionManager_EvictOldest(t *testing.T) {
 
 	// Fill to capacity
 	for i := 0; i < maxSessions; i++ {
-		m.Create(clientInfo)
+		m.Create(clientInfo, "")
 	}
 
 	if m.Count() != maxSessions {
@@ -212,7 +212,7 @@ func TestSessionManager_EvictOldest(t *testing.T) {
 	m.mu.Unlock()
 
 	// Create one more - should evict the oldest
-	m.Create(clientInfo)
+	m.Create(clientInfo, "")
 
 	if m.Count() != maxSessions {
 		t.Errorf("expected %d after eviction, got %d", maxSessions, m.Count())
@@ -228,7 +228,7 @@ func TestSessionManager_EvictOldest_EvictsCorrectSession(t *testing.T) {
 
 	// Fill to capacity
 	for i := 0; i < maxSessions; i++ {
-		m.Create(clientInfo)
+		m.Create(clientInfo, "")
 	}
 
 	// Make two sessions old, but one older than the other
@@ -245,7 +245,7 @@ func TestSessionManager_EvictOldest_EvictsCorrectSession(t *testing.T) {
 	m.mu.Unlock()
 
 	// Create one more - should evict the *oldest* (ids[0])
-	m.Create(clientInfo)
+	m.Create(clientInfo, "")
 
 	if m.Get(ids[0]) != nil {
 		t.Error("oldest session (2h old) should have been evicted")
@@ -268,7 +268,7 @@ func TestSessionManager_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			session := m.Create(clientInfo)
+			session := m.Create(clientInfo, "")
 			createdIDs.Store(session.ID, true)
 		}()
 	}

--- a/pkg/mcp/streamable.go
+++ b/pkg/mcp/streamable.go
@@ -200,8 +200,9 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 	// observers can attribute calls per client. Sessions created before
 	// PR 2 may have an empty ClientID; WithClientID is a no-op in that case.
 	ctx := r.Context()
-	if gSession := s.gateway.sessions.Get(sessionID); gSession != nil && gSession.ClientID != "" {
+	if gSession := s.gateway.sessions.Get(sessionID); gSession != nil {
 		ctx = WithClientID(ctx, gSession.ClientID)
+		ctx = WithClientAccessID(ctx, gSession.AccessID)
 	}
 
 	resp := s.handleRequest(ctx, session, &req)
@@ -217,7 +218,7 @@ func (s *StreamableHTTPServer) handleInitialize(w http.ResponseWriter, r *http.R
 		_ = json.Unmarshal(req.Params, &params)
 	}
 
-	result, gSession, err := s.gateway.HandleInitialize(params)
+	result, gSession, err := s.gateway.HandleInitialize(params, clientAccessIDFromRequest(r))
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(jsonrpc.NewErrorResponse(req.ID, jsonrpc.InternalError, err.Error()))
@@ -349,7 +350,7 @@ func (s *StreamableHTTPServer) handleRequest(ctx context.Context, session *Strea
 	case "notifications/initialized":
 		return jsonrpc.NewSuccessResponse(req.ID, nil)
 	case "tools/list":
-		return s.handleToolsList(session, req)
+		return s.handleToolsList(ctx, session, req)
 	case "tools/call":
 		return s.handleToolsCall(ctx, session, req)
 	case "prompts/list":
@@ -367,8 +368,8 @@ func (s *StreamableHTTPServer) handleRequest(ctx context.Context, session *Strea
 	}
 }
 
-func (s *StreamableHTTPServer) handleToolsList(_ *StreamableSession, req *jsonrpc.Request) jsonrpc.Response {
-	result, err := s.gateway.HandleToolsList()
+func (s *StreamableHTTPServer) handleToolsList(ctx context.Context, _ *StreamableSession, req *jsonrpc.Request) jsonrpc.Response {
+	result, err := s.gateway.HandleToolsList(ctx)
 	if err != nil {
 		return jsonrpc.NewErrorResponse(req.ID, jsonrpc.InternalError, err.Error())
 	}

--- a/pkg/provisioner/claude.go
+++ b/pkg/provisioner/claude.go
@@ -19,7 +19,7 @@ func newClaudeDesktop() *ClaudeDesktop {
 	c.buildEntry = func(opts LinkOptions) map[string]any {
 		url := opts.GatewayURL
 		if opts.Port > 0 {
-			url = GatewayHTTPURL(opts.Port)
+			url = gatewayHTTPURLForOpts(opts)
 		}
 		return bridgeConfig(url)
 	}

--- a/pkg/provisioner/claudecode.go
+++ b/pkg/provisioner/claudecode.go
@@ -21,7 +21,7 @@ func newClaudeCode() *ClaudeCode {
 	c.buildEntry = func(opts LinkOptions) map[string]any {
 		url := opts.GatewayURL
 		if opts.Port > 0 {
-			url = GatewayHTTPURL(opts.Port)
+			url = gatewayHTTPURLForOpts(opts)
 		}
 		return httpConfig(url, "http")
 	}

--- a/pkg/provisioner/clientid_test.go
+++ b/pkg/provisioner/clientid_test.go
@@ -1,0 +1,41 @@
+package provisioner
+
+import "testing"
+
+func TestAppendClientParam(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		clientID string
+		want     string
+	}{
+		{"empty client id is a no-op", "http://localhost:8180/sse", "", "http://localhost:8180/sse"},
+		{"appends to bare url", "http://localhost:8180/sse", "cursor", "http://localhost:8180/sse?client=cursor"},
+		{"appends to http url", "http://localhost:8180/mcp", "team-bot", "http://localhost:8180/mcp?client=team-bot"},
+		{"replaces existing client param", "http://localhost:8180/mcp?client=old", "new", "http://localhost:8180/mcp?client=new"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AppendClientParam(tt.url, tt.clientID); got != tt.want {
+				t.Errorf("AppendClientParam(%q, %q) = %q, want %q", tt.url, tt.clientID, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHTTPNativeBuildEntry_EmbedsClientID covers the HTTP-native provisioner
+// path that rebuilds the URL from the port: the client identifier must survive.
+func TestHTTPNativeBuildEntry_EmbedsClientID(t *testing.T) {
+	c := newClaudeCode()
+	entry := c.buildEntry(LinkOptions{Port: 8180, ClientID: "team-bot"})
+	url, _ := entry["url"].(string)
+	if url != "http://localhost:8180/mcp?client=team-bot" {
+		t.Errorf("buildEntry url = %q, want embedded client param", url)
+	}
+
+	// No client id: legacy URL, unchanged behavior.
+	entry = c.buildEntry(LinkOptions{Port: 8180})
+	if url, _ := entry["url"].(string); url != "http://localhost:8180/mcp" {
+		t.Errorf("buildEntry url = %q, want bare /mcp", url)
+	}
+}

--- a/pkg/provisioner/cline.go
+++ b/pkg/provisioner/cline.go
@@ -24,7 +24,7 @@ func newCline() *Cline {
 	c.buildEntry = func(opts LinkOptions) map[string]any {
 		url := opts.GatewayURL
 		if opts.Port > 0 {
-			url = GatewayHTTPURL(opts.Port)
+			url = gatewayHTTPURLForOpts(opts)
 		}
 		return bridgeConfig(url)
 	}

--- a/pkg/provisioner/gemini.go
+++ b/pkg/provisioner/gemini.go
@@ -19,7 +19,7 @@ func newGeminiCLI() *GeminiCLI {
 	c.buildEntry = func(opts LinkOptions) map[string]any {
 		url := opts.GatewayURL
 		if opts.Port > 0 {
-			url = GatewayHTTPURL(opts.Port)
+			url = gatewayHTTPURLForOpts(opts)
 		}
 		return httpConfig(url, "streamable-http")
 	}

--- a/pkg/provisioner/grok.go
+++ b/pkg/provisioner/grok.go
@@ -51,7 +51,7 @@ func (g *GrokBuild) Detect() (string, bool) {
 func (g *GrokBuild) buildEntry(opts LinkOptions) map[string]any {
 	url := opts.GatewayURL
 	if opts.Port > 0 {
-		url = GatewayHTTPURL(opts.Port)
+		url = gatewayHTTPURLForOpts(opts)
 	}
 	return map[string]any{
 		"url":     url,

--- a/pkg/provisioner/opencode.go
+++ b/pkg/provisioner/opencode.go
@@ -66,7 +66,7 @@ func (o *OpenCode) IsLinked(configPath string, serverName string) (bool, error) 
 func (o *OpenCode) buildEntry(opts LinkOptions) map[string]any {
 	url := opts.GatewayURL
 	if opts.Port > 0 {
-		url = GatewayHTTPURL(opts.Port)
+		url = gatewayHTTPURLForOpts(opts)
 	}
 	return httpConfig(url, "remote")
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -6,6 +6,7 @@ package provisioner
 import (
 	"errors"
 	"fmt"
+	"net/url"
 )
 
 // Sentinel errors for link operations.
@@ -47,6 +48,7 @@ type LinkOptions struct {
 	GatewayURL string // e.g., "http://localhost:8180/sse"
 	Port       int    // Gateway port for HTTP URL construction
 	ServerName string // Key name in config (default: "gridctl")
+	ClientID   string // Stable client identifier embedded as the `client` query param (empty = none)
 	Force      bool   // Overwrite existing entry
 	DryRun     bool   // Show what would change without modifying files
 }
@@ -206,4 +208,30 @@ func GatewayURL(port int) string {
 // GatewayHTTPURL constructs the streamable HTTP gateway URL from a port.
 func GatewayHTTPURL(port int) string {
 	return fmt.Sprintf("http://localhost:%d/mcp", port)
+}
+
+// gatewayHTTPURLForOpts returns the streamable HTTP gateway URL with the stable
+// client identifier embedded as the `client` query parameter when one is set.
+// Used by HTTP-native provisioners that rebuild the URL from the port and would
+// otherwise drop the parameter already present on opts.GatewayURL.
+func gatewayHTTPURLForOpts(opts LinkOptions) string {
+	return AppendClientParam(GatewayHTTPURL(opts.Port), opts.ClientID)
+}
+
+// AppendClientParam adds (or replaces) the `client` query parameter on a gateway
+// URL so the gateway can resolve the connecting client's stable access
+// identifier from the wire. Returns the URL unchanged when clientID is empty or
+// the URL cannot be parsed.
+func AppendClientParam(rawURL, clientID string) string {
+	if clientID == "" {
+		return rawURL
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	q.Set("client", clientID)
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/tests/integration/codemode_cost_test.go
+++ b/tests/integration/codemode_cost_test.go
@@ -63,7 +63,7 @@ func TestCodeMode_CostAttributionThroughSandbox(t *testing.T) {
 	gw.SetToolCallObserver(obs)
 
 	cm := mcp.NewCodeMode(5 * time.Second)
-	tools, err := gw.HandleToolsList()
+	tools, err := gw.HandleToolsListUnscoped()
 	if err != nil {
 		t.Fatalf("HandleToolsList: %v", err)
 	}

--- a/tests/integration/gateway_lifecycle_test.go
+++ b/tests/integration/gateway_lifecycle_test.go
@@ -52,7 +52,7 @@ func TestGatewayRegisterHTTPServer(t *testing.T) {
 		t.Errorf("expected server name 'test-http', got %q", statuses[0].Name)
 	}
 
-	result, err := gw.HandleToolsList()
+	result, err := gw.HandleToolsListUnscoped()
 	if err != nil {
 		t.Fatalf("HandleToolsList: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestGatewayUnregisterServer(t *testing.T) {
 	}
 
 	// Confirm tools visible before unregister.
-	before, err := gw.HandleToolsList()
+	before, err := gw.HandleToolsListUnscoped()
 	if err != nil {
 		t.Fatalf("HandleToolsList (before unregister): %v", err)
 	}
@@ -116,7 +116,7 @@ func TestGatewayUnregisterServer(t *testing.T) {
 		t.Errorf("expected empty Status() after unregister, got %d entries", len(statuses))
 	}
 
-	after, err := gw.HandleToolsList()
+	after, err := gw.HandleToolsListUnscoped()
 	if err != nil {
 		t.Fatalf("HandleToolsList (after unregister): %v", err)
 	}

--- a/tests/integration/per_client_scope_test.go
+++ b/tests/integration/per_client_scope_test.go
@@ -1,0 +1,164 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// TestPerClientScope_EnforcedAcrossPaths is the end-to-end guard for the
+// per-client access model. It runs two real mock MCP servers ("alpha" and
+// "beta"), scopes a client to "alpha" only under default-deny, and asserts the
+// scope holds on every exposure path for two distinct client identities —
+// crucially including the code-mode search/execute surface, which sources its
+// tool universe from the same aggregated set as the direct path and would
+// otherwise be a bypass.
+func TestPerClientScope_EnforcedAcrossPaths(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if mockHTTPServerBin == "" {
+		t.Skip("mock server binary not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	alphaPort := freePort(t)
+	betaPort := freePort(t)
+	startMockServer(t, mockHTTPServerBin, "-port", fmt.Sprintf("%d", alphaPort))
+	startMockServer(t, mockHTTPServerBin, "-port", fmt.Sprintf("%d", betaPort))
+	waitForPort(t, ctx, alphaPort)
+	waitForPort(t, ctx, betaPort)
+
+	gw := mcp.NewGateway()
+	t.Cleanup(func() { gw.Close() })
+
+	for name, port := range map[string]int{"alpha": alphaPort, "beta": betaPort} {
+		cfg := mcp.MCPServerConfig{
+			Name:      name,
+			Transport: mcp.TransportHTTP,
+			Endpoint:  fmt.Sprintf("http://127.0.0.1:%d/mcp", port),
+		}
+		if err := gw.RegisterMCPServer(ctx, cfg); err != nil {
+			t.Fatalf("RegisterMCPServer(%s): %v", name, err)
+		}
+	}
+
+	// cursor is scoped to alpha only; everyone else is denied by default.
+	gw.SetClientAccessPolicy(mcp.NewClientAccessPolicy(&mcp.ClientAccessSpec{
+		Default: "deny",
+		Profiles: map[string]mcp.ClientProfileSpec{
+			"cursor": {Servers: []string{"alpha"}},
+		},
+	}))
+
+	cursorCtx := mcp.WithClientAccessID(ctx, "cursor")
+	windsurfCtx := mcp.WithClientAccessID(ctx, "windsurf") // unlisted -> denied
+
+	// --- Direct path: tools/list (code mode off) ---
+	t.Run("tools_list_scoped", func(t *testing.T) {
+		res, err := gw.HandleToolsList(cursorCtx)
+		if err != nil {
+			t.Fatalf("HandleToolsList: %v", err)
+		}
+		if len(res.Tools) == 0 {
+			t.Fatal("scoped client should see alpha tools, got none")
+		}
+		for _, tool := range res.Tools {
+			if !strings.HasPrefix(tool.Name, "alpha__") {
+				t.Errorf("cursor tools/list leaked out-of-scope tool %q", tool.Name)
+			}
+		}
+
+		// Unlisted client under default-deny sees nothing.
+		res, err = gw.HandleToolsList(windsurfCtx)
+		if err != nil {
+			t.Fatalf("HandleToolsList(windsurf): %v", err)
+		}
+		if len(res.Tools) != 0 {
+			t.Errorf("unlisted client should see no tools, got %d", len(res.Tools))
+		}
+	})
+
+	// --- Direct path: tools/call rejection ---
+	t.Run("tools_call_denied", func(t *testing.T) {
+		res, err := gw.HandleToolsCall(cursorCtx, mcp.ToolCallParams{
+			Name:      "beta__echo",
+			Arguments: map[string]any{"message": "hi"},
+		})
+		if err != nil {
+			t.Fatalf("HandleToolsCall: %v", err)
+		}
+		if !res.IsError || !strings.Contains(res.Content[0].Text, "access scope") {
+			t.Errorf("expected beta__echo to be denied for cursor, got %+v", res.Content)
+		}
+
+		// An in-scope call succeeds against the real downstream server.
+		res, err = gw.HandleToolsCall(cursorCtx, mcp.ToolCallParams{
+			Name:      "alpha__echo",
+			Arguments: map[string]any{"message": "hi"},
+		})
+		if err != nil {
+			t.Fatalf("HandleToolsCall(alpha__echo): %v", err)
+		}
+		if res.IsError {
+			t.Errorf("in-scope alpha__echo should succeed, got %+v", res.Content)
+		}
+	})
+
+	// --- Code-mode path: search universe + execute enforcement ---
+	t.Run("code_mode_universe_scoped", func(t *testing.T) {
+		gw.SetCodeMode(10 * time.Second)
+
+		// search must not reveal beta tools to cursor.
+		res, err := gw.HandleToolsCall(cursorCtx, mcp.ToolCallParams{
+			Name:      mcp.MetaToolSearch,
+			Arguments: map[string]any{"query": ""},
+		})
+		if err != nil {
+			t.Fatalf("code-mode search: %v", err)
+		}
+		if strings.Contains(res.Content[0].Text, "beta__") {
+			t.Errorf("code-mode search leaked beta tools to cursor: %q", res.Content[0].Text)
+		}
+		if !strings.Contains(res.Content[0].Text, "alpha__echo") {
+			t.Errorf("code-mode search should expose in-scope alpha tools: %q", res.Content[0].Text)
+		}
+
+		// execute calling an out-of-scope tool is blocked inside the sandbox
+		// because the scoped universe excludes it.
+		denied, err := gw.HandleToolsCall(cursorCtx, mcp.ToolCallParams{
+			Name: mcp.MetaToolExecute,
+			Arguments: map[string]any{
+				"code": `(async () => { return await mcp.callTool("beta", "echo", {message: "x"}); })()`,
+			},
+		})
+		if err != nil {
+			t.Fatalf("code-mode execute(beta): %v", err)
+		}
+		if !denied.IsError || !strings.Contains(denied.Content[0].Text, "access denied") {
+			t.Errorf("expected code-mode beta call to be denied, got %+v", denied.Content)
+		}
+
+		// execute calling an in-scope tool succeeds end-to-end.
+		ok, err := gw.HandleToolsCall(cursorCtx, mcp.ToolCallParams{
+			Name: mcp.MetaToolExecute,
+			Arguments: map[string]any{
+				"code": `(async () => { return await mcp.callTool("alpha", "echo", {message: "ok"}); })()`,
+			},
+		})
+		if err != nil {
+			t.Fatalf("code-mode execute(alpha): %v", err)
+		}
+		if ok.IsError {
+			t.Errorf("in-scope code-mode alpha call should succeed, got %+v", ok.Content)
+		}
+	})
+}

--- a/tests/integration/replica_stackless_mode_test.go
+++ b/tests/integration/replica_stackless_mode_test.go
@@ -89,7 +89,7 @@ func TestReplicas_StacklessMode(t *testing.T) {
 
 	// A single server name — tool list must not leak replica ids into the
 	// prefix. Every tool is exposed as "<serverName>__<tool>".
-	toolsRes, err := gw.HandleToolsList()
+	toolsRes, err := gw.HandleToolsListUnscoped()
 	if err != nil {
 		t.Fatalf("HandleToolsList: %v", err)
 	}


### PR DESCRIPTION
## Description

Adds a real per-client tool access model to the gateway: an optional top-level `clients:` block in `stack.yaml` restricts which servers and tools each connecting client can reach, enforced at a single chokepoint across every exposure path. This is PR 3 of 4 for per-client access scoping; it delivers the security-critical backend (the visualization PRs #743/#744 already shipped; wiring the viz to real scope + editing UI is PR 4).

## Type of Change

- [x] New feature (backend, security-sensitive)

## Changes Made

- **`clients:` config block** with Kubernetes NetworkPolicy semantics: absent block = legacy "every client sees everything" (Article IX); present block restricts profiles to their `servers:`/`tools:` allow-list, and unlisted clients are governed by `default:` (`deny` unless `allow`). Unknown server/tool references fail config validation.
- **Single scope chokepoint** applied to `tools/list`, `tools/call` rejection, **and the code-mode search/execute tool universe** — a scoped client cannot reach a denied tool via code mode. Operator-facing views (web console, optimize) use an explicit unscoped accessor.
- **Stable client identity** reconciled across wire, config, and UI: resolved at initialize from `?client=` / `X-Gridctl-Client-Id` (assigned by `gridctl link --client-id`), then config `aliases:`, then normalized `clientInfo.name` as fallback.
- **Hot-reload contract**: scope is re-resolved from live config each request, so a `clients:` change applies to subsequent calls including existing sessions.
- **Effective-scope API**: `/api/clients` returns each client's backend-computed servers/tools.
- Documented v1 decisions: scope covers **tools only** (skills/resources stay global); the identifier is self-declared (least-privilege guardrail, not auth).

## Testing

- Exhaustive table-driven filter tests (listed/unlisted, server/tool-level, unknown-ref, default allow/deny, empty-no-block, alias/normalization).
- Identity reconciliation tests (query/header/fallback precedence, wire vs config).
- Gateway chokepoint + operator-bypass tests.
- Real-runtime integration test (`-race`) with two client identities asserting tools/list scoping, tools/call denial, and the code-mode bypass guard.
- `make test`, `make test-frontend`, `go build ./...`, `golangci-lint` (0 issues), and `gridctl validate` (exit 1 on bad config) all pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #742