### PR TITLE
feat: Topology Access Lens — draft-staged per-client access authoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Topology Access Lens — author per-client scope on the canvas.** A new
+  "Access Lens" toggle in the Topology header turns the graph into an editing
+  surface: with a client selected, MCP server nodes become draft grant/revoke
+  targets. Clicking a server (or its checkbox in the new right-anchored
+  slide-over editor, which keeps the canvas interactive) stages the change in a
+  draft and re-lights the canvas live against it — granted servers carry an amber
+  ring, denied ones desaturate. Both surfaces edit one shared draft; nothing is
+  written until an explicit commit. A floating action bar shows live impact
+  ("N servers granted · M tools visible") with Save/Discard. Saving opens a
+  commit gate showing the exact `stack.yaml` patch diff and a per-client impact
+  summary (which clients lose access, a first-block deny-by-default warning, and
+  a blocking lockout warning when a draft would leave a client reaching nothing),
+  backed by a read-only `POST /api/clients/{slug}/scope/preview` endpoint that
+  computes the patch and consequences server-side without writing. A dirty draft
+  prompts discard-with-confirm on mode exit, client change, or navigation. Tool
+  allow-lists are preserved on every save.
+
 - **Access Scope in the client inspector.** Selecting a client in the topology
   now shows an "Access Scope" inspector section summarizing its real reach
   ("N of M servers" when scoped, or "Unscoped · all servers" otherwise) with the

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -242,6 +242,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/optimize", s.handleOptimize)
 	mux.HandleFunc("GET /api/traces", s.handleTraces)
 	mux.HandleFunc("GET /api/traces/{traceId}", s.handleTraces)
+	mux.HandleFunc("POST /api/clients/{slug}/scope/preview", s.handleClientScopePreview)
 	mux.HandleFunc("PUT /api/clients/{slug}/scope", s.handleSetClientScope)
 	mux.HandleFunc("/api/clients", s.handleClients)
 	mux.HandleFunc("/api/reload", s.handleReload)

--- a/internal/api/clients_preview.go
+++ b/internal/api/clients_preview.go
@@ -1,0 +1,209 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// clientScopeImpact is the per-client before/after delta the commit gate renders
+// as a plain-language impact summary ("loses gitlab; 12 of 43 tools visible").
+type clientScopeImpact struct {
+	Name          string   `json:"name"`
+	Slug          string   `json:"slug"`
+	BeforeServers int      `json:"beforeServers"`
+	AfterServers  int      `json:"afterServers"`
+	BeforeTools   int      `json:"beforeTools"`
+	AfterTools    int      `json:"afterTools"`
+	LostServers   []string `json:"lostServers"`
+	GainedServers []string `json:"gainedServers"`
+}
+
+// scopePreviewResponse is the read-only preview of committing a client-scope
+// draft: the exact stack.yaml patch that the matching PUT would write, plus the
+// computed per-client consequences. Nothing is written.
+type scopePreviewResponse struct {
+	Client       string              `json:"client"`
+	ProfileKey   string              `json:"profileKey"`
+	CreatesBlock bool                `json:"createsBlock"`
+	Lockout      bool                `json:"lockout"`
+	TotalServers int                 `json:"totalServers"`
+	TotalTools   int                 `json:"totalTools"`
+	Diff         string              `json:"diff"`
+	Selected     clientScopeImpact   `json:"selected"`
+	Affected     []clientScopeImpact `json:"affected"`
+}
+
+// handleClientScopePreview computes what committing a per-client access draft
+// would do, without touching the stack file. It returns the exact YAML patch
+// (produced by the same yaml.Node round-trip the write path uses, so comments,
+// ordering, and sibling profiles are faithful) and a per-client impact summary
+// covering the edited client plus, when the draft would create the `clients:`
+// block, the unlisted clients that flip to default-deny.
+//
+// POST /api/clients/{slug}/scope/preview
+func (s *Server) handleClientScopePreview(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	if slug == "" {
+		writeJSONError(w, "Client slug is required", http.StatusBadRequest)
+		return
+	}
+	profileKey := mcp.NormalizeClientID(slug)
+	if profileKey == "" {
+		writeStructuredError(w, http.StatusBadRequest, errCodeInvalidClient,
+			"Client identifier is empty after normalization.",
+			"Provide a non-empty client slug.")
+		return
+	}
+	if s.stackFile == "" {
+		writeJSONError(w, "No stack file configured", http.StatusServiceUnavailable)
+		return
+	}
+	if s.gateway == nil {
+		writeJSONError(w, "Gateway unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, setToolsRequestMaxBytes))
+	if err != nil {
+		writeJSONError(w, "Failed to read request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	var req setClientScopeRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Servers == nil && req.Tools == nil {
+		writeJSONError(w, "Request must set servers and/or tools", http.StatusBadRequest)
+		return
+	}
+	servers := normalizeScopeAxis(req.Servers)
+	tools := normalizeScopeAxis(req.Tools)
+	for _, v := range append(append([]string{}, derefStrings(servers)...), derefStrings(tools)...) {
+		if v == "" {
+			writeJSONError(w, "Server and tool names must be non-empty strings", http.StatusBadRequest)
+			return
+		}
+	}
+	// Same validation as the write path so the preview can't promise a scope the
+	// write would reject with a 422.
+	if code, msg := s.validateClientScope(derefStrings(servers), derefStrings(tools)); code != "" {
+		writeStructuredError(w, http.StatusUnprocessableEntity, code, msg,
+			"Refresh the workspace to pick up the current servers and tools, then try again.")
+		return
+	}
+
+	// Exact patch: run the real round-trip against the on-disk file and diff.
+	original, err := os.ReadFile(s.stackFile)
+	if err != nil {
+		writeJSONError(w, "Failed to read stack file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	updated, err := patchClientScope(original, profileKey, servers, tools)
+	if err != nil {
+		writeJSONError(w, "Failed to compute patch: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := scopePreviewResponse{
+		Client:       slug,
+		ProfileKey:   profileKey,
+		CreatesBlock: !s.gateway.ClientAccessConfigured(),
+		TotalServers: len(s.gateway.Status()),
+		TotalTools:   len(s.gateway.CatalogToolNames()),
+		Diff:         unifiedDiff(string(original), string(updated), 3),
+	}
+
+	before := s.gateway.ClientScope(slug)
+	after := s.gateway.ClientScopePreview(slug, derefStrings(servers), derefStringsNil(tools))
+	resp.Selected = impactFromScopes(slug, slug, before, after)
+	// An empty resulting scope is the lockout footgun: a profiled client that can
+	// reach nothing. The editor forbids saving it; flag it so the gate can block.
+	resp.Lockout = after.Configured && !after.Unscoped &&
+		len(after.Servers) == 0 && len(after.Tools) == 0
+
+	// Cross-client consequence: creating the block flips every other listed
+	// client to the default policy. Per-client scope is otherwise independent, so
+	// an edit to an existing block touches no one else.
+	if resp.CreatesBlock {
+		resp.Affected = s.affectedByNewBlock(profileKey)
+	}
+
+	slog.Default().Debug("client scope preview computed", "client", profileKey,
+		"createsBlock", resp.CreatesBlock, "lockout", resp.Lockout, "affected", len(resp.Affected))
+	writeJSON(w, resp)
+}
+
+// affectedByNewBlock lists the linked clients (other than the one being edited)
+// that lose access when a `clients:` block is created for the first time: with
+// no block today they reach everything, and an unlisted client under the default
+// (deny) policy reaches nothing.
+func (s *Server) affectedByNewBlock(editedKey string) []clientScopeImpact {
+	if s.provisioners == nil {
+		return nil
+	}
+	serverName := s.linkServerName
+	if serverName == "" {
+		serverName = "gridctl"
+	}
+	var out []clientScopeImpact
+	for _, info := range s.provisioners.AllClientInfo(serverName) {
+		if !info.Linked || mcp.NormalizeClientID(info.Slug) == editedKey {
+			continue
+		}
+		before := s.gateway.ClientScope(info.Slug)
+		after := mcp.ClientScopeResult{Configured: true} // default-deny: reaches nothing
+		out = append(out, impactFromScopes(info.Name, info.Slug, before, after))
+	}
+	return out
+}
+
+// impactFromScopes diffs a before/after scope into a UI-facing delta, computing
+// which servers a client gains or loses.
+func impactFromScopes(name, slug string, before, after mcp.ClientScopeResult) clientScopeImpact {
+	beforeSet := make(map[string]bool, len(before.Servers))
+	for _, s := range before.Servers {
+		beforeSet[s] = true
+	}
+	afterSet := make(map[string]bool, len(after.Servers))
+	for _, s := range after.Servers {
+		afterSet[s] = true
+	}
+	var lost, gained []string
+	for _, s := range before.Servers {
+		if !afterSet[s] {
+			lost = append(lost, s)
+		}
+	}
+	for _, s := range after.Servers {
+		if !beforeSet[s] {
+			gained = append(gained, s)
+		}
+	}
+	return clientScopeImpact{
+		Name:          name,
+		Slug:          slug,
+		BeforeServers: len(before.Servers),
+		AfterServers:  len(after.Servers),
+		BeforeTools:   len(before.Tools),
+		AfterTools:    len(after.Tools),
+		LostServers:   lost,
+		GainedServers: gained,
+	}
+}
+
+// derefStringsNil returns the slice value of a possibly-nil *[]string, keeping
+// nil as nil. Unlike derefStrings (which coerces nil to an empty slice for
+// validation), the preview needs nil preserved so ClientScopePreview can tell
+// "leave the tools axis untouched" apart from "replace tools with none".
+func derefStringsNil(p *[]string) []string {
+	if p == nil {
+		return nil
+	}
+	return *p
+}

--- a/internal/api/clients_preview_test.go
+++ b/internal/api/clients_preview_test.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+func TestImpactFromScopes_LosesAndGains(t *testing.T) {
+	before := mcp.ClientScopeResult{
+		Configured: true,
+		Servers:    []string{"github", "gitlab"},
+		Tools:      []string{"github__a", "github__b", "gitlab__c"},
+	}
+	after := mcp.ClientScopeResult{
+		Configured: true,
+		Servers:    []string{"github", "slack"},
+		Tools:      []string{"github__a", "github__b", "slack__d"},
+	}
+	imp := impactFromScopes("Cursor", "cursor", before, after)
+
+	assert.Equal(t, "Cursor", imp.Name)
+	assert.Equal(t, "cursor", imp.Slug)
+	assert.Equal(t, 2, imp.BeforeServers)
+	assert.Equal(t, 2, imp.AfterServers)
+	assert.Equal(t, 3, imp.BeforeTools)
+	assert.Equal(t, 3, imp.AfterTools)
+	assert.Equal(t, []string{"gitlab"}, imp.LostServers)
+	assert.Equal(t, []string{"slack"}, imp.GainedServers)
+}
+
+func TestImpactFromScopes_FullLockout(t *testing.T) {
+	before := mcp.ClientScopeResult{Configured: true, Servers: []string{"github"}, Tools: []string{"github__a"}}
+	after := mcp.ClientScopeResult{Configured: true} // reaches nothing
+	imp := impactFromScopes("Bot", "bot", before, after)
+
+	assert.Equal(t, 0, imp.AfterServers)
+	assert.Equal(t, 0, imp.AfterTools)
+	assert.Equal(t, []string{"github"}, imp.LostServers)
+	assert.Empty(t, imp.GainedServers)
+}
+
+func TestDerefStringsNil_PreservesNil(t *testing.T) {
+	assert.Nil(t, derefStringsNil(nil))
+	got := derefStringsNil(sp("a", "b"))
+	assert.Equal(t, []string{"a", "b"}, got)
+}

--- a/internal/api/textdiff.go
+++ b/internal/api/textdiff.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+)
+
+// unifiedDiff renders a unified-style line diff of old vs new with `context`
+// unchanged lines of surrounding context per hunk. It is intentionally small
+// (an LCS line walk, no external dependency) since the only consumer is the
+// client-scope preview, which diffs a single stack.yaml round-trip. Returns an
+// empty string when the two inputs are identical.
+//
+// Output lines are prefixed " " (context), "-" (removed), or "+" (added) so the
+// UI can render a copyable monospace patch. Hunk headers use the standard
+// "@@ -a,b +c,d @@" form.
+func unifiedDiff(oldText, newText string, context int) string {
+	if oldText == newText {
+		return ""
+	}
+	if context < 0 {
+		context = 0
+	}
+	oldLines := splitLines(oldText)
+	newLines := splitLines(newText)
+
+	ops := diffOps(oldLines, newLines)
+	if len(ops) == 0 {
+		return ""
+	}
+
+	// Group ops into hunks separated by runs of >2*context equal lines, keeping
+	// up to `context` equal lines on each side of a change.
+	var b strings.Builder
+	for _, h := range buildHunks(ops, context) {
+		fmt.Fprintf(&b, "@@ -%d,%d +%d,%d @@\n", h.oldStart, h.oldCount, h.newStart, h.newCount)
+		for _, ln := range h.lines {
+			b.WriteString(ln)
+			b.WriteByte('\n')
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// splitLines splits text into lines, dropping a single trailing newline so a
+// file that ends in "\n" does not yield a spurious empty final line.
+func splitLines(text string) []string {
+	if text == "" {
+		return nil
+	}
+	text = strings.TrimSuffix(text, "\n")
+	return strings.Split(text, "\n")
+}
+
+type diffOp struct {
+	kind byte // ' ' equal, '-' removed, '+' added
+	text string
+}
+
+// diffOps computes a line-level diff via the classic LCS dynamic-programming
+// table, then walks it into a flat op list in source order.
+func diffOps(a, b []string) []diffOp {
+	n, m := len(a), len(b)
+	// lcs[i][j] = length of the LCS of a[i:] and b[j:].
+	lcs := make([][]int, n+1)
+	for i := range lcs {
+		lcs[i] = make([]int, m+1)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else if lcs[i+1][j] >= lcs[i][j+1] {
+				lcs[i][j] = lcs[i+1][j]
+			} else {
+				lcs[i][j] = lcs[i][j+1]
+			}
+		}
+	}
+
+	var ops []diffOp
+	i, j := 0, 0
+	for i < n && j < m {
+		switch {
+		case a[i] == b[j]:
+			ops = append(ops, diffOp{' ', a[i]})
+			i++
+			j++
+		case lcs[i+1][j] >= lcs[i][j+1]:
+			ops = append(ops, diffOp{'-', a[i]})
+			i++
+		default:
+			ops = append(ops, diffOp{'+', b[j]})
+			j++
+		}
+	}
+	for ; i < n; i++ {
+		ops = append(ops, diffOp{'-', a[i]})
+	}
+	for ; j < m; j++ {
+		ops = append(ops, diffOp{'+', b[j]})
+	}
+	return ops
+}
+
+type hunk struct {
+	oldStart, oldCount int
+	newStart, newCount int
+	lines              []string
+}
+
+// buildHunks slices the op stream into hunks, trimming long equal runs down to
+// `context` lines on each side so the patch stays focused on the changes.
+func buildHunks(ops []diffOp, context int) []hunk {
+	// Mark which ops are within `context` of a change; everything else is elided.
+	keep := make([]bool, len(ops))
+	for i, op := range ops {
+		if op.kind == ' ' {
+			continue
+		}
+		lo := i - context
+		if lo < 0 {
+			lo = 0
+		}
+		hi := i + context
+		if hi >= len(ops) {
+			hi = len(ops) - 1
+		}
+		for k := lo; k <= hi; k++ {
+			keep[k] = true
+		}
+	}
+
+	var hunks []hunk
+	oldLine, newLine := 1, 1
+	i := 0
+	for i < len(ops) {
+		if !keep[i] {
+			if ops[i].kind != '+' {
+				oldLine++
+			}
+			if ops[i].kind != '-' {
+				newLine++
+			}
+			i++
+			continue
+		}
+		h := hunk{oldStart: oldLine, newStart: newLine}
+		for i < len(ops) && keep[i] {
+			op := ops[i]
+			h.lines = append(h.lines, string(op.kind)+op.text)
+			switch op.kind {
+			case ' ':
+				h.oldCount++
+				h.newCount++
+				oldLine++
+				newLine++
+			case '-':
+				h.oldCount++
+				oldLine++
+			case '+':
+				h.newCount++
+				newLine++
+			}
+			i++
+		}
+		hunks = append(hunks, h)
+	}
+	return hunks
+}

--- a/internal/api/textdiff_test.go
+++ b/internal/api/textdiff_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnifiedDiff_Identical(t *testing.T) {
+	assert.Equal(t, "", unifiedDiff("a\nb\n", "a\nb\n", 3))
+	assert.Equal(t, "", unifiedDiff("", "", 3))
+}
+
+func TestUnifiedDiff_AddedLines(t *testing.T) {
+	old := "version: \"1\"\nname: example\n"
+	updated := "version: \"1\"\nname: example\nclients:\n  default: deny\n"
+	diff := unifiedDiff(old, updated, 3)
+
+	assert.Contains(t, diff, "+clients:")
+	assert.Contains(t, diff, "+  default: deny")
+	// Unchanged context lines carry a single leading space, not a +/-.
+	assert.Contains(t, diff, " version: \"1\"")
+	assert.NotContains(t, diff, "-version")
+	assert.True(t, strings.HasPrefix(diff, "@@"), "diff should start with a hunk header")
+}
+
+func TestUnifiedDiff_RemovedAndChanged(t *testing.T) {
+	old := "a\nb\nc\n"
+	updated := "a\nB\nc\n"
+	diff := unifiedDiff(old, updated, 1)
+	assert.Contains(t, diff, "-b")
+	assert.Contains(t, diff, "+B")
+	assert.Contains(t, diff, " a")
+	assert.Contains(t, diff, " c")
+}
+
+func TestUnifiedDiff_ContextTrimsDistantLines(t *testing.T) {
+	// 20 identical lines with one change in the middle; context=2 should elide
+	// the far-away unchanged lines into separate/limited context.
+	var oldB, newB strings.Builder
+	for i := 0; i < 20; i++ {
+		oldB.WriteString("line\n")
+		if i == 10 {
+			newB.WriteString("CHANGED\n")
+		} else {
+			newB.WriteString("line\n")
+		}
+	}
+	diff := unifiedDiff(oldB.String(), newB.String(), 2)
+	assert.Contains(t, diff, "+CHANGED")
+	assert.Contains(t, diff, "-line")
+	// Only a handful of context lines survive, not all 19 unchanged ones.
+	assert.LessOrEqual(t, strings.Count(diff, " line"), 5)
+}
+
+func TestUnifiedDiff_HunkHeaderCounts(t *testing.T) {
+	diff := unifiedDiff("a\n", "a\nb\n", 3)
+	// One context line (a) + one added (b): old has 1 line, new has 2.
+	assert.Contains(t, diff, "@@ -1,1 +1,2 @@")
+}

--- a/pkg/mcp/clientscope.go
+++ b/pkg/mcp/clientscope.go
@@ -167,6 +167,30 @@ type ClientScopeResult struct {
 	Tools []string `json:"tools"`
 }
 
+// profileAllowLists returns the configured server and tool allow-lists for a
+// profile key, as sorted slices, plus whether a profile exists. It lets the
+// preview path preserve an operator-authored tool allow-list when a server-only
+// draft is simulated (tools nil = "leave that axis untouched"). A nil policy or
+// an unlisted key returns empty lists and false.
+func (p *ClientAccessPolicy) profileAllowLists(key string) (servers, tools []string, listed bool) {
+	if p == nil {
+		return nil, nil, false
+	}
+	prof, ok := p.profiles[NormalizeClientID(key)]
+	if !ok {
+		return nil, nil, false
+	}
+	for s := range prof.servers {
+		servers = append(servers, s)
+	}
+	for t := range prof.tools {
+		tools = append(tools, t)
+	}
+	sort.Strings(servers)
+	sort.Strings(tools)
+	return servers, tools, true
+}
+
 // scopeResult computes the effective scope for accessID against a fully-known
 // tool surface. allTools is the global (unscoped) catalog of prefixed tools.
 func (p *ClientAccessPolicy) scopeResult(accessID string, allTools []Tool) ClientScopeResult {

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -277,6 +277,43 @@ func (g *Gateway) ClientScope(accessID string) ClientScopeResult {
 	return g.clientAccessPolicy().scopeResult(NormalizeClientID(accessID), g.router.CatalogTools())
 }
 
+// ClientScopePreview computes the effective scope a client WOULD have under a
+// hypothetical server/tool allow-list, intersected with the live tool surface,
+// without mutating any installed policy (read-only). It backs the per-client
+// "what changes" preview the Topology Access Lens shows before a commit.
+//
+// servers and tools are tri-state allow-lists matching the PUT /scope contract:
+// a nil tools slice preserves the client's currently-configured tool allow-list
+// (so a server-only draft never appears to clobber an operator-authored tool
+// list), while a non-nil tools slice replaces it. A listed client's scope
+// depends only on its own profile, so simulating one profile in isolation is
+// faithful to what enforcement would compute after the write.
+func (g *Gateway) ClientScopePreview(accessID string, servers, tools []string) ClientScopeResult {
+	key := NormalizeClientID(accessID)
+	if tools == nil {
+		if _, saved, listed := g.clientAccessPolicy().profileAllowLists(key); listed {
+			tools = saved
+		}
+	}
+	spec := &ClientAccessSpec{
+		Profiles: map[string]ClientProfileSpec{
+			key: {Servers: servers, Tools: tools},
+		},
+	}
+	return NewClientAccessPolicy(spec).scopeResult(key, g.router.CatalogTools())
+}
+
+// CatalogToolNames returns every prefixed tool name on the live surface,
+// unscoped. The scope preview uses its length as the "of N tools" denominator.
+func (g *Gateway) CatalogToolNames() []string {
+	tools := g.router.CatalogTools()
+	names := make([]string, 0, len(tools))
+	for _, t := range tools {
+		names = append(names, t.Name)
+	}
+	return names
+}
+
 // SetDefaultOutputFormat sets the gateway-level default output format.
 func (g *Gateway) SetDefaultOutputFormat(format string) {
 	g.mu.Lock()

--- a/pkg/mcp/gateway_scopepreview_test.go
+++ b/pkg/mcp/gateway_scopepreview_test.go
@@ -1,0 +1,68 @@
+package mcp
+
+import "testing"
+
+// TestClientScopePreview_ServerDraft verifies the read-only preview computes a
+// hypothetical server allow-list against the live surface without installing any
+// policy: a github-only draft reaches exactly github's two tools.
+func TestClientScopePreview_ServerDraft(t *testing.T) {
+	g := newScopeTestGateway(t)
+
+	res := g.ClientScopePreview("cursor", []string{"github"}, nil)
+	if res.Unscoped {
+		t.Fatalf("a narrowed draft should not be unscoped")
+	}
+	if len(res.Servers) != 1 || res.Servers[0] != "github" {
+		t.Errorf("servers = %v, want [github]", res.Servers)
+	}
+	want := []string{"github__create-issue", "github__search-repos"}
+	if len(res.Tools) != len(want) || res.Tools[0] != want[0] || res.Tools[1] != want[1] {
+		t.Errorf("tools = %v, want %v", res.Tools, want)
+	}
+
+	// The preview must not mutate gateway state: with no policy installed, the
+	// real scope stays unscoped.
+	live := g.ClientScope("cursor")
+	if !live.Unscoped {
+		t.Errorf("preview leaked into installed policy: live scope = %+v", live)
+	}
+}
+
+// TestClientScopePreview_PreservesToolAllowList confirms a server-only draft
+// (tools nil) keeps an operator-authored tool allow-list on the live profile,
+// rather than silently widening the client to every tool of the drafted servers.
+func TestClientScopePreview_PreservesToolAllowList(t *testing.T) {
+	g := newScopeTestGateway(t)
+	g.SetClientAccessPolicy(NewClientAccessPolicy(&ClientAccessSpec{
+		Profiles: map[string]ClientProfileSpec{
+			"cursor": {Servers: []string{"github"}, Tools: []string{"github__search-repos"}},
+		},
+	}))
+
+	// Draft adds gitlab at the server level but leaves the tools axis untouched
+	// (nil). The tool allow-list is GLOBAL, not per-server, so preserving it keeps
+	// the client pinned to github__search-repos even though gitlab is now granted
+	// — the faithful consequence the commit gate must show, and exactly why a
+	// client-side guess would mislead.
+	res := g.ClientScopePreview("cursor", []string{"github", "gitlab"}, nil)
+	want := []string{"github__search-repos"}
+	if len(res.Tools) != len(want) || res.Tools[0] != want[0] {
+		t.Fatalf("tools = %v, want %v", res.Tools, want)
+	}
+}
+
+// TestClientScopePreview_EmptyServersMeansAll documents the backend footgun the
+// editor guards against: an empty server allow-list is "no restriction" (all
+// servers), NOT "deny everything". The UI must forbid saving an empty selection
+// precisely because committing it would silently grant the full surface.
+func TestClientScopePreview_EmptyServersMeansAll(t *testing.T) {
+	g := newScopeTestGateway(t)
+	// Both axes explicitly empty: per config semantics this is unrestricted.
+	res := g.ClientScopePreview("bot", []string{}, []string{})
+	if !res.Unscoped {
+		t.Errorf("empty allow-lists should be unscoped (all), got %+v", res)
+	}
+	if len(res.Tools) != 4 {
+		t.Errorf("empty draft should reach all 4 tools, got %v", res.Tools)
+	}
+}

--- a/web/src/__tests__/AccessLens.test.tsx
+++ b/web/src/__tests__/AccessLens.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AccessLens } from '../components/topology/AccessLens';
+import { useStackStore } from '../stores/useStackStore';
+import { useAccessLensStore } from '../stores/useAccessLensStore';
+import type { ClientStatus, MCPServerStatus } from '../types';
+
+const SERVERS: MCPServerStatus[] = [
+  { name: 'github', transport: 'http', initialized: true, toolCount: 2, tools: ['search', 'create'] },
+  { name: 'gitlab', transport: 'http', initialized: true, toolCount: 1, tools: ['list'] },
+];
+
+const CURSOR: ClientStatus = {
+  name: 'Cursor',
+  slug: 'cursor',
+  detected: true,
+  linked: true,
+  transport: 'native SSE',
+  effectiveScope: { configured: true, unscoped: false, servers: ['github'], tools: ['github__search', 'github__create'] },
+};
+
+function renderLens() {
+  return render(
+    <MemoryRouter>
+      <AccessLens servers={SERVERS} />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  useAccessLensStore.getState().clearDraft();
+  useAccessLensStore.setState({ enabled: false, isSaving: false });
+  useStackStore.setState({ clients: [CURSOR], selectedNodeId: null });
+});
+
+describe('AccessLens', () => {
+  it('exposes the header toggle with aria-pressed reflecting mode', () => {
+    renderLens();
+    const toggle = screen.getByRole('button', { name: 'Toggle Access Lens' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(toggle);
+    expect(screen.getByRole('button', { name: 'Toggle Access Lens' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('hints to select a client when none is selected', () => {
+    renderLens();
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Access Lens' }));
+    expect(screen.getByText(/Select a client to shape its access/i)).toBeInTheDocument();
+  });
+
+  it('seeds a draft and shows the action bar once dirty', () => {
+    renderLens();
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Access Lens' }));
+
+    // Select the client; the seeding effect mirrors its saved scope as baseline.
+    act(() => {
+      useStackStore.setState({ selectedNodeId: 'client-cursor' });
+    });
+    expect(screen.getByText('Cursor')).toBeInTheDocument();
+    // Clean draft → no action bar yet.
+    expect(screen.queryByRole('button', { name: 'Save access scope' })).not.toBeInTheDocument();
+
+    // Grant gitlab in the draft → dirty → action bar appears with live impact.
+    act(() => {
+      useAccessLensStore.getState().toggleServer('gitlab');
+    });
+    expect(screen.getByRole('button', { name: 'Save access scope' })).toBeInTheDocument();
+    // Live impact text spans multiple nodes; assert on the combined content.
+    expect(document.body.textContent).toMatch(/2\s*servers granted/);
+  });
+
+  it('reverts the draft when Discard is clicked', () => {
+    renderLens();
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Access Lens' }));
+    act(() => {
+      useStackStore.setState({ selectedNodeId: 'client-cursor' });
+    });
+    act(() => {
+      useAccessLensStore.getState().toggleServer('gitlab');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Discard/ }));
+    expect(useAccessLensStore.getState().draft).toEqual(['github']);
+  });
+
+  it('prompts discard-with-confirm when turning the mode off while dirty', () => {
+    renderLens();
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Access Lens' }));
+    act(() => {
+      useStackStore.setState({ selectedNodeId: 'client-cursor' });
+    });
+    act(() => {
+      useAccessLensStore.getState().toggleServer('gitlab');
+    });
+    // Click the toggle to turn off → confirm appears, mode still on until resolved.
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Access Lens' }));
+    expect(screen.getByText(/discard unsaved access changes/i)).toBeInTheDocument();
+    expect(useAccessLensStore.getState().enabled).toBe(true);
+
+    // Discard → mode off, draft cleared.
+    fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
+    expect(useAccessLensStore.getState().enabled).toBe(false);
+    expect(useAccessLensStore.getState().clientSlug).toBeNull();
+  });
+});

--- a/web/src/__tests__/SlideOver.test.tsx
+++ b/web/src/__tests__/SlideOver.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { SlideOver } from '../components/ui/SlideOver';
+
+beforeEach(() => cleanup());
+
+describe('SlideOver', () => {
+  it('renders title and children when open', () => {
+    render(
+      <SlideOver isOpen onClose={() => {}} title="Access editor">
+        <p>body content</p>
+      </SlideOver>,
+    );
+    expect(screen.getByText('Access editor')).toBeInTheDocument();
+    expect(screen.getByText('body content')).toBeInTheDocument();
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <SlideOver isOpen={false} onClose={() => {}} title="Access editor">
+        <p>body content</p>
+      </SlideOver>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('is a non-modal dialog (no aria-modal, so the canvas stays interactive)', () => {
+    render(
+      <SlideOver isOpen onClose={() => {}} title="Access editor">
+        <p>body</p>
+      </SlideOver>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).not.toHaveAttribute('aria-modal');
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(
+      <SlideOver isOpen onClose={onClose} title="Access editor">
+        <p>body</p>
+      </SlideOver>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('closes via the close button', () => {
+    const onClose = vi.fn();
+    render(
+      <SlideOver isOpen onClose={onClose} title="Access editor">
+        <p>body</p>
+      </SlideOver>,
+    );
+    fireEvent.click(screen.getByLabelText('Close access editor'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/__tests__/useAccessLensStore.test.ts
+++ b/web/src/__tests__/useAccessLensStore.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  useAccessLensStore,
+  canonical,
+  isDirty,
+  canSaveDraft,
+  buildDraftScope,
+} from '../stores/useAccessLensStore';
+import type { MCPServerStatus } from '../types';
+
+function server(name: string, tools: string[]): MCPServerStatus {
+  return { name, transport: 'http', initialized: true, toolCount: tools.length, tools };
+}
+
+const SERVERS: MCPServerStatus[] = [
+  server('github', ['search-repos', 'create-issue']),
+  server('gitlab', ['list-issues', 'merge-request']),
+];
+
+describe('access-lens pure helpers', () => {
+  it('canonical de-dupes and sorts', () => {
+    expect(canonical(['gitlab', 'github', 'gitlab'])).toEqual(['github', 'gitlab']);
+  });
+
+  it('isDirty is order-independent', () => {
+    expect(isDirty(['github', 'gitlab'], ['gitlab', 'github'])).toBe(false);
+    expect(isDirty(['github'], ['gitlab', 'github'])).toBe(true);
+  });
+
+  it('canSaveDraft forbids an empty selection even when dirty', () => {
+    // Empty means "all" in the backend model, so it can never express deny.
+    expect(canSaveDraft([], ['github'])).toBe(false);
+    expect(canSaveDraft(['github'], ['github', 'gitlab'])).toBe(true);
+    expect(canSaveDraft(['github', 'gitlab'], ['github', 'gitlab'])).toBe(false);
+  });
+});
+
+describe('buildDraftScope', () => {
+  it('surfaces every tool of granted servers when no tool allow-list', () => {
+    const scope = buildDraftScope(['github'], SERVERS, []);
+    expect(scope.configured).toBe(true);
+    expect(scope.unscoped).toBe(false);
+    expect(scope.servers).toEqual(['github']);
+    expect(scope.tools).toEqual(['github__create-issue', 'github__search-repos']);
+  });
+
+  it('treats the tool allow-list as global, gating newly granted servers', () => {
+    // Adding gitlab at the server level does NOT surface its tools while the
+    // global allow-list pins visibility to github__search-repos (faithful to
+    // the backend so the live canvas matches the commit).
+    const scope = buildDraftScope(['github', 'gitlab'], SERVERS, ['github__search-repos']);
+    expect(scope.tools).toEqual(['github__search-repos']);
+    expect(scope.servers).toEqual(['github']);
+  });
+
+  it('drops a granted server that surfaces no visible tool', () => {
+    const scope = buildDraftScope(['github', 'gitlab'], SERVERS, ['gitlab__list-issues']);
+    expect(scope.servers).toEqual(['gitlab']);
+    expect(scope.tools).toEqual(['gitlab__list-issues']);
+  });
+});
+
+describe('useAccessLensStore', () => {
+  beforeEach(() => {
+    useAccessLensStore.getState().clearDraft();
+    useAccessLensStore.setState({ enabled: false, isSaving: false });
+  });
+
+  it('seeds the draft from the saved baseline', () => {
+    useAccessLensStore.getState().seed({
+      slug: 'cursor',
+      name: 'Cursor',
+      baseline: ['gitlab', 'github'],
+      savedTools: [],
+      createsBlock: false,
+    });
+    const s = useAccessLensStore.getState();
+    expect(s.clientSlug).toBe('cursor');
+    expect(s.draft).toEqual(['github', 'gitlab']);
+    expect(isDirty(s.draft, s.baseline)).toBe(false);
+  });
+
+  it('toggleServer mutates only the draft, never the baseline', () => {
+    const st = useAccessLensStore.getState();
+    st.seed({ slug: 'cursor', name: 'Cursor', baseline: ['github'], savedTools: [], createsBlock: false });
+    st.toggleServer('gitlab');
+    let s = useAccessLensStore.getState();
+    expect(s.draft.sort()).toEqual(['github', 'gitlab']);
+    expect(s.baseline).toEqual(['github']);
+    expect(isDirty(s.draft, s.baseline)).toBe(true);
+
+    st.toggleServer('gitlab');
+    s = useAccessLensStore.getState();
+    expect(s.draft).toEqual(['github']);
+    expect(isDirty(s.draft, s.baseline)).toBe(false);
+  });
+
+  it('discardDraft reverts to the baseline; clearDraft resets the target', () => {
+    const st = useAccessLensStore.getState();
+    st.seed({ slug: 'cursor', name: 'Cursor', baseline: ['github'], savedTools: [], createsBlock: false });
+    st.toggleServer('gitlab');
+    st.discardDraft();
+    expect(useAccessLensStore.getState().draft).toEqual(['github']);
+
+    st.clearDraft();
+    expect(useAccessLensStore.getState().clientSlug).toBeNull();
+    expect(useAccessLensStore.getState().draft).toEqual([]);
+  });
+});

--- a/web/src/__tests__/usePathHighlight.test.ts
+++ b/web/src/__tests__/usePathHighlight.test.ts
@@ -294,6 +294,51 @@ describe('computeHighlightState with per-client effective scope', () => {
   });
 });
 
+describe('computeHighlightState with a draft scope override (Access Lens)', () => {
+  // Saved scope reaches only x; the draft override grants y instead, proving the
+  // override drives the highlight in place of the saved effectiveScope.
+  function makeGraph(savedScope: unknown): { nodes: Node[]; edges: Edge[] } {
+    const nodes: Node[] = [
+      { id: 'client-a', position: { x: 0, y: 0 }, data: { type: 'client', effectiveScope: savedScope } },
+      { id: 'gateway', position: { x: 0, y: 0 }, data: { type: 'gateway' } },
+      { id: 'mcp-x', position: { x: 0, y: 0 }, data: { type: 'mcp-server', name: 'x' } },
+      { id: 'mcp-y', position: { x: 0, y: 0 }, data: { type: 'mcp-server', name: 'y' } },
+    ];
+    const edges: Edge[] = [
+      { id: 'e-c-g', source: 'client-a', target: 'gateway', data: { relationType: 'client-to-gateway', isHighlightable: true } },
+      { id: 'e-g-x', source: 'gateway', target: 'mcp-x', data: { relationType: 'gateway-to-server', isHighlightable: true } },
+      { id: 'e-g-y', source: 'gateway', target: 'mcp-y', data: { relationType: 'gateway-to-server', isHighlightable: true } },
+    ];
+    return { nodes, edges };
+  }
+
+  const savedScope = { configured: true, unscoped: false, servers: ['x'], tools: ['x__a'] };
+
+  it('lights the draft servers, not the saved scope', () => {
+    const { nodes, edges } = makeGraph(savedScope);
+    const draft = { configured: true, unscoped: false, servers: ['y'], tools: ['y__b'] };
+    const state = computeHighlightState(nodes, edges, 'client-a', draft);
+
+    expect(state.highlightedNodeIds.has('mcp-y')).toBe(true);
+    expect(state.highlightedNodeIds.has('mcp-x')).toBe(false);
+  });
+
+  it('falls back to the saved scope when override is null', () => {
+    const { nodes, edges } = makeGraph(savedScope);
+    const state = computeHighlightState(nodes, edges, 'client-a', null);
+    expect(state.highlightedNodeIds.has('mcp-x')).toBe(true);
+    expect(state.highlightedNodeIds.has('mcp-y')).toBe(false);
+  });
+
+  it('lights both servers when the draft grants both', () => {
+    const { nodes, edges } = makeGraph(savedScope);
+    const draft = { configured: true, unscoped: false, servers: ['x', 'y'], tools: ['x__a', 'y__b'] };
+    const state = computeHighlightState(nodes, edges, 'client-a', draft);
+    expect(state.highlightedNodeIds.has('mcp-x')).toBe(true);
+    expect(state.highlightedNodeIds.has('mcp-y')).toBe(true);
+  });
+});
+
 describe('isNodeDimmed / isEdgeDimmed', () => {
   it('dims nothing when there is no selection', () => {
     const state = computeHighlightState([], [], null);

--- a/web/src/components/graph/Canvas.tsx
+++ b/web/src/components/graph/Canvas.tsx
@@ -13,6 +13,7 @@ import { nodeTypes } from './nodeTypes';
 import { useStackStore } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
 import { useWizardStore } from '../../stores/useWizardStore';
+import { useAccessLensStore, buildDraftScope } from '../../stores/useAccessLensStore';
 import { COLORS } from '../../lib/constants';
 import { usePathHighlight } from '../../hooks/usePathHighlight';
 import { cn } from '../../lib/cn';
@@ -48,6 +49,26 @@ export function Canvas() {
   const showSecretHeatmap = useUIStore((s) => s.showSecretHeatmap);
   const toggleSecretHeatmap = useUIStore((s) => s.toggleSecretHeatmap);
 
+  // Access Lens: a draft per-client scope edited on the canvas. When active for
+  // the selected client, the highlight previews the draft instead of the saved
+  // scope, and clicking a server node grants/revokes it in the draft.
+  const mcpServers = useStackStore((s) => s.mcpServers);
+  const lensEnabled = useAccessLensStore((s) => s.enabled);
+  const lensClientSlug = useAccessLensStore((s) => s.clientSlug);
+  const lensDraft = useAccessLensStore((s) => s.draft);
+  const lensSavedTools = useAccessLensStore((s) => s.savedTools);
+  const toggleDraftServer = useAccessLensStore((s) => s.toggleServer);
+
+  // The lens edits exactly the selected client; a mismatch (or no client
+  // selected) means the canvas behaves normally.
+  const lensActive =
+    lensEnabled && lensClientSlug != null && selectedNodeId === `client-${lensClientSlug}`;
+
+  const scopeOverride = useMemo(
+    () => (lensActive ? buildDraftScope(lensDraft, mcpServers, lensSavedTools) : null),
+    [lensActive, lensDraft, mcpServers, lensSavedTools],
+  );
+
   // React Flow controls
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const { zoom } = useViewport();
@@ -61,8 +82,9 @@ export function Canvas() {
     }
   }, [compactCards, resetLayout]);
 
-  // Path highlighting for selected agents
-  const highlightState = usePathHighlight(nodes, edges, selectedNodeId);
+  // Path highlighting for selected agents. In Access Lens, the draft scope
+  // override re-lights the canvas live against unsaved edits.
+  const highlightState = usePathHighlight(nodes, edges, selectedNodeId, scopeOverride);
 
   // Auto-fit the view to a focused client's reachable subgraph. The fit key
   // captures the highlighted node set, so the view re-fits whenever that set
@@ -129,12 +151,18 @@ export function Canvas() {
   // Handle node selection. Tool fan-out nodes are read-only affordances: a
   // click should not select them or open the sidebar (the "+N more" node
   // handles its own popover internally).
-  const onNodeClick = useCallback((_: React.MouseEvent, node: { id: string; data?: { type?: string } }) => {
+  const onNodeClick = useCallback((_: React.MouseEvent, node: { id: string; data?: { type?: string; name?: string } }) => {
     const nodeType = node.data?.type;
     if (nodeType === 'tool' || nodeType === 'tool-overflow') return;
+    // In Access Lens, a server-node click grants/revokes it in the draft instead
+    // of selecting it — the draft mutates, never the stack (commit gate writes).
+    if (lensActive && nodeType === 'mcp-server' && node.data?.name) {
+      toggleDraftServer(node.data.name);
+      return;
+    }
     selectNode(node.id);
     setSidebarOpen(true);
-  }, [selectNode, setSidebarOpen]);
+  }, [selectNode, setSidebarOpen, lensActive, toggleDraftServer]);
 
   // Handle pane click (deselect). Reset focus and zoom back out to frame the
   // whole graph, complementing the zoom-to-fit on client selection.

--- a/web/src/components/graph/CustomNode.tsx
+++ b/web/src/components/graph/CustomNode.tsx
@@ -7,6 +7,7 @@ import { StatusDot } from '../ui/StatusDot';
 import { getTransportIcon, getTransportColorClasses } from '../../lib/transport';
 import { useUIStore } from '../../stores/useUIStore';
 import { useStackStore } from '../../stores/useStackStore';
+import { useAccessLensStore } from '../../stores/useAccessLensStore';
 import { useTokenHeat } from '../../hooks/useTokenHeat';
 import { LAYOUT } from '../../lib/constants';
 import { TelemetryNodeDot } from '../telemetry/TelemetryNodeDot';
@@ -31,6 +32,17 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
   const toggleServerExpanded = useStackStore((s) => s.toggleServerExpanded);
   const serverToolCount = isServer ? (data as MCPServerNodeData).toolCount : 0;
   const canExpand = isServer && (serverToolCount ?? 0) > 0;
+
+  // Access Lens draft visuals: when the lens targets the currently-selected
+  // client, server nodes become grant/revoke targets. Granted = amber ring +
+  // inner glow; revoked = desaturated + dashed border. Reads the shared draft
+  // store so the canvas and the slide-over stay in sync.
+  const lensEnabled = useAccessLensStore((s) => s.enabled);
+  const lensClientSlug = useAccessLensStore((s) => s.clientSlug);
+  const selectedNodeId = useStackStore((s) => s.selectedNodeId);
+  const lensGranted = useAccessLensStore((s) => s.draft.includes(data.name));
+  const lensActiveForNode =
+    isServer && lensEnabled && lensClientSlug != null && selectedNodeId === `client-${lensClientSlug}`;
   const isExternal = isServer && (data as MCPServerNodeData).external;
   const isLocalProcess = isServer && (data as MCPServerNodeData).localProcess;
   const isSSH = isServer && (data as MCPServerNodeData).ssh;
@@ -73,8 +85,14 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
         autoscale?.lastDecision === 'up' && 'ring-2 ring-inset ring-primary/40 animate-pulse-glow',
         autoscale?.lastDecision === 'down' && 'ring-2 ring-inset ring-secondary/40',
         !selected && 'hover:shadow-node-hover',
-        !selected && isServer && 'hover:border-violet-400/60',
-        !selected && !isServer && 'hover:border-secondary/70'
+        !selected && isServer && !lensActiveForNode && 'hover:border-violet-400/60',
+        !selected && !isServer && 'hover:border-secondary/70',
+        // Access Lens draft state (overrides the violet server accents).
+        lensActiveForNode && 'cursor-pointer',
+        lensActiveForNode && lensGranted &&
+          'border-primary/60 ring-2 ring-primary/60 shadow-[inset_0_0_24px_rgba(245,158,11,0.18),0_0_16px_rgba(245,158,11,0.22)]',
+        lensActiveForNode && !lensGranted &&
+          'border-dashed border-border/50 saturate-[0.35]'
       )}
       style={{
         height: isCompact ? LAYOUT.NODE_HEIGHT_COMPACT : undefined,

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -33,6 +33,7 @@ import { getClientIcon } from '../../lib/clientIcons';
 import { summarizeClientReach } from '../../lib/clientScope';
 import { useStackStore, useSelectedNodeData } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
+import { useAccessLensStore } from '../../stores/useAccessLensStore';
 import { useWindowManager } from '../../hooks/useWindowManager';
 import { formatRelativeTime } from '../../lib/time';
 import type { MCPServerNodeData, ResourceNodeData, ClientNodeData } from '../../types';
@@ -47,7 +48,8 @@ export function Sidebar() {
   const autoscaleDecisions = useStackStore((s) => s.autoscaleDecisions);
   const clients = useStackStore((s) => s.clients);
   const mcpServers = useStackStore((s) => s.mcpServers);
-  const openAccessEditor = useUIStore((s) => s.openAccessEditor);
+  const enableAccessLens = useAccessLensStore((s) => s.setEnabled);
+  const openAccessLensEditor = useAccessLensStore((s) => s.openSlideOver);
   const { openDetachedWindow } = useWindowManager();
   const navigate = useNavigate();
 
@@ -377,7 +379,12 @@ export function Sidebar() {
 
                 <button
                   type="button"
-                  onClick={() => openAccessEditor(clientData.slug)}
+                  onClick={() => {
+                    // Enter Access Lens on this (already-selected) client and open
+                    // the slide-over beside the canvas, so edits preview live.
+                    enableAccessLens(true);
+                    openAccessLensEditor();
+                  }}
                   className={cn(
                     'w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all',
                     'bg-primary/10 text-primary border border-primary/30',

--- a/web/src/components/shell/WorkspaceSwitcher.tsx
+++ b/web/src/components/shell/WorkspaceSwitcher.tsx
@@ -1,6 +1,7 @@
 import { NavLink, useLocation } from 'react-router-dom';
 import { cn } from '../../lib/cn';
 import { WORKSPACE_CONFIG, type WorkspaceConfig } from '../../types/workspace';
+import { useAccessLensStore, isDirty } from '../../stores/useAccessLensStore';
 
 interface WorkspacePillProps {
   workspace: WorkspaceConfig;
@@ -11,12 +12,29 @@ function WorkspacePill({ workspace }: WorkspacePillProps) {
   const isActive =
     pathname === `/${workspace.id}` || pathname.startsWith(`/${workspace.id}/`);
   const Icon = workspace.icon;
+
+  // Dirty-draft navigate-away guard. The Access Lens draft lives in the Topology
+  // workspace; leaving it while dirty must confirm. BrowserRouter has no
+  // useBlocker, so cancel the NavLink here and route through the store, which
+  // AccessLens turns into a discard-with-confirm.
+  const handleClick = (e: React.MouseEvent) => {
+    const s = useAccessLensStore.getState();
+    const leavingTopology =
+      (pathname === '/topology' || pathname.startsWith('/topology/')) && workspace.id !== 'topology';
+    const draftDirty = s.enabled && s.clientSlug != null && isDirty(s.draft, s.baseline);
+    if (leavingTopology && draftDirty) {
+      e.preventDefault();
+      s.requestExitNav(`/${workspace.id}`);
+    }
+  };
+
   return (
     <NavLink
       to={`/${workspace.id}`}
       role="tab"
       aria-selected={isActive}
       data-workspace={workspace.id}
+      onClick={handleClick}
       className={cn(
         'inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors',
         'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/60',

--- a/web/src/components/topology/AccessLens.tsx
+++ b/web/src/components/topology/AccessLens.tsx
@@ -1,0 +1,347 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ScanEye, PanelRightOpen, Save, Undo2, AlertTriangle } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useStackStore } from '../../stores/useStackStore';
+import {
+  useAccessLensStore,
+  isDirty,
+  canSaveDraft,
+  buildDraftScope,
+  canonical,
+  type SeedParams,
+} from '../../stores/useAccessLensStore';
+import { baselineServers } from '../../hooks/useClientScopeEditor';
+import { SlideOver } from '../ui/SlideOver';
+import { Modal } from '../ui/Modal';
+import { AccessLensEditorBody } from './AccessLensEditorBody';
+import { AccessLensCommitGate } from './AccessLensCommitGate';
+import type { ClientStatus, MCPServerStatus } from '../../types';
+
+interface AccessLensProps {
+  servers: MCPServerStatus[];
+}
+
+interface ExitRequest {
+  message: string;
+  proceed: () => void;
+  cancel?: () => void;
+}
+
+// AccessLens is the Topology authoring surface: a header toggle that turns the
+// canvas into a draft editor for the selected client's server access, a floating
+// action bar reporting live impact, the right-anchored slide-over editor, the
+// commit gate (the only write boundary), and the dirty-draft discard-with-confirm
+// guard on every exit path (mode-off, client-change, navigate-away). The draft
+// itself lives in the lifted store so the canvas can preview it without this
+// component or the slide-over being the owner.
+export function AccessLens({ servers }: AccessLensProps) {
+  const clients = useStackStore((s) => s.clients);
+  const selectedNodeId = useStackStore((s) => s.selectedNodeId);
+  const selectNode = useStackStore((s) => s.selectNode);
+
+  const enabled = useAccessLensStore((s) => s.enabled);
+  const slideOverOpen = useAccessLensStore((s) => s.slideOverOpen);
+  const clientSlug = useAccessLensStore((s) => s.clientSlug);
+  const clientName = useAccessLensStore((s) => s.clientName);
+  const draft = useAccessLensStore((s) => s.draft);
+  const baseline = useAccessLensStore((s) => s.baseline);
+  const savedTools = useAccessLensStore((s) => s.savedTools);
+  const setEnabled = useAccessLensStore((s) => s.setEnabled);
+  const seed = useAccessLensStore((s) => s.seed);
+  const openSlideOver = useAccessLensStore((s) => s.openSlideOver);
+  const closeSlideOver = useAccessLensStore((s) => s.closeSlideOver);
+  const discardDraft = useAccessLensStore((s) => s.discardDraft);
+  const clearDraft = useAccessLensStore((s) => s.clearDraft);
+  const exitNavTarget = useAccessLensStore((s) => s.exitNavTarget);
+  const clearExitNav = useAccessLensStore((s) => s.clearExitNav);
+  const pendingSwitchSlug = useAccessLensStore((s) => s.pendingSwitchSlug);
+  const requestSwitch = useAccessLensStore((s) => s.requestSwitch);
+  const clearSwitch = useAccessLensStore((s) => s.clearSwitch);
+  const navigate = useNavigate();
+
+  const [gateOpen, setGateOpen] = useState(false);
+  // Local exit confirm for mode-off (set from an event handler, never an effect).
+  // Client-switch and navigate-away confirms are store-driven (see below).
+  const [exit, setExit] = useState<ExitRequest | null>(null);
+
+  const dirty = clientSlug != null && isDirty(draft, baseline);
+  const canSave = clientSlug != null && canSaveDraft(draft, baseline);
+
+  const selectedClient = useMemo<ClientStatus | null>(() => {
+    if (!selectedNodeId?.startsWith('client-')) return null;
+    const slug = selectedNodeId.slice('client-'.length);
+    return clients.find((c) => c.slug === slug && c.linked) ?? null;
+  }, [selectedNodeId, clients]);
+
+  const allServerNames = useMemo(() => servers.map((s) => s.name), [servers]);
+
+  const makeSeed = useCallback(
+    (client: ClientStatus): SeedParams => ({
+      slug: client.slug,
+      name: client.name,
+      baseline: baselineServers(client, allServerNames),
+      savedTools: client.effectiveScope?.tools ?? [],
+      createsBlock: !client.effectiveScope?.configured,
+    }),
+    [allServerNames],
+  );
+
+  // Seed / re-seed the draft as the selected client changes, guarding a dirty
+  // draft on a client switch (discard-with-confirm). Never reseeds an unchanged
+  // client's in-progress edit; reseeds a same-client baseline only when a refresh
+  // moved it and the draft is clean.
+  useEffect(() => {
+    if (!enabled || !selectedClient || pendingSwitchSlug) return;
+
+    if (selectedClient.slug === clientSlug) {
+      const fresh = canonical(baselineServers(selectedClient, allServerNames));
+      if (!isDirty(draft, baseline) && isDirty(fresh, baseline)) {
+        seed(makeSeed(selectedClient));
+      }
+      return;
+    }
+
+    // A different client became selected. A dirty draft must be confirmed before
+    // we retarget — stash the intent in the store (a store update is allowed in
+    // an effect; React setState is not).
+    if (clientSlug != null && isDirty(draft, baseline)) {
+      requestSwitch(selectedClient.slug);
+      return;
+    }
+    seed(makeSeed(selectedClient));
+  }, [
+    enabled,
+    selectedClient,
+    clientSlug,
+    draft,
+    baseline,
+    allServerNames,
+    pendingSwitchSlug,
+    makeSeed,
+    seed,
+    requestSwitch,
+  ]);
+
+  // Hard page unload (reload/close): warn while a draft is unsaved.
+  useEffect(() => {
+    if (!dirty) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [dirty]);
+
+  const requestDisable = useCallback(() => {
+    if (dirty) {
+      setExit({
+        message: 'Turn off Access Lens and discard unsaved access changes?',
+        proceed: () => {
+          clearDraft();
+          setEnabled(false);
+        },
+      });
+      return;
+    }
+    clearDraft();
+    setEnabled(false);
+  }, [dirty, clearDraft, setEnabled]);
+
+  const hasPendingExit = exit != null || pendingSwitchSlug != null || exitNavTarget != null;
+
+  // Escape exits the mode (honoring the dirty confirm) when no overlay of its own
+  // is handling the key. The gate (Modal) and slide-over own their Escape.
+  useEffect(() => {
+    if (!enabled) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (gateOpen || slideOverOpen || hasPendingExit) return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      e.stopPropagation();
+      requestDisable();
+    };
+    // Capture so the lens claims Escape before the global deselect handler.
+    document.addEventListener('keydown', onKey, true);
+    return () => document.removeEventListener('keydown', onKey, true);
+  }, [enabled, gateOpen, slideOverOpen, hasPendingExit, requestDisable]);
+
+  const toolsVisible = useMemo(
+    () => (clientSlug ? buildDraftScope(draft, servers, savedTools).tools.length : 0),
+    [clientSlug, draft, servers, savedTools],
+  );
+
+  // Unify the three exit-confirm sources into one descriptor. Mode-off is local
+  // React state; client-switch and navigate-away are store-driven so they never
+  // require setState inside an effect.
+  const switchTarget = pendingSwitchSlug
+    ? clients.find((c) => c.slug === pendingSwitchSlug && c.linked) ?? null
+    : null;
+  const activeExit: ExitRequest | null =
+    exit ??
+    (pendingSwitchSlug
+      ? {
+          message: `Discard unsaved access changes to ${clientName}?`,
+          proceed: () => {
+            if (switchTarget) seed(makeSeed(switchTarget));
+            clearSwitch();
+          },
+          cancel: () => {
+            if (clientSlug) selectNode(`client-${clientSlug}`);
+            clearSwitch();
+          },
+        }
+      : exitNavTarget
+        ? {
+            message: 'Leave Access Lens and discard unsaved access changes?',
+            proceed: () => {
+              clearDraft();
+              setEnabled(false);
+              clearExitNav();
+              navigate(exitNavTarget);
+            },
+            cancel: () => clearExitNav(),
+          }
+        : null);
+
+  function resolveExit(run?: () => void) {
+    run?.();
+    setExit(null);
+  }
+
+  return (
+    <>
+      {/* Header toggle — net-new to Topology. Amber when on, with aria-pressed. */}
+      <div className="absolute top-3 left-3 z-20 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => (enabled ? requestDisable() : setEnabled(true))}
+          aria-pressed={enabled}
+          aria-label="Toggle Access Lens"
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium border transition-colors glass-panel',
+            enabled
+              ? 'bg-primary/15 text-primary border-primary/40 shadow-glow-primary'
+              : 'text-text-muted border-border/40 hover:text-text-secondary hover:border-border',
+          )}
+        >
+          <ScanEye size={12} aria-hidden="true" />
+          Access Lens
+        </button>
+
+        {enabled && (
+          <div className="glass-panel rounded-md px-2.5 py-1.5 text-[10px] text-text-muted flex items-center gap-2" role="status">
+            {selectedClient ? (
+              <>
+                <span>
+                  Editing <span className="text-text-secondary font-mono">{selectedClient.name}</span>{' '}
+                  — click servers to grant or revoke
+                </span>
+                <button
+                  type="button"
+                  onClick={openSlideOver}
+                  className="inline-flex items-center gap-1 text-[10px] text-secondary hover:text-secondary-light transition-colors"
+                >
+                  <PanelRightOpen size={11} aria-hidden="true" />
+                  Editor
+                </button>
+              </>
+            ) : (
+              <span>Select a client to shape its access. Multi-select is not editable here.</span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Slide-over editor — beside the canvas, which stays interactive. */}
+      <SlideOver
+        isOpen={enabled && slideOverOpen && selectedClient != null}
+        onClose={closeSlideOver}
+        title="Access editor"
+      >
+        <AccessLensEditorBody servers={servers} />
+      </SlideOver>
+
+      {/* Floating action bar — visible whenever the draft is dirty. */}
+      {dirty && (
+        <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-30 animate-fade-in-up">
+          <div className="glass-panel-elevated shadow-bevel rounded-xl px-4 py-2.5 flex items-center gap-4">
+            <span className="text-[11px] text-text-secondary" role="status">
+              <span className="font-mono text-primary">{draft.length}</span> server
+              {draft.length === 1 ? '' : 's'} granted ·{' '}
+              <span className="font-mono text-primary">{toolsVisible}</span> tool
+              {toolsVisible === 1 ? '' : 's'} visible
+            </span>
+            <div className="h-4 w-px bg-border/50" aria-hidden="true" />
+            <button
+              type="button"
+              onClick={discardDraft}
+              className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[11px] text-text-secondary hover:text-text-primary transition-colors"
+            >
+              <Undo2 size={12} aria-hidden="true" />
+              Discard
+            </button>
+            <button
+              type="button"
+              onClick={() => setGateOpen(true)}
+              disabled={!canSave}
+              aria-label="Save access scope"
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-[11px] font-medium border transition-colors',
+                canSave
+                  ? 'bg-primary/20 text-primary border-primary/30 hover:bg-primary/30'
+                  : 'bg-surface-highlight/50 text-text-muted border-border/30 cursor-not-allowed',
+              )}
+            >
+              <Save size={12} aria-hidden="true" />
+              Save Scope
+            </button>
+          </div>
+        </div>
+      )}
+
+      <AccessLensCommitGate
+        isOpen={gateOpen}
+        onClose={() => setGateOpen(false)}
+        onCommitted={() => {
+          setGateOpen(false);
+          closeSlideOver();
+        }}
+      />
+
+      {/* Discard-with-confirm — shared by mode-off, client-change, navigate-away. */}
+      <Modal
+        isOpen={activeExit != null}
+        onClose={() => resolveExit(activeExit?.cancel)}
+        title="Unsaved access changes"
+      >
+        <div className="space-y-4 text-sm">
+          <div className="flex items-start gap-2.5 rounded-md border border-status-pending/40 bg-status-pending/[0.06] px-3 py-3">
+            <AlertTriangle size={14} className="text-status-pending flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <p className="text-[12px] text-text-secondary leading-relaxed">{activeExit?.message}</p>
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => resolveExit(activeExit?.cancel)}
+              className="rounded-md px-3 py-1.5 text-[11px] text-text-secondary hover:text-text-primary transition-colors"
+            >
+              Keep editing
+            </button>
+            <button
+              type="button"
+              onClick={() => resolveExit(activeExit?.proceed)}
+              className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] font-medium border border-status-pending/40 bg-status-pending/10 text-status-pending hover:bg-status-pending/20 transition-colors"
+            >
+              Discard changes
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+}
+
+export default AccessLens;

--- a/web/src/components/topology/AccessLensCommitGate.tsx
+++ b/web/src/components/topology/AccessLensCommitGate.tsx
@@ -1,0 +1,315 @@
+import { useCallback, useEffect, useState } from 'react';
+import { AlertTriangle, Check, Copy, Loader2, ShieldAlert } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { Modal } from '../ui/Modal';
+import { useAccessLensStore, canonical } from '../../stores/useAccessLensStore';
+import {
+  AuthError,
+  ClientScopeError,
+  previewClientScope,
+  updateClientScope,
+  type ClientScopePreview,
+} from '../../lib/api';
+import { showToast } from '../ui/Toast';
+
+interface AccessLensCommitGateProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Called after the scope is written and state refreshed. */
+  onCommitted: () => void;
+}
+
+// AccessLensCommitGate is the single write boundary for the Access Lens draft.
+// It is a focus-trapped Modal (the gate IS modal, unlike the slide-over) that
+// fetches the server-computed preview — the exact stack.yaml patch and the
+// per-client impact — and only writes via PUT /scope when the operator confirms.
+// A draft that would lock the client out of everything blocks the commit.
+export function AccessLensCommitGate({ isOpen, onClose, onCommitted }: AccessLensCommitGateProps) {
+  const clientSlug = useAccessLensStore((s) => s.clientSlug);
+  const clientName = useAccessLensStore((s) => s.clientName);
+  const draft = useAccessLensStore((s) => s.draft);
+  const markSaved = useAccessLensStore((s) => s.markSaved);
+  const setConflict = useAccessLensStore((s) => s.setConflict);
+
+  const [preview, setPreview] = useState<ClientScopePreview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [committing, setCommitting] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const body = clientSlug ? { servers: canonical(draft) } : null;
+
+  const loadPreview = useCallback(async () => {
+    if (!clientSlug || !body) return;
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const result = await previewClientScope(clientSlug, body);
+      setPreview(result);
+    } catch (err) {
+      if (err instanceof AuthError) {
+        setLoadError('Authentication required.');
+      } else if (err instanceof ClientScopeError) {
+        setLoadError(err.hint ? `${err.message} — ${err.hint}` : err.message);
+      } else {
+        setLoadError(err instanceof Error ? err.message : 'Preview failed');
+      }
+    } finally {
+      setLoading(false);
+    }
+    // body is derived from clientSlug + draft; depending on those is sufficient.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clientSlug, draft]);
+
+  useEffect(() => {
+    // Defer out of the synchronous effect body (the fetch sets loading state, and
+    // close resets it) so we don't trip the no-setState-in-effect rule.
+    const t = setTimeout(() => {
+      if (isOpen) {
+        void loadPreview();
+      } else {
+        setPreview(null);
+        setLoadError(null);
+        setCopied(false);
+      }
+    }, 0);
+    return () => clearTimeout(t);
+  }, [isOpen, loadPreview]);
+
+  async function copyDiff() {
+    if (!preview?.diff) return;
+    try {
+      await navigator.clipboard.writeText(preview.diff);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard may be unavailable; ignore */
+    }
+  }
+
+  async function confirm() {
+    if (!clientSlug || preview?.lockout) return;
+    setCommitting(true);
+    try {
+      const resp = await updateClientScope(clientSlug, { servers: canonical(draft) });
+      if (resp.reloaded === false) {
+        showToast('warning', 'Stack updated. Run "gridctl reload" or restart with --watch to apply.');
+      } else {
+        showToast('success', `Access saved for ${clientName ?? clientSlug}`);
+      }
+      markSaved();
+      onCommitted();
+    } catch (err) {
+      if (err instanceof AuthError) {
+        showToast('error', 'Authentication required.');
+      } else if (err instanceof ClientScopeError) {
+        if (err.code === 'stack_modified') {
+          // Preserve the draft; surface the conflict on the slide-over and bounce
+          // back so the operator can reload and retry without losing edits.
+          setConflict(err.hint || err.message);
+          showToast('warning', 'The stack file changed on disk. Reload and retry — your draft is kept.');
+          onClose();
+          return;
+        }
+        showToast('error', err.hint ? `${err.message} — ${err.hint}` : err.message);
+      } else {
+        showToast('error', err instanceof Error ? err.message : 'Save failed');
+      }
+    } finally {
+      setCommitting(false);
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Review access change" size="wide">
+      <div className="space-y-4 text-sm">
+        {loading && (
+          <div className="flex items-center gap-2 text-[12px] text-text-muted py-6 justify-center" role="status">
+            <Loader2 size={14} className="animate-spin" />
+            Computing the patch and impact…
+          </div>
+        )}
+
+        {loadError && !loading && (
+          <div className="flex items-start gap-2 rounded-md border border-status-error/40 bg-status-error/[0.06] px-3 py-2" role="alert">
+            <ShieldAlert size={13} className="text-status-error flex-shrink-0 mt-0.5" />
+            <div className="flex-1 space-y-1.5">
+              <p className="text-[11px] text-status-error">{loadError}</p>
+              <button
+                type="button"
+                onClick={() => void loadPreview()}
+                className="text-[10px] text-secondary hover:text-secondary-light transition-colors"
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        )}
+
+        {preview && !loading && (
+          <>
+            {preview.lockout && (
+              <GateWarning tone="error" icon={<ShieldAlert size={13} className="text-status-error" />}>
+                This draft leaves <span className="font-medium">{clientName}</span> able to reach{' '}
+                <span className="font-medium">no servers or tools</span>. Grant at least one reachable
+                server before saving — an empty allow-list means &ldquo;all&rdquo;, so this is blocked
+                to avoid a silent lockout.
+              </GateWarning>
+            )}
+
+            {preview.createsBlock && (
+              <GateWarning tone="pending" icon={<AlertTriangle size={13} className="text-status-pending" />}>
+                This creates the <span className="font-mono">clients</span> block. Unlisted clients
+                become <span className="font-medium">deny by default</span>.
+                {preview.affected && preview.affected.length > 0 && (
+                  <ul className="mt-1.5 space-y-0.5 text-[10px] text-text-muted">
+                    {preview.affected.map((a) => (
+                      <li key={a.slug}>
+                        <span className="font-mono text-text-secondary">{a.name}</span> loses access to
+                        all {a.beforeServers} server{a.beforeServers === 1 ? '' : 's'} ({a.beforeTools}{' '}
+                        tool{a.beforeTools === 1 ? '' : 's'} hidden)
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </GateWarning>
+            )}
+
+            <SelectedImpact preview={preview} clientName={clientName ?? preview.client} />
+
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">
+                  stack.yaml patch
+                </span>
+                <button
+                  type="button"
+                  onClick={() => void copyDiff()}
+                  disabled={!preview.diff}
+                  className="inline-flex items-center gap-1 text-[10px] text-text-muted hover:text-text-secondary transition-colors disabled:opacity-40"
+                >
+                  {copied ? <Check size={10} className="text-status-running" /> : <Copy size={10} />}
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+              <pre className="max-h-56 overflow-auto scrollbar-dark rounded-md border border-border/40 bg-background/70 px-3 py-2 text-[11px] font-mono leading-relaxed">
+                {preview.diff ? <DiffLines diff={preview.diff} /> : (
+                  <span className="text-text-muted/60 italic">No file change (draft matches saved scope).</span>
+                )}
+              </pre>
+            </div>
+
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={committing}
+                className="rounded-md px-3 py-1.5 text-[11px] text-text-secondary hover:text-text-primary transition-colors disabled:opacity-50"
+              >
+                Back
+              </button>
+              <button
+                type="button"
+                onClick={() => void confirm()}
+                disabled={committing || preview.lockout || !preview.diff}
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] font-medium border transition-colors',
+                  committing || preview.lockout || !preview.diff
+                    ? 'bg-surface-highlight/50 text-text-muted border-border/30 cursor-not-allowed'
+                    : 'bg-primary/20 text-primary border-primary/30 hover:bg-primary/30',
+                )}
+              >
+                {committing ? (
+                  <>
+                    <Loader2 size={11} className="animate-spin" />
+                    Writing…
+                  </>
+                ) : (
+                  'Save & write'
+                )}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+function SelectedImpact({ preview, clientName }: { preview: ClientScopePreview; clientName: string }) {
+  const sel = preview.selected;
+  const lost = sel.lostServers ?? [];
+  const gained = sel.gainedServers ?? [];
+  return (
+    <div className="rounded-md border border-border/30 bg-background/40 px-3 py-2.5 text-[11px] text-text-secondary space-y-1" role="status">
+      <p>
+        <span className="font-medium text-text-primary">{clientName}</span> will reach{' '}
+        <span className="font-mono text-primary">{sel.afterServers}</span> of {preview.totalServers}{' '}
+        servers · <span className="font-mono text-primary">{sel.afterTools}</span> of{' '}
+        {preview.totalTools} tools.
+      </p>
+      {lost.length > 0 && (
+        <p className="text-status-pending">
+          Loses: <span className="font-mono">{lost.join(', ')}</span>
+        </p>
+      )}
+      {gained.length > 0 && (
+        <p className="text-status-running">
+          Gains: <span className="font-mono">{gained.join(', ')}</span>
+        </p>
+      )}
+    </div>
+  );
+}
+
+// DiffLines colorizes a unified diff: additions teal, removals muted-red,
+// context dim. Hunk headers get a subtle accent.
+function DiffLines({ diff }: { diff: string }) {
+  return (
+    <>
+      {diff.split('\n').map((line, i) => {
+        const c = line[0];
+        const cls =
+          c === '+'
+            ? 'text-secondary'
+            : c === '-'
+              ? 'text-status-error/80'
+              : line.startsWith('@@')
+                ? 'text-primary/70'
+                : 'text-text-muted';
+        return (
+          <div key={i} className={cls}>
+            {line || ' '}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function GateWarning({
+  tone,
+  icon,
+  children,
+}: {
+  tone: 'error' | 'pending';
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'flex items-start gap-2.5 rounded-md px-3 py-3',
+        tone === 'error'
+          ? 'border border-status-error/40 bg-status-error/[0.06]'
+          : 'border border-status-pending/40 bg-status-pending/[0.06]',
+      )}
+    >
+      <span className="flex-shrink-0 mt-0.5">{icon}</span>
+      <div className="text-[12px] text-text-secondary leading-relaxed">{children}</div>
+    </div>
+  );
+}
+
+export default AccessLensCommitGate;

--- a/web/src/components/topology/AccessLensEditorBody.tsx
+++ b/web/src/components/topology/AccessLensEditorBody.tsx
@@ -1,0 +1,171 @@
+import { useMemo } from 'react';
+import { AlertCircle, Check, RefreshCw, ShieldCheck } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useStackStore } from '../../stores/useStackStore';
+import { useAccessLensStore } from '../../stores/useAccessLensStore';
+import { fetchClients, fetchStatus } from '../../lib/api';
+import type { MCPServerStatus } from '../../types';
+
+interface AccessLensEditorBodyProps {
+  servers: MCPServerStatus[];
+}
+
+// AccessLensEditorBody is the keyboard-driven twin of the canvas node toggling:
+// a checkbox list bound to the SAME Topology-scoped draft store the canvas reads
+// and writes, so checking a box here lights the node out there and vice versa.
+// It deliberately reuses the visual language of the Tools ClientScopePane but
+// sources its state from the lifted draft store, not useClientScopeEditor (which
+// stays the controller for the standalone Tools modal).
+export function AccessLensEditorBody({ servers }: AccessLensEditorBodyProps) {
+  const clientName = useAccessLensStore((s) => s.clientName);
+  const clientSlug = useAccessLensStore((s) => s.clientSlug);
+  const draft = useAccessLensStore((s) => s.draft);
+  const savedTools = useAccessLensStore((s) => s.savedTools);
+  const createsBlock = useAccessLensStore((s) => s.createsBlock);
+  const conflict = useAccessLensStore((s) => s.conflict);
+  const toggleServer = useAccessLensStore((s) => s.toggleServer);
+  const selectAll = useAccessLensStore((s) => s.selectAll);
+  const clearAll = useAccessLensStore((s) => s.clearAll);
+  const setConflict = useAccessLensStore((s) => s.setConflict);
+
+  const serverNames = useMemo(() => servers.map((s) => s.name), [servers]);
+  const selected = useMemo(() => new Set(draft), [draft]);
+  const noneSelected = draft.length === 0;
+  const hasToolScope = savedTools.length > 0;
+
+  async function handleReloadFromDisk() {
+    try {
+      const [clients, status] = await Promise.all([fetchClients(), fetchStatus()]);
+      useStackStore.getState().setClients(clients);
+      useStackStore.getState().setGatewayStatus(status);
+      setConflict(null);
+    } catch {
+      /* polling will catch up */
+    }
+  }
+
+  return (
+    <div className="px-4 py-3 space-y-3">
+      <div className="flex items-center gap-2">
+        <ShieldCheck size={14} className="text-primary/70" aria-hidden="true" />
+        <h3 className="text-sm font-medium text-text-primary">{clientName}</h3>
+        <span className="font-mono text-[10px] text-text-muted">{clientSlug}</span>
+      </div>
+      <p className="text-[11px] text-text-muted leading-relaxed">
+        Toggle which MCP servers <span className="text-text-secondary">{clientName}</span> can reach.
+        Edits stage in a draft — the canvas re-lights live, but nothing is written until you save.
+      </p>
+
+      {hasToolScope && (
+        <p className="text-[10px] text-text-muted/80 leading-relaxed">
+          This client has a tool-level allow-list in stack.yaml; it is preserved on save and still
+          gates which tools are visible.
+        </p>
+      )}
+
+      {createsBlock && (
+        <div className="flex items-start gap-2 rounded-md border border-status-pending/30 bg-status-pending/[0.06] px-3 py-2">
+          <AlertCircle size={12} className="text-status-pending flex-shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="text-[11px] text-text-secondary leading-relaxed">
+            No <span className="font-mono text-status-pending">clients</span> block exists yet. Saving
+            creates one; unlisted clients become <span className="font-medium">deny by default</span>.
+          </p>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 text-[11px] text-text-muted">
+        <span>
+          <span className="text-text-secondary font-medium">{draft.length}</span> of{' '}
+          <span className="text-text-secondary font-medium">{serverNames.length}</span> servers
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => selectAll(serverNames)}
+            className="text-[10px] text-secondary hover:text-secondary-light transition-colors"
+          >
+            All
+          </button>
+          <span className="text-border" aria-hidden="true">·</span>
+          <button
+            type="button"
+            onClick={clearAll}
+            className="text-[10px] text-secondary hover:text-secondary-light transition-colors"
+          >
+            None
+          </button>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border/40 bg-background/60 divide-y divide-border/20">
+        {serverNames.length === 0 && (
+          <p className="px-3 py-4 text-[11px] text-text-muted/60 italic text-center">
+            No MCP servers in the active stack.
+          </p>
+        )}
+        {serverNames.map((name) => {
+          const isOn = selected.has(name);
+          return (
+            <button
+              key={name}
+              type="button"
+              role="checkbox"
+              aria-checked={isOn}
+              onClick={() => toggleServer(name)}
+              className="w-full flex items-center gap-2.5 px-3 py-2 text-left hover:bg-surface-highlight/40 transition-colors"
+            >
+              <span
+                className={cn(
+                  'w-3.5 h-3.5 rounded border flex items-center justify-center flex-shrink-0 transition-colors',
+                  isOn ? 'bg-primary/20 border-primary/60' : 'border-border/60 bg-background/50',
+                )}
+              >
+                {isOn && <Check size={10} className="text-primary" aria-hidden="true" />}
+              </span>
+              <span
+                className={cn(
+                  'text-xs font-mono truncate',
+                  isOn ? 'text-text-primary' : 'text-text-secondary',
+                )}
+              >
+                {name}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {noneSelected && (
+        <p className="text-[10px] text-status-pending" role="status">
+          Select at least one server to save. An empty list means &ldquo;all servers&rdquo;, not
+          &ldquo;deny&rdquo;.
+        </p>
+      )}
+
+      {conflict && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md border border-status-pending/40 bg-status-pending/[0.05] px-3 py-2"
+        >
+          <AlertCircle size={12} className="text-status-pending flex-shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0 space-y-1">
+            <p className="text-[11px] text-status-pending font-medium">
+              The stack file changed on disk.
+            </p>
+            <p className="text-[10px] text-text-muted">{conflict}</p>
+            <button
+              type="button"
+              onClick={handleReloadFromDisk}
+              className="inline-flex items-center gap-1 text-[10px] text-secondary hover:text-secondary-light transition-colors"
+            >
+              <RefreshCw size={10} />
+              Reload file (keeps your draft)
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default AccessLensEditorBody;

--- a/web/src/components/ui/SlideOver.tsx
+++ b/web/src/components/ui/SlideOver.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useId, type ReactNode } from 'react';
+import { X } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+interface SlideOverProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  /** Width of the panel. Defaults to a comfortable editing column. */
+  widthClass?: string;
+  /** Accessible description id wiring, if the body provides one. */
+  describedById?: string;
+}
+
+/**
+ * SlideOver is a right-anchored panel that sits beside the content rather than
+ * over it. Unlike ui/Modal it deliberately has NO full-viewport backdrop and NO
+ * focus trap: the Topology canvas behind it must stay pannable, selectable, and
+ * clickable (canvas server clicks edit the same draft the slide-over does), so a
+ * trap or backdrop would defeat the entire interaction model. It is keyboard
+ * operable on its own (Escape closes, content is tabbable) and labels itself as
+ * a non-modal dialog.
+ *
+ * Built on the existing slide-in-right keyframe — no motion library.
+ */
+export function SlideOver({ isOpen, onClose, title, children, widthClass, describedById }: SlideOverProps) {
+  const titleId = useId();
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+        (e.target as HTMLElement).blur();
+        return;
+      }
+      onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, handleKeyDown]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-labelledby={titleId}
+      aria-describedby={describedById}
+      className={cn(
+        // Anchored to the right edge, below the app header band. Pointer events
+        // are confined to the panel so the canvas stays live everywhere else.
+        'absolute top-3 bottom-3 right-3 z-30 flex flex-col',
+        'glass-panel-elevated rounded-xl shadow-bevel animate-slide-in-right',
+        widthClass ?? 'w-[340px]',
+      )}
+    >
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border/30 flex-shrink-0">
+        <h2 id={titleId} className="text-sm font-medium text-text-primary">
+          {title}
+        </h2>
+        <button
+          onClick={onClose}
+          aria-label="Close access editor"
+          className="p-1.5 rounded-lg hover:bg-surface-highlight transition-colors"
+        >
+          <X size={14} className="text-text-muted" />
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto scrollbar-dark min-h-0">{children}</div>
+    </div>
+  );
+}
+
+export default SlideOver;

--- a/web/src/components/workspaces/TopologyWorkspace.tsx
+++ b/web/src/components/workspaces/TopologyWorkspace.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { AlertCircle, RefreshCw, WifiOff } from 'lucide-react';
 import { Sidebar } from '../layout/Sidebar';
 import { Canvas } from '../graph/Canvas';
-import { ClientAccessEditor } from './ClientAccessEditor';
+import { AccessLens } from '../topology/AccessLens';
 import { ResizeHandle } from '../ui/ResizeHandle';
 import { useStackStore } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
@@ -23,9 +23,6 @@ export function TopologyWorkspace() {
   const error = useStackStore((s) => s.error);
   const mcpServers = useStackStore((s) => s.mcpServers);
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
-  const accessEditorOpen = useUIStore((s) => s.accessEditorOpen);
-  const accessEditorSeedSlug = useUIStore((s) => s.accessEditorSeedSlug);
-  const closeAccessEditor = useUIStore((s) => s.closeAccessEditor);
 
   const accessServers = useMemo(
     () => [...mcpServers].sort((a, b) => a.name.localeCompare(b.name)),
@@ -111,6 +108,11 @@ export function TopologyWorkspace() {
           )}
 
           <Canvas />
+
+          {/* Access Lens authoring surface: header toggle, slide-over editor,
+              action bar, commit gate, and dirty-exit guard. Mounted in the
+              canvas column so its absolute overlays anchor to the canvas. */}
+          <AccessLens servers={accessServers} />
         </div>
 
         {sidebarOpen && (
@@ -126,16 +128,6 @@ export function TopologyWorkspace() {
           </aside>
         )}
       </div>
-
-      {/* Per-client access editor, opened from the inspector's "Edit Scope"
-          seeded to the inspected client. */}
-      <ClientAccessEditor
-        key={accessEditorSeedSlug ?? 'default'}
-        isOpen={accessEditorOpen}
-        onClose={closeAccessEditor}
-        servers={accessServers}
-        initialSlug={accessEditorSeedSlug}
-      />
     </div>
   );
 }

--- a/web/src/hooks/usePathHighlight.ts
+++ b/web/src/hooks/usePathHighlight.ts
@@ -182,12 +182,17 @@ function narrowToClientScope(
  * @param nodes - All nodes in the graph
  * @param edges - All edges in the graph
  * @param selectedNodeId - Currently selected node ID, or null
+ * @param scopeOverride - When set and a client is selected, this scope is used
+ *   in place of the client node's saved `effectiveScope`. The Topology Access
+ *   Lens passes a draft `ClientScopeResult` here so the canvas re-lights live
+ *   against the unsaved draft. Passing null/undefined uses the saved scope.
  * @returns Highlight state with sets of node/edge IDs
  */
 export function computeHighlightState(
   nodes: Node[],
   edges: Edge[],
-  selectedNodeId: string | null
+  selectedNodeId: string | null,
+  scopeOverride?: ClientScopeResult | null
 ): HighlightState {
   // No selection = no highlighting
   if (!selectedNodeId) {
@@ -218,8 +223,9 @@ export function computeHighlightState(
 
   // When the selected client has a configured, narrowed scope, restrict the
   // highlight to what it can actually reach. An absent or `unscoped` scope
-  // preserves the gateway-exposed reach (the no-clients-block case).
-  const scope = nodeData?.effectiveScope as ClientScopeResult | undefined;
+  // preserves the gateway-exposed reach (the no-clients-block case). A
+  // scopeOverride (the Access Lens draft) takes precedence over the saved scope.
+  const scope = (scopeOverride ?? nodeData?.effectiveScope) as ClientScopeResult | undefined;
   let inScopeTools: Set<string> | undefined;
   if (isClient && scope && scope.configured && !scope.unscoped) {
     narrowToClientScope(highlightedNodeIds, highlightedEdgeIds, nodes, edges, scope);
@@ -246,16 +252,18 @@ export function computeHighlightState(
  * @param nodes - All nodes in the graph
  * @param edges - All edges in the graph
  * @param selectedNodeId - Currently selected node ID, or null
+ * @param scopeOverride - Optional draft scope to preview (see computeHighlightState)
  * @returns Highlight state with sets of node/edge IDs
  */
 export function usePathHighlight(
   nodes: Node[],
   edges: Edge[],
-  selectedNodeId: string | null
+  selectedNodeId: string | null,
+  scopeOverride?: ClientScopeResult | null
 ): HighlightState {
   return useMemo(
-    () => computeHighlightState(nodes, edges, selectedNodeId),
-    [nodes, edges, selectedNodeId]
+    () => computeHighlightState(nodes, edges, selectedNodeId, scopeOverride),
+    [nodes, edges, selectedNodeId, scopeOverride]
   );
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -434,6 +434,78 @@ export async function updateClientScope(
   return data as UpdateClientScopeResponse;
 }
 
+// ClientScopeImpact is one client's before/after access delta in a scope
+// preview. Mirrors api.clientScopeImpact.
+export interface ClientScopeImpact {
+  name: string;
+  slug: string;
+  beforeServers: number;
+  afterServers: number;
+  beforeTools: number;
+  afterTools: number;
+  lostServers: string[] | null;
+  gainedServers: string[] | null;
+}
+
+// ClientScopePreview is the read-only result of POST /scope/preview: the exact
+// stack.yaml patch a commit would write plus its per-client consequences.
+// Mirrors api.scopePreviewResponse.
+export interface ClientScopePreview {
+  client: string;
+  profileKey: string;
+  createsBlock: boolean;
+  lockout: boolean;
+  totalServers: number;
+  totalTools: number;
+  diff: string;
+  selected: ClientScopeImpact;
+  affected: ClientScopeImpact[] | null;
+}
+
+/**
+ * Preview committing a client access draft without writing. Returns the exact
+ * YAML patch and the per-client impact computed server-side (the faithful
+ * source the commit gate renders). Rejects with ClientScopeError on 422 (stale
+ * server/tool reference), AuthError on 401, or a plain Error otherwise.
+ * POST /api/clients/{slug}/scope/preview
+ */
+export async function previewClientScope(
+  slug: string,
+  update: ClientScopeUpdate,
+): Promise<ClientScopePreview> {
+  const response = await fetch(
+    `${API_BASE}/api/clients/${encodeURIComponent(slug)}/scope/preview`,
+    {
+      method: 'POST',
+      headers: buildHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(update),
+    },
+  );
+
+  if (response.status === 401) throw new AuthError('Authentication required');
+
+  const data = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const err = data?.error;
+    if (err && typeof err === 'object' && typeof err.code === 'string') {
+      throw new ClientScopeError(
+        err.code,
+        err.message ?? 'Scope preview failed',
+        err.hint,
+        response.status,
+      );
+    }
+    const msg =
+      typeof err === 'string'
+        ? err
+        : `Scope preview failed: ${response.status} ${response.statusText}`;
+    throw new Error(msg);
+  }
+
+  return data as ClientScopePreview;
+}
+
 // === Structured Log Entry (from gateway) ===
 
 export interface LogEntry {

--- a/web/src/stores/useAccessLensStore.ts
+++ b/web/src/stores/useAccessLensStore.ts
@@ -1,0 +1,194 @@
+import { create } from 'zustand';
+import type { ClientScopeResult, MCPServerStatus } from '../types';
+
+// canonical de-dupes and sorts a server-name list so draft/baseline comparisons
+// and YAML-bound output are order-independent.
+export function canonical(names: string[]): string[] {
+  return Array.from(new Set(names)).sort();
+}
+
+// isDirty reports whether a draft selection differs from its saved baseline.
+export function isDirty(draft: string[], baseline: string[]): boolean {
+  const a = canonical(draft);
+  const b = canonical(baseline);
+  if (a.length !== b.length) return true;
+  return a.some((v, i) => v !== b[i]);
+}
+
+// canSaveDraft mirrors useClientScopeEditor.canSave: a save needs at least one
+// server selected (an empty list means "all" in the backend model, never
+// "deny") AND a change from the baseline.
+export function canSaveDraft(draft: string[], baseline: string[]): boolean {
+  return draft.length > 0 && isDirty(draft, baseline);
+}
+
+/**
+ * buildDraftScope derives the ClientScopeResult a client WOULD have under a
+ * draft server selection, faithfully replicating the backend's global tool
+ * allow-list semantics so the live canvas preview matches what a commit writes:
+ *
+ *  - The tool axis is global, not per-server. When the client has a saved tool
+ *    allow-list, reachable tools are that list intersected with the drafted
+ *    servers' tools (adding a server does NOT surface its tools if they aren't
+ *    in the allow-list). With no saved allow-list, every tool of a drafted
+ *    server is reachable.
+ *  - Reachable servers are derived from the reachable tools (a server with no
+ *    visible tool contributes nothing), matching pkg/mcp.scopeResult.
+ *
+ * The result feeds usePathHighlight in place of the saved effectiveScope, so the
+ * dim/light updates instantly as the operator toggles.
+ */
+export function buildDraftScope(
+  draftServers: string[],
+  servers: MCPServerStatus[],
+  savedTools: string[],
+): ClientScopeResult {
+  const granted = new Set(draftServers);
+  const toolAllow = savedTools.length ? new Set(savedTools) : null;
+  const tools: string[] = [];
+  for (const s of servers) {
+    if (!granted.has(s.name)) continue;
+    for (const t of s.tools ?? []) {
+      const prefixed = `${s.name}__${t}`;
+      if (toolAllow && !toolAllow.has(prefixed)) continue;
+      tools.push(prefixed);
+    }
+  }
+  const reachableServers = new Set<string>();
+  for (const t of tools) {
+    const idx = t.indexOf('__');
+    if (idx > 0) reachableServers.add(t.slice(0, idx));
+  }
+  return {
+    configured: true,
+    unscoped: false,
+    servers: [...reachableServers].sort(),
+    tools: tools.sort(),
+  };
+}
+
+// SeedParams describes the saved state the draft is initialized from when a
+// client becomes the Access Lens target.
+export interface SeedParams {
+  slug: string;
+  name: string;
+  baseline: string[];
+  savedTools: string[];
+  createsBlock: boolean;
+}
+
+interface AccessLensState {
+  // Access Lens mode is on. Net-new to Topology (no prior mode toggle).
+  enabled: boolean;
+  // The slide-over editor (the keyboard-driven twin of canvas node toggling).
+  slideOverOpen: boolean;
+
+  // Draft target + saved baseline. clientSlug is the only client the draft
+  // applies to; the canvas gates toggling to exactly this selected client.
+  clientSlug: string | null;
+  clientName: string | null;
+  baseline: string[];
+  savedTools: string[];
+  createsBlock: boolean;
+
+  // The live draft selection (server names). The single source the canvas nodes,
+  // the slide-over checkboxes, the action bar, and the highlight all read/write.
+  draft: string[];
+
+  conflict: string | null;
+  isSaving: boolean;
+
+  setEnabled: (enabled: boolean) => void;
+  openSlideOver: () => void;
+  closeSlideOver: () => void;
+  // seed sets the draft target and resets the draft to the saved baseline. The
+  // controller calls it only when the target client (or its baseline) changes,
+  // so an in-progress edit on an unchanged client is left alone.
+  seed: (params: SeedParams) => void;
+  toggleServer: (name: string) => void;
+  setDraft: (names: string[]) => void;
+  selectAll: (allServerNames: string[]) => void;
+  clearAll: () => void;
+  // markSaved advances the baseline to the current draft after a successful
+  // commit, so the draft is no longer dirty and the action bar retracts (a poll
+  // refresh then reseeds from the persisted effectiveScope).
+  markSaved: () => void;
+  // discardDraft reverts the selection to the saved baseline (keeps the target).
+  discardDraft: () => void;
+  // clearDraft fully resets the draft target — used after commit, discard, or
+  // exiting the mode.
+  clearDraft: () => void;
+  setConflict: (conflict: string | null) => void;
+  setSaving: (saving: boolean) => void;
+
+  // exitNavTarget holds an in-app navigation the dirty-draft guard intercepted.
+  // The app uses BrowserRouter (no useBlocker), so the WorkspaceSwitcher cancels
+  // the NavLink and stashes the target here; AccessLens confirms, then routes.
+  exitNavTarget: string | null;
+  requestExitNav: (path: string) => void;
+  clearExitNav: () => void;
+
+  // pendingSwitchSlug holds the client the operator selected while a dirty draft
+  // for another client was open. Set from the seeding effect (a store update, so
+  // it stays out of React setState-in-effect); the confirm renders from it.
+  pendingSwitchSlug: string | null;
+  requestSwitch: (slug: string) => void;
+  clearSwitch: () => void;
+}
+
+const EMPTY_TARGET = {
+  clientSlug: null,
+  clientName: null,
+  baseline: [] as string[],
+  savedTools: [] as string[],
+  createsBlock: false,
+  draft: [] as string[],
+  conflict: null,
+  exitNavTarget: null as string | null,
+  pendingSwitchSlug: null as string | null,
+};
+
+export const useAccessLensStore = create<AccessLensState>((set, get) => ({
+  enabled: false,
+  slideOverOpen: false,
+  ...EMPTY_TARGET,
+  isSaving: false,
+
+  setEnabled: (enabled) => set({ enabled }),
+  openSlideOver: () => set({ slideOverOpen: true }),
+  closeSlideOver: () => set({ slideOverOpen: false }),
+
+  seed: ({ slug, name, baseline, savedTools, createsBlock }) =>
+    set({
+      clientSlug: slug,
+      clientName: name,
+      baseline: canonical(baseline),
+      savedTools,
+      createsBlock,
+      draft: canonical(baseline),
+      conflict: null,
+    }),
+
+  toggleServer: (name) => {
+    const next = new Set(get().draft);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    set({ draft: [...next] });
+  },
+  setDraft: (names) => set({ draft: [...names] }),
+  selectAll: (allServerNames) => set({ draft: canonical(allServerNames) }),
+  clearAll: () => set({ draft: [] }),
+
+  markSaved: () => set((s) => ({ baseline: canonical(s.draft), conflict: null })),
+  discardDraft: () => set((s) => ({ draft: canonical(s.baseline), conflict: null })),
+  clearDraft: () => set({ ...EMPTY_TARGET, slideOverOpen: false }),
+
+  setConflict: (conflict) => set({ conflict }),
+  setSaving: (isSaving) => set({ isSaving }),
+
+  requestExitNav: (path) => set({ exitNavTarget: path }),
+  clearExitNav: () => set({ exitNavTarget: null }),
+
+  requestSwitch: (slug) => set({ pendingSwitchSlug: slug }),
+  clearSwitch: () => set({ pendingSwitchSlug: null }),
+}));


### PR DESCRIPTION
## Description

Adds the Topology Access Lens: an explicit mode that turns the canvas into a draft editor for a selected client's server access, with one shared draft edited by both the canvas nodes and a right-anchored slide-over, and a single commit gate as the only write boundary. This is Phase 1 of the per-client policy authoring UX (Phase 0 shipped in #748).

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- **Read-only preview endpoint** `POST /api/clients/{slug}/scope/preview` returns the exact `stack.yaml` patch (same yaml.Node round-trip as the write path) plus faithful per-client impact (counts, lost/gained servers, lockout, first-block deny-by-default consequences). Writes nothing.
- **`Gateway.ClientScopePreview`** computes a hypothetical scope against the live tool surface without installing a policy, preserving operator-authored tool allow-lists.
- **Topology-scoped draft store** (`useAccessLensStore`) is the single source the canvas highlight, the canvas nodes, the slide-over, the action bar, and the gate all read/write.
- **Live preview** via a draft `ClientScopeResult` routed into `usePathHighlight` (no fork of the pure functions).
- **Access Lens header toggle** (`aria-pressed`), canvas server-node grant/revoke with amber-ring/desaturated visuals, **`SlideOver`** primitive (no canvas-blocking backdrop/trap), floating glass action bar with live impact, and a focus-trapped **commit gate** (copyable YAML diff + impact + lockout/first-block warnings, `PUT … tools:null`, 409-preserves-draft).
- **Dirty-draft discard-with-confirm** on mode-off, client-change, and navigate-away (NavLink interception + `beforeunload`, since the app uses BrowserRouter).

## Testing

- `make build`; `golangci-lint run ./internal/api/... ./pkg/mcp/...` (0 issues); `go test ./internal/api/... ./pkg/mcp/...`
- `npx tsc --noEmit`; `npx vitest run` (890 passing); eslint clean on touched files
- New tests: unified diff, scope impact, gateway scope preview, draft store + helpers, highlight override, SlideOver, and the lens toggle/dirty-exit flow

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #747