### PR TITLE
feat: wire topology to per-client scope + access editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Per-client access in the topology and Tools workspace.** The topology view
+  now reflects each client's real access: clicking a client highlights only the
+  servers and tools its configured scope can reach, fading everything else
+  (a client scoped to nothing shows it reaching the gateway and stopping there).
+  A new "Access" button in the Tools workspace opens a per-client editor that
+  sets which servers each linked client may reach and writes the result to the
+  `clients:` block in stack.yaml via an atomic, conflict-detected write
+  (`PUT /api/clients/{slug}/scope`), triggering a hot reload. Saving the first
+  profile warns that it creates the `clients:` block and flips unlisted clients
+  to deny-by-default. The `/api/clients` response carries each client's
+  effective scope. (Tool-level allow-lists remain enforced and editable directly
+  in stack.yaml.)
+
 - **Per-client access scoping (`clients:` block).** A new optional top-level
   `clients:` block in `stack.yaml` lets an operator restrict which servers and
   tools each connecting client can reach, following Kubernetes NetworkPolicy

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -268,10 +268,55 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/clients
     "detected": true,
     "linked": true,
     "transport": "sse",
-    "configPath": "/Users/user/Library/Application Support/Claude/claude_desktop_config.json"
+    "configPath": "/Users/user/Library/Application Support/Claude/claude_desktop_config.json",
+    "effectiveScope": {
+      "configured": true,
+      "unscoped": false,
+      "servers": ["github"],
+      "tools": ["github__search-repos", "github__create-issue"]
+    }
   }
 ]
 ```
+
+`effectiveScope` is the backend-computed per-client access scope when a
+`clients:` block is configured (servers and prefixed tools the client can
+reach). It is absent when no scoping is in effect.
+
+#### `PUT /api/clients/{slug}/scope`
+
+Sets a client's server-level access profile in the `clients:` block of the live
+stack YAML and triggers a hot reload. The slug is normalized to the stable
+profile key used for enforcement. The write is atomic and conflict-detected.
+
+**Auth:** Yes
+
+```bash
+curl -X PUT -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"servers": ["github"], "tools": []}' \
+  http://localhost:8180/api/clients/cursor/scope
+```
+
+**Request body:** `servers` and `tools` are allow-lists; an empty `tools`
+leaves the client unrestricted within its allowed servers.
+
+**Response (200):**
+```json
+{
+  "client": "cursor",
+  "profileKey": "cursor",
+  "servers": ["github"],
+  "tools": [],
+  "reloaded": true,
+  "reloadedAt": "2026-05-29T17:00:00Z"
+}
+```
+
+**Errors:** `422` (`unknown_server`/`unknown_tool`) when the scope references a
+server or tool the gateway does not know; `409` (`stack_modified`) when the
+stack file changed on disk since it was read; `502` (`reload_failed`) when the
+write succeeded but the hot reload failed.
 
 ---
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -696,6 +696,18 @@ The gateway re-resolves each client's scope from the live configuration on every
 watch or `POST /api/reload`) therefore takes effect on the next request,
 including for already-established sessions — no restart required.
 
+### Editing in the web UI
+
+The Tools workspace has an **Access** button that opens a per-client editor:
+pick which servers each linked client may reach and save. This writes a
+server-level profile (`servers:` allow-list) to the `clients:` block via an
+atomic, conflict-detected write and triggers a hot reload, so the topology view
+then reflects the new scope on the next poll. Saving the first profile creates
+the `clients:` block, which flips clients you have not listed to the `default:`
+policy (deny); the editor warns before that happens. Finer tool-level
+allow-lists (`tools:`) are enforced by the gateway but edited directly in
+stack.yaml.
+
 ---
 
 ## Skill Sources

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -242,6 +242,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/optimize", s.handleOptimize)
 	mux.HandleFunc("GET /api/traces", s.handleTraces)
 	mux.HandleFunc("GET /api/traces/{traceId}", s.handleTraces)
+	mux.HandleFunc("PUT /api/clients/{slug}/scope", s.handleSetClientScope)
 	mux.HandleFunc("/api/clients", s.handleClients)
 	mux.HandleFunc("/api/reload", s.handleReload)
 	mux.HandleFunc("/health", s.handleHealth)

--- a/internal/api/clients.go
+++ b/internal/api/clients.go
@@ -1,0 +1,202 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+const (
+	// errCodeUnknownServer is returned on 422 when a client scope references a
+	// server that the gateway does not know about.
+	errCodeUnknownServer = "unknown_server"
+	// errCodeInvalidClient is returned on 400 when the client identifier
+	// normalizes to an empty profile key.
+	errCodeInvalidClient = "invalid_client"
+)
+
+// setClientScopeRequest is the wire shape for PUT /api/clients/{slug}/scope.
+// Both fields are allow-lists; nil or empty means "no restriction on this axis"
+// (an empty profile sees every tool, per the clients: block semantics).
+type setClientScopeRequest struct {
+	Servers *[]string `json:"servers"`
+	Tools   *[]string `json:"tools"`
+}
+
+// setClientScopeResponse is the success payload.
+type setClientScopeResponse struct {
+	Client     string   `json:"client"`
+	ProfileKey string   `json:"profileKey"`
+	Servers    []string `json:"servers"`
+	Tools      []string `json:"tools"`
+	Reloaded   bool     `json:"reloaded"`
+	ReloadedAt string   `json:"reloadedAt,omitempty"`
+}
+
+// handleSetClientScope writes a single client's access profile (allowed servers
+// and/or tools) into the live stack YAML's `clients:` block and triggers a hot
+// reload. The profile key is the client's stable identifier, normalized the
+// same way enforcement normalizes it so the written profile matches the key the
+// gateway scopes on. The YAML write is atomic and conflict-detected: an external
+// edit between read and write surfaces as 409 so the UI can re-fetch.
+//
+// PUT /api/clients/{slug}/scope
+func (s *Server) handleSetClientScope(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	if slug == "" {
+		writeJSONError(w, "Client slug is required", http.StatusBadRequest)
+		return
+	}
+	profileKey := mcp.NormalizeClientID(slug)
+	if profileKey == "" {
+		writeStructuredError(w, http.StatusBadRequest, errCodeInvalidClient,
+			"Client identifier is empty after normalization.",
+			"Provide a non-empty client slug.")
+		return
+	}
+
+	if s.stackFile == "" {
+		writeJSONError(w, "No stack file configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, setToolsRequestMaxBytes))
+	if err != nil {
+		writeJSONError(w, "Failed to read request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	var req setClientScopeRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if req.Servers == nil && req.Tools == nil {
+		writeJSONError(w, "Request must set servers and/or tools", http.StatusBadRequest)
+		return
+	}
+	// Each axis is tri-state: a present array replaces it, an absent one leaves
+	// it untouched (so a server-only edit preserves an operator's tool list).
+	servers := normalizeScopeAxis(req.Servers)
+	tools := normalizeScopeAxis(req.Tools)
+	for _, v := range append(append([]string{}, derefStrings(servers)...), derefStrings(tools)...) {
+		if v == "" {
+			writeJSONError(w, "Server and tool names must be non-empty strings", http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Validate the provided allow-lists against the live tool surface so a stale
+	// UI cannot persist a reference to a server or tool that does not exist.
+	if code, msg := s.validateClientScope(derefStrings(servers), derefStrings(tools)); code != "" {
+		writeStructuredError(w, http.StatusUnprocessableEntity, code, msg,
+			"Refresh the workspace to pick up the current servers and tools, then try again.")
+		return
+	}
+
+	switch err := setClientScope(s.stackFile, profileKey, servers, tools); {
+	case err == nil:
+		// proceed
+	case errors.Is(err, errStackModified):
+		writeStructuredError(w, http.StatusConflict, errCodeStackModified,
+			"The stack file was modified outside the canvas.",
+			"Reload the file to see the latest contents, then re-apply your changes.")
+		return
+	default:
+		slog.Default().Warn("client scope write failed", "client", profileKey, "error", err)
+		writeJSONError(w, "Failed to update stack: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	slog.Default().Info("client access scope updated", "client", profileKey,
+		"servers", len(derefStrings(servers)), "tools", len(derefStrings(tools)))
+
+	resp := setClientScopeResponse{
+		Client:     slug,
+		ProfileKey: profileKey,
+		Servers:    derefStrings(servers),
+		Tools:      derefStrings(tools),
+	}
+
+	if s.reloadHandler != nil {
+		result, err := s.reloadHandler.Reload(r.Context())
+		if err != nil {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed, err.Error(),
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+		if !result.Success {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed, result.Message,
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+		resp.Reloaded = true
+		resp.ReloadedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	writeJSON(w, resp)
+}
+
+// validateClientScope checks the requested servers and tools against the live
+// gateway surface. Returns an empty code when the scope is valid, otherwise a
+// structured error code and message identifying the first offending reference.
+func (s *Server) validateClientScope(servers, tools []string) (code, message string) {
+	if s.gateway == nil {
+		return "", ""
+	}
+
+	knownServers := make(map[string]bool)
+	for _, st := range s.gateway.Status() {
+		knownServers[st.Name] = true
+	}
+	for _, srv := range servers {
+		if !knownServers[srv] {
+			return errCodeUnknownServer, fmt.Sprintf("Unknown MCP server %q", srv)
+		}
+	}
+
+	if len(tools) == 0 {
+		return "", ""
+	}
+	knownTools := make(map[string]bool)
+	if catalog, err := s.gateway.HandleToolsCatalog(); err == nil && catalog != nil {
+		for _, t := range catalog.Tools {
+			knownTools[t.Name] = true
+		}
+	}
+	for _, t := range tools {
+		if !knownTools[t] {
+			return errCodeUnknownTool, fmt.Sprintf("Unknown tool %q", t)
+		}
+	}
+	return "", ""
+}
+
+// normalizeScopeAxis canonicalizes a tri-state allow-list axis: nil stays nil
+// (leave the axis untouched), while a present slice is copied and sorted for
+// deterministic YAML output. A non-nil empty slice is preserved (it means
+// "replace with no restriction").
+func normalizeScopeAxis(p *[]string) *[]string {
+	if p == nil {
+		return nil
+	}
+	out := append([]string{}, *p...)
+	sort.Strings(out)
+	return &out
+}
+
+// derefStrings returns the slice value of a possibly-nil *[]string (nil -> []),
+// for validation and response echoing.
+func derefStrings(p *[]string) []string {
+	if p == nil || *p == nil {
+		return []string{}
+	}
+	return *p
+}

--- a/internal/api/clients_edit.go
+++ b/internal/api/clients_edit.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// setClientScope writes the per-client access profile (servers/tools allow-list)
+// for profileKey into the stack YAML at path. It mirrors setServerTools: it
+// serializes concurrent callers on the same path, detects external edits via a
+// pre-read hash vs. pre-write re-read, and writes atomically.
+//
+// servers and tools are each tri-state: a nil pointer leaves that axis of the
+// profile untouched (so a server-only edit never clobbers an operator-authored
+// tool allow-list), while a non-nil pointer replaces it (an empty slice drops
+// the key, which per config semantics means "no restriction on that axis").
+//
+// The update is a yaml.Node round-trip so comments, ordering, sibling profiles,
+// clients.default, and unrelated keys all survive (Article IX). Returns
+// errStackModified when the file changed between the initial read and the
+// write, or a wrapped error on parse/IO failure.
+func setClientScope(path, profileKey string, servers, tools *[]string) error {
+	if path == "" {
+		return errStackFileEmpty
+	}
+
+	mu := stackFileLock(path)
+	mu.Lock()
+	defer mu.Unlock()
+
+	original, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read stack file: %w", err)
+	}
+	originalHash := sha256.Sum256(original)
+
+	updated, err := patchClientScope(original, profileKey, servers, tools)
+	if err != nil {
+		return err
+	}
+
+	fireBetweenReadsHook()
+
+	current, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("re-read stack file: %w", err)
+	}
+	if sha256.Sum256(current) != originalHash {
+		return errStackModified
+	}
+
+	return atomicWrite(path, updated)
+}
+
+// patchClientScope rewrites the YAML source so that
+// clients.profiles.<profileKey> carries the given servers and tools allow-lists.
+// It creates the `clients:` mapping, its `profiles:` mapping, and the profile
+// entry on demand without disturbing any existing keys (clients.default, other
+// profiles, profile aliases).
+//
+// servers and tools are tri-state: a nil pointer leaves that axis untouched, so
+// a server-only edit preserves an operator-authored tool allow-list. A non-nil
+// pointer replaces the axis; an empty slice drops the key (per config
+// semantics, "no restriction on that axis").
+func patchClientScope(source []byte, profileKey string, servers, tools *[]string) ([]byte, error) {
+	if profileKey == "" {
+		return nil, fmt.Errorf("client profile key must not be empty")
+	}
+	if servers == nil && tools == nil {
+		return nil, fmt.Errorf("at least one of servers or tools must be set")
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(source, &root); err != nil {
+		return nil, fmt.Errorf("parse stack yaml: %w", err)
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil, fmt.Errorf("parse stack yaml: not a document")
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse stack yaml: top-level not a mapping")
+	}
+
+	clientsNode, err := ensureChildMapping(doc, "clients")
+	if err != nil {
+		return nil, err
+	}
+	profilesNode, err := ensureChildMapping(clientsNode, "profiles")
+	if err != nil {
+		return nil, err
+	}
+	profileNode, err := ensureChildMapping(profilesNode, profileKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if servers != nil {
+		replaceOrInsertStringSeq(profileNode, "servers", *servers)
+	}
+	if tools != nil {
+		replaceOrInsertStringSeq(profileNode, "tools", *tools)
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// scalarNode builds a plain string scalar node.
+func scalarNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+}
+
+// ensureChildMapping returns the mapping node at parent[key], creating it when
+// absent and replacing an explicit-null value (e.g. a bare `clients:` line)
+// with a fresh mapping. It errors when the key holds a non-null, non-mapping
+// value so a malformed block is reported rather than silently overwritten.
+func ensureChildMapping(parent *yaml.Node, key string) (*yaml.Node, error) {
+	existing := findMappingValue(parent, key)
+	if existing != nil {
+		if existing.Kind == yaml.MappingNode {
+			return existing, nil
+		}
+		// A bare `key:` parses to a null scalar; replace it with a mapping.
+		if existing.Kind == yaml.ScalarNode && (existing.Tag == "!!null" || existing.Value == "") {
+			existing.Kind = yaml.MappingNode
+			existing.Tag = "!!map"
+			existing.Value = ""
+			existing.Content = nil
+			return existing, nil
+		}
+		return nil, fmt.Errorf("%s is not a mapping", key)
+	}
+	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	parent.Content = append(parent.Content, scalarNode(key), node)
+	return node, nil
+}
+
+// replaceOrInsertStringSeq sets mapping[key] to a block sequence of values,
+// replacing an existing sequence or appending the key. An empty values slice
+// removes the key entirely (so an empty allow-list is expressed as the absence
+// of the field, matching the per-server tools: convention).
+func replaceOrInsertStringSeq(mapping *yaml.Node, key string, values []string) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			if len(values) == 0 {
+				mapping.Content = append(mapping.Content[:i], mapping.Content[i+2:]...)
+				return
+			}
+			mapping.Content[i+1] = toolsSequenceNode(values)
+			return
+		}
+	}
+	if len(values) == 0 {
+		return
+	}
+	mapping.Content = append(mapping.Content, scalarNode(key), toolsSequenceNode(values))
+}

--- a/internal/api/clients_edit_test.go
+++ b/internal/api/clients_edit_test.go
@@ -1,0 +1,277 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/gridctl/gridctl/pkg/config"
+)
+
+const clientsStack = `version: "1"
+name: example
+network:
+  name: example-net
+mcp-servers:
+  - name: github
+    url: https://api.github.com/mcp
+    transport: http
+    env:
+      GITHUB_TOKEN: "${vault:GITHUB_TOKEN}" # do not expand on write
+  - name: gitlab
+    image: gridctl/gitlab:latest
+    port: 3100
+clients:
+  default: deny
+  profiles:
+    cursor:
+      servers:
+        - github
+    team-bot:
+      aliases:
+        - "Custom Agent" # keep this comment
+      servers:
+        - gitlab
+      tools:
+        - gitlab__list-issues
+`
+
+// sp returns a pointer to a string slice, for the tri-state patch axes.
+func sp(v ...string) *[]string {
+	s := append([]string{}, v...)
+	return &s
+}
+
+// parseClients round-trips patched YAML back into a Stack for assertions.
+func parseClients(t *testing.T, out []byte) *config.Stack {
+	t.Helper()
+	var stack config.Stack
+	require.NoError(t, yaml.Unmarshal(out, &stack))
+	return &stack
+}
+
+func TestPatchClientScope_CreatesBlockWhenAbsent(t *testing.T) {
+	src := `version: "1"
+name: example
+network:
+  name: example-net
+mcp-servers:
+  - name: github
+    url: https://api.github.com/mcp
+    transport: http
+`
+	out, err := patchClientScope([]byte(src), "cursor", sp("github"), sp("github__search-repos"))
+	require.NoError(t, err)
+
+	stack := parseClients(t, out)
+	require.NotNil(t, stack.Clients)
+	prof, ok := stack.Clients.Profiles["cursor"]
+	require.True(t, ok, "cursor profile should be created")
+	assert.Equal(t, []string{"github"}, prof.Servers)
+	assert.Equal(t, []string{"github__search-repos"}, prof.Tools)
+	assert.Contains(t, string(out), "name: github")
+}
+
+func TestPatchClientScope_UpdatesProfileWithoutClobberingSiblings(t *testing.T) {
+	out, err := patchClientScope([]byte(clientsStack), "cursor", sp("github", "gitlab"), nil)
+	require.NoError(t, err)
+
+	stack := parseClients(t, out)
+	assert.ElementsMatch(t, []string{"github", "gitlab"}, stack.Clients.Profiles["cursor"].Servers)
+	// Sibling profile + its alias + tools + default untouched.
+	assert.Equal(t, "deny", stack.Clients.Default)
+	teamBot := stack.Clients.Profiles["team-bot"]
+	assert.Equal(t, []string{"gitlab"}, teamBot.Servers)
+	assert.Equal(t, []string{"Custom Agent"}, teamBot.Aliases)
+	assert.Equal(t, []string{"gitlab__list-issues"}, teamBot.Tools)
+	// Comments + vault ref preserved (Article IX round-trip).
+	s := string(out)
+	assert.Contains(t, s, "keep this comment")
+	assert.Contains(t, s, `GITHUB_TOKEN: "${vault:GITHUB_TOKEN}"`)
+	assert.Contains(t, s, "do not expand on write")
+}
+
+// The key regression for the server-level editor: editing a tool-scoped
+// profile's servers (tools axis nil) must NOT wipe its tool allow-list.
+func TestPatchClientScope_ServerOnlyEditPreservesTools(t *testing.T) {
+	out, err := patchClientScope([]byte(clientsStack), "team-bot", sp("github", "gitlab"), nil)
+	require.NoError(t, err)
+	stack := parseClients(t, out)
+	teamBot := stack.Clients.Profiles["team-bot"]
+	assert.ElementsMatch(t, []string{"github", "gitlab"}, teamBot.Servers)
+	assert.Equal(t, []string{"gitlab__list-issues"}, teamBot.Tools, "tool allow-list must survive a server-only edit")
+}
+
+func TestPatchClientScope_ToolsOnlyEditPreservesServers(t *testing.T) {
+	out, err := patchClientScope([]byte(clientsStack), "cursor", nil, sp("github__search-repos"))
+	require.NoError(t, err)
+	stack := parseClients(t, out)
+	assert.Equal(t, []string{"github"}, stack.Clients.Profiles["cursor"].Servers, "server list must survive a tools-only edit")
+	assert.Equal(t, []string{"github__search-repos"}, stack.Clients.Profiles["cursor"].Tools)
+}
+
+func TestPatchClientScope_EmptyAxisDropsKey(t *testing.T) {
+	// A present empty slice replaces the axis by dropping the key (no
+	// restriction), distinct from nil which leaves it untouched.
+	out, err := patchClientScope([]byte(clientsStack), "team-bot", sp("gitlab"), sp())
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "gitlab__list-issues", "empty tools slice should drop the tools key")
+	stack := parseClients(t, out)
+	assert.Empty(t, stack.Clients.Profiles["team-bot"].Tools)
+	assert.Equal(t, []string{"gitlab"}, stack.Clients.Profiles["team-bot"].Servers)
+}
+
+func TestPatchClientScope_AddsNewProfileToExistingBlock(t *testing.T) {
+	out, err := patchClientScope([]byte(clientsStack), "windsurf", sp("gitlab"), nil)
+	require.NoError(t, err)
+	stack := parseClients(t, out)
+	assert.Len(t, stack.Clients.Profiles, 3)
+	assert.Equal(t, []string{"gitlab"}, stack.Clients.Profiles["windsurf"].Servers)
+	assert.Equal(t, []string{"github"}, stack.Clients.Profiles["cursor"].Servers)
+}
+
+func TestPatchClientScope_CreatesBlockFromBareNullNode(t *testing.T) {
+	src := `version: "1"
+name: example
+network:
+  name: example-net
+mcp-servers:
+  - name: github
+    url: https://api.github.com/mcp
+    transport: http
+clients:
+`
+	out, err := patchClientScope([]byte(src), "cursor", sp("github"), nil)
+	require.NoError(t, err)
+	stack := parseClients(t, out)
+	require.NotNil(t, stack.Clients)
+	assert.Equal(t, []string{"github"}, stack.Clients.Profiles["cursor"].Servers)
+}
+
+func TestPatchClientScope_EmptyKeyErrors(t *testing.T) {
+	_, err := patchClientScope([]byte(clientsStack), "", sp("github"), nil)
+	assert.Error(t, err)
+}
+
+func TestPatchClientScope_BothAxesNilErrors(t *testing.T) {
+	_, err := patchClientScope([]byte(clientsStack), "cursor", nil, nil)
+	assert.Error(t, err)
+}
+
+func TestPatchClientScope_PatchedStackPassesValidation(t *testing.T) {
+	out, err := patchClientScope([]byte(clientsStack), "windsurf", sp("github"), sp("github__search-repos"))
+	require.NoError(t, err)
+	stack := parseClients(t, out)
+	assert.NoError(t, config.Validate(stack))
+}
+
+// newClientScopeHarness writes a stack with a clients block and returns a
+// Server wired to it (no gateway, so scope validation is skipped).
+func newClientScopeHarness(t *testing.T) (string, *Server) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(clientsStack), 0o600))
+	s := &Server{}
+	s.SetStackFile(path)
+	return path, s
+}
+
+func TestHandleSetClientScope_HappyPath_NoReload(t *testing.T) {
+	path, s := newClientScopeHarness(t)
+
+	body, _ := json.Marshal(map[string]any{"servers": []string{"github", "gitlab"}})
+	req := httptest.NewRequest(http.MethodPut, "/api/clients/cursor/scope", strings.NewReader(string(body)))
+	req.SetPathValue("slug", "cursor")
+	w := httptest.NewRecorder()
+
+	s.handleSetClientScope(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp setClientScopeResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "cursor", resp.ProfileKey)
+	assert.False(t, resp.Reloaded)
+
+	out, _ := os.ReadFile(path)
+	stack := parseClients(t, out)
+	assert.ElementsMatch(t, []string{"github", "gitlab"}, stack.Clients.Profiles["cursor"].Servers)
+}
+
+// A server-only request (no tools key) must preserve an existing tool list.
+func TestHandleSetClientScope_ServerOnlyPreservesTools(t *testing.T) {
+	path, s := newClientScopeHarness(t)
+
+	body, _ := json.Marshal(map[string]any{"servers": []string{"github", "gitlab"}})
+	req := httptest.NewRequest(http.MethodPut, "/api/clients/team-bot/scope", strings.NewReader(string(body)))
+	req.SetPathValue("slug", "team-bot")
+	w := httptest.NewRecorder()
+
+	s.handleSetClientScope(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	out, _ := os.ReadFile(path)
+	stack := parseClients(t, out)
+	assert.Equal(t, []string{"gitlab__list-issues"}, stack.Clients.Profiles["team-bot"].Tools)
+}
+
+func TestHandleSetClientScope_NormalizesSlugToProfileKey(t *testing.T) {
+	path, s := newClientScopeHarness(t)
+
+	body, _ := json.Marshal(map[string]any{"servers": []string{"github"}})
+	req := httptest.NewRequest(http.MethodPut, "/api/clients/Claude%20Code/scope", strings.NewReader(string(body)))
+	req.SetPathValue("slug", "Claude Code")
+	w := httptest.NewRecorder()
+
+	s.handleSetClientScope(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	out, _ := os.ReadFile(path)
+	stack := parseClients(t, out)
+	_, ok := stack.Clients.Profiles["claude-code"]
+	assert.True(t, ok, "slug should normalize to claude-code profile key")
+}
+
+func TestHandleSetClientScope_ConflictOnExternalEdit(t *testing.T) {
+	path, s := newClientScopeHarness(t)
+
+	swapBetweenReadsHook(func() {
+		_ = os.WriteFile(path, []byte(clientsStack+"\n# external edit\n"), 0o600)
+	})
+	defer swapBetweenReadsHook(nil)
+
+	body, _ := json.Marshal(map[string]any{"servers": []string{"github"}})
+	req := httptest.NewRequest(http.MethodPut, "/api/clients/cursor/scope", strings.NewReader(string(body)))
+	req.SetPathValue("slug", "cursor")
+	w := httptest.NewRecorder()
+
+	s.handleSetClientScope(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), errCodeStackModified)
+}
+
+func TestHandleSetClientScope_RejectsEmptySlug(t *testing.T) {
+	_, s := newClientScopeHarness(t)
+	req := httptest.NewRequest(http.MethodPut, "/api/clients//scope", strings.NewReader(`{"servers":["github"]}`))
+	req.SetPathValue("slug", "")
+	w := httptest.NewRecorder()
+	s.handleSetClientScope(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleSetClientScope_RejectsEmptyBody(t *testing.T) {
+	_, s := newClientScopeHarness(t)
+	req := httptest.NewRequest(http.MethodPut, "/api/clients/cursor/scope", strings.NewReader(`{}`))
+	req.SetPathValue("slug", "cursor")
+	w := httptest.NewRecorder()
+	s.handleSetClientScope(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/web/src/__tests__/useClientScopeEditor.test.ts
+++ b/web/src/__tests__/useClientScopeEditor.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  useClientScopeEditor,
+  baselineServers,
+} from '../hooks/useClientScopeEditor';
+import type { ClientStatus } from '../types';
+import * as apiModule from '../lib/api';
+import { ClientScopeError } from '../lib/api';
+
+vi.mock('../components/ui/Toast', () => ({ showToast: vi.fn() }));
+
+const mockStoreState = {
+  setClients: vi.fn(),
+  setGatewayStatus: vi.fn(),
+};
+
+vi.mock('../stores/useStackStore', () => ({
+  useStackStore: Object.assign(vi.fn(), { getState: () => mockStoreState }),
+}));
+
+const ALL_SERVERS = ['github', 'gitlab', 'atlassian'];
+
+function client(scope?: ClientStatus['effectiveScope']): ClientStatus {
+  return {
+    name: 'Cursor',
+    slug: 'cursor',
+    detected: true,
+    linked: true,
+    transport: 'native SSE',
+    effectiveScope: scope,
+  };
+}
+
+beforeEach(() => {
+  mockStoreState.setClients.mockReset();
+  mockStoreState.setGatewayStatus.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe('baselineServers', () => {
+  it('returns all servers for an unscoped (no-block) client', () => {
+    expect(baselineServers(client(undefined), ALL_SERVERS)).toEqual([
+      'atlassian',
+      'github',
+      'gitlab',
+    ]);
+  });
+
+  it('returns all servers when the scope is configured but unscoped', () => {
+    const c = client({ configured: true, unscoped: true, servers: [], tools: [] });
+    expect(baselineServers(c, ALL_SERVERS)).toEqual(['atlassian', 'github', 'gitlab']);
+  });
+
+  it('returns the scoped servers for a narrowed client', () => {
+    const c = client({ configured: true, unscoped: false, servers: ['github'], tools: [] });
+    expect(baselineServers(c, ALL_SERVERS)).toEqual(['github']);
+  });
+
+  it('returns nothing for a default-deny unlisted client', () => {
+    const c = client({ configured: true, unscoped: false, servers: [], tools: [] });
+    expect(baselineServers(c, ALL_SERVERS)).toEqual([]);
+  });
+});
+
+describe('useClientScopeEditor', () => {
+  it('seeds the selection from the client baseline and is not dirty', () => {
+    const c = client({ configured: true, unscoped: false, servers: ['github'], tools: [] });
+    const { result } = renderHook(() => useClientScopeEditor(c, ALL_SERVERS));
+    expect([...result.current.selected].sort()).toEqual(['github']);
+    expect(result.current.dirty).toBe(false);
+  });
+
+  it('marks createsBlock when no clients block is configured yet', () => {
+    const { result } = renderHook(() => useClientScopeEditor(client(undefined), ALL_SERVERS));
+    expect(result.current.createsBlock).toBe(true);
+  });
+
+  it('becomes dirty on toggle and clears when reverted', () => {
+    const c = client({ configured: true, unscoped: false, servers: ['github'], tools: [] });
+    const { result } = renderHook(() => useClientScopeEditor(c, ALL_SERVERS));
+
+    act(() => result.current.toggle('gitlab'));
+    expect(result.current.dirty).toBe(true);
+    expect(result.current.selected.has('gitlab')).toBe(true);
+
+    act(() => result.current.toggle('gitlab'));
+    expect(result.current.dirty).toBe(false);
+  });
+
+  it('saves the selected servers as a server-level profile and refreshes', async () => {
+    const c = client({ configured: true, unscoped: false, servers: ['github'], tools: [] });
+    const update = vi
+      .spyOn(apiModule, 'updateClientScope')
+      .mockResolvedValue({
+        client: 'cursor',
+        profileKey: 'cursor',
+        servers: ['github', 'gitlab'],
+        tools: [],
+        reloaded: true,
+      });
+    vi.spyOn(apiModule, 'fetchClients').mockResolvedValue([]);
+    vi.spyOn(apiModule, 'fetchStatus').mockResolvedValue({} as never);
+
+    const { result } = renderHook(() => useClientScopeEditor(c, ALL_SERVERS));
+    act(() => result.current.toggle('gitlab'));
+    await act(async () => {
+      await result.current.save();
+    });
+
+    // The server-level editor omits the tools axis so an existing tool
+    // allow-list on the profile is preserved.
+    expect(update).toHaveBeenCalledWith('cursor', { servers: ['github', 'gitlab'] });
+    await waitFor(() => expect(mockStoreState.setClients).toHaveBeenCalled());
+  });
+
+  it('cannot save with zero servers selected (empty means all, not none)', () => {
+    const c = client({ configured: true, unscoped: false, servers: ['github'], tools: [] });
+    const { result } = renderHook(() => useClientScopeEditor(c, ALL_SERVERS));
+    act(() => result.current.clearAll());
+    expect(result.current.selected.size).toBe(0);
+    expect(result.current.dirty).toBe(true);
+    expect(result.current.canSave).toBe(false);
+  });
+
+  it('surfaces a 409 conflict instead of throwing', async () => {
+    const c = client({ configured: true, unscoped: false, servers: ['github'], tools: [] });
+    vi.spyOn(apiModule, 'updateClientScope').mockRejectedValue(
+      new ClientScopeError('stack_modified', 'changed on disk', 'reload it', 409),
+    );
+
+    const { result } = renderHook(() => useClientScopeEditor(c, ALL_SERVERS));
+    act(() => result.current.toggle('gitlab'));
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(result.current.conflict).toBeTruthy();
+    expect(result.current.isSaving).toBe(false);
+  });
+});

--- a/web/src/__tests__/usePathHighlight.test.ts
+++ b/web/src/__tests__/usePathHighlight.test.ts
@@ -196,6 +196,104 @@ describe('computeHighlightState with expanded tool fan-out', () => {
   });
 });
 
+describe('computeHighlightState with per-client effective scope', () => {
+  // client-a reaches servers x and y at the gateway, each with tools. The
+  // client's effectiveScope narrows what is actually highlighted.
+  function makeScopedGraph(scope: unknown): { nodes: Node[]; edges: Edge[] } {
+    const nodes: Node[] = [
+      { id: 'client-a', position: { x: 0, y: 0 }, data: { type: 'client', effectiveScope: scope } },
+      { id: 'gateway', position: { x: 0, y: 0 }, data: { type: 'gateway' } },
+      { id: 'mcp-x', position: { x: 0, y: 0 }, data: { type: 'mcp-server', name: 'x' } },
+      { id: 'mcp-y', position: { x: 0, y: 0 }, data: { type: 'mcp-server', name: 'y' } },
+      { id: 'tool-mcp-x-search', position: { x: 0, y: 0 }, data: { type: 'tool', serverNodeId: 'mcp-x', serverName: 'x', name: 'search' } },
+      { id: 'tool-mcp-x-write', position: { x: 0, y: 0 }, data: { type: 'tool', serverNodeId: 'mcp-x', serverName: 'x', name: 'write' } },
+      { id: 'tool-mcp-y-read', position: { x: 0, y: 0 }, data: { type: 'tool', serverNodeId: 'mcp-y', serverName: 'y', name: 'read' } },
+    ];
+    const edges: Edge[] = [
+      { id: 'e-c-g', source: 'client-a', target: 'gateway', data: { relationType: 'client-to-gateway', isHighlightable: true } },
+      { id: 'e-g-x', source: 'gateway', target: 'mcp-x', data: { relationType: 'gateway-to-server', isHighlightable: true } },
+      { id: 'e-g-y', source: 'gateway', target: 'mcp-y', data: { relationType: 'gateway-to-server', isHighlightable: true } },
+      { id: 'e-x-search', source: 'mcp-x', target: 'tool-mcp-x-search', data: { relationType: 'server-to-tool', isHighlightable: false } },
+      { id: 'e-x-write', source: 'mcp-x', target: 'tool-mcp-x-write', data: { relationType: 'server-to-tool', isHighlightable: false } },
+      { id: 'e-y-read', source: 'mcp-y', target: 'tool-mcp-y-read', data: { relationType: 'server-to-tool', isHighlightable: false } },
+    ];
+    return { nodes, edges };
+  }
+
+  it('narrows reachable servers to the client scope (server-level)', () => {
+    const { nodes, edges } = makeScopedGraph({
+      configured: true,
+      unscoped: false,
+      servers: ['x'],
+      tools: ['x__search', 'x__write'],
+    });
+    const state = computeHighlightState(nodes, edges, 'client-a');
+
+    expect(state.highlightedNodeIds.has('mcp-x')).toBe(true);
+    expect(state.highlightedNodeIds.has('mcp-y')).toBe(false); // out of scope -> dimmed
+    expect(state.highlightedEdgeIds.has('e-g-x')).toBe(true);
+    expect(state.highlightedEdgeIds.has('e-g-y')).toBe(false);
+    // Gateway still on the path.
+    expect(state.highlightedNodeIds.has('gateway')).toBe(true);
+  });
+
+  it('dims tools of an in-scope server that are not in the tool scope', () => {
+    const { nodes, edges } = makeScopedGraph({
+      configured: true,
+      unscoped: false,
+      servers: ['x'],
+      tools: ['x__search'], // only search is in scope; write is not
+    });
+    const state = computeHighlightState(nodes, edges, 'client-a');
+
+    expect(state.highlightedNodeIds.has('tool-mcp-x-search')).toBe(true);
+    expect(state.highlightedNodeIds.has('tool-mcp-x-write')).toBe(false);
+    expect(state.highlightedEdgeIds.has('e-x-search')).toBe(true);
+    expect(state.highlightedEdgeIds.has('e-x-write')).toBe(false);
+  });
+
+  it('shows a scoped-to-nothing client reaching only the gateway', () => {
+    const { nodes, edges } = makeScopedGraph({
+      configured: true,
+      unscoped: false,
+      servers: [],
+      tools: [],
+    });
+    const state = computeHighlightState(nodes, edges, 'client-a');
+
+    expect([...state.highlightedNodeIds].sort()).toEqual(['client-a', 'gateway']);
+    expect(state.highlightedNodeIds.has('mcp-x')).toBe(false);
+    expect(state.highlightedNodeIds.has('tool-mcp-x-search')).toBe(false);
+  });
+
+  it('preserves full gateway-exposed reach when scope is unscoped', () => {
+    const { nodes, edges } = makeScopedGraph({
+      configured: true,
+      unscoped: true,
+      servers: [],
+      tools: [],
+    });
+    const state = computeHighlightState(nodes, edges, 'client-a');
+
+    // unscoped: no narrowing, so both servers and all their tools light up.
+    expect(state.highlightedNodeIds.has('mcp-x')).toBe(true);
+    expect(state.highlightedNodeIds.has('mcp-y')).toBe(true);
+    expect(state.highlightedNodeIds.has('tool-mcp-x-write')).toBe(true);
+  });
+
+  it('preserves full reach when no clients block is configured', () => {
+    const { nodes, edges } = makeScopedGraph({
+      configured: false,
+      unscoped: true,
+      servers: [],
+      tools: [],
+    });
+    const state = computeHighlightState(nodes, edges, 'client-a');
+    expect(state.highlightedNodeIds.has('mcp-x')).toBe(true);
+    expect(state.highlightedNodeIds.has('mcp-y')).toBe(true);
+  });
+});
+
 describe('isNodeDimmed / isEdgeDimmed', () => {
   it('dims nothing when there is no selection', () => {
     const state = computeHighlightState([], [], null);

--- a/web/src/components/workspaces/ClientAccessEditor.tsx
+++ b/web/src/components/workspaces/ClientAccessEditor.tsx
@@ -1,0 +1,296 @@
+import { useMemo, useState } from 'react';
+import { AlertCircle, Check, Loader2, RefreshCw, Save, ShieldCheck, Users } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useStackStore } from '../../stores/useStackStore';
+import { useClientScopeEditor } from '../../hooks/useClientScopeEditor';
+import { fetchClients, fetchStatus } from '../../lib/api';
+import { Modal } from '../ui/Modal';
+import type { ClientStatus, MCPServerStatus } from '../../types';
+
+interface ClientAccessEditorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  servers: MCPServerStatus[];
+}
+
+// ClientAccessEditor is the per-client access surface for the Tools workspace.
+// It lists linked clients, and for the selected client edits which MCP servers
+// that client may reach, persisting a server-level profile to the stack
+// `clients:` block. Tool-level allow-lists are enforced (PR3) and editable in
+// stack.yaml directly; this editor manages the coarser server-level access that
+// the topology view reflects.
+export function ClientAccessEditor({ isOpen, onClose, servers }: ClientAccessEditorProps) {
+  const clients = useStackStore((s) => s.clients);
+  const linked = useMemo(
+    () => clients.filter((c) => c.linked).sort((a, b) => a.name.localeCompare(b.name)),
+    [clients],
+  );
+
+  const [activeSlug, setActiveSlug] = useState<string | null>(null);
+  const activeClient = useMemo(
+    () => linked.find((c) => c.slug === activeSlug) ?? linked[0] ?? null,
+    [linked, activeSlug],
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Client access" size="wide">
+      <div className="flex h-[60vh] min-h-[360px]">
+        <ClientList
+          clients={linked}
+          activeSlug={activeClient?.slug ?? null}
+          onSelect={setActiveSlug}
+        />
+        <div className="flex-1 min-w-0 overflow-y-auto scrollbar-dark">
+          {activeClient ? (
+            <ClientScopePane key={activeClient.slug} client={activeClient} servers={servers} />
+          ) : (
+            <EmptyClients />
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function ClientList({
+  clients,
+  activeSlug,
+  onSelect,
+}: {
+  clients: ClientStatus[];
+  activeSlug: string | null;
+  onSelect: (slug: string) => void;
+}) {
+  return (
+    <aside className="w-56 flex-shrink-0 border-r border-border-subtle overflow-y-auto scrollbar-dark py-2 pr-2">
+      <div className="px-3 pb-2 text-[10px] font-medium text-text-muted/60 uppercase tracking-[0.3em]">
+        clients
+      </div>
+      {clients.map((c) => {
+        const scoped = c.effectiveScope?.configured && !c.effectiveScope.unscoped;
+        return (
+          <button
+            key={c.slug}
+            onClick={() => onSelect(c.slug)}
+            aria-current={c.slug === activeSlug}
+            className={cn(
+              'w-full flex items-center gap-2 px-3 py-1.5 rounded-md text-left transition-colors',
+              c.slug === activeSlug
+                ? 'bg-primary/10 text-primary'
+                : 'text-text-secondary hover:bg-surface-highlight/50 hover:text-text-primary',
+            )}
+          >
+            <span className="flex-1 min-w-0 text-xs truncate">{c.name}</span>
+            <span
+              className={cn(
+                'flex-shrink-0 text-[9px] font-mono px-1.5 py-0.5 rounded',
+                scoped ? 'bg-primary/15 text-primary' : 'bg-surface-elevated text-text-muted',
+              )}
+              title={scoped ? 'Scoped to specific servers' : 'Reaches all servers'}
+            >
+              {scoped ? `${c.effectiveScope?.servers.length ?? 0}` : 'all'}
+            </span>
+          </button>
+        );
+      })}
+    </aside>
+  );
+}
+
+function ClientScopePane({
+  client,
+  servers,
+}: {
+  client: ClientStatus;
+  servers: MCPServerStatus[];
+}) {
+  const serverNames = useMemo(() => servers.map((s) => s.name), [servers]);
+  const { selected, toggle, selectAll, clearAll, canSave, isSaving, conflict, createsBlock, save } =
+    useClientScopeEditor(client, serverNames);
+
+  const noneSelected = selected.size === 0;
+  // This client has an operator-authored tool-level allow-list. The server-level
+  // editor preserves it (it omits the tools axis on save); surface that so the
+  // operator knows tool restrictions are managed in stack.yaml, not here.
+  const hasToolScope = (client.effectiveScope?.tools.length ?? 0) > 0;
+
+  async function handleReloadFromDisk() {
+    try {
+      const [clients, status] = await Promise.all([fetchClients(), fetchStatus()]);
+      useStackStore.getState().setClients(clients);
+      useStackStore.getState().setGatewayStatus(status);
+    } catch {
+      /* polling will catch up */
+    }
+  }
+
+  return (
+    <div className="px-5 py-4 space-y-3" aria-busy={isSaving}>
+      <div className="flex items-center gap-2">
+        <ShieldCheck size={14} className="text-primary/70" aria-hidden="true" />
+        <h3 className="text-sm font-medium text-text-primary">{client.name}</h3>
+        <span className="font-mono text-[10px] text-text-muted">{client.slug}</span>
+      </div>
+      <p className="text-[11px] text-text-muted leading-relaxed">
+        Choose which MCP servers <span className="text-text-secondary">{client.name}</span> can
+        reach. To deny a client entirely, leave it unlisted under a deny default
+        rather than clearing every server here.
+      </p>
+
+      {hasToolScope && (
+        <p className="text-[10px] text-text-muted/80 leading-relaxed">
+          This client has a tool-level allow-list set in stack.yaml; it is preserved when you save
+          server changes here.
+        </p>
+      )}
+
+      {createsBlock && (
+        <div className="flex items-start gap-2 rounded-md border border-status-pending/30 bg-status-pending/[0.06] px-3 py-2">
+          <AlertCircle size={12} className="text-status-pending flex-shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="text-[11px] text-text-secondary leading-relaxed">
+            No <span className="font-mono text-status-pending">clients</span> block exists yet.
+            Saving creates one; clients you have not listed will then be{' '}
+            <span className="font-medium">denied by default</span>.
+          </p>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 text-[11px] text-text-muted">
+        <span>
+          <span className="text-text-secondary font-medium">{selected.size}</span> of{' '}
+          <span className="text-text-secondary font-medium">{serverNames.length}</span> servers
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={selectAll}
+            disabled={isSaving}
+            className="text-[10px] text-secondary hover:text-secondary-light transition-colors disabled:opacity-50"
+          >
+            All
+          </button>
+          <span className="text-border" aria-hidden="true">·</span>
+          <button
+            type="button"
+            onClick={clearAll}
+            disabled={isSaving}
+            className="text-[10px] text-secondary hover:text-secondary-light transition-colors disabled:opacity-50"
+          >
+            None
+          </button>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border/40 bg-background/60 divide-y divide-border/20">
+        {serverNames.length === 0 && (
+          <p className="px-3 py-4 text-[11px] text-text-muted/60 italic text-center">
+            No MCP servers in the active stack.
+          </p>
+        )}
+        {serverNames.map((name) => {
+          const isOn = selected.has(name);
+          return (
+            <button
+              key={name}
+              type="button"
+              role="checkbox"
+              aria-checked={isOn}
+              onClick={() => toggle(name)}
+              disabled={isSaving}
+              className="w-full flex items-center gap-2.5 px-3 py-2 text-left hover:bg-surface-highlight/40 transition-colors disabled:opacity-60"
+            >
+              <span
+                className={cn(
+                  'w-3.5 h-3.5 rounded border flex items-center justify-center flex-shrink-0 transition-colors',
+                  isOn ? 'bg-primary/20 border-primary/60' : 'border-border/60 bg-background/50',
+                )}
+              >
+                {isOn && <Check size={10} className="text-primary" aria-hidden="true" />}
+              </span>
+              <span
+                className={cn(
+                  'text-xs font-mono truncate',
+                  isOn ? 'text-text-primary' : 'text-text-secondary',
+                )}
+              >
+                {name}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {noneSelected && (
+        <p className="text-[10px] text-status-pending" role="status">
+          Select at least one server to save.
+        </p>
+      )}
+
+      {conflict && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md border border-status-pending/40 bg-status-pending/[0.05] px-3 py-2"
+        >
+          <AlertCircle size={12} className="text-status-pending flex-shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0 space-y-1">
+            <p className="text-[11px] text-status-pending font-medium">
+              The stack file was modified outside the canvas.
+            </p>
+            <p className="text-[10px] text-text-muted">{conflict}</p>
+            <button
+              type="button"
+              onClick={handleReloadFromDisk}
+              className="inline-flex items-center gap-1 text-[10px] text-secondary hover:text-secondary-light transition-colors"
+            >
+              <RefreshCw size={10} />
+              Reload file
+            </button>
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={save}
+        disabled={!canSave || isSaving}
+        aria-label={canSave ? 'Save client access and reload' : 'Saved'}
+        className={cn(
+          'w-full inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-[11px] font-medium transition-colors',
+          canSave && !isSaving
+            ? 'bg-primary/20 text-primary border border-primary/30 hover:bg-primary/30'
+            : 'bg-surface-highlight/50 text-text-muted border border-border/30 cursor-not-allowed',
+        )}
+      >
+        {isSaving ? (
+          <>
+            <Loader2 size={11} className="animate-spin" />
+            Saving…
+          </>
+        ) : (
+          <>
+            <Save size={11} />
+            {canSave ? 'Save access & Reload' : 'Saved'}
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
+function EmptyClients() {
+  return (
+    <div className="h-full flex items-center justify-center px-6 py-12">
+      <div className="max-w-xs text-center space-y-3">
+        <div className="mx-auto w-12 h-12 rounded-2xl bg-primary/10 border border-primary/20 flex items-center justify-center">
+          <Users size={22} className="text-primary/70" />
+        </div>
+        <p className="text-xs text-text-muted leading-relaxed">
+          No linked clients yet. Run <span className="font-mono text-text-secondary">gridctl link</span>{' '}
+          to connect a client, then set its access here.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default ClientAccessEditor;

--- a/web/src/components/workspaces/ToolsWorkspace.tsx
+++ b/web/src/components/workspaces/ToolsWorkspace.tsx
@@ -11,6 +11,7 @@ import {
   RefreshCw,
   Save,
   Search,
+  Users,
   Wrench,
   X,
 } from 'lucide-react';
@@ -36,6 +37,7 @@ import { WorkspaceShell } from '../layout/WorkspaceShell';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { StatusDot } from '../ui/StatusDot';
 import { FleetActions } from './FleetActions';
+import { ClientAccessEditor } from './ClientAccessEditor';
 import { ToolDetailPanel } from './ToolDetailPanel';
 import type { MCPServerStatus, NodeStatus, Tool, ToolUsageStat } from '../../types';
 
@@ -137,6 +139,8 @@ export function ToolsWorkspace() {
   const [auditWindow, setAuditWindow] = useState<AuditWindow>(DEFAULT_AUDIT_WINDOW);
   // Fleet bulk-action panel (expose-all / hide-pattern across servers).
   const [fleetOpen, setFleetOpen] = useState(false);
+  // Per-client access editor (which servers each client may reach).
+  const [accessOpen, setAccessOpen] = useState(false);
   const { usage, fetchedAt } = useToolUsage(auditMode);
   const windowMs = auditWindowMs(auditWindow);
   const usageByServer = usage?.servers;
@@ -265,6 +269,7 @@ export function ToolsWorkspace() {
             observedSince={usage?.observedSince}
             onOpenFleet={() => setFleetOpen(true)}
             fleetDisabled={servers.length === 0}
+            onOpenAccess={() => setAccessOpen(true)}
           />
 
           <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark">
@@ -318,6 +323,12 @@ export function ToolsWorkspace() {
         servers={servers}
         activeServerName={activeServerName}
       />
+
+      <ClientAccessEditor
+        isOpen={accessOpen}
+        onClose={() => setAccessOpen(false)}
+        servers={servers}
+      />
     </div>
   );
 }
@@ -338,6 +349,7 @@ interface ToolsHeaderProps {
   observedSince?: string;
   onOpenFleet: () => void;
   fleetDisabled: boolean;
+  onOpenAccess: () => void;
 }
 
 function ToolsHeader({
@@ -352,6 +364,7 @@ function ToolsHeader({
   observedSince,
   onOpenFleet,
   fleetDisabled,
+  onOpenAccess,
 }: ToolsHeaderProps) {
   const searching = query.trim().length > 0;
   const windowLabel = AUDIT_WINDOWS.find((w) => w.id === auditWindow)?.label ?? '7 days';
@@ -371,6 +384,18 @@ function ToolsHeader({
         </div>
 
         <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onOpenAccess}
+            aria-label="Open per-client access editor"
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[10px] font-medium border transition-colors',
+              'bg-background/40 text-text-muted border-border/40 hover:text-text-secondary hover:border-border',
+            )}
+          >
+            <Users size={11} aria-hidden="true" />
+            Access
+          </button>
           <button
             type="button"
             onClick={onOpenFleet}

--- a/web/src/hooks/useClientScopeEditor.ts
+++ b/web/src/hooks/useClientScopeEditor.ts
@@ -1,0 +1,171 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useStackStore } from '../stores/useStackStore';
+import { showToast } from '../components/ui/Toast';
+import {
+  AuthError,
+  ClientScopeError,
+  fetchClients,
+  fetchStatus,
+  updateClientScope,
+} from '../lib/api';
+import type { ClientStatus } from '../types';
+
+function canonical(names: string[]): string[] {
+  return Array.from(new Set(names)).sort();
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/**
+ * Derive the server set a client currently reaches, used as the editor's saved
+ * baseline. An unscoped client (no clients block, default-allow, or an empty
+ * profile) reaches every server, so the baseline is all server names; a scoped
+ * client's baseline is its effective servers (which is [] when it reaches
+ * nothing under default-deny).
+ */
+export function baselineServers(
+  client: ClientStatus | null,
+  allServerNames: string[],
+): string[] {
+  const scope = client?.effectiveScope;
+  if (!scope || !scope.configured || scope.unscoped) {
+    return canonical(allServerNames);
+  }
+  return canonical(scope.servers);
+}
+
+export interface UseClientScopeEditor {
+  selected: Set<string>;
+  toggle: (server: string) => void;
+  selectAll: () => void;
+  clearAll: () => void;
+  dirty: boolean;
+  /** Save is allowed only with at least one server selected: an empty servers
+   *  list means "all servers" in the config model, so it can't express "deny",
+   *  and committing zero would silently grant everything. */
+  canSave: boolean;
+  isSaving: boolean;
+  conflict: string | null;
+  /** True when no clients: block exists yet, so saving creates one and flips
+   *  unlisted clients to the default (deny) policy (a stack-wide consequence). */
+  createsBlock: boolean;
+  save: () => Promise<void>;
+  reset: () => void;
+}
+
+/**
+ * useClientScopeEditor owns the per-client server-access editing controller: it
+ * tracks the draft set of servers a client may reach, dirty state against the
+ * client's current effective scope, and the save-and-reload flow (mirroring
+ * useToolsEditor's structured-error handling). Saving writes a server-level
+ * profile (servers allow-list, tools unrestricted) to the stack `clients:`
+ * block via updateClientScope, then refreshes the client list so the topology
+ * reflects the new scope.
+ */
+export function useClientScopeEditor(
+  client: ClientStatus | null,
+  allServerNames: string[],
+): UseClientScopeEditor {
+  const saved = useMemo(
+    () => baselineServers(client, allServerNames),
+    [client, allServerNames],
+  );
+  const createsBlock = !client?.effectiveScope?.configured;
+
+  const [selection, setSelection] = useState<string[]>(saved);
+  const [isSaving, setIsSaving] = useState(false);
+  const [conflict, setConflict] = useState<string | null>(null);
+
+  // Re-seed the draft when the selected client (or its saved baseline) changes,
+  // keyed on the client slug + the canonical baseline signature so a polling
+  // refresh that doesn't change membership leaves an in-progress edit alone.
+  const slug = client?.slug ?? '';
+  const savedSignature = saved.join(' ');
+  const seededRef = useRef('');
+  useEffect(() => {
+    const key = `${slug} ${savedSignature}`;
+    if (seededRef.current !== key) {
+      seededRef.current = key;
+      setSelection(saved);
+      setConflict(null);
+    }
+  }, [slug, savedSignature, saved]);
+
+  const selected = useMemo(() => new Set(selection), [selection]);
+  const dirty = !arraysEqual(canonical(selection), saved);
+  const canSave = dirty && selection.length > 0;
+
+  const toggle = (server: string) => {
+    const next = new Set(selected);
+    if (next.has(server)) next.delete(server);
+    else next.add(server);
+    setSelection([...next]);
+  };
+  const selectAll = () => setSelection(canonical(allServerNames));
+  const clearAll = () => setSelection([]);
+  const reset = () => {
+    setSelection(saved);
+    setConflict(null);
+  };
+
+  const save = async () => {
+    if (!client || selection.length === 0) return;
+    setIsSaving(true);
+    setConflict(null);
+    try {
+      // Server-level scope: write the selected servers; omit tools so an
+      // operator-authored tool allow-list on this profile is preserved.
+      const resp = await updateClientScope(client.slug, {
+        servers: canonical(selection),
+      });
+      showToast('success', `Access saved for ${client.name}`);
+      if (resp.reloaded === false) {
+        showToast('warning', 'Stack updated. Run "gridctl reload" or restart with --watch to apply.');
+      }
+      // Refresh clients (carries the recomputed effectiveScope) and gateway
+      // status so the topology and editor reflect the new scope.
+      try {
+        const [clients, status] = await Promise.all([fetchClients(), fetchStatus()]);
+        useStackStore.getState().setClients(clients);
+        useStackStore.getState().setGatewayStatus(status);
+      } catch {
+        /* ignore refresh failures; polling will catch up */
+      }
+    } catch (err) {
+      if (err instanceof AuthError) throw err;
+      if (err instanceof ClientScopeError) {
+        if (err.code === 'stack_modified') {
+          setConflict(err.hint || err.message);
+          return;
+        }
+        if (err.code === 'reload_failed') {
+          showToast('error', `Access saved for ${client.name}, but reload failed: ${err.message}.`);
+          return;
+        }
+        showToast('error', err.message);
+        return;
+      }
+      showToast('error', err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return {
+    selected,
+    toggle,
+    selectAll,
+    clearAll,
+    dirty,
+    canSave,
+    isSaving,
+    conflict,
+    createsBlock,
+    save,
+    reset,
+  };
+}

--- a/web/src/hooks/usePathHighlight.ts
+++ b/web/src/hooks/usePathHighlight.ts
@@ -9,6 +9,7 @@
 import { useMemo } from 'react';
 import type { Node, Edge } from '@xyflow/react';
 import type { EdgeMetadata } from '../lib/graph/types';
+import type { ClientScopeResult } from '../types';
 
 /**
  * Highlight state returned by the hook
@@ -94,23 +95,77 @@ function includeHighlightedServerTools(
   highlightedNodeIds: Set<string>,
   highlightedEdgeIds: Set<string>,
   nodes: Node[],
-  edges: Edge[]
+  edges: Edge[],
+  inScopeTools?: Set<string>
 ): void {
   for (const node of nodes) {
-    const data = node.data as { type?: string; serverNodeId?: string };
+    const data = node.data as {
+      type?: string;
+      serverNodeId?: string;
+      serverName?: string;
+      name?: string;
+    };
     if (
       (data.type === 'tool' || data.type === 'tool-overflow') &&
       data.serverNodeId &&
       highlightedNodeIds.has(data.serverNodeId)
     ) {
+      // When a per-client tool scope is active, only individual tool nodes
+      // whose prefixed name (server__tool) is in scope light up; out-of-scope
+      // tools stay dimmed. The "+N more" overflow follows its server.
+      if (inScopeTools && data.type === 'tool') {
+        const prefixed = `${data.serverName}__${data.name}`;
+        if (!inScopeTools.has(prefixed)) continue;
+      }
       highlightedNodeIds.add(node.id);
     }
   }
 
   for (const edge of edges) {
     const meta = edge.data as EdgeMetadata | undefined;
-    if (meta?.relationType === 'server-to-tool' && highlightedNodeIds.has(edge.source)) {
+    if (
+      meta?.relationType === 'server-to-tool' &&
+      highlightedNodeIds.has(edge.source) &&
+      highlightedNodeIds.has(edge.target)
+    ) {
       highlightedEdgeIds.add(edge.id);
+    }
+  }
+}
+
+/**
+ * Narrow an already-traced highlight to a client's real access scope, in place.
+ *
+ * Removes any highlighted MCP-server node whose name is not in the client's
+ * `effectiveScope.servers`, along with the edges leading to it. The gateway and
+ * client stay highlighted, so a client scoped to nothing shows as reaching the
+ * gateway and stopping there (the empty-state) rather than the full graph.
+ * Tools of pruned servers fall out automatically since their parent server is
+ * no longer highlighted.
+ */
+function narrowToClientScope(
+  highlightedNodeIds: Set<string>,
+  highlightedEdgeIds: Set<string>,
+  nodes: Node[],
+  edges: Edge[],
+  scope: ClientScopeResult
+): void {
+  const inScopeServers = new Set(scope.servers);
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
+
+  const removed = new Set<string>();
+  for (const id of highlightedNodeIds) {
+    const data = nodeById.get(id)?.data as { type?: string; name?: string } | undefined;
+    if (data?.type === 'mcp-server' && !inScopeServers.has(data.name ?? '')) {
+      removed.add(id);
+    }
+  }
+  for (const id of removed) {
+    highlightedNodeIds.delete(id);
+  }
+  for (const edge of edges) {
+    if (removed.has(edge.target)) {
+      highlightedEdgeIds.delete(edge.id);
     }
   }
 }
@@ -150,18 +205,34 @@ export function computeHighlightState(
   }
 
   const nodeData = selectedNode.data as Record<string, unknown>;
+  const isClient = nodeData?.type === 'client';
 
   // Client nodes: highlight the transitive client -> gateway -> servers path.
   // Other node types: just highlight the selected node.
-  const { highlightedNodeIds, highlightedEdgeIds } =
-    nodeData?.type === 'client'
-      ? traceReachablePath(selectedNodeId, edges)
-      : {
-          highlightedNodeIds: new Set([selectedNodeId]),
-          highlightedEdgeIds: new Set<string>(),
-        };
+  const { highlightedNodeIds, highlightedEdgeIds } = isClient
+    ? traceReachablePath(selectedNodeId, edges)
+    : {
+        highlightedNodeIds: new Set([selectedNodeId]),
+        highlightedEdgeIds: new Set<string>(),
+      };
 
-  includeHighlightedServerTools(highlightedNodeIds, highlightedEdgeIds, nodes, edges);
+  // When the selected client has a configured, narrowed scope, restrict the
+  // highlight to what it can actually reach. An absent or `unscoped` scope
+  // preserves the gateway-exposed reach (the no-clients-block case).
+  const scope = nodeData?.effectiveScope as ClientScopeResult | undefined;
+  let inScopeTools: Set<string> | undefined;
+  if (isClient && scope && scope.configured && !scope.unscoped) {
+    narrowToClientScope(highlightedNodeIds, highlightedEdgeIds, nodes, edges, scope);
+    inScopeTools = new Set(scope.tools);
+  }
+
+  includeHighlightedServerTools(
+    highlightedNodeIds,
+    highlightedEdgeIds,
+    nodes,
+    edges,
+    inScopeTools
+  );
 
   return { highlightedNodeIds, highlightedEdgeIds, hasSelection: true };
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -350,6 +350,90 @@ export async function setServerToolsBatch(
   return data as SetServerToolsBatchResponse;
 }
 
+// ClientScopeError carries the structured envelope from the per-client scope
+// write endpoint, mirroring SetServerToolsError:
+//   - "stack_modified" (409): the stack file changed on disk since read.
+//   - "unknown_server"/"unknown_tool" (422): the scope references a server or
+//     tool the gateway does not know about (stale UI).
+//   - "reload_failed" (502): the YAML write succeeded but the reload failed.
+export class ClientScopeError extends Error {
+  code: string;
+  hint?: string;
+  httpStatus: number;
+
+  constructor(code: string, message: string, hint: string | undefined, httpStatus: number) {
+    super(message);
+    this.name = 'ClientScopeError';
+    this.code = code;
+    this.hint = hint;
+    this.httpStatus = httpStatus;
+  }
+}
+
+// ClientScopeUpdate is the allow-list written for one client profile. Each axis
+// is independent: an omitted field leaves that axis untouched (so a server-only
+// edit preserves an operator's tool list), while a present array replaces it.
+export interface ClientScopeUpdate {
+  servers?: string[];
+  tools?: string[];
+}
+
+// UpdateClientScopeResponse is the success payload from the write endpoint.
+export interface UpdateClientScopeResponse {
+  client: string;
+  profileKey: string;
+  servers: string[];
+  tools: string[];
+  reloaded: boolean;
+  reloadedAt?: string;
+}
+
+/**
+ * Persist a client's access profile (allowed servers and/or tools) to the live
+ * stack YAML's `clients:` block and trigger a hot reload. The slug is the
+ * client identifier; the gateway normalizes it to the stable profile key.
+ *
+ * Rejects with ClientScopeError on 409/422/502 (structured envelope), AuthError
+ * on 401, or a plain Error otherwise.
+ * PUT /api/clients/{slug}/scope
+ */
+export async function updateClientScope(
+  slug: string,
+  update: ClientScopeUpdate,
+): Promise<UpdateClientScopeResponse> {
+  const response = await fetch(
+    `${API_BASE}/api/clients/${encodeURIComponent(slug)}/scope`,
+    {
+      method: 'PUT',
+      headers: buildHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(update),
+    },
+  );
+
+  if (response.status === 401) throw new AuthError('Authentication required');
+
+  const data = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const err = data?.error;
+    if (err && typeof err === 'object' && typeof err.code === 'string') {
+      throw new ClientScopeError(
+        err.code,
+        err.message ?? 'Update client scope failed',
+        err.hint,
+        response.status,
+      );
+    }
+    const msg =
+      typeof err === 'string'
+        ? err
+        : `Update client scope failed: ${response.status} ${response.statusText}`;
+    throw new Error(msg);
+  }
+
+  return data as UpdateClientScopeResponse;
+}
+
 // === Structured Log Entry (from gateway) ===
 
 export interface LogEntry {

--- a/web/src/lib/graph/nodes.ts
+++ b/web/src/lib/graph/nodes.ts
@@ -143,6 +143,7 @@ export function createClientNodes(clients: ClientStatus[]): Node[] {
         slug: client.slug,
         transport: client.transport,
         configPath: client.configPath,
+        effectiveScope: client.effectiveScope,
         status: 'running' as const,
       },
       draggable: true,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -87,6 +87,16 @@ export interface ResourceStatus {
   network?: string;
 }
 
+// Backend-computed per-client access scope (from the stack.yaml `clients:` block).
+// Mirrors mcp.ClientScopeResult. When no clients: block is configured,
+// `configured` is false and `unscoped` is true.
+export interface ClientScopeResult {
+  configured: boolean;  // A clients: block exists in the stack
+  unscoped: boolean;    // This client reaches the full tool surface
+  servers: string[];    // Reachable server names
+  tools: string[];      // Reachable prefixed tool names (server__tool)
+}
+
 // LLM client status from GET /api/clients
 export interface ClientStatus {
   name: string;       // Human-readable name (e.g., "Claude Desktop")
@@ -95,6 +105,7 @@ export interface ClientStatus {
   linked: boolean;    // Whether gridctl entry exists in client config
   transport: string;  // "native SSE", "native HTTP", or "mcp-remote bridge"
   configPath?: string; // Config file path (only if detected)
+  effectiveScope?: ClientScopeResult; // Per-client access scope (when scoping is configured)
 }
 
 // Token counts for a session or server


### PR DESCRIPTION
## Description

The final phase of per-client access scoping: the topology view now consumes each client's real `effectiveScope`, and the Tools workspace gains an editor that writes per-client server access to the `clients:` block. With PRs #743/#744 (visualization) and #745 (backend access model) merged, this closes the loop from config to canvas.

## Type of Change

- [x] New feature (full-stack)

## Changes Made

- **Topology reflects real scope.** Clicking a client highlights only the servers and tools its configured scope can reach; out-of-scope servers/tools fade (a client scoped to nothing shows it reaching the gateway and stopping there). An absent or `unscoped` scope preserves the prior full-reach behavior (no `clients:` block = unchanged). `usePathHighlight` narrows on the client node's `effectiveScope`; edges stay neutral gray.
- **Per-client access editor.** A new "Access" button in the Tools workspace opens an editor to choose which MCP servers each linked client may reach. Saving writes a server-level profile via `PUT /api/clients/{slug}/scope` and hot-reloads. The write is a `yaml.Node` round-trip (preserves comments, ordering, sibling profiles, `default`, and aliases) with the same hash-based conflict detection (409) as the server-tools editor; unknown server/tool references return 422.
- **Tool-axis safety.** Each scope axis is independently settable: a server-only edit omits `tools`, so an operator-authored tool allow-list on the profile is preserved (never silently broadened). The editor requires at least one server (an empty `servers:` means "all" in the config model, so it cannot express "deny") and warns that saving the first profile creates the `clients:` block and flips unlisted clients to deny-by-default.
- `/api/clients` types extended with `effectiveScope`; `updateClientScope` added with a typed error class mirroring `SetServerToolsError`.

## Testing

- Go: table-driven tests for the YAML patch (new/updated profile, sibling/comment/alias preservation, tool-axis preservation on server-only edit, empty-axis drop, bare-null `clients:` node, validation) and the handler (slug normalization, 400/409, tools preserved).
- Frontend (Vitest): scope-aware highlight narrowing (scoped/unscoped/empty/no-block), tool dimming by `effectiveScope.tools`, and the editor controller (baseline, dirty, can't-save-with-zero-servers, save payload omits tools, 409 conflict).
- `make test`, `make test-frontend` (863 pass), `golangci-lint` (0 issues), ESLint on changed files, and `make build` all pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #742