### PR TITLE
docs: sync stack schema reference and remove em dashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Guidance for AI coding agents working in this repository. Follows the [agents.md](https://agents.md) open specification — a single, predictable entry point for agent-relevant context. Human-facing onboarding lives in `README.md` and `CONTRIBUTING.md`; agent-specific tooling files (`CLAUDE.md`, etc.) re-export this file rather than duplicating it.
+Guidance for AI coding agents working in this repository. Follows the [agents.md](https://agents.md) open specification: a single, predictable entry point for agent-relevant context. Human-facing onboarding lives in `README.md` and `CONTRIBUTING.md`; agent-specific tooling files (`CLAUDE.md`, etc.) re-export this file rather than duplicating it.
 
 ## What gridctl is
 
@@ -16,8 +16,8 @@ The Makefile is the entry point for everything. Common targets:
 | `make build-go` | Backend only. Skips the embed tag if `cmd/gridctl/web/dist` is absent (UI 404s in that case). |
 | `make build-web` | Frontend only (`cd web && npm run build`). |
 | `make dev` | Runs the Vite dev server (`web/`) against a separately-running backend. |
-| `make test` | `go test -v ./...` — unit tests only. |
-| `make test-integration` | `go test -v -tags=integration ./tests/integration/...`. Requires Docker (or Podman) — these tests hit real container runtimes per Article IV of `CONSTITUTION.md`; mocks are disallowed in `tests/integration/`. |
+| `make test` | `go test -v ./...` (unit tests only). |
+| `make test-integration` | `go test -v -tags=integration ./tests/integration/...`. Requires Docker (or Podman). These tests hit real container runtimes per Article IV of `CONSTITUTION.md`; mocks are disallowed in `tests/integration/`. |
 | `make test-frontend` | `cd web && npm test` (Vitest). |
 | `make generate` | Regenerates `go.uber.org/mock` mocks under `pkg/mcp/` and `pkg/runtime/`. Required after touching the interfaces they're generated from. |
 | `make update-pricing` | Refreshes the embedded LiteLLM pricing snapshot at `pkg/pricing/data/model_prices.json` (weekly cadence). |
@@ -37,8 +37,8 @@ go test -v -race -tags=integration -run TestGatewayLifecycle ./tests/integration
 Lint:
 
 ```bash
-golangci-lint run                # backend (gosec is enabled — see .golangci.yml for the curated exclusions)
-cd web && npm run lint           # frontend; pre-existing errors live in src/pages/Detached*.tsx — scope review to files you touched
+golangci-lint run                # backend (gosec is enabled; see .golangci.yml for the curated exclusions)
+cd web && npm run lint           # frontend; pre-existing errors live in src/pages/Detached*.tsx (scope review to files you touched)
 ```
 
 ## Code architecture
@@ -46,7 +46,7 @@ cd web && npm run lint           # frontend; pre-existing errors live in src/pag
 The shape of the codebase from the outside in:
 
 ```
-cmd/gridctl/        Cobra CLI entry points — one file per subcommand (apply, serve, link, var, skill, optimize, …).
+cmd/gridctl/        Cobra CLI entry points, one file per subcommand (apply, serve, link, var, skill, optimize, …).
                     embed.go pulls in cmd/gridctl/web/dist via go:embed under the embed_web build tag.
 internal/server/    HTTP server bootstrap: mounts the API, the embedded UI, and the MCP transports.
 internal/api/       REST handlers backing the web UI (one file per resource: stack, skills, vault, pins, telemetry, traces, …).
@@ -58,14 +58,14 @@ pkg/runtime/        Container orchestration. Orchestrator is the WorkloadRuntime
 pkg/builder/        Image building from git or local Dockerfiles, with a content-addressed cache.
 pkg/mcp/            MCP protocol: gateway (router + tool aggregation), stdio/SSE/streamable transports, OpenAPI-as-MCP,
                     autoscaler, code mode sandbox (goja), replica sets, schema pinning hooks.
-pkg/registry/       Skills registry — discovers SKILL.md files, parses frontmatter, validates, serves as MCP prompts.
+pkg/registry/       Skills registry: discovers SKILL.md files, parses frontmatter, validates, serves as MCP prompts.
 pkg/skills/         Remote skill management (git import, lockfile, fingerprinting, updater).
 pkg/provisioner/    LLM-client config writers (claude, claudecode, cursor, windsurf, gemini, opencode, grok, goose,
                     cline, anythingllm, roo, zed, continue, vscode). JSON and TOML helpers in json.go / toml.go.
                     Backed by `gridctl link` / `gridctl unlink`.
 pkg/vault/          Encrypted variable store (XChaCha20-Poly1305 + Argon2id). The `gridctl var` and (deprecated) `gridctl vault` CLIs.
 pkg/pins/           TOFU schema pinning for tool definitions; drift surfaces in pkg/pins + `gridctl pins`.
-pkg/optimize/       Cost analysis — feeds `gridctl optimize` and the UI's findings panel using the embedded LiteLLM prices.
+pkg/optimize/       Cost analysis: feeds `gridctl optimize` and the UI's findings panel using the embedded LiteLLM prices.
 pkg/telemetry/      Tool-call accounting (counts, latency, cost). Buffered in-memory; surfaced via /api/telemetry.
 pkg/tracing/        OTLP exporter + in-memory trace buffer for `gridctl traces` and the UI traces panel.
 pkg/reload/         Stack hot-reload (file watcher + diff-and-apply path).
@@ -91,13 +91,13 @@ End-to-end for the web UI: React store action → `/api/...` handler in `interna
 
 `CONSTITUTION.md` is binding for every change. Articles that most often catch a refactor by surprise:
 
-- **III — Test-first:** every exported function gets a test before merge; bug fixes need a regression test.
-- **IV — Integration tests use real dependencies:** anything under `tests/integration/` runs against real Docker/Podman and must pass `-race`. Mocks are unit-test only.
-- **V — No panics in `pkg/` or `internal/`:** return errors. CLI init in `cmd/` is the only place panic is allowed.
-- **VI — Context propagation:** any I/O, blocking, or external call takes `context.Context` as the first arg and respects cancellation.
-- **IX — Stack YAML back-compat:** new `stack.yaml` fields are optional with a default that preserves existing behavior. Renames and removals are breaking changes.
-- **X — Machine-readable CLI output:** structured commands need a `--format json` (or equivalent) and meaningful exit codes (`0`/`1`/`2`).
-- **XIV — Structured logging:** use `log/slog` in library code; no `fmt.Println` / `log.Printf`.
-- **XV — Changelog discipline:** every user-visible change lands an entry under `[Unreleased]` in `CHANGELOG.md` in the same PR.
+- **III (Test-first):** every exported function gets a test before merge; bug fixes need a regression test.
+- **IV (Integration tests use real dependencies):** anything under `tests/integration/` runs against real Docker/Podman and must pass `-race`. Mocks are unit-test only.
+- **V (No panics in `pkg/` or `internal/`):** return errors. CLI init in `cmd/` is the only place panic is allowed.
+- **VI (Context propagation):** any I/O, blocking, or external call takes `context.Context` as the first arg and respects cancellation.
+- **IX (Stack YAML back-compat):** new `stack.yaml` fields are optional with a default that preserves existing behavior. Renames and removals are breaking changes.
+- **X (Machine-readable CLI output):** structured commands need a `--format json` (or equivalent) and meaningful exit codes (`0`/`1`/`2`).
+- **XIV (Structured logging):** use `log/slog` in library code; no `fmt.Println` / `log.Printf`.
+- **XV (Changelog discipline):** every user-visible change lands an entry under `[Unreleased]` in `CHANGELOG.md` in the same PR.
 
-`CONTRIBUTING.md` covers branch prefixes, commit format, and the PR/CI process — follow it rather than re-deriving conventions.
+`CONTRIBUTING.md` covers branch prefixes, commit format, and the PR/CI process; follow it rather than re-deriving conventions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
-- **Topology Access Lens — author per-client scope on the canvas.** A new
+- **Topology Access Lens: author per-client scope on the canvas.** A new
   "Access Lens" toggle in the Topology header turns the graph into an editing
   surface: with a client selected, MCP server nodes become draft grant/revoke
   targets. Clicking a server (or its checkbox in the new right-anchored
   slide-over editor, which keeps the canvas interactive) stages the change in a
-  draft and re-lights the canvas live against it — granted servers carry an amber
+  draft and re-lights the canvas live against it: granted servers carry an amber
   ring, denied ones desaturate. Both surfaces edit one shared draft; nothing is
   written until an explicit commit. A floating action bar shows live impact
   ("N servers granted · M tools visible") with Save/Discard. Saving opens a
@@ -47,12 +47,12 @@ All notable changes to gridctl will be documented in this file.
   `clients:` block in `stack.yaml` lets an operator restrict which servers and
   tools each connecting client can reach, following Kubernetes NetworkPolicy
   semantics: omitting the block preserves today's behavior (every client sees
-  every tool), while adding it opts into least-privilege — a client matching a
+  every tool), while adding it opts into least-privilege: a client matching a
   profile is limited to that profile's `servers:`/`tools:` allow-list, and a
   client matching no profile is governed by `default:` (`deny` unless set to
   `allow`). The filter is applied at a single chokepoint that every exposure
-  path funnels through — `tools/list`, `tools/call` rejection, and the code-mode
-  search/execute tool universe — so a scoped client cannot reach a denied tool
+  path funnels through (`tools/list`, `tools/call` rejection, and the code-mode
+  search/execute tool universe), so a scoped client cannot reach a denied tool
   via code mode. Enforcement keys on a stable client identifier reconciled
   across the wire, configuration, and the UI: `gridctl link --client-id <id>`
   embeds the identifier as the `client` query parameter on the gateway URL (the
@@ -164,7 +164,7 @@ All notable changes to gridctl will be documented in this file.
   also self-healing: a lock entry whose skill is no longer in the registry is
   skipped and pruned from the lock file instead of failing the source, which
   clears lock files that already accumulated orphaned entries. Skills still
-  present in the registry whose update genuinely fails are unaffected — they are
+  present in the registry whose update genuinely fails are unaffected; they are
   still reported and retained.
 
 - **Skill state preserved across sync.** `Importer.Update` no longer
@@ -220,7 +220,7 @@ All notable changes to gridctl will be documented in this file.
   parameters, doc comments, and error messages in `pkg/mcp/router.go` and
   `pkg/mcp/gateway.go` now use `serverName` and "server" terminology
   consistently. `PrefixTool` / `ParsePrefixedTool` keep their public
-  signatures; only their named-return parameters changed (godoc only —
+  signatures; only their named-return parameters changed (godoc only;
   no Go ABI change). Public interface and method names (`AgentClient`,
   `AddClient`, `RemoveClient`) are unchanged.
 - **CLI command registration consolidated** in `cmd/gridctl/root.go`.
@@ -232,7 +232,7 @@ All notable changes to gridctl will be documented in this file.
 ### Migration
 
 - Bookmarks for `/skills`, `/runs`, `/runs/:id`, and `/agent` now redirect
-  to `/library` silently — no error toast, no 404.
+  to `/library` silently: no error toast, no 404.
 - Callers of the typed-skill CLI (`gridctl agent dev`, `gridctl run`,
   `gridctl runs *`) and the `/api/agent/*` / `/api/playground/*` REST
   surfaces need to migrate to an external agent runtime (LangGraph,
@@ -257,7 +257,7 @@ All notable changes to gridctl will be documented in this file.
   carry `Deprecation: true`, `Sunset`, and `Link` headers pointing at the
   canonical surface.
 - **Vault on-disk format bumped to v2** (`{"version": 2, "variables": [...],
-  "sets": [...]}`). Loading is backward-compatible — v0 (legacy flat array)
+  "sets": [...]}`). Loading is backward-compatible: v0 (legacy flat array)
   and v1 (`{"secrets": [...]}`) files migrate in-memory with every entry
   defaulting to `is_secret=true`, `type=string` (Article XII). Every save
   writes v2.
@@ -265,7 +265,7 @@ All notable changes to gridctl will be documented in this file.
   window name string changed from `gridctl-vault` to `gridctl-var`.
 - **`web/src/lib/api.ts` `VaultSecret` interface renamed to `Variable`**;
   every `*VaultSecret*` / `*VaultSet*` function renamed to its
-  `*Variable*` / `*VariableSet*` counterpart. No JS-level aliases — the
+  `*Variable*` / `*VariableSet*` counterpart. No JS-level aliases; the
   hard rename forces every callsite to update.
 
 ### Added
@@ -300,7 +300,7 @@ All notable changes to gridctl will be documented in this file.
 ### Changed
 
 - **Log redaction now only applies to values stored with `--secret`**
-  (the default). Plaintext variables — REGION, CLUSTER_ID, account IDs —
+  (the default). Plaintext variables (REGION, CLUSTER_ID, account IDs)
   appear unredacted in logs, ending the masking fatigue that came from
   treating every vault value as sensitive. Wired through
   `Store.Values()` → `RegisterRedactValues` at every existing callsite
@@ -338,14 +338,14 @@ All notable changes to gridctl will be documented in this file.
 - Single-writer multi-agent orchestrator ([#588](https://github.com/gridctl/gridctl/pull/588))
 - JSONL run persistence, time-travel resume, approval gates ([#598](https://github.com/gridctl/gridctl/pull/598))
 - Add visual IDE for agent runtime (phase F slices 1–3) ([#599](https://github.com/gridctl/gridctl/pull/599))
-- Phase G — CLI surface (run, agent build/validate) ([#600](https://github.com/gridctl/gridctl/pull/600))
-- Phase H — optimize heuristics, observed wrapper, AGENTS.md sync ([#601](https://github.com/gridctl/gridctl/pull/601))
+- Phase G: CLI surface (run, agent build/validate) ([#600](https://github.com/gridctl/gridctl/pull/600))
+- Phase H: optimize heuristics, observed wrapper, AGENTS.md sync ([#601](https://github.com/gridctl/gridctl/pull/601))
 - Add agent init --lang and --prompt-only flags ([#605](https://github.com/gridctl/gridctl/pull/605))
-- Phase 2 — Go skill scaffold body + compile-check ([#606](https://github.com/gridctl/gridctl/pull/606))
-- Phase 3 — skill.RunContext cut + TS hybrid parity ([#607](https://github.com/gridctl/gridctl/pull/607))
+- Phase 2: Go skill scaffold body + compile-check ([#606](https://github.com/gridctl/gridctl/pull/606))
+- Phase 3: skill.RunContext cut + TS hybrid parity ([#607](https://github.com/gridctl/gridctl/pull/607))
 - Real go build path with manifest guardrails ([#608](https://github.com/gridctl/gridctl/pull/608))
-- Phase 5 — gateway-builder go plugin loader ([#609](https://github.com/gridctl/gridctl/pull/609))
-- Phase 6 — three-flavor skill examples and Anthropic compat test ([#610](https://github.com/gridctl/gridctl/pull/610))
+- Phase 5: gateway-builder go plugin loader ([#609](https://github.com/gridctl/gridctl/pull/609))
+- Phase 6: three-flavor skill examples and Anthropic compat test ([#610](https://github.com/gridctl/gridctl/pull/610))
 - Add agent skill launch endpoint ([#625](https://github.com/gridctl/gridctl/pull/625))
 - Add agent skill run launcher UI ([#626](https://github.com/gridctl/gridctl/pull/626))
 - Emit per-node telemetry from typed-skill runs ([#630](https://github.com/gridctl/gridctl/pull/630))

--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@
 
 ![Gridctl](assets/gridctl.gif)
 
-Gridctl aggregates tools from [MCP](https://modelcontextprotocol.io/) servers into a single gateway and serves [Agent Skills](https://agentskills.io) as MCP prompts to upstream clients. Define your stack in YAML, apply with one command, and connect Claude Desktop — or any MCP client — through one endpoint.
+Gridctl aggregates tools from [MCP](https://modelcontextprotocol.io/) servers into a single gateway and serves [Agent Skills](https://agentskills.io) as MCP prompts to upstream clients. Define your stack in YAML, apply with one command, and connect Claude Desktop (or any MCP client) through one endpoint.
 
 ```bash
 gridctl apply stack.yaml
 ```
 
-Designed for fast, ephemeral, stateless environments — inspired by [Containerlab](https://containerlab.dev).
+Designed for fast, ephemeral, stateless environments, inspired by [Containerlab](https://containerlab.dev).
 
 ## ⚡️ Why gridctl
 
-MCP servers are everywhere — different transports, different hosting models, different `.json` files accumulating like dust. Skills are a separate sprawl on top. Switching projects shouldn't mean rewriting every client config.
+MCP servers are everywhere: different transports, different hosting models, different `.json` files accumulating like dust. Skills are a separate sprawl on top. Switching projects shouldn't mean rewriting every client config.
 
 Gridctl gives you one declarative file for everything you want connected, one local endpoint your client talks to, and a UI that shows you what's actually running. Build fast, throw it away, rebuild it tomorrow.
 
@@ -136,7 +136,7 @@ Restart Claude Desktop after editing. All tools from your stack are now availabl
 
 ### Stack as Code
 
-Declarative, version-controlled MCP environments. Validate before you commit, plan before you apply, and detect the moment your environment drifts from what's in version control. Drift detection runs in the background — the canvas flags servers running but absent from your spec, and declarations in your spec that haven't been deployed.
+Declarative, version-controlled MCP environments. Validate before you commit, plan before you apply, and detect the moment your environment drifts from what's in version control. Drift detection runs in the background: the canvas flags servers running but absent from your spec, and declarations in your spec that haven't been deployed.
 
 ```bash
 gridctl validate stack.yaml    # Lint and schema-check the spec (exit 0/1/2)
@@ -149,7 +149,7 @@ Learn more → [Configuration Reference](docs/config-schema.md)
 
 ### `gridctl optimize` & Cost Observability
 
-Every tool call is priced against an embedded snapshot of LiteLLM model rates. `gridctl optimize` scans the running gateway and surfaces actionable findings with weekly USD impact — unused servers, unused tools, schema overhead, format-conversion shortfalls, and expensive-model-on-cheap-task patterns — plus a paste-ready YAML remediation for each.
+Every tool call is priced against an embedded snapshot of LiteLLM model rates. `gridctl optimize` scans the running gateway and surfaces actionable findings with weekly USD impact (unused servers, unused tools, schema overhead, format-conversion shortfalls, and expensive-model-on-cheap-task patterns), plus a paste-ready YAML remediation for each.
 
 ```bash
 gridctl optimize                          # styled findings table
@@ -161,7 +161,7 @@ Learn more → [Cost Observability](docs/cost-observability.md)
 
 ### Output Format Conversion
 
-Tool call results default to JSON. Set `output_format` at the gateway or per-server level to convert structured responses into `TOON` or `CSV` before they reach the client — reducing token consumption by **25–61%** for tabular and key-value data. Non-JSON responses and payloads over 1 MB are passed through unchanged.
+Tool call results default to JSON. Set `output_format` at the gateway or per-server level to convert structured responses into `TOON` or `CSV` before they reach the client, reducing token consumption by **25–61%** for tabular and key-value data. Non-JSON responses and payloads over 1 MB are passed through unchanged.
 
 ```yaml
 gateway:
@@ -176,7 +176,7 @@ Learn more → [Configuration Reference](docs/config-schema.md)
 
 ### Skill Library
 
-Every `SKILL.md` in your registry surfaces to upstream MCP clients as a prompt. Author in the Library workspace in the web UI (or via `gridctl skill *` on the CLI), activate, and the prompt becomes available to Claude Desktop, Claude Code, Cursor, Codex — anything that speaks MCP.
+Every `SKILL.md` in your registry surfaces to upstream MCP clients as a prompt. Author in the Library workspace in the web UI (or via `gridctl skill *` on the CLI), activate, and the prompt becomes available to Claude Desktop, Claude Code, Cursor, Codex, or anything that speaks MCP.
 
 ```bash
 gridctl skill list                        # Show what's in the registry
@@ -184,7 +184,7 @@ gridctl skill add <git-repo>              # Import skills from a remote repo
 gridctl activate my-skill                 # Promote a draft → active
 ```
 
-Skills follow the [agentskills.io specification](https://agentskills.io) — author them as plain markdown with frontmatter and they work with every skill-aware client, not just gridctl.
+Skills follow the [agentskills.io specification](https://agentskills.io): author them as plain markdown with frontmatter and they work with every skill-aware client, not just gridctl.
 
 Learn more → [Skills guide](docs/skills.md)
 
@@ -203,10 +203,10 @@ Learn more → [Skills guide](docs/skills.md)
 
 ## 📖 Documentation
 
-- **Getting started** — [Installation](docs/installation.md)
-- **Reference** — [CLI](docs/cli-reference.md) · [Configuration](docs/config-schema.md) · [REST API](docs/api-reference.md)
-- **Guides** — [Skills](docs/skills.md) · [Scaling](docs/scaling.md) · [Cost Observability](docs/cost-observability.md)
-- **Operations** — [Project Status](docs/project-status.md) · [Troubleshooting](docs/troubleshooting.md)
+- **Getting started**: [Installation](docs/installation.md)
+- **Reference**: [CLI](docs/cli-reference.md) · [Configuration](docs/config-schema.md) · [REST API](docs/api-reference.md)
+- **Guides**: [Skills](docs/skills.md) · [Scaling](docs/scaling.md) · [Cost Observability](docs/cost-observability.md)
+- **Operations**: [Project Status](docs/project-status.md) · [Troubleshooting](docs/troubleshooting.md)
 
 Full index at [`docs/`](docs/README.md).
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -211,7 +211,7 @@ Returns per-(server, tool) usage observed by the gateway: cumulative call count 
 
 Usage is recorded for both direct tool calls and tools invoked through code mode's `execute` (both flow through the same observer). For servers with metrics persistence enabled, the data is restored from disk on startup so it survives gateway restarts; otherwise it reflects activity since the last gateway start.
 
-`observedSince` is when this gateway process began recording. With persistence enabled, restored counts and timestamps may predate it — clients should treat tools absent from `servers` (or with no `lastCalledAt`) as "no recorded calls" rather than asserting a longer disuse history than `observedSince` supports.
+`observedSince` is when this gateway process began recording. With persistence enabled, restored counts and timestamps may predate it; clients should treat tools absent from `servers` (or with no `lastCalledAt`) as "no recorded calls" rather than asserting a longer disuse history than `observedSince` supports.
 
 **Auth:** Yes
 
@@ -579,7 +579,7 @@ The body must be a JSON object with a `tools` field. An empty array (`[]`) clear
 
 #### `PUT /api/mcp-servers/tools`
 
-Applies tool-whitelist changes to **multiple** servers in one atomic `stack.yaml` write and triggers a **single** hot reload — the fleet-bulk counterpart to the per-server endpoint above. Powers the Tools workspace bulk actions (fleet-wide expose-all / clear / pattern filtering), where applying N servers via N single-server calls would cost N reloads.
+Applies tool-whitelist changes to **multiple** servers in one atomic `stack.yaml` write and triggers a **single** hot reload, the fleet-bulk counterpart to the per-server endpoint above. Powers the Tools workspace bulk actions (fleet-wide expose-all / clear / pattern filtering), where applying N servers via N single-server calls would cost N reloads.
 
 **Transaction semantics: all-or-nothing.** Every server's tools are validated before anything is written; if any tool is unknown the whole batch is rejected (`400 unknown_tool`, naming the offending server) and the stack file is left untouched. This prevents a half-applied fleet edit. The reload runs once after the single write.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -55,7 +55,7 @@ Skills are prose; the registry surfaces every active `SKILL.md` to MCP clients a
 
 ## Variables
 
-The variable store holds both secrets (encrypted at rest, redacted in logs) and plaintext configuration. Reference entries from stack YAML with `${var:KEY}` — see [Variable Expansion](config-schema.md#variable-expansion).
+The variable store holds both secrets (encrypted at rest, redacted in logs) and plaintext configuration. Reference entries from stack YAML with `${var:KEY}` (see [Variable Expansion](config-schema.md#variable-expansion)).
 
 | Command | Purpose |
 |---|---|

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -9,24 +9,32 @@ The root configuration object.
 ```yaml
 version: "1"
 name: my-stack
+extends: base-stack.yaml
 gateway: ...
+logging: ...
+telemetry: ...
 secrets: ...
 network: ...
 networks: ...
 mcp-servers: ...
 resources: ...
+clients: ...
 ```
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `version` | string | No | `"1"` | Configuration format version |
 | `name` | string | **Yes** | - | Stack identifier. Used for container naming and network defaults |
+| `extends` | string | No | - | Path to a parent stack file this stack composes on top of |
 | `gateway` | object | No | - | Gateway-level settings (auth, CORS, code mode) |
+| `logging` | object | No | - | Log file output with rotation (see [Logging](#logging)) |
+| `telemetry` | object | No | - | Opt-in disk persistence for logs/metrics/traces (see [Telemetry Persistence](#telemetry-persistence)) |
 | `secrets` | object | No | - | Variable set references for automatic secret injection |
 | `network` | object | No | See below | Single network configuration (simple mode) |
 | `networks` | []object | No | - | Multiple network configurations (advanced mode) |
 | `mcp-servers` | []object | No | - | MCP server definitions |
 | `resources` | []object | No | - | Supporting container definitions (databases, caches, etc.) |
+| `clients` | object | No | - | Per-client access scoping (see [Clients](#clients-per-client-access-scoping)) |
 
 ---
 
@@ -56,6 +64,7 @@ gateway:
 | `code_mode` | string | No | `"off"` | Enable code mode: `"on"` or `"off"` *(experimental)* |
 | `code_mode_timeout` | int | No | `30` | Code mode execution timeout in seconds. Must be >= 0 *(experimental)* |
 | `output_format` | string | No | `"json"` | Default output format for tool call results: `"json"`, `"toon"`, `"csv"`, or `"text"`. Per-server `output_format` overrides this value |
+| `maxToolResultBytes` | int | No | `65536` | Maximum size of a tool result in bytes before truncation. Results over the limit are truncated with a suffix noting the original size. `0` uses the default (64 KB) |
 | `security` | object | No | - | Security settings (see [Security](#security)) |
 | `tokenizer` | string | No | `"embedded"` | Token counting mode: `"embedded"` (cl100k_base approximation) or `"api"` (exact counts via Anthropic `count_tokens` endpoint) |
 | `tokenizer_api_key` | string | No | - | Anthropic API key for `tokenizer: api`. Falls back to `ANTHROPIC_API_KEY` env var. Supports `${VAR}` and `${var:KEY}` references |
@@ -151,6 +160,27 @@ gateway:
 
 > Cloud backends typically require auth headers (e.g. `x-honeycomb-team` for Honeycomb).
 > Use an OTel Collector as a proxy to inject headers without embedding credentials in `stack.yaml`.
+
+---
+
+## Logging
+
+Optional log file output with automatic rotation. When `file` is set, logs are written to both the in-memory ring buffer (web UI) and the file simultaneously. This is distinct from [Telemetry Persistence](#telemetry-persistence), which captures per-server signals.
+
+```yaml
+logging:
+  file: /var/log/gridctl.log
+  maxSizeMB: 100
+  maxAgeDays: 7
+  maxBackups: 3
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `file` | string | No | - | Path to the log file. When set, logs are also written here |
+| `maxSizeMB` | int | No | `100` | Maximum log file size in MB before rotation |
+| `maxAgeDays` | int | No | `7` | Maximum days to retain rotated log files |
+| `maxBackups` | int | No | `3` | Maximum number of compressed rotated files to keep |
 
 ---
 
@@ -658,7 +688,7 @@ clients:
 A profile's effective scope is the intersection of its `servers:` and `tools:`
 allow-lists with each server's own `tools:` whitelist. A profile with neither
 `servers:` nor `tools:` is listed but unrestricted (sees everything). Unknown
-server references — directly or via a tool prefix — fail config validation.
+server references (directly or via a tool prefix) fail config validation.
 
 ### Client identity
 
@@ -694,7 +724,7 @@ resources is deferred.
 The gateway re-resolves each client's scope from the live configuration on every
 `tools/list` and `tools/call`. A `clients:` change applied via hot-reload (file
 watch or `POST /api/reload`) therefore takes effect on the next request,
-including for already-established sessions — no restart required.
+including for already-established sessions, with no restart required.
 
 ### Editing in the web UI
 
@@ -809,7 +839,7 @@ configuration. The on-disk metadata distinguishes them:
 | Secret (default) | `gridctl var set KEY` | Encrypted at rest when the store is locked; values are replaced with `[REDACTED]` in logs. |
 | Plaintext | `gridctl var set KEY --value value --plaintext` | Stored alongside secrets but kept legible in logs and the web UI. |
 
-Secrets and plaintext variables share the same lookup path — `${var:KEY}`
+Secrets and plaintext variables share the same lookup path: `${var:KEY}`
 works for both. The unification means a `stack.yaml` can carry environment
 knobs (region, cluster ID, account ID) without leaking them through redaction
 fatigue, and without forcing the operator into a parallel `.env` workflow.

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -40,7 +40,7 @@ Last updated: **v0.1.0-beta.9** (see [CHANGELOG.md](../CHANGELOG.md) for release
 | Go plugin skill loader | Removed in v0.1.x | Replaced by prompt-only skills |
 | Agent IDE (`gridctl agent dev`) | Removed in v0.1.x | Use the Library workspace instead |
 | Multi-agent orchestrator (A2A) | Removed in v0.1.x | Use an external agent runtime (LangGraph, CrewAI, AutoGen, OpenAI Agents SDK) over gridctl as the MCP gateway |
-| JSONL run ledger + resume | Removed in v0.1.x | — |
+| JSONL run ledger + resume | Removed in v0.1.x | - |
 | LLM provider abstraction | Removed in v0.1.x | Was internal to the playground |
 
 ## Known limitations

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -30,17 +30,17 @@ The frontmatter follows the [agentskills.io spec](https://agentskills.io/specifi
 
 The registry implements the MCP `prompts/list` and `prompts/get` endpoints. When an upstream client connects to gridctl, it sees every active skill as a prompt. The user picks the prompt; the client sends `prompts/get`; the gateway returns the post-frontmatter body verbatim.
 
-There is no template expansion, no variable substitution, no execution layer. The body is the artifact. If you write `{{servername}}` in your skill, it surfaces to the client as the literal string `{{servername}}` — the client may choose to fill it in, but gridctl never does.
+There is no template expansion, no variable substitution, no execution layer. The body is the artifact. If you write `{{servername}}` in your skill, it surfaces to the client as the literal string `{{servername}}`; the client may choose to fill it in, but gridctl never does.
 
 ## Authoring in the Library workspace
 
 The web UI's Library tab (⌘2 in the unified shell, also available as the detached `library-window` page) is the primary authoring surface.
 
 - **List** every skill in the registry. Filter by state (`active` / `draft` / `disabled`) or by name.
-- **Create** a new skill — gridctl prompts for the name, populates default frontmatter, and opens the editor on the body.
+- **Create** a new skill: gridctl prompts for the name, populates default frontmatter, and opens the editor on the body.
 - **Edit** the body and frontmatter inline. The SkillEditor renders a side-by-side YAML form (for frontmatter) plus a markdown editor (for the body), with validation against the agentskills.io schema.
 - **Activate / disable** a skill via the state badge. Disabled skills stay on disk but are dropped from `prompts/list` responses.
-- **Delete** a skill — removes the directory from the registry.
+- **Delete** a skill: removes the directory from the registry.
 
 The Library is backed by the REST endpoints under `/api/registry/skills/*` (see [`docs/api-reference.md`](./api-reference.md)). Everything you can do in the UI you can also do over HTTP.
 
@@ -67,9 +67,9 @@ Skills don't have to be authored locally. `gridctl skill add <repo-url>` clones 
 
 Supported auth flows for private repos:
 
-- `--auth-token <pat>` — an ephemeral HTTPS personal access token, suitable for CI.
-- `--vault-key <key>` — resolves the token from a `${var:KEY}` entry; suitable for long-running daemons.
-- `--ssh-key <path>` — SSH private key path.
+- `--auth-token <pat>`: an ephemeral HTTPS personal access token, suitable for CI.
+- `--vault-key <key>`: resolves the token from a `${var:KEY}` entry; suitable for long-running daemons.
+- `--ssh-key <path>`: SSH private key path.
 
 ## What gridctl deliberately does not do
 
@@ -79,13 +79,13 @@ A short list of choices worth knowing about.
 
 **`kind:` in the frontmatter.** File presence used to be the discriminator between flavors. With execution removed there is only one flavor (prompt-only); a `kind:` field would carry no information.
 
-**Template expansion in the body.** The agentskills.io spec is permissive about body content; clients are free to interpret `{{...}}` placeholders however they like. gridctl does not template-expand them server-side — that policy belongs in the client, where the model and the conversation context live.
+**Template expansion in the body.** The agentskills.io spec is permissive about body content; clients are free to interpret `{{...}}` placeholders however they like. gridctl does not template-expand them server-side; that policy belongs in the client, where the model and the conversation context live.
 
-**A marketplace.** `gridctl skill add <git-repo>` is the closest thing — a per-repo distribution mechanism. There is no central index, by design; if you want to share skills, publish them as a git repo and others can `skill add` from it.
+**A marketplace.** `gridctl skill add <git-repo>` is the closest thing, a per-repo distribution mechanism. There is no central index, by design; if you want to share skills, publish them as a git repo and others can `skill add` from it.
 
 ## References
 
-- [agentskills.io specification](https://agentskills.io/specification) — the SKILL.md schema gridctl reads.
-- [`docs/api-reference.md`](./api-reference.md) — the REST surface backing the Library workspace.
-- [`docs/cli-reference.md`](./cli-reference.md) — the CLI subcommands.
-- [`docs/project-status.md`](./project-status.md) — current stability tiers for skill features.
+- [agentskills.io specification](https://agentskills.io/specification): the SKILL.md schema gridctl reads.
+- [`docs/api-reference.md`](./api-reference.md): the REST surface backing the Library workspace.
+- [`docs/cli-reference.md`](./cli-reference.md): the CLI subcommands.
+- [`docs/project-status.md`](./project-status.md): current stability tiers for skill features.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,7 +137,7 @@ failed to start server on port 9000: listen tcp :9000: bind: address already in 
    gridctl destroy
    ```
 
-3. Start on a different port — `--port` sets the gateway/web UI port (default `8180`), `--base-port` sets the MCP server host-port allocation base (default `9000`):
+3. Start on a different port: `--port` sets the gateway/web UI port (default `8180`), `--base-port` sets the MCP server host-port allocation base (default `9000`):
    ```bash
    gridctl apply stack.yaml --port 8181 --base-port 9100
    ```


### PR DESCRIPTION
## Description

Syncs the stack schema reference with the current config structs and removes em dashes from all documentation per the project writing style.

## Type of Change

- [x] Documentation

## Changes Made

- `docs/config-schema.md`: document the four top-level `stack.yaml` fields the Stack table/example omitted (`extends`, `logging`, `telemetry`, `clients`), add a `## Logging` section for `LoggingConfig`, and add the gateway `maxToolResultBytes` field. All verified against `pkg/config/types.go`.
- Remove all em dashes (—) across `docs/`, `README.md`, `AGENTS.md`, and `CHANGELOG.md`, converting asides to parentheses, colons, or semicolons. The legitimate en dash range (`25–61%`) is preserved.

## Testing

Docs-only change. `rg '—'` across the documentation now returns nothing; internal anchor links resolve.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed