### PR TITLE
feat: interactive tool fan-out pills in Topology view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ All notable changes to gridctl will be documented in this file.
 
 - **Inspect a tool from the Topology canvas.** Clicking a fanned-out tool pill
   on an expanded server now opens a canvas-anchored detail popover with the
-  tool's qualified name, description, a collapsible input-schema preview, and a
-  best-effort "last used" line (fetched on demand; absent when the tool has no
-  recorded calls). Two actions are included: "Open in Tools" deep-links to the
-  tool in the Tools workspace, and "Copy name" copies the prefixed
+  tool's qualified name, description, and a best-effort "last used" line
+  (fetched on demand; absent when the tool has no recorded calls). Two actions
+  are included: "Open in Tools" deep-links to the tool in the Tools workspace
+  (where its full input schema is shown), and "Copy name" copies the prefixed
   `server__tool` name. The "+N more" overflow popover's listed tools are
   clickable to the same detail, and the pill is keyboard-activatable. The
   popover dismisses on Escape, an outside click, or a re-click. This retires the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Inspect a tool from the Topology canvas.** Clicking a fanned-out tool pill
+  on an expanded server now opens a canvas-anchored detail popover with the
+  tool's qualified name, description, a collapsible input-schema preview, and a
+  best-effort "last used" line (fetched on demand; absent when the tool has no
+  recorded calls). Two actions are included: "Open in Tools" deep-links to the
+  tool in the Tools workspace, and "Copy name" copies the prefixed
+  `server__tool` name. The "+N more" overflow popover's listed tools are
+  clickable to the same detail, and the pill is keyboard-activatable. The
+  popover dismisses on Escape, an outside click, or a re-click. This retires the
+  staging decision that left the fan-out nodes non-interactive.
+
 - **Topology Access Lens: author per-client scope on the canvas.** A new
   "Access Lens" toggle in the Topology header turns the graph into an editing
   surface: with a client selected, MCP server nodes become draft grant/revoke

--- a/web/src/__tests__/ToolNode.test.tsx
+++ b/web/src/__tests__/ToolNode.test.tsx
@@ -92,6 +92,18 @@ describe('ToolNode', () => {
     expect(screen.queryByText('github__search-repos')).not.toBeInTheDocument();
   });
 
+  it('reveals the input schema only after expanding it', async () => {
+    renderNode();
+    fireEvent.click(trigger());
+    await screen.findByText('github__search-repos');
+    // Collapsed by default to keep the popover compact.
+    expect(screen.queryByRole('region', { name: /input schema/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /input schema/i }));
+    expect(
+      screen.getByRole('region', { name: /github__search-repos input schema/i }),
+    ).toBeInTheDocument();
+  });
+
   it('renders empty states when the tool is absent from the catalog', async () => {
     useStackStore.setState({ toolCatalog: [] });
     renderNode();

--- a/web/src/__tests__/ToolNode.test.tsx
+++ b/web/src/__tests__/ToolNode.test.tsx
@@ -92,18 +92,6 @@ describe('ToolNode', () => {
     expect(screen.queryByText('github__search-repos')).not.toBeInTheDocument();
   });
 
-  it('reveals the input schema only after expanding it', async () => {
-    renderNode();
-    fireEvent.click(trigger());
-    await screen.findByText('github__search-repos');
-    // Collapsed by default to keep the popover compact.
-    expect(screen.queryByRole('region', { name: /input schema/i })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /input schema/i }));
-    expect(
-      screen.getByRole('region', { name: /github__search-repos input schema/i }),
-    ).toBeInTheDocument();
-  });
-
   it('renders empty states when the tool is absent from the catalog', async () => {
     useStackStore.setState({ toolCatalog: [] });
     renderNode();

--- a/web/src/__tests__/ToolNode.test.tsx
+++ b/web/src/__tests__/ToolNode.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+
+// React Flow primitives are mocked the same way the other node-component tests
+// do, so the pill can render outside a real <ReactFlow> provider.
+vi.mock('@xyflow/react', () => ({
+  Handle: ({ id }: { id: string }) => <div data-testid={`handle-${id}`} />,
+  Position: { Left: 'left', Right: 'right' },
+  MarkerType: { ArrowClosed: 'arrowclosed' },
+}));
+
+// Usage is fetched best-effort when the popover opens; mock the one-shot.
+vi.mock('../lib/api', () => ({
+  fetchToolUsage: vi.fn().mockResolvedValue({ servers: {} }),
+}));
+
+import ToolNode from '../components/graph/ToolNode';
+import { fetchToolUsage } from '../lib/api';
+import { useStackStore } from '../stores/useStackStore';
+import type { ToolNodeData } from '../types';
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="location">{loc.pathname + loc.search}</div>;
+}
+
+const data: ToolNodeData = {
+  type: 'tool',
+  name: 'search-repos',
+  serverName: 'github',
+  serverNodeId: 'mcp-github',
+};
+
+function renderNode(nodeData: ToolNodeData = data) {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <ToolNode data={nodeData} />
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+}
+
+const trigger = () => screen.getByRole('button', { name: /show details for github tool search-repos/i });
+
+beforeEach(() => {
+  useStackStore.setState({
+    toolCatalog: [
+      {
+        name: 'github__search-repos',
+        description: 'Search repositories',
+        inputSchema: { type: 'object', properties: { q: { type: 'string' } } },
+      },
+    ],
+  });
+  (fetchToolUsage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ servers: {} });
+});
+
+describe('ToolNode', () => {
+  it('renders the unprefixed tool name', () => {
+    renderNode();
+    expect(screen.getByText('search-repos')).toBeInTheDocument();
+  });
+
+  it('exposes a keyboard-activatable trigger with aria-expanded', () => {
+    renderNode();
+    expect(trigger()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens a detail popover on click with the prefixed name and description', async () => {
+    renderNode();
+    fireEvent.click(trigger());
+    expect(await screen.findByText('github__search-repos')).toBeInTheDocument();
+    expect(screen.getByText('Search repositories')).toBeInTheDocument();
+    expect(trigger()).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('closes on re-click', async () => {
+    renderNode();
+    fireEvent.click(trigger());
+    expect(await screen.findByText('github__search-repos')).toBeInTheDocument();
+    fireEvent.click(trigger());
+    expect(screen.queryByText('github__search-repos')).not.toBeInTheDocument();
+  });
+
+  it('closes on Escape', async () => {
+    renderNode();
+    fireEvent.click(trigger());
+    expect(await screen.findByText('github__search-repos')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('github__search-repos')).not.toBeInTheDocument();
+  });
+
+  it('renders empty states when the tool is absent from the catalog', async () => {
+    useStackStore.setState({ toolCatalog: [] });
+    renderNode();
+    fireEvent.click(trigger());
+    expect(await screen.findByText(/No description available/i)).toBeInTheDocument();
+  });
+
+  it('copies the prefixed name to the clipboard', async () => {
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    renderNode();
+    fireEvent.click(trigger());
+    fireEvent.click(await screen.findByRole('button', { name: /copy name/i }));
+    expect(writeText).toHaveBeenCalledWith('github__search-repos');
+  });
+
+  it('deep-links to the Tools workspace and closes', async () => {
+    renderNode();
+    fireEvent.click(trigger());
+    fireEvent.click(await screen.findByRole('button', { name: /open in tools/i }));
+    expect(screen.getByTestId('location')).toHaveTextContent('/tools?server=github&q=search-repos');
+    expect(screen.queryByText('github__search-repos')).not.toBeInTheDocument();
+  });
+
+  it('shows a best-effort usage line when usage data is available', async () => {
+    (fetchToolUsage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      servers: { github: { 'search-repos': { calls: 3, lastCalledAt: new Date().toISOString() } } },
+    });
+    renderNode();
+    fireEvent.click(trigger());
+    expect(await screen.findByText(/Last used/i)).toBeInTheDocument();
+  });
+
+  it('omits the usage line when no usage data exists', async () => {
+    renderNode();
+    fireEvent.click(trigger());
+    // Wait for the popover (and its usage fetch) to settle, then assert absence.
+    await screen.findByText('github__search-repos');
+    expect(screen.queryByText(/Last used/i)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/ToolOverflowNode.test.tsx
+++ b/web/src/__tests__/ToolOverflowNode.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@xyflow/react', () => ({
+  Handle: ({ id }: { id: string }) => <div data-testid={`handle-${id}`} />,
+  Position: { Left: 'left', Right: 'right' },
+  MarkerType: { ArrowClosed: 'arrowclosed' },
+}));
+
+vi.mock('../lib/api', () => ({
+  fetchToolUsage: vi.fn().mockResolvedValue({ servers: {} }),
+}));
+
+import ToolOverflowNode from '../components/graph/ToolOverflowNode';
+import { fetchToolUsage } from '../lib/api';
+import { useStackStore } from '../stores/useStackStore';
+import type { ToolOverflowNodeData } from '../types';
+
+const data: ToolOverflowNodeData = {
+  type: 'tool-overflow',
+  serverName: 'github',
+  serverNodeId: 'mcp-github',
+  overflowCount: 2,
+  hiddenTools: ['create-issue', 'delete-repo'],
+};
+
+function renderNode() {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <ToolOverflowNode data={data} />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  useStackStore.setState({
+    toolCatalog: [
+      {
+        name: 'github__create-issue',
+        description: 'Open a new issue',
+        inputSchema: { type: 'object' },
+      },
+    ],
+  });
+  (fetchToolUsage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ servers: {} });
+});
+
+describe('ToolOverflowNode', () => {
+  it('renders the overflow count', () => {
+    renderNode();
+    expect(screen.getByText('+2 more')).toBeInTheDocument();
+  });
+
+  it('reveals the hidden tools when the list is opened', () => {
+    renderNode();
+    fireEvent.click(screen.getByRole('button', { name: /show 2 more github tools/i }));
+    expect(screen.getByText('create-issue')).toBeInTheDocument();
+    expect(screen.getByText('delete-repo')).toBeInTheDocument();
+  });
+
+  it('opens the shared detail popover for a hidden tool', async () => {
+    renderNode();
+    fireEvent.click(screen.getByRole('button', { name: /show 2 more github tools/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show details for github tool create-issue/i }));
+    expect(await screen.findByText('github__create-issue')).toBeInTheDocument();
+    expect(screen.getByText('Open a new issue')).toBeInTheDocument();
+  });
+
+  it('shows empty-state detail for a hidden tool missing from the catalog', async () => {
+    renderNode();
+    fireEvent.click(screen.getByRole('button', { name: /show 2 more github tools/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show details for github tool delete-repo/i }));
+    expect(await screen.findByText('github__delete-repo')).toBeInTheDocument();
+    expect(screen.getByText(/No description available/i)).toBeInTheDocument();
+  });
+
+  it('dismisses overlays on Escape', async () => {
+    renderNode();
+    fireEvent.click(screen.getByRole('button', { name: /show 2 more github tools/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show details for github tool create-issue/i }));
+    expect(await screen.findByText('github__create-issue')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('github__create-issue')).not.toBeInTheDocument();
+    expect(screen.queryByText('create-issue')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/graph/Canvas.tsx
+++ b/web/src/components/graph/Canvas.tsx
@@ -148,9 +148,10 @@ export function Canvas() {
     });
   }, [edges, highlightState]);
 
-  // Handle node selection. Tool fan-out nodes are read-only affordances: a
-  // click should not select them or open the sidebar (the "+N more" node
-  // handles its own popover internally).
+  // Handle node selection. Tool fan-out nodes own their own click handling:
+  // each renders an anchored detail popover internally, so a canvas-level click
+  // must not select them or open the sidebar. The node already stops
+  // propagation; this early return is the belt-and-suspenders guard.
   const onNodeClick = useCallback((_: React.MouseEvent, node: { id: string; data?: { type?: string; name?: string } }) => {
     const nodeType = node.data?.type;
     if (nodeType === 'tool' || nodeType === 'tool-overflow') return;

--- a/web/src/components/graph/ToolDetailPopover.tsx
+++ b/web/src/components/graph/ToolDetailPopover.tsx
@@ -138,9 +138,10 @@ const ToolDetailPopover = memo(({ serverName, toolName, onClose }: ToolDetailPop
             (entry?.inputSchema ? (
               <CodeViewer
                 language="json"
+                wrap
                 content={JSON.stringify(entry.inputSchema, null, 2)}
                 ariaLabel={`${prefixedName} input schema`}
-                className="rounded-md border border-border/30 bg-background/80 max-h-48"
+                className="w-full overflow-hidden rounded-md border border-border/30 bg-background/80 max-h-48"
               />
             ) : (
               <p className="text-[10px] text-text-muted/70 italic">No input schema available.</p>

--- a/web/src/components/graph/ToolDetailPopover.tsx
+++ b/web/src/components/graph/ToolDetailPopover.tsx
@@ -1,12 +1,11 @@
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Wrench, X, ArrowUpRight, Copy, ChevronDown, ChevronRight } from 'lucide-react';
+import { Wrench, X, ArrowUpRight, Copy } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { TOOL_NAME_DELIMITER } from '../../lib/constants';
 import { formatLastUsed } from '../../lib/toolAudit';
 import { fetchToolUsage } from '../../lib/api';
 import { useStackStore } from '../../stores/useStackStore';
-import { CodeViewer } from '../ui/CodeViewer';
 
 interface ToolDetailPopoverProps {
   // Owning MCP server name.
@@ -19,15 +18,15 @@ interface ToolDetailPopoverProps {
 /**
  * Canvas-anchored detail card for a single fanned-out tool. Mirrors
  * ToolOverflowNode's popover mechanics (absolute, in-node, pans/zooms with the
- * graph) rather than a portal, so it stays glued to its pill. Resolves
- * description and input schema from the globally-polled tool catalog and shows
- * a best-effort "last used" line. The parent owns open/close state and the
- * outside-click/Escape dismissal (see useDismiss); this card only renders and
- * fires onClose from its own close button.
+ * graph) rather than a portal, so it stays glued to its pill. Resolves the
+ * description from the globally-polled tool catalog and shows a best-effort
+ * "last used" line. The parent owns open/close state and the outside-click/
+ * Escape dismissal (see useDismiss); this card only renders and fires onClose
+ * from its own close button.
  *
- * A trimmed inline layout is used instead of sharing ToolDetailPanel's sections
- * because the popover wants a compact, collapse-by-default schema that the
- * workspace rail does not; a shared component would have a single consumer.
+ * The input schema is intentionally left out: it does not render legibly in a
+ * compact canvas popover. "Open in Tools" deep-links to the workspace rail,
+ * which shows the full schema with room to read it.
  */
 const ToolDetailPopover = memo(({ serverName, toolName, onClose }: ToolDetailPopoverProps) => {
   const navigate = useNavigate();
@@ -35,7 +34,7 @@ const ToolDetailPopover = memo(({ serverName, toolName, onClose }: ToolDetailPop
 
   // The catalog is keyed by the prefixed name and is populated app-wide by the
   // poll cycle, so it is already present on the Topology page. A missing entry
-  // (e.g. first paint before the first poll) renders explicit empty states.
+  // (e.g. first paint before the first poll) renders an explicit empty state.
   // Select the array and resolve the entry in a memo so a poll that replaces an
   // unrelated tool does not re-run the lookup.
   const toolCatalog = useStackStore((s) => s.toolCatalog);
@@ -44,7 +43,6 @@ const ToolDetailPopover = memo(({ serverName, toolName, onClose }: ToolDetailPop
     [toolCatalog, prefixedName],
   );
 
-  const [schemaOpen, setSchemaOpen] = useState(false);
   const [lastCalledAt, setLastCalledAt] = useState<string | undefined>(undefined);
 
   // Usage is not globally polled (the hook only runs under Audit Mode), so we
@@ -119,33 +117,6 @@ const ToolDetailPopover = memo(({ serverName, toolName, onClose }: ToolDetailPop
           ) : (
             <p className="text-[10px] text-text-muted/70 italic">No description available.</p>
           )}
-        </section>
-
-        <section className="space-y-1.5">
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              setSchemaOpen((v) => !v);
-            }}
-            aria-expanded={schemaOpen}
-            className="flex items-center gap-1 text-[9px] uppercase tracking-[0.18em] text-text-muted/70 hover:text-text-secondary transition-colors"
-          >
-            {schemaOpen ? <ChevronDown size={10} aria-hidden="true" /> : <ChevronRight size={10} aria-hidden="true" />}
-            Input schema
-          </button>
-          {schemaOpen &&
-            (entry?.inputSchema ? (
-              <CodeViewer
-                language="json"
-                wrap
-                content={JSON.stringify(entry.inputSchema, null, 2)}
-                ariaLabel={`${prefixedName} input schema`}
-                className="w-full overflow-hidden rounded-md border border-border/30 bg-background/80 max-h-48"
-              />
-            ) : (
-              <p className="text-[10px] text-text-muted/70 italic">No input schema available.</p>
-            ))}
         </section>
 
         {lastCalledAt && (

--- a/web/src/components/graph/ToolDetailPopover.tsx
+++ b/web/src/components/graph/ToolDetailPopover.tsx
@@ -1,0 +1,182 @@
+import { memo, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Wrench, X, ArrowUpRight, Copy, ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { TOOL_NAME_DELIMITER } from '../../lib/constants';
+import { formatLastUsed } from '../../lib/toolAudit';
+import { fetchToolUsage } from '../../lib/api';
+import { useStackStore } from '../../stores/useStackStore';
+import { CodeViewer } from '../ui/CodeViewer';
+
+interface ToolDetailPopoverProps {
+  // Owning MCP server name.
+  serverName: string;
+  // Unprefixed tool name (as carried by fan-out nodes).
+  toolName: string;
+  onClose: () => void;
+}
+
+/**
+ * Canvas-anchored detail card for a single fanned-out tool. Mirrors
+ * ToolOverflowNode's popover mechanics (absolute, in-node, pans/zooms with the
+ * graph) rather than a portal, so it stays glued to its pill. Resolves
+ * description and input schema from the globally-polled tool catalog and shows
+ * a best-effort "last used" line. The parent owns open/close state and the
+ * outside-click/Escape dismissal (see useDismiss); this card only renders and
+ * fires onClose from its own close button.
+ *
+ * A trimmed inline layout is used instead of sharing ToolDetailPanel's sections
+ * because the popover wants a compact, collapse-by-default schema that the
+ * workspace rail does not; a shared component would have a single consumer.
+ */
+const ToolDetailPopover = memo(({ serverName, toolName, onClose }: ToolDetailPopoverProps) => {
+  const navigate = useNavigate();
+  const prefixedName = `${serverName}${TOOL_NAME_DELIMITER}${toolName}`;
+
+  // The catalog is keyed by the prefixed name and is populated app-wide by the
+  // poll cycle, so it is already present on the Topology page. A missing entry
+  // (e.g. first paint before the first poll) renders explicit empty states.
+  // Select the array and resolve the entry in a memo so a poll that replaces an
+  // unrelated tool does not re-run the lookup.
+  const toolCatalog = useStackStore((s) => s.toolCatalog);
+  const entry = useMemo(
+    () => toolCatalog.find((t) => t.name === prefixedName),
+    [toolCatalog, prefixedName],
+  );
+
+  const [schemaOpen, setSchemaOpen] = useState(false);
+  const [lastCalledAt, setLastCalledAt] = useState<string | undefined>(undefined);
+
+  // Usage is not globally polled (the hook only runs under Audit Mode), so we
+  // fetch it best-effort when the popover opens. Failures and absences leave
+  // the usage line hidden rather than surfacing noise.
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      try {
+        const usage = await fetchToolUsage();
+        if (!active) return;
+        setLastCalledAt(usage.servers?.[serverName]?.[toolName]?.lastCalledAt);
+      } catch {
+        /* best-effort: leave the usage line hidden */
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [serverName, toolName]);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    void navigator.clipboard?.writeText(prefixedName);
+  };
+
+  const handleOpenInTools = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onClose();
+    navigate(`/tools?server=${encodeURIComponent(serverName)}&q=${encodeURIComponent(toolName)}`);
+  };
+
+  return (
+    <div
+      // stopPropagation so a click inside the card never reaches the canvas
+      // pane/node handlers; dismissal is the parent's job via useDismiss.
+      onClick={(e) => e.stopPropagation()}
+      className={cn(
+        'nodrag absolute left-full top-0 ml-2 z-50 w-72',
+        'rounded-lg border border-border bg-surface-elevated/95',
+        'backdrop-blur-xl shadow-bevel animate-fade-in-scale',
+      )}
+    >
+      <div className="flex items-start gap-2 px-3 py-2 border-b border-border/40">
+        <Wrench size={12} className="text-primary/80 flex-shrink-0 mt-0.5" aria-hidden="true" />
+        <span
+          className="flex-1 min-w-0 font-mono text-[11px] text-text-primary break-all"
+          title={prefixedName}
+        >
+          {prefixedName}
+        </span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          aria-label="Close tool details"
+          className="flex-shrink-0 p-0.5 rounded hover:bg-surface-highlight transition-colors"
+        >
+          <X size={12} className="text-text-muted" />
+        </button>
+      </div>
+
+      <div className="px-3 py-2.5 space-y-3 max-h-80 overflow-y-auto scrollbar-dark">
+        <section className="space-y-1">
+          <h4 className="text-[9px] uppercase tracking-[0.18em] text-text-muted/70">Description</h4>
+          {entry?.description ? (
+            <p className="text-[11px] text-text-secondary leading-relaxed break-words whitespace-pre-wrap">
+              {entry.description}
+            </p>
+          ) : (
+            <p className="text-[10px] text-text-muted/70 italic">No description available.</p>
+          )}
+        </section>
+
+        <section className="space-y-1.5">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setSchemaOpen((v) => !v);
+            }}
+            aria-expanded={schemaOpen}
+            className="flex items-center gap-1 text-[9px] uppercase tracking-[0.18em] text-text-muted/70 hover:text-text-secondary transition-colors"
+          >
+            {schemaOpen ? <ChevronDown size={10} aria-hidden="true" /> : <ChevronRight size={10} aria-hidden="true" />}
+            Input schema
+          </button>
+          {schemaOpen &&
+            (entry?.inputSchema ? (
+              <CodeViewer
+                language="json"
+                content={JSON.stringify(entry.inputSchema, null, 2)}
+                ariaLabel={`${prefixedName} input schema`}
+                className="rounded-md border border-border/30 bg-background/80 max-h-48"
+              />
+            ) : (
+              <p className="text-[10px] text-text-muted/70 italic">No input schema available.</p>
+            ))}
+        </section>
+
+        {lastCalledAt && (
+          <p className="text-[10px] text-text-muted">Last used {formatLastUsed(lastCalledAt)}</p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 px-3 py-2 border-t border-border/40">
+        <button
+          type="button"
+          onClick={handleOpenInTools}
+          className="inline-flex items-center gap-1 text-[10px] text-secondary hover:text-secondary-light transition-colors"
+        >
+          <ArrowUpRight size={11} aria-hidden="true" />
+          Open in Tools
+        </button>
+        <span className="text-border" aria-hidden="true">
+          ·
+        </span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="inline-flex items-center gap-1 text-[10px] text-text-muted hover:text-text-secondary transition-colors"
+        >
+          <Copy size={11} aria-hidden="true" />
+          Copy name
+        </button>
+      </div>
+    </div>
+  );
+});
+
+ToolDetailPopover.displayName = 'ToolDetailPopover';
+
+export default ToolDetailPopover;

--- a/web/src/components/graph/ToolNode.tsx
+++ b/web/src/components/graph/ToolNode.tsx
@@ -1,8 +1,10 @@
-import { memo } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { Handle, Position } from '@xyflow/react';
 import { Wrench } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { LAYOUT } from '../../lib/constants';
+import { useDismiss } from '../../hooks/useDismiss';
+import ToolDetailPopover from './ToolDetailPopover';
 import type { ToolNodeData } from '../../types';
 
 interface ToolNodeProps {
@@ -14,41 +16,72 @@ interface ToolNodeProps {
  * neutral pill that matches the linked-client theme (surface gradient, neutral
  * border, monochrome accents) rather than the violet server theme, so "tools"
  * read as a distinct layer from the MCP servers they belong to. Slides in from
- * the left when mounted. Not selectable - it is a read-only affordance for PR 2.
+ * the left when mounted.
+ *
+ * Clicking (or keyboard-activating) the pill opens a canvas-anchored detail
+ * popover with the tool's description, input schema, and quick actions. The
+ * pill is `nodrag` so a click is a clean activation rather than a drag start,
+ * matching the "+N more" overflow node.
  */
 const ToolNode = memo(({ data }: ToolNodeProps) => {
+  const [open, setOpen] = useState(false);
+  const close = useCallback(() => setOpen(false), []);
+  const wrapperRef = useDismiss<HTMLDivElement>(open, close);
+
   return (
     <div
-      className={cn(
-        'animate-slide-in-right',
-        'flex items-center gap-2 px-2.5 rounded-lg relative',
-        'border border-border bg-gradient-to-b from-surface/95 via-surface/90 to-surface/80',
-        'backdrop-blur-xl shadow-bevel',
-        'transition-colors duration-200 hover:shadow-node-hover hover:border-text-secondary/40'
-      )}
-      style={{ width: LAYOUT.TOOL_WIDTH, height: LAYOUT.TOOL_HEIGHT }}
-      title={`${data.serverName} · ${data.name}`}
+      ref={wrapperRef}
+      className="nodrag animate-slide-in-right relative"
+      style={{ width: LAYOUT.TOOL_WIDTH }}
     >
-      {/* Top accent line, matching the client nodes. */}
-      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+      <button
+        type="button"
+        onClick={(e) => {
+          // Keep the click off the canvas node/pane handlers; the popover is
+          // self-contained, so the node must never select or open the sidebar.
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        aria-expanded={open}
+        aria-label={`Show details for ${data.serverName} tool ${data.name}`}
+        title={`${data.serverName} · ${data.name}`}
+        className={cn(
+          'w-full flex items-center gap-2 px-2.5 rounded-lg relative text-left',
+          'border border-border bg-gradient-to-b from-surface/95 via-surface/90 to-surface/80',
+          'backdrop-blur-xl shadow-bevel',
+          'transition-colors duration-200 hover:shadow-node-hover hover:border-text-secondary/40',
+        )}
+        style={{ height: LAYOUT.TOOL_HEIGHT }}
+      >
+        {/* Top accent line, matching the client nodes. */}
+        <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
 
-      <Wrench size={11} className="text-text-secondary flex-shrink-0" />
-      {/* min-w-0 lets the flex item shrink; tool-label re-asserts
-          overflow:hidden (see index.css) so truncate clips long tool names
-          instead of overflowing the pill. */}
-      <span className="tool-label min-w-0 flex-1 font-mono text-[11px] text-text-secondary truncate tracking-tight">
-        {data.name}
-      </span>
+        <Wrench size={11} className="text-text-secondary flex-shrink-0" aria-hidden="true" />
+        {/* min-w-0 lets the flex item shrink; tool-label re-asserts
+            overflow:hidden (see index.css) so truncate clips long tool names
+            instead of overflowing the pill. */}
+        <span className="tool-label min-w-0 flex-1 font-mono text-[11px] text-text-secondary truncate tracking-tight">
+          {data.name}
+        </span>
+      </button>
 
       <Handle
         type="target"
         position={Position.Left}
         className={cn(
           '!w-2 !h-2 !bg-text-secondary !border-2 !border-background !rounded-full',
-          'transition-all duration-200'
+          'transition-all duration-200',
         )}
         id="input"
       />
+
+      {open && (
+        <ToolDetailPopover
+          serverName={data.serverName}
+          toolName={data.name}
+          onClose={close}
+        />
+      )}
     </div>
   );
 });

--- a/web/src/components/graph/ToolOverflowNode.tsx
+++ b/web/src/components/graph/ToolOverflowNode.tsx
@@ -3,6 +3,8 @@ import { Handle, Position } from '@xyflow/react';
 import { MoreHorizontal, Wrench } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { LAYOUT } from '../../lib/constants';
+import { useDismiss } from '../../hooks/useDismiss';
+import ToolDetailPopover from './ToolDetailPopover';
 import type { ToolOverflowNodeData } from '../../types';
 
 interface ToolOverflowNodeProps {
@@ -15,9 +17,25 @@ interface ToolOverflowNodeProps {
  * remaining tools rather than mounting more canvas nodes, so a large server
  * stays legible. The popover lives inside this single node, anchored to it,
  * so it pans and zooms with the canvas.
+ *
+ * Each listed tool is itself a button that opens the same canvas-anchored
+ * detail popover the visible tool pills use, so the hidden tools are just as
+ * inspectable as the ones below the cap.
  */
 const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
   const [open, setOpen] = useState(false);
+  // The hidden tool whose detail popover is showing, or null. Distinct from
+  // `open` (the list itself) so the list stays put while a detail is inspected.
+  const [selectedTool, setSelectedTool] = useState<string | null>(null);
+
+  const closeAll = useCallback(() => {
+    setOpen(false);
+    setSelectedTool(null);
+  }, []);
+
+  // One wrapper ref covers the trigger, the list, and any open detail popover,
+  // so an outside click or Escape dismisses the whole node's overlays at once.
+  const wrapperRef = useDismiss<HTMLDivElement>(open || selectedTool !== null, closeAll);
 
   const toggle = useCallback((event: React.MouseEvent) => {
     // Keep the click from bubbling to the canvas node-selection handler.
@@ -26,7 +44,7 @@ const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
   }, []);
 
   return (
-    <div className="relative nodrag" style={{ width: LAYOUT.TOOL_WIDTH }}>
+    <div ref={wrapperRef} className="relative nodrag" style={{ width: LAYOUT.TOOL_WIDTH }}>
       <button
         type="button"
         onClick={toggle}
@@ -61,14 +79,25 @@ const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
           </div>
           <ul className="space-y-0.5">
             {data.hiddenTools.map((tool) => (
-              <li
-                key={tool}
-                className="flex items-center gap-1.5 px-1.5 py-1 rounded-md hover:bg-white/[0.06]"
-              >
-                <Wrench size={10} className="text-text-secondary/80 flex-shrink-0" />
-                <span className="tool-label min-w-0 flex-1 font-mono text-[11px] text-text-secondary truncate" title={tool}>
-                  {tool}
-                </span>
+              <li key={tool}>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSelectedTool(tool);
+                  }}
+                  aria-label={`Show details for ${data.serverName} tool ${tool}`}
+                  className={cn(
+                    'w-full flex items-center gap-1.5 px-1.5 py-1 rounded-md text-left',
+                    'hover:bg-white/[0.06] transition-colors',
+                    selectedTool === tool && 'bg-white/[0.06]',
+                  )}
+                >
+                  <Wrench size={10} className="text-text-secondary/80 flex-shrink-0" aria-hidden="true" />
+                  <span className="tool-label min-w-0 flex-1 font-mono text-[11px] text-text-secondary truncate" title={tool}>
+                    {tool}
+                  </span>
+                </button>
               </li>
             ))}
           </ul>
@@ -84,6 +113,14 @@ const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
         )}
         id="input"
       />
+
+      {selectedTool && (
+        <ToolDetailPopover
+          serverName={data.serverName}
+          toolName={selectedTool}
+          onClose={() => setSelectedTool(null)}
+        />
+      )}
     </div>
   );
 });

--- a/web/src/hooks/useDismiss.ts
+++ b/web/src/hooks/useDismiss.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react';
+
+// useDismiss wires the two standard "close this overlay" gestures, Escape and
+// an outside click, to a single onClose. It returns a ref to attach to the
+// overlay's wrapper; a pointer event whose target is inside that wrapper is
+// treated as interaction, not dismissal, so clicks on the trigger and the
+// popover body never close it. Listeners are only bound while `open` is true.
+//
+// Lives here (not inside a node component) because the tool pill and the
+// "+N more" overflow node share the exact same dismissal contract.
+export function useDismiss<T extends HTMLElement = HTMLDivElement>(
+  open: boolean,
+  onClose: () => void,
+): React.RefObject<T | null> {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    const onPointerDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('mousedown', onPointerDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('mousedown', onPointerDown);
+    };
+  }, [open, onClose]);
+
+  return ref;
+}


### PR DESCRIPTION
## Description

Makes the fanned-out tool pills in the Topology view interactive: a primary click (or keyboard activation) on a tool pill opens a canvas-anchored detail popover. This retires the staging decision from the fan-out PR that left the nodes non-interactive, and gives high-cardinality servers an in-place answer to "what is this tool?".

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- New `ToolDetailPopover`: a canvas-anchored card showing the qualified `server__tool` name, description, a collapse-by-default JSON schema preview, a best-effort "last used" line, and "Open in Tools" / "Copy name" actions. Mirrors the existing overflow popover's absolute, pans-with-canvas mechanics (no portal).
- `ToolNode`: the pill is now a keyboard-activatable button (`aria-expanded`, `aria-label`) that toggles the popover; marked `nodrag` so a click is a clean activation, consistent with the overflow node.
- `ToolOverflowNode`: the "+N more" list items are now buttons that open the same detail popover, so hidden tools are as inspectable as visible ones.
- New `useDismiss` hook: shared Escape + outside-click dismissal (ref-contains guard) used by both nodes.
- Description and input schema come from the already-polled tool catalog (no new fetch); usage is fetched best-effort on open (`fetchToolUsage`, unmount-guarded) and the line is omitted when absent, which is the common case on Topology.
- `Canvas.onNodeClick` is unchanged functionally (tool nodes still early-return); only the comment was updated to reflect that nodes now own their click handling.

## Notes

- A shared `ToolDetailContent` extraction from `ToolDetailPanel` was considered but skipped: the popover's compact, collapse-by-default schema differs from the workspace rail, so a shared component would have a single consumer. The inline layout is documented in-code.
- Tool pills are no longer drag targets (now `nodrag`), matching the overflow node; the tiny pills had little drag value.
- Possible follow-ups: a `?tool=` deep-link param for a one-click reveal in the Tools workspace, and edge-aware popover flipping near the viewport boundary.

## Testing

- New `ToolNode.test.tsx` and `ToolOverflowNode.test.tsx` cover open/close (click, re-click, Escape), prefixed-name + description rendering, empty states, copy-to-clipboard, the Tools deep-link, best-effort usage line, and overflow-item detail.
- `make build` passes; full frontend suite 905/905 passes; lint clean on changed files.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #763