### PR TITLE
fix: reload per-client clients block changes into gateway policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,17 @@ All notable changes to gridctl will be documented in this file.
 
 ### Fixed
 
+- **Per-client access scoping now takes effect on hot reload.** Changes that
+  touched only the `clients:` block (saving a scope through the Topology Access
+  Lens / `PUT /api/clients/{slug}/scope`, or a watched edit) were classified as
+  "no changes" by the reload diff, so the reload short-circuited before rebuilding
+  the gateway's in-memory access policy. The file was written and the API reported
+  a successful reload, but the running gateway kept its stale (usually unscoped)
+  policy, so the saved restriction was silently not enforced until a restart. The
+  reload diff now detects `clients:` changes (`ConfigDiff.ClientsChanged`), so the
+  policy is rebuilt in place with no container or network churn. Cold start was
+  unaffected.
+
 - **Sync no longer reports ghost-skill failures for deleted skills.** Deleting a
   skill from the Library UI (`DELETE /api/registry/skills/{name}`) now also
   scrubs it from `skills.lock.yaml`, matching the CLI path (`gridctl skill rm`).

--- a/pkg/reload/diff.go
+++ b/pkg/reload/diff.go
@@ -1,6 +1,8 @@
 package reload
 
 import (
+	"reflect"
+
 	"github.com/gridctl/gridctl/pkg/config"
 )
 
@@ -10,6 +12,10 @@ type ConfigDiff struct {
 	Resources  ResourceDiff
 	// NetworkChanged indicates if the network config changed (requires full restart)
 	NetworkChanged bool
+	// ClientsChanged indicates the per-client access (`clients:`) block changed.
+	// It needs an in-memory policy refresh (via the reload's onConfigApplied hook)
+	// but no container or network work, so it must still mark the diff non-empty.
+	ClientsChanged bool
 }
 
 // MCPServerDiff contains changes to MCP servers.
@@ -53,7 +59,8 @@ func (d *ConfigDiff) IsEmpty() bool {
 		len(d.Resources.Added) == 0 &&
 		len(d.Resources.Removed) == 0 &&
 		len(d.Resources.Modified) == 0 &&
-		!d.NetworkChanged
+		!d.NetworkChanged &&
+		!d.ClientsChanged
 }
 
 // ComputeDiff computes the differences between two stack configurations.
@@ -69,7 +76,19 @@ func ComputeDiff(old, new *config.Stack) *ConfigDiff {
 	// Diff resources
 	diff.Resources = diffResources(old.Resources, new.Resources)
 
+	// Detect per-client access (`clients:`) changes
+	diff.ClientsChanged = clientsChanged(old, new)
+
 	return diff
+}
+
+// clientsChanged reports whether the per-client access (`clients:`) block
+// differs between two stacks. A change here requires the gateway's in-memory
+// ClientAccessPolicy to be rebuilt (via the reload's onConfigApplied hook) but
+// touches no containers, networks, or resources. DeepEqual handles the nil↔set
+// transitions (block added or removed) directly.
+func clientsChanged(old, new *config.Stack) bool {
+	return !reflect.DeepEqual(old.Clients, new.Clients)
 }
 
 func isNetworkChanged(old, new *config.Stack) bool {

--- a/pkg/reload/diff_test.go
+++ b/pkg/reload/diff_test.go
@@ -284,6 +284,107 @@ func TestComputeDiff_AutoscaleToStaticIsRestart(t *testing.T) {
 	}
 }
 
+func TestComputeDiff_ClientsOnlyChange(t *testing.T) {
+	servers := []config.MCPServer{{Name: "github", Image: "image1", Port: 3000}}
+	old := &config.Stack{
+		Name:       "test",
+		Network:    config.Network{Name: "test-net", Driver: "bridge"},
+		MCPServers: servers,
+	}
+	new := &config.Stack{
+		Name:       "test",
+		Network:    config.Network{Name: "test-net", Driver: "bridge"},
+		MCPServers: servers,
+		Clients: &config.ClientsConfig{
+			Profiles: map[string]config.ClientProfile{
+				"grok": {Servers: []string{"github"}},
+			},
+		},
+	}
+
+	diff := ComputeDiff(old, new)
+	if !diff.ClientsChanged {
+		t.Error("expected ClientsChanged to be true")
+	}
+	if diff.IsEmpty() {
+		t.Error("expected non-empty diff for a clients-only change")
+	}
+	// A clients-only change must not touch containers, networks, or resources.
+	if len(diff.MCPServers.Added) != 0 || len(diff.MCPServers.Removed) != 0 ||
+		len(diff.MCPServers.Modified) != 0 || len(diff.MCPServers.AutoscalePolicyChanges) != 0 {
+		t.Error("expected no MCP server changes for a clients-only change")
+	}
+	if len(diff.Resources.Added) != 0 || len(diff.Resources.Removed) != 0 ||
+		len(diff.Resources.Modified) != 0 {
+		t.Error("expected no resource changes for a clients-only change")
+	}
+	if diff.NetworkChanged {
+		t.Error("expected NetworkChanged to be false for a clients-only change")
+	}
+}
+
+func TestComputeDiff_ClientsIdentical(t *testing.T) {
+	clients := &config.ClientsConfig{
+		Default: "deny",
+		Profiles: map[string]config.ClientProfile{
+			"grok": {Servers: []string{"github"}},
+		},
+	}
+	old := &config.Stack{
+		Name:    "test",
+		Network: config.Network{Name: "test-net", Driver: "bridge"},
+		Clients: clients,
+	}
+	new := &config.Stack{
+		Name:    "test",
+		Network: config.Network{Name: "test-net", Driver: "bridge"},
+		Clients: &config.ClientsConfig{
+			Default: "deny",
+			Profiles: map[string]config.ClientProfile{
+				"grok": {Servers: []string{"github"}},
+			},
+		},
+	}
+
+	diff := ComputeDiff(old, new)
+	if diff.ClientsChanged {
+		t.Error("expected ClientsChanged to be false for identical clients blocks")
+	}
+	if !diff.IsEmpty() {
+		t.Error("expected empty diff for stacks with identical clients blocks")
+	}
+}
+
+func TestComputeDiff_ClientsNilToSet(t *testing.T) {
+	old := &config.Stack{Name: "test", Network: config.Network{Name: "test-net", Driver: "bridge"}}
+	new := &config.Stack{
+		Name:    "test",
+		Network: config.Network{Name: "test-net", Driver: "bridge"},
+		Clients: &config.ClientsConfig{
+			Profiles: map[string]config.ClientProfile{"grok": {Servers: []string{"github"}}},
+		},
+	}
+
+	if !ComputeDiff(old, new).ClientsChanged {
+		t.Error("expected adding a clients block to be detected")
+	}
+}
+
+func TestComputeDiff_ClientsSetToNil(t *testing.T) {
+	old := &config.Stack{
+		Name:    "test",
+		Network: config.Network{Name: "test-net", Driver: "bridge"},
+		Clients: &config.ClientsConfig{
+			Profiles: map[string]config.ClientProfile{"grok": {Servers: []string{"github"}}},
+		},
+	}
+	new := &config.Stack{Name: "test", Network: config.Network{Name: "test-net", Driver: "bridge"}}
+
+	if !ComputeDiff(old, new).ClientsChanged {
+		t.Error("expected removing a clients block to be detected")
+	}
+}
+
 func TestComputeDiff_AutoscaleWithUnrelatedChangeIsRestart(t *testing.T) {
 	oldS := config.MCPServer{Name: "junos", Command: []string{"python", "j.py"},
 		Autoscale: &config.AutoscaleConfig{Min: 1, Max: 4, TargetInFlight: 3}}

--- a/pkg/reload/reload_test.go
+++ b/pkg/reload/reload_test.go
@@ -178,6 +178,71 @@ mcp-servers:
 	}
 }
 
+func TestHandler_Reload_ClientsOnlyChange(t *testing.T) {
+	// A change touching only the `clients:` block must still apply: it needs an
+	// in-memory policy refresh (the onConfigApplied hook) but no container work.
+	base := `
+name: test
+network:
+  name: test-net
+mcp-servers:
+  - name: server1
+    image: alpine:latest
+    port: 3000
+`
+	stackPath := writeStackFile(t, base)
+
+	initialCfg, err := config.LoadStack(stackPath)
+	if err != nil {
+		t.Fatalf("failed to load initial config: %v", err)
+	}
+
+	h, _ := setupHandler(t, stackPath, initialCfg)
+
+	hookFired := false
+	var applied *config.Stack
+	h.SetOnConfigApplied(func(newCfg *config.Stack) {
+		hookFired = true
+		applied = newCfg
+	})
+	// A clients-only change must not register or restart any server.
+	h.SetRegisterServerFunc(func(ctx context.Context, server config.MCPServer, replicas []ReplicaRuntime, stackPath string) error {
+		t.Errorf("registerServer must not be called for a clients-only change (server %q)", server.Name)
+		return nil
+	})
+
+	// Edit the file in place: same server, now with a clients block.
+	withClients := base + `clients:
+  profiles:
+    grok:
+      servers:
+        - server1
+`
+	if err := os.WriteFile(stackPath, []byte(withClients), 0644); err != nil {
+		t.Fatalf("failed to rewrite stack file: %v", err)
+	}
+
+	result, err := h.Reload(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("expected success, got: %s", result.Message)
+	}
+	if result.Message == "no changes detected" {
+		t.Error("clients-only change should not be treated as no changes")
+	}
+	if !hookFired {
+		t.Error("expected onConfigApplied to fire so the access policy is rebuilt")
+	}
+	if applied == nil || applied.Clients == nil {
+		t.Fatal("expected the applied config to carry the new clients block")
+	}
+	if h.CurrentConfig().Clients == nil {
+		t.Error("expected currentCfg to be swapped to the config with the clients block")
+	}
+}
+
 func TestHandler_Reload_ConfigLoadFailure(t *testing.T) {
 	stackPath := writeStackFile(t, "invalid: yaml: content: [")
 


### PR DESCRIPTION
## Description

Runtime changes that touched only the `clients:` block (saving a scope through the Topology Access Lens / `PUT /api/clients/{slug}/scope`, or a watched edit) were silently not enforced. The reload diff only compared `mcp-servers` and `resources`, so a clients-only change was classified as "no changes" and the reload short-circuited before rebuilding the gateway's in-memory `ClientAccessPolicy`. The file was written and the API reported a successful reload, but the running gateway kept its stale (usually unscoped) policy until a restart.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `ComputeDiff` now detects `clients:` block changes via `ConfigDiff.ClientsChanged` (`reflect.DeepEqual` on `Stack.Clients`, which handles block add/remove).
- `ConfigDiff.IsEmpty()` accounts for `ClientsChanged`, so a clients-only change is no longer treated as empty and the reload reaches the existing `onConfigApplied` hook that rebuilds the access policy — with no container or network work.
- No second policy rebuild and no special-casing in the reload handler; the fix only lets the reload pass the empty-diff gate.
- Regression tests at the diff level (clients-only change, identical-clients no-op, nil↔set transitions) and reload level (hook fires, `currentCfg` swapped, no server restart).

## Testing

- `go test ./pkg/reload/...` (incl. `-race`) — green.
- `go test ./...` — green (28 packages).
- `golangci-lint run pkg/reload/...` — 0 issues.

Cold start was unaffected (the policy is built directly at `Build` time); the bug was specific to runtime mutation.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #760