### PR TITLE
feat: client Access Scope inspector + discoverable Tools Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Access Scope in the client inspector.** Selecting a client in the topology
+  now shows an "Access Scope" inspector section summarizing its real reach
+  ("N of M servers" when scoped, or "Unscoped · all servers" otherwise) with the
+  reachable servers listed, plus an "Edit Scope" button that opens the per-client
+  access editor focused on that client. The Tools workspace "Access" button is
+  now styled as a primary action for discoverability. Both open the same editor.
+
 - **Per-client access in the topology and Tools workspace.** The topology view
   now reflects each client's real access: clicking a client highlights only the
   servers and tools its configured scope can reach, fading everything else

--- a/web/src/__tests__/clientScope.test.ts
+++ b/web/src/__tests__/clientScope.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeClientReach } from '../lib/clientScope';
+import type { ClientScopeResult } from '../types';
+
+const ALL = ['github', 'atlassian', 'gitlab'];
+
+describe('summarizeClientReach', () => {
+  it('treats undefined scope as unscoped (reaches all)', () => {
+    const r = summarizeClientReach(undefined, ALL);
+    expect(r.scoped).toBe(false);
+    expect(r.reachableCount).toBe(3);
+    expect(r.totalCount).toBe(3);
+    expect(r.servers).toEqual(['atlassian', 'github', 'gitlab']); // sorted
+  });
+
+  it('treats an unscoped result as reaching all even when configured', () => {
+    const scope: ClientScopeResult = { configured: true, unscoped: true, servers: [], tools: [] };
+    const r = summarizeClientReach(scope, ALL);
+    expect(r.scoped).toBe(false);
+    expect(r.reachableCount).toBe(3);
+    expect(r.servers).toEqual(['atlassian', 'github', 'gitlab']);
+  });
+
+  it('treats a not-configured result as reaching all', () => {
+    const scope: ClientScopeResult = { configured: false, unscoped: true, servers: [], tools: [] };
+    const r = summarizeClientReach(scope, ALL);
+    expect(r.scoped).toBe(false);
+    expect(r.reachableCount).toBe(3);
+  });
+
+  it('reports the scoped subset (N of M) when configured and not unscoped', () => {
+    const scope: ClientScopeResult = {
+      configured: true,
+      unscoped: false,
+      servers: ['gitlab', 'github'],
+      tools: [],
+    };
+    const r = summarizeClientReach(scope, ALL);
+    expect(r.scoped).toBe(true);
+    expect(r.reachableCount).toBe(2);
+    expect(r.totalCount).toBe(3);
+    expect(r.servers).toEqual(['github', 'gitlab']); // sorted
+  });
+
+  it('handles an empty stack (no servers)', () => {
+    const r = summarizeClientReach(undefined, []);
+    expect(r.scoped).toBe(false);
+    expect(r.reachableCount).toBe(0);
+    expect(r.totalCount).toBe(0);
+    expect(r.servers).toEqual([]);
+  });
+});

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -14,6 +14,8 @@ import {
   Activity,
   Database,
   ArrowUpRight,
+  ShieldCheck,
+  SlidersHorizontal,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { cn } from '../../lib/cn';
@@ -28,6 +30,7 @@ import { AutoscalePanel } from '../status/AutoscalePanel';
 import { SidebarTelemetrySection } from '../telemetry/SidebarTelemetrySection';
 import { getTransportIcon, getTransportColorClasses } from '../../lib/transport';
 import { getClientIcon } from '../../lib/clientIcons';
+import { summarizeClientReach } from '../../lib/clientScope';
 import { useStackStore, useSelectedNodeData } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
 import { useWindowManager } from '../../hooks/useWindowManager';
@@ -42,6 +45,9 @@ export function Sidebar() {
   const selectNode = useStackStore((s) => s.selectNode);
   const autoscaleHistory = useStackStore((s) => s.autoscaleHistory);
   const autoscaleDecisions = useStackStore((s) => s.autoscaleDecisions);
+  const clients = useStackStore((s) => s.clients);
+  const mcpServers = useStackStore((s) => s.mcpServers);
+  const openAccessEditor = useUIStore((s) => s.openAccessEditor);
   const { openDetachedWindow } = useWindowManager();
   const navigate = useNavigate();
 
@@ -317,6 +323,74 @@ export function Sidebar() {
             )}
           </div>
         </InspectorSection>
+
+        {/* Access Scope Section (clients only) */}
+        {isClient && clientData && (() => {
+          // Read scope from the live store client (canonical, refreshes on poll)
+          // and fall back to the node snapshot.
+          const liveClient = clients.find((c) => c.slug === clientData.slug);
+          const scope = liveClient?.effectiveScope ?? clientData.effectiveScope;
+          const reach = summarizeClientReach(
+            scope,
+            mcpServers.map((s) => s.name),
+          );
+          return (
+            <InspectorSection title="Access Scope" icon={ShieldCheck} defaultOpen>
+              <div className="space-y-3">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-sm text-text-muted">Reach</span>
+                  {reach.scoped ? (
+                    <span className="text-xs px-2 py-0.5 rounded-md font-mono font-medium bg-primary/10 text-primary">
+                      {reach.reachableCount} of {reach.totalCount} servers
+                    </span>
+                  ) : (
+                    <span className="text-xs px-2 py-0.5 rounded-md font-mono font-medium bg-secondary/10 text-secondary">
+                      Unscoped · all servers
+                    </span>
+                  )}
+                </div>
+
+                {reach.scoped ? (
+                  reach.servers.length > 0 ? (
+                    <div className="flex flex-wrap gap-1.5">
+                      {reach.servers.map((name) => (
+                        <span
+                          key={name}
+                          className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-background/60 border border-border/40 text-text-secondary"
+                        >
+                          {name}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-[11px] text-text-muted leading-relaxed">
+                      Reaches the gateway but no servers. Unlisted under a deny default, this client
+                      sees nothing.
+                    </p>
+                  )
+                ) : (
+                  <p className="text-[11px] text-text-muted leading-relaxed">
+                    No <span className="font-mono text-text-secondary">clients</span> scope applies;
+                    this client can reach every MCP server in the stack.
+                  </p>
+                )}
+
+                <button
+                  type="button"
+                  onClick={() => openAccessEditor(clientData.slug)}
+                  className={cn(
+                    'w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all',
+                    'bg-primary/10 text-primary border border-primary/30',
+                    'hover:bg-primary/20 hover:border-primary/50',
+                  )}
+                >
+                  <SlidersHorizontal size={14} />
+                  Edit Scope
+                </button>
+              </div>
+            </InspectorSection>
+          );
+        })()}
 
         {/* Token Usage Section (MCP servers only) */}
         {isServer && (

--- a/web/src/components/workspaces/ClientAccessEditor.tsx
+++ b/web/src/components/workspaces/ClientAccessEditor.tsx
@@ -11,6 +11,9 @@ interface ClientAccessEditorProps {
   isOpen: boolean;
   onClose: () => void;
   servers: MCPServerStatus[];
+  // Optional client slug to focus when the editor opens (e.g. from the Topology
+  // inspector's "Edit Scope"). When omitted, the first linked client is shown.
+  initialSlug?: string | null;
 }
 
 // ClientAccessEditor is the per-client access surface for the Tools workspace.
@@ -19,14 +22,18 @@ interface ClientAccessEditorProps {
 // `clients:` block. Tool-level allow-lists are enforced (PR3) and editable in
 // stack.yaml directly; this editor manages the coarser server-level access that
 // the topology view reflects.
-export function ClientAccessEditor({ isOpen, onClose, servers }: ClientAccessEditorProps) {
+export function ClientAccessEditor({ isOpen, onClose, servers, initialSlug }: ClientAccessEditorProps) {
   const clients = useStackStore((s) => s.clients);
   const linked = useMemo(
     () => clients.filter((c) => c.linked).sort((a, b) => a.name.localeCompare(b.name)),
     [clients],
   );
 
-  const [activeSlug, setActiveSlug] = useState<string | null>(null);
+  // Seeded from `initialSlug` at mount. Callers that open the editor focused on
+  // a specific client (the Topology inspector) pass a `key` keyed to that slug so
+  // a fresh seed remounts here; the Tools entry passes no seed and starts on the
+  // first linked client.
+  const [activeSlug, setActiveSlug] = useState<string | null>(initialSlug ?? null);
   const activeClient = useMemo(
     () => linked.find((c) => c.slug === activeSlug) ?? linked[0] ?? null,
     [linked, activeSlug],

--- a/web/src/components/workspaces/ToolsWorkspace.tsx
+++ b/web/src/components/workspaces/ToolsWorkspace.tsx
@@ -390,7 +390,7 @@ function ToolsHeader({
             aria-label="Open per-client access editor"
             className={cn(
               'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[10px] font-medium border transition-colors',
-              'bg-background/40 text-text-muted border-border/40 hover:text-text-secondary hover:border-border',
+              'bg-primary/10 text-primary border-primary/30 hover:bg-primary/20 hover:border-primary/50',
             )}
           >
             <Users size={11} aria-hidden="true" />

--- a/web/src/components/workspaces/TopologyWorkspace.tsx
+++ b/web/src/components/workspaces/TopologyWorkspace.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { AlertCircle, RefreshCw, WifiOff } from 'lucide-react';
 import { Sidebar } from '../layout/Sidebar';
 import { Canvas } from '../graph/Canvas';
+import { ClientAccessEditor } from './ClientAccessEditor';
 import { ResizeHandle } from '../ui/ResizeHandle';
 import { useStackStore } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
@@ -20,7 +21,16 @@ export function TopologyWorkspace() {
 
   const isLoading = useStackStore((s) => s.isLoading);
   const error = useStackStore((s) => s.error);
+  const mcpServers = useStackStore((s) => s.mcpServers);
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
+  const accessEditorOpen = useUIStore((s) => s.accessEditorOpen);
+  const accessEditorSeedSlug = useUIStore((s) => s.accessEditorSeedSlug);
+  const closeAccessEditor = useUIStore((s) => s.closeAccessEditor);
+
+  const accessServers = useMemo(
+    () => [...mcpServers].sort((a, b) => a.name.localeCompare(b.name)),
+    [mcpServers],
+  );
 
   const { refresh } = usePolling();
 
@@ -116,6 +126,16 @@ export function TopologyWorkspace() {
           </aside>
         )}
       </div>
+
+      {/* Per-client access editor, opened from the inspector's "Edit Scope"
+          seeded to the inspected client. */}
+      <ClientAccessEditor
+        key={accessEditorSeedSlug ?? 'default'}
+        isOpen={accessEditorOpen}
+        onClose={closeAccessEditor}
+        servers={accessServers}
+        initialSlug={accessEditorSeedSlug}
+      />
     </div>
   );
 }

--- a/web/src/lib/clientScope.ts
+++ b/web/src/lib/clientScope.ts
@@ -1,0 +1,29 @@
+import type { ClientScopeResult } from '../types';
+
+// summarizeClientReach condenses a client's backend-computed access scope into
+// the shape the inspector renders. A client is "scoped" only when a `clients:`
+// block is configured AND it does not reach the full surface; otherwise it is
+// unscoped and reaches every server (the legacy, no-policy default).
+export interface ClientReach {
+  scoped: boolean; // configured && !unscoped
+  reachableCount: number; // servers this client can reach
+  totalCount: number; // total MCP servers in the stack
+  servers: string[]; // reachable server names (sorted)
+}
+
+export function summarizeClientReach(
+  scope: ClientScopeResult | undefined,
+  allServerNames: string[],
+): ClientReach {
+  const total = allServerNames.length;
+  const sortedAll = [...allServerNames].sort((a, b) => a.localeCompare(b));
+
+  const scoped = Boolean(scope?.configured) && !scope?.unscoped;
+  if (!scoped) {
+    // Unscoped (or no policy configured): reaches every server.
+    return { scoped: false, reachableCount: total, totalCount: total, servers: sortedAll };
+  }
+
+  const servers = [...(scope?.servers ?? [])].sort((a, b) => a.localeCompare(b));
+  return { scoped: true, reachableCount: servers.length, totalCount: total, servers };
+}

--- a/web/src/stores/useUIStore.ts
+++ b/web/src/stores/useUIStore.ts
@@ -144,6 +144,13 @@ interface UIState extends WorkspaceSlice, CompactModeSlice {
   showVault: boolean;
   setShowVault: (show: boolean) => void;
   toggleVault: () => void;
+
+  // Per-client access editor: opened from the Topology inspector ("Edit Scope")
+  // seeded to a specific client. Transient (not persisted).
+  accessEditorOpen: boolean;
+  accessEditorSeedSlug: string | null;
+  openAccessEditor: (slug?: string | null) => void;
+  closeAccessEditor: () => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -191,6 +198,10 @@ export const useUIStore = create<UIState>()(
       // Command palette (always starts closed)
       commandPaletteOpen: false,
 
+      // Access editor (always starts closed)
+      accessEditorOpen: false,
+      accessEditorSeedSlug: null,
+
       setSidebarOpen: (sidebarOpen) => set({ sidebarOpen }),
       toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
       setActiveTab: (activeTab) => set({ activeTab }),
@@ -225,6 +236,10 @@ export const useUIStore = create<UIState>()(
       showVault: false,
       setShowVault: (showVault) => set({ showVault }),
       toggleVault: () => set((s) => ({ showVault: !s.showVault })),
+
+      openAccessEditor: (slug) =>
+        set({ accessEditorOpen: true, accessEditorSeedSlug: slug ?? null }),
+      closeAccessEditor: () => set({ accessEditorOpen: false, accessEditorSeedSlug: null }),
 
       // Detached window actions
       setLogsDetached: (logsDetached) => set({ logsDetached }),

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -344,6 +344,7 @@ export interface ClientNodeData extends NodeDataBase {
   transport: string;
   configPath?: string;
   status: NodeStatus;
+  effectiveScope?: ClientScopeResult; // Per-client access scope (mirrors ClientStatus.effectiveScope)
 }
 
 // --- Agent Skills Registry Types ---


### PR DESCRIPTION
## Description

Phase 0 of per-client policy authoring: make scope editing reachable from where a client is selected. Adds an "Access Scope" section to the client inspector and promotes the Tools "Access" button to a primary action. Frontend-only; builds on the existing `PUT /api/clients/{slug}/scope` editor.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- **Client inspector "Access Scope" section**: summarizes a client's real reach ("N of M servers" when scoped, "Unscoped · all servers" otherwise), lists reachable servers as mono chips, and offers an "Edit Scope" button.
- **Seeded editor bridge**: "Edit Scope" opens the existing `ClientAccessEditor` focused on the inspected client, via transient `openAccessEditor(slug)` UI-store state and a seed-keyed mount in the topology workspace.
- **Discoverability**: the Tools workspace "Access" button is restyled as a primary (amber) action, consistent with the Audit/Fleet header family.
- **Type correctness**: `effectiveScope` is now declared on `ClientNodeData` (it was already attached at runtime).
- New `summarizeClientReach()` pure helper with unit tests.

## Testing

- `cd web && npm run build` (tsc + vite) passes.
- `npx vitest run src/__tests__/clientScope.test.ts` — 5 new tests pass; related suites (ToolsWorkspace, useUIStore, CommandPalette) green.
- Manual: select a client node in Topology → Access Scope section shows correct reach and opens the editor seeded to that client.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #747