### PR TITLE
fix: make web skill sync drift-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Reconciliation API for git-sourced skills.** The skills HTTP API gained the
+  building blocks for editing imported skills safely. `GET /api/skills/sources`
+  now reports drift (`driftedSkills` per source, `hasLocalEdits` per skill). The
+  per-source and bulk update endpoints accept an optional `{ "force": bool,
+  "skills": [..] }` body. Three per-skill endpoints were added: `GET
+  .../skills/{skill}/diff` (local vs upstream `SKILL.md` plus a unified diff,
+  computed without writing to disk), `POST .../skills/{skill}/detach` (drop the
+  origin sidecar and lock entry to make a skill local-only), and `POST
+  .../skills/{skill}/reset` (back up and force-restore a single skill to
+  upstream). All new fields are additive and optional.
+
 - **Richer skill instructions in the Library.** The Library inspector's
   Instructions tab and the SkillEditor preview now render `SKILL.md` bodies as a
   designed surface rather than raw browser-default markdown: fenced code blocks
@@ -191,6 +202,25 @@ All notable changes to gridctl will be documented in this file.
   web UI client list. This is gridctl's first TOML-based client provisioner.
 
 ### Fixed
+
+- **The web UI no longer silently overwrites locally-edited skills on sync.**
+  Both sync paths (`POST /api/skills/sources/{name}/update` and the bulk `POST
+  /api/skills/sources/update`) called the importer with no drift check, so
+  clicking "Sync" discarded any local edits to an imported `SKILL.md` — the data
+  loss the CLI already guards against. Drifted skills are now skipped by default
+  (reported as `skipped: "local edits"`) while their version tracking is advanced
+  to the latest upstream commit, so the reviewed version stops showing as an
+  available update without touching the on-disk file or its installed-hash
+  baseline (drift stays visible). Passing `force: true` overwrites as before, but
+  first writes a `SKILL.md.pre-<sha>` backup next to the file. A `--force` skill
+  update (CLI or `reset`) now also re-installs from upstream even when the commit
+  is unchanged, so it can be used to discard local edits and restore the tracked
+  version.
+
+- **`govulncheck` CI gate passes again.** Bumped the Go toolchain to `go1.26.4`,
+  which carries the fixes for `GO-2026-5037` (crypto/x509) and `GO-2026-5039`
+  (net/textproto). The Gatekeeper workflow reads its Go version from `go.mod`, so
+  no workflow change was needed.
 
 - **Per-client access scoping now takes effect on hot reload.** Changes that
   touched only the `clients:` block (saving a scope through the Topology Access

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -71,6 +71,32 @@ Supported auth flows for private repos:
 - `--vault-key <key>`: resolves the token from a `${var:KEY}` entry; suitable for long-running daemons.
 - `--ssh-key <path>`: SSH private key path.
 
+### Reconciling local edits (web UI)
+
+A `SKILL.md` imported from git can be edited in the Library workspace. An edited
+file is "drifted" from its installed snapshot, and the same protection the CLI
+applies (`gridctl skill update` refuses to overwrite a drifted skill unless
+`--force`) now applies to the web API:
+
+- `GET /api/skills/sources` reports drift: each source carries `driftedSkills`
+  and each skill entry carries `hasLocalEdits`.
+- `POST /api/skills/sources/{name}/update` and `POST /api/skills/sources/update`
+  accept an optional body `{ "force": bool, "skills": [..] }`. Without `force`, a
+  drifted skill is skipped (reported as `skipped: "local edits"`) while its
+  version tracking is advanced to the latest upstream commit, so it stops showing
+  as an available update but its on-disk content and drift status are preserved.
+  With `force: true`, the current `SKILL.md` is copied to `SKILL.md.pre-<sha>`
+  next to it before being overwritten.
+- `GET /api/skills/sources/{name}/skills/{skill}/diff` returns the local vs
+  upstream `SKILL.md` (plus a unified diff) without writing anything to disk.
+- `POST /api/skills/sources/{name}/skills/{skill}/detach` removes the skill's
+  origin sidecar and lock entry so it becomes local-only.
+- `POST /api/skills/sources/{name}/skills/{skill}/reset` backs up and
+  force-restores a single skill to its upstream content.
+
+The bytes served to agents are never changed by any of this beyond the explicit
+overwrite a `reset` or `force` sync performs.
+
 ## What gridctl deliberately does not do
 
 A short list of choices worth knowing about.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gridctl/gridctl
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -319,6 +319,11 @@ func (s *Server) Handler() http.Handler {
 	// leaking them into query strings or browser history.
 	mux.HandleFunc("GET /api/skills/sources/{name}/preview", s.handleSkillSourcePreview)
 	mux.HandleFunc("POST /api/skills/sources/{name}/preview", s.handleSkillSourcePreview)
+	// Per-skill reconciliation: compare with upstream, detach to local-only, or
+	// reset (force-overwrite with backup) a single tracked skill.
+	mux.HandleFunc("GET /api/skills/sources/{name}/skills/{skill}/diff", s.handleSkillDiff)
+	mux.HandleFunc("POST /api/skills/sources/{name}/skills/{skill}/detach", s.handleSkillDetach)
+	mux.HandleFunc("POST /api/skills/sources/{name}/skills/{skill}/reset", s.handleSkillReset)
 
 	// Wizard endpoints
 	mux.HandleFunc("GET /api/wizard/drafts", s.handleWizardDraftsList)

--- a/internal/api/skills.go
+++ b/internal/api/skills.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -56,6 +57,9 @@ type SkillSourceStatus struct {
 	LastFetched    string             `json:"lastFetched,omitempty"`
 	CommitSHA      string             `json:"commitSha,omitempty"`
 	UpdateAvail    bool               `json:"updateAvailable"`
+	// DriftedSkills lists the skills in this source whose on-disk SKILL.md has
+	// local edits (drift) that a sync would otherwise overwrite.
+	DriftedSkills []string `json:"driftedSkills,omitempty"`
 }
 
 // SkillSourceEntry represents a single skill within a source.
@@ -65,6 +69,9 @@ type SkillSourceEntry struct {
 	State       string `json:"state"`
 	IsRemote    bool   `json:"isRemote"`
 	ContentHash string `json:"contentHash,omitempty"`
+	// HasLocalEdits is true when the on-disk SKILL.md diverges from the hash
+	// snapshotted at the last import/sync (i.e. the user edited it locally).
+	HasLocalEdits bool `json:"hasLocalEdits"`
 }
 
 // SkillPreview represents a previewed skill from a repo (not yet imported).
@@ -194,7 +201,7 @@ func writeGitError(w http.ResponseWriter, prefix string, err error) {
 
 // handleSkillSourcesList returns all configured skill sources with update status.
 // GET /api/skills/sources
-func (s *Server) handleSkillSourcesList(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleSkillSourcesList(w http.ResponseWriter, r *http.Request) {
 	if s.registryServer == nil {
 		writeJSONError(w, "Registry not available", http.StatusServiceUnavailable)
 		return
@@ -202,6 +209,16 @@ func (s *Server) handleSkillSourcesList(w http.ResponseWriter, _ *http.Request) 
 	store := s.registryServer.Store()
 	lockPath := s.lockFilePath()
 	lf, _ := skills.ReadLockFile(lockPath)
+
+	// Per-skill drift (local edits). Local hashing only — no git fetch — so it
+	// is cheap enough to compute on every list. Fails open to "no drift" on
+	// error so a transient read problem never hides sources.
+	driftedSet := make(map[string]bool)
+	if drifted, err := skills.DetectDrift(r.Context(), store, lockPath, ""); err == nil {
+		for _, name := range drifted {
+			driftedSet[name] = true
+		}
+	}
 
 	// Load skills.yaml config
 	cfg, err := skills.LoadSkillsConfig(s.configFilePath())
@@ -250,6 +267,10 @@ func (s *Server) handleSkillSourcesList(w http.ResponseWriter, _ *http.Request) 
 				entry.Description = sk.Description
 				entry.State = string(sk.State)
 			}
+			if driftedSet[skillName] {
+				entry.HasLocalEdits = true
+				src.DriftedSkills = append(src.DriftedSkills, skillName)
+			}
 			src.Skills = append(src.Skills, entry)
 
 			// The cache is keyed by skill name; if any skill in this source
@@ -261,6 +282,7 @@ func (s *Server) handleSkillSourcesList(w http.ResponseWriter, _ *http.Request) 
 			}
 		}
 
+		sort.Strings(src.DriftedSkills)
 		sources = append(sources, src)
 	}
 
@@ -443,7 +465,74 @@ func (s *Server) resolveCheckAuth(req *AuthRequest, storedRef string) (skills.Au
 	}, nil
 }
 
-// handleSkillSourceUpdate applies available updates for a source.
+// syncSkill applies the drift-safe update policy to a single skill within a
+// source and returns its per-skill outcome:
+//   - not drifted: updated normally.
+//   - drifted, force=false: skipped ("local edits"). Its tracking metadata is
+//     advanced to the latest upstream commit so it stops showing as an
+//     available update, but the on-disk SKILL.md and InstalledHash are left
+//     untouched (drift remains visible).
+//   - drifted, force=true: the current SKILL.md is backed up, then overwritten.
+//
+// authCfg is used only for the on-demand FetchAndCompare (skip-advance and
+// backup naming); Importer.Update independently re-resolves credentials from
+// the stored origin.
+func (s *Server) syncSkill(ctx context.Context, imp *skills.Importer, authCfg skills.AuthConfig, src skills.LockedSource, skillName string, drifted, force bool) SkillSyncResult {
+	entry := SkillSyncResult{Skill: skillName}
+
+	if !drifted {
+		result, err := imp.Update(skillName, false, false)
+		if err != nil {
+			entry.Error = gitpkg.RedactError(err).Error()
+			return entry
+		}
+		entry.Imported = len(result.Imported)
+		entry.Warnings = result.Warnings
+		return entry
+	}
+
+	if !force {
+		// Skip the overwrite but advance tracking to the latest upstream commit
+		// so the reviewed version no longer reads as "update available".
+		if newSHA, changed, ferr := skills.FetchAndCompare(src.Repo, src.Ref, src.CommitSHA, authCfg, slog.Default()); ferr == nil && changed && newSHA != "" {
+			if aerr := imp.AdvanceTracking(ctx, skillName, newSHA); aerr != nil {
+				entry.Warnings = append(entry.Warnings, "failed to advance tracking: "+aerr.Error())
+			}
+		}
+		entry.Skipped = "local edits"
+		return entry
+	}
+
+	// Forced overwrite of a drifted skill: back up the current SKILL.md first.
+	newSHA, _, _ := skills.FetchAndCompare(src.Repo, src.Ref, src.CommitSHA, authCfg, slog.Default())
+	if backup, berr := imp.BackupSkillFile(ctx, skillName, skills.ShortSHA(newSHA)); berr != nil {
+		entry.Warnings = append(entry.Warnings, "backup failed: "+berr.Error())
+	} else {
+		entry.Backup = backup
+	}
+
+	result, err := imp.Update(skillName, false, true)
+	if err != nil {
+		entry.Error = gitpkg.RedactError(err).Error()
+		return entry
+	}
+	entry.Imported = len(result.Imported)
+	entry.Warnings = append(entry.Warnings, result.Warnings...)
+	return entry
+}
+
+// skillUpdateRequest is the optional body accepted by the per-source and
+// sync-all update endpoints. All fields are optional; an empty body preserves
+// the historical "update everything, skip drifted" behavior with force=false.
+type skillUpdateRequest struct {
+	Force  bool         `json:"force,omitempty"`
+	Skills []string     `json:"skills,omitempty"` // restrict to these skills (empty = all)
+	Auth   *AuthRequest `json:"auth,omitempty"`
+}
+
+// handleSkillSourceUpdate applies available updates for a source. Locally-edited
+// (drifted) skills are skipped unless force is set; an optional skills filter
+// restricts the operation to named skills.
 // POST /api/skills/sources/{name}/update
 func (s *Server) handleSkillSourceUpdate(w http.ResponseWriter, r *http.Request) {
 	sourceName := r.PathValue("name")
@@ -451,6 +540,11 @@ func (s *Server) handleSkillSourceUpdate(w http.ResponseWriter, r *http.Request)
 	if s.registryServer == nil {
 		writeJSONError(w, "Registry not available", http.StatusServiceUnavailable)
 		return
+	}
+
+	var req skillUpdateRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		_ = json.NewDecoder(r.Body).Decode(&req)
 	}
 
 	lockPath := s.lockFilePath()
@@ -468,22 +562,44 @@ func (s *Server) handleSkillSourceUpdate(w http.ResponseWriter, r *http.Request)
 
 	store := s.registryServer.Store()
 	registryDir := store.Dir()
+	ctx := r.Context()
+
+	authCfg, err := s.resolveCheckAuth(req.Auth, src.CredentialRef)
+	if err != nil {
+		writeJSONError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	imp := skills.NewImporter(store, registryDir, lockPath, slog.Default())
 	imp.SetCredentialResolver(s.credentialResolver())
 
-	// Update each skill from this source. Importer.Update re-resolves the
-	// stored CredentialRef from the origin using the resolver we just set.
-	var results []map[string]any
-	for skillName := range src.Skills {
-		result, err := imp.Update(skillName, false, false)
-		entry := map[string]any{"skill": skillName}
-		if err != nil {
-			entry["error"] = gitpkg.RedactError(err).Error()
-		} else {
-			entry["imported"] = len(result.Imported)
-			entry["warnings"] = result.Warnings
+	// Drifted skills in this source (local edits). Computed once up front.
+	driftedSet := make(map[string]bool)
+	if drifted, derr := skills.DetectDrift(ctx, store, lockPath, sourceName); derr == nil {
+		for _, name := range drifted {
+			driftedSet[name] = true
 		}
-		results = append(results, entry)
+	}
+
+	// Optional filter: restrict to named skills that actually belong to this
+	// source. An empty filter means all skills in the source.
+	filter := make(map[string]bool, len(req.Skills))
+	for _, name := range req.Skills {
+		filter[name] = true
+	}
+
+	skillNames := make([]string, 0, len(src.Skills))
+	for skillName := range src.Skills {
+		if len(filter) > 0 && !filter[skillName] {
+			continue
+		}
+		skillNames = append(skillNames, skillName)
+	}
+	sort.Strings(skillNames)
+
+	results := make([]SkillSyncResult, 0, len(skillNames))
+	for _, skillName := range skillNames {
+		results = append(results, s.syncSkill(ctx, imp, authCfg, src, skillName, driftedSet[skillName], req.Force))
 	}
 
 	s.refreshRegistryRouter()
@@ -607,6 +723,7 @@ type SourceSyncSummary struct {
 	Sources       []SourceSyncResult `json:"sources"`
 	SyncedSources int                `json:"syncedSources"`
 	UpdatedSkills int                `json:"updatedSkills"`
+	SkippedSkills int                `json:"skippedSkills"`
 	FailedSources int                `json:"failedSources"`
 	PinnedSources int                `json:"pinnedSources"`
 }
@@ -626,6 +743,12 @@ type SkillSyncResult struct {
 	Imported int      `json:"imported,omitempty"`
 	Warnings []string `json:"warnings,omitempty"`
 	Error    string   `json:"error,omitempty"`
+	// Skipped, when set, is the reason a drifted skill was left untouched
+	// (e.g. "local edits"). Its tracking metadata is still advanced.
+	Skipped string `json:"skipped,omitempty"`
+	// Backup is the file name of the pre-overwrite SKILL.md backup written
+	// when a drifted skill was force-overwritten.
+	Backup string `json:"backup,omitempty"`
 }
 
 // syncAllConcurrency caps the number of sources synced in parallel. Matches
@@ -643,6 +766,12 @@ func (s *Server) handleSkillSourcesSyncAll(w http.ResponseWriter, r *http.Reques
 	}
 
 	ctx := r.Context()
+
+	var req skillUpdateRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+	}
+
 	lockPath := s.lockFilePath()
 	lf, err := skills.ReadLockFile(lockPath)
 	if err != nil {
@@ -655,6 +784,16 @@ func (s *Server) handleSkillSourcesSyncAll(w http.ResponseWriter, r *http.Reques
 	logger := slog.Default()
 	imp := skills.NewImporter(store, registryDir, lockPath, logger)
 	imp.SetCredentialResolver(s.credentialResolver())
+
+	// Drift (local edits) across every imported skill, computed once before the
+	// fan-out so the goroutines never read the lock file while it is being
+	// rewritten. Local hashing only — no git fetch.
+	driftedSet := make(map[string]bool)
+	if drifted, derr := skills.DetectDrift(ctx, store, lockPath, ""); derr == nil {
+		for _, name := range drifted {
+			driftedSet[name] = true
+		}
+	}
 
 	// Pre-sort source names for deterministic output.
 	names := make([]string, 0, len(lf.Sources))
@@ -687,6 +826,11 @@ func (s *Server) handleSkillSourcesSyncAll(w http.ResponseWriter, r *http.Reques
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
+			// Best-effort auth for the on-demand fetches in syncSkill (skip
+			// tracking-advance, backup naming). Errors are non-fatal: Update
+			// independently resolves credentials from the stored origin.
+			authCfg, _ := s.resolveCheckAuth(req.Auth, source.CredentialRef)
+
 			// Skill names sorted so per-skill output order is stable too.
 			skillNames := make([]string, 0, len(source.Skills))
 			for sn := range source.Skills {
@@ -706,7 +850,6 @@ func (s *Server) handleSkillSourcesSyncAll(w http.ResponseWriter, r *http.Reques
 					})
 					continue
 				}
-				entry := SkillSyncResult{Skill: skillName}
 
 				// The skill is in the lock file but no longer in the registry
 				// (deleted out from under the lock file, e.g. via the UI).
@@ -717,18 +860,14 @@ func (s *Server) handleSkillSourcesSyncAll(w http.ResponseWriter, r *http.Reques
 				// still reported and retained.
 				if _, err := store.GetSkill(skillName); err != nil {
 					ghostsBySource[idx] = append(ghostsBySource[idx], skillName)
-					entry.Warnings = []string{"skill no longer in registry; removed stale lock entry"}
-					results[idx].Skills = append(results[idx].Skills, entry)
+					results[idx].Skills = append(results[idx].Skills, SkillSyncResult{
+						Skill:    skillName,
+						Warnings: []string{"skill no longer in registry; removed stale lock entry"},
+					})
 					continue
 				}
 
-				result, updErr := imp.Update(skillName, false, false)
-				if updErr != nil {
-					entry.Error = gitpkg.RedactError(updErr).Error()
-				} else {
-					entry.Imported = len(result.Imported)
-					entry.Warnings = result.Warnings
-				}
+				entry := s.syncSkill(ctx, imp, authCfg, source, skillName, driftedSet[skillName], req.Force)
 				results[idx].Skills = append(results[idx].Skills, entry)
 			}
 		}(i, name, src)
@@ -772,6 +911,9 @@ func (s *Server) handleSkillSourcesSyncAll(w http.ResponseWriter, r *http.Reques
 					sourceFailed = true
 				}
 				summary.UpdatedSkills += sk.Imported
+				if sk.Skipped != "" {
+					summary.SkippedSkills++
+				}
 			}
 			if sourceFailed {
 				summary.FailedSources++
@@ -832,4 +974,154 @@ func (s *Server) handleSkillUpdates(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	writeJSON(w, summary)
+}
+
+// SkillDiffResponse is the body of the per-skill compare-with-upstream endpoint.
+type SkillDiffResponse struct {
+	Skill       string `json:"skill"`
+	Local       string `json:"local"`
+	Upstream    string `json:"upstream"`
+	UnifiedDiff string `json:"unifiedDiff,omitempty"`
+	Drifted     bool   `json:"drifted"`
+}
+
+// handleSkillDiff returns the local vs upstream SKILL.md for an imported skill
+// without writing anything to the registry. The upstream side is the content
+// an update would install; auth is taken from the skill's stored credentialRef.
+// GET /api/skills/sources/{name}/skills/{skill}/diff
+func (s *Server) handleSkillDiff(w http.ResponseWriter, r *http.Request) {
+	skillName := r.PathValue("skill")
+
+	if s.registryServer == nil {
+		writeJSONError(w, "Registry not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	store := s.registryServer.Store()
+	imp := skills.NewImporter(store, store.Dir(), s.lockFilePath(), slog.Default())
+	imp.SetCredentialResolver(s.credentialResolver())
+
+	diff, err := imp.Diff(r.Context(), skillName)
+	if err != nil {
+		writeGitError(w, "Diff failed: ", err)
+		return
+	}
+
+	writeJSON(w, SkillDiffResponse{
+		Skill:       diff.Skill,
+		Local:       diff.Local,
+		Upstream:    diff.Upstream,
+		UnifiedDiff: unifiedDiff(diff.Local, diff.Upstream, 3),
+		Drifted:     diff.Drifted,
+	})
+}
+
+// handleSkillDetach removes a skill's origin sidecar and lock-file entry so it
+// becomes local-only and is no longer touched by sync.
+// POST /api/skills/sources/{name}/skills/{skill}/detach
+func (s *Server) handleSkillDetach(w http.ResponseWriter, r *http.Request) {
+	sourceName := r.PathValue("name")
+	skillName := r.PathValue("skill")
+
+	if s.registryServer == nil {
+		writeJSONError(w, "Registry not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	lockPath := s.lockFilePath()
+	lf, err := skills.ReadLockFile(lockPath)
+	if err != nil {
+		writeJSONError(w, "Failed to read lock file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	src, ok := lf.Sources[sourceName]
+	if !ok {
+		writeJSONError(w, "Source not found: "+sourceName, http.StatusNotFound)
+		return
+	}
+	if _, ok := src.Skills[skillName]; !ok {
+		writeJSONError(w, "Skill not found in source: "+skillName, http.StatusNotFound)
+		return
+	}
+
+	store := s.registryServer.Store()
+	imp := skills.NewImporter(store, store.Dir(), lockPath, slog.Default())
+
+	if err := imp.Detach(r.Context(), skillName); err != nil {
+		writeJSONError(w, "Detach failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	s.refreshRegistryRouter()
+
+	writeJSON(w, map[string]any{"detached": skillName})
+}
+
+// handleSkillReset force-updates a single skill to its upstream content,
+// backing up the current (possibly edited) SKILL.md first.
+// POST /api/skills/sources/{name}/skills/{skill}/reset
+func (s *Server) handleSkillReset(w http.ResponseWriter, r *http.Request) {
+	sourceName := r.PathValue("name")
+	skillName := r.PathValue("skill")
+
+	if s.registryServer == nil {
+		writeJSONError(w, "Registry not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req skillUpdateRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+	}
+
+	lockPath := s.lockFilePath()
+	lf, err := skills.ReadLockFile(lockPath)
+	if err != nil {
+		writeJSONError(w, "Failed to read lock file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	src, ok := lf.Sources[sourceName]
+	if !ok {
+		writeJSONError(w, "Source not found: "+sourceName, http.StatusNotFound)
+		return
+	}
+	if _, ok := src.Skills[skillName]; !ok {
+		writeJSONError(w, "Skill not found in source: "+skillName, http.StatusNotFound)
+		return
+	}
+
+	store := s.registryServer.Store()
+	ctx := r.Context()
+
+	authCfg, err := s.resolveCheckAuth(req.Auth, src.CredentialRef)
+	if err != nil {
+		writeJSONError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	imp := skills.NewImporter(store, store.Dir(), lockPath, slog.Default())
+	imp.SetCredentialResolver(s.credentialResolver())
+
+	// Reset always overwrites to upstream. Pass drifted=true so a locally-edited
+	// skill is backed up before the overwrite; a clean skill simply re-pulls.
+	drifted := false
+	if d, derr := skills.DetectDrift(ctx, store, lockPath, sourceName); derr == nil {
+		for _, name := range d {
+			if name == skillName {
+				drifted = true
+				break
+			}
+		}
+	}
+
+	entry := s.syncSkill(ctx, imp, authCfg, src, skillName, drifted, true)
+
+	s.refreshRegistryRouter()
+
+	if entry.Error != "" {
+		writeJSONError(w, "Reset failed: "+entry.Error, http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, entry)
 }

--- a/internal/api/skills_reconcile_test.go
+++ b/internal/api/skills_reconcile_test.go
@@ -1,0 +1,273 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+
+	"github.com/gridctl/gridctl/pkg/registry"
+	"github.com/gridctl/gridctl/pkg/skills"
+)
+
+// seedDriftedSkill writes a skill, a lock-file source entry, and an origin
+// sidecar whose InstalledHash deliberately mismatches the on-disk file so
+// DetectDrift reports the skill as locally edited. No git repo involved.
+func seedDriftedSkill(t *testing.T, srv *Server, regServer *registry.Server, sourceName, repo, skillName string) string {
+	t.Helper()
+	seedSkill(t, regServer, skillName, registry.StateActive)
+	seedSkillSource(t, srv, sourceName, repo, skillName)
+
+	store := regServer.Store()
+	skillDir := filepath.Join(store.Dir(), "skills", skillName)
+	origin := &skills.Origin{
+		Repo:          repo,
+		Ref:           "main",
+		Path:          skillName,
+		CommitSHA:     "abc1234567890abc1234567890abc1234567890a",
+		ImportedAt:    time.Now().UTC(),
+		InstalledHash: "0000000000000000000000000000000000000000000000000000000000000000",
+	}
+	if err := skills.WriteOrigin(skillDir, origin); err != nil {
+		t.Fatalf("write origin: %v", err)
+	}
+	skillPath := filepath.Join(skillDir, "SKILL.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read skill: %v", err)
+	}
+	return string(data)
+}
+
+func TestHandleSkillSourcesList_ReportsDrift(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedDriftedSkill(t, srv, regServer, "my-source", "https://github.com/org/repo", "drifted-skill")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/skills/sources", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var result []SkillSourceStatus
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 source, got %d", len(result))
+	}
+	if len(result[0].DriftedSkills) != 1 || result[0].DriftedSkills[0] != "drifted-skill" {
+		t.Errorf("expected driftedSkills=[drifted-skill], got %v", result[0].DriftedSkills)
+	}
+	if len(result[0].Skills) != 1 || !result[0].Skills[0].HasLocalEdits {
+		t.Errorf("expected skill entry to report hasLocalEdits=true, got %+v", result[0].Skills)
+	}
+}
+
+func TestHandleSkillSourceUpdate_SkipsDriftedByDefault(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	original := seedDriftedSkill(t, srv, regServer, "my-source", "https://github.com/org/repo", "drifted-skill")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/skills/sources/my-source/update", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Results []SkillSyncResult `json:"results"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(resp.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(resp.Results))
+	}
+	if resp.Results[0].Skipped != "local edits" {
+		t.Errorf("expected skipped=%q, got %+v", "local edits", resp.Results[0])
+	}
+
+	// The on-disk SKILL.md must not have been overwritten.
+	skillDir := filepath.Join(regServer.Store().Dir(), "skills", "drifted-skill")
+	data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read skill: %v", err)
+	}
+	if string(data) != original {
+		t.Errorf("drifted skill was overwritten by a default sync")
+	}
+}
+
+func TestHandleSkillDetach(t *testing.T) {
+	srv, regServer := setupRegistryTestServer(t)
+	seedDriftedSkill(t, srv, regServer, "my-source", "https://github.com/org/repo", "drifted-skill")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/skills/sources/my-source/skills/drifted-skill/detach", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	skillDir := filepath.Join(regServer.Store().Dir(), "skills", "drifted-skill")
+	if skills.HasOrigin(skillDir) {
+		t.Errorf("origin sidecar should be gone after detach")
+	}
+	lf, err := skills.ReadLockFile(srv.lockFilePath())
+	if err != nil {
+		t.Fatalf("read lock: %v", err)
+	}
+	if _, _, found := lf.FindSkillSource("drifted-skill"); found {
+		t.Errorf("lock entry should be gone after detach")
+	}
+	if _, err := regServer.Store().GetSkill("drifted-skill"); err != nil {
+		t.Errorf("skill should remain in the registry after detach: %v", err)
+	}
+}
+
+// importLocalSkill initializes a local git repo with one SKILL.md and imports
+// it into the server's registry + lock file, returning the repo for follow-up
+// commits.
+func importLocalSkill(t *testing.T, srv *Server, regServer *registry.Server, body string) (string, *git.Repository) {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	content := "---\nname: repo-skill\ndescription: imported\nstate: active\n---\n\n" + body
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	commitWorktree(t, repo, "initial")
+
+	store := regServer.Store()
+	imp := skills.NewImporter(store, store.Dir(), srv.lockFilePath(), slog.Default())
+	if _, err := imp.Import(skills.ImportOptions{Repo: dir, Ref: "master", Trust: true}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	return dir, repo
+}
+
+func commitWorktree(t *testing.T, repo *git.Repository, msg string) {
+	t.Helper()
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if _, err := wt.Add("SKILL.md"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := wt.Commit(msg, &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com"},
+	}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}
+
+func TestHandleSkillSourceUpdate_ForceBacksUpAndOverwrites(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv, regServer := setupRegistryTestServer(t)
+	dir, _ := importLocalSkill(t, srv, regServer, "# Repo skill\n\nupstream body.\n")
+
+	// Local edit → drift.
+	store := regServer.Store()
+	skillDir := filepath.Join(store.Dir(), "skills", "repo-skill")
+	skillPath := filepath.Join(skillDir, "SKILL.md")
+	edited, _ := os.ReadFile(skillPath)
+	editedStr := string(edited) + "\n\nLOCAL EDIT MARKER\n"
+	if err := os.WriteFile(skillPath, []byte(editedStr), 0644); err != nil {
+		t.Fatalf("edit skill: %v", err)
+	}
+	sourceName := skills.RepoToName(dir)
+
+	body := strings.NewReader(`{"force":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/skills/sources/"+sourceName+"/update", body)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// A backup of the pre-overwrite content must exist next to the skill.
+	entries, _ := os.ReadDir(skillDir)
+	var backup string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "SKILL.md.pre-") {
+			backup = e.Name()
+		}
+	}
+	if backup == "" {
+		t.Fatalf("expected a SKILL.md.pre-* backup, dir has: %v", entries)
+	}
+	backupData, _ := os.ReadFile(filepath.Join(skillDir, backup))
+	if !strings.Contains(string(backupData), "LOCAL EDIT MARKER") {
+		t.Errorf("backup should contain the pre-overwrite local edit")
+	}
+
+	// The live SKILL.md must have been overwritten (local marker gone).
+	after, _ := os.ReadFile(skillPath)
+	if strings.Contains(string(after), "LOCAL EDIT MARKER") {
+		t.Errorf("force sync should overwrite the local edit")
+	}
+}
+
+func TestHandleSkillDiff(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv, regServer := setupRegistryTestServer(t)
+	dir, repo := importLocalSkill(t, srv, regServer, "# Repo skill\n\nv1 body.\n")
+
+	// Local edit + an upstream commit so both sides differ.
+	store := regServer.Store()
+	skillPath := filepath.Join(store.Dir(), "skills", "repo-skill", "SKILL.md")
+	edited, _ := os.ReadFile(skillPath)
+	if err := os.WriteFile(skillPath, []byte(string(edited)+"\n\nLOCAL NOTE\n"), 0644); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: repo-skill\ndescription: imported v2\nstate: active\n---\n\n# Repo skill\n\nv2 body.\n"), 0644); err != nil {
+		t.Fatalf("upstream edit: %v", err)
+	}
+	commitWorktree(t, repo, "v2")
+
+	sourceName := skills.RepoToName(dir)
+	req := httptest.NewRequest(http.MethodGet, "/api/skills/sources/"+sourceName+"/skills/repo-skill/diff", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var diff SkillDiffResponse
+	if err := json.NewDecoder(rec.Body).Decode(&diff); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if !diff.Drifted {
+		t.Errorf("expected drifted=true")
+	}
+	if !strings.Contains(diff.Local, "LOCAL NOTE") {
+		t.Errorf("local side should contain the local edit")
+	}
+	if !strings.Contains(diff.Upstream, "v2 body.") {
+		t.Errorf("upstream side should contain the latest commit, got: %q", diff.Upstream)
+	}
+	if diff.UnifiedDiff == "" {
+		t.Errorf("expected a non-empty unified diff")
+	}
+
+	// Diff must not have mutated the on-disk file.
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("skill missing after diff: %v", err)
+	}
+}

--- a/pkg/skills/importer.go
+++ b/pkg/skills/importer.go
@@ -367,17 +367,20 @@ func (imp *Importer) Update(skillName string, dryRun, force bool) (*ImportResult
 		return nil, fmt.Errorf("checking updates: %w", err)
 	}
 
-	if !changed {
+	// force re-installs from upstream even when the commit is unchanged, so a
+	// caller can discard local edits and restore the tracked version (reset).
+	// Without force, an unchanged commit is a no-op.
+	if !changed && !force {
 		return &ImportResult{
 			Warnings: []string{fmt.Sprintf("%s is already up to date", skillName)},
 		}, nil
 	}
 
-	imp.logger.Info("update available", "skill", skillName, "current", origin.CommitSHA[:8], "latest", newSHA[:8])
+	imp.logger.Info("update available", "skill", skillName, "current", ShortSHA(origin.CommitSHA), "latest", ShortSHA(newSHA))
 
 	if dryRun {
 		return &ImportResult{
-			Warnings: []string{fmt.Sprintf("%s: update available (%s → %s)", skillName, origin.CommitSHA[:8], newSHA[:8])},
+			Warnings: []string{fmt.Sprintf("%s: update available (%s → %s)", skillName, ShortSHA(origin.CommitSHA), ShortSHA(newSHA))},
 		}, nil
 	}
 

--- a/pkg/skills/reconcile.go
+++ b/pkg/skills/reconcile.go
@@ -1,0 +1,222 @@
+package skills
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/registry"
+)
+
+// ShortSHA returns the first 8 characters of a commit SHA, or the whole string
+// when it is shorter (including the empty string from an uncached fetch). It
+// keeps SHA formatting panic-free for logs, backup names, and messages.
+func ShortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}
+
+// DiffResult holds a skill's current on-disk SKILL.md alongside the content an
+// update would install, for on-demand comparison. Producing it changes no
+// registry state, SHAs, or InstalledHashes.
+type DiffResult struct {
+	Skill    string `json:"skill"`
+	Local    string `json:"local"`    // current on-disk full SKILL.md text
+	Upstream string `json:"upstream"` // content an update would install
+	Drifted  bool   `json:"drifted"`  // on-disk file diverges from InstalledHash
+}
+
+// Diff fetches the latest upstream SKILL.md for an imported skill and returns
+// both the current on-disk content and the content an update would install,
+// without writing anything to the registry or changing any SHAs/InstalledHash.
+// It is on-demand only — the caller pays for one git fetch.
+func (imp *Importer) Diff(ctx context.Context, skillName string) (*DiffResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	skillDir := imp.skillDir(skillName)
+	origin, err := ReadOrigin(skillDir)
+	if err != nil {
+		return nil, fmt.Errorf("skill %q has no origin (not an imported skill): %w", skillName, err)
+	}
+
+	auth, err := imp.authFromOrigin(origin)
+	if err != nil {
+		return nil, err
+	}
+
+	localPath := filepath.Join(skillDir, "SKILL.md")
+	localBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading local SKILL.md: %w", err)
+	}
+
+	// Resolve the latest upstream commit and discover at that exact SHA. A
+	// cached clone's local branch does not fast-forward on fetch, so checking
+	// out by ref name would surface stale content; checking out the resolved
+	// commit hash lands the worktree on true upstream. When the repo is not yet
+	// cached, FetchAndCompare returns no SHA and a fresh clone at the ref already
+	// yields the latest.
+	ref := origin.Ref
+	if newSHA, _, ferr := FetchAndCompare(origin.Repo, origin.Ref, origin.CommitSHA, auth, imp.logger); ferr == nil && newSHA != "" {
+		ref = newSHA
+	}
+
+	result, err := CloneAndDiscover(origin.Repo, ref, origin.Path, auth, imp.logger)
+	if err != nil {
+		return nil, fmt.Errorf("fetching upstream: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// origin.Path points to the skill's own directory, so there is normally
+	// exactly one discovered skill; match by name, then fall back to the sole
+	// result.
+	var discovered *DiscoveredSkill
+	for i := range result.Skills {
+		if result.Skills[i].Name == skillName {
+			discovered = &result.Skills[i]
+			break
+		}
+	}
+	if discovered == nil && len(result.Skills) == 1 {
+		discovered = &result.Skills[0]
+	}
+	if discovered == nil {
+		return nil, fmt.Errorf("skill %q not found at upstream path %q", skillName, origin.Path)
+	}
+
+	// Render the content an update would install: the same skill with its name
+	// preserved and its state carried over (PreserveState semantics, matching
+	// Import) so the comparison reflects the actual installed bytes rather than
+	// a raw upstream file.
+	upstreamSkill := discovered.Skill
+	upstreamSkill.Name = skillName
+	if existing, err := imp.store.GetSkill(skillName); err == nil && existing.State != "" {
+		upstreamSkill.State = existing.State
+	}
+	upstreamBytes, err := registry.RenderSkillMD(upstreamSkill)
+	if err != nil {
+		return nil, fmt.Errorf("rendering upstream SKILL.md: %w", err)
+	}
+
+	currentHash, _ := ContentHashFile(localPath)
+	drifted := origin.InstalledHash != "" && currentHash != origin.InstalledHash
+
+	return &DiffResult{
+		Skill:    skillName,
+		Local:    string(localBytes),
+		Upstream: string(upstreamBytes),
+		Drifted:  drifted,
+	}, nil
+}
+
+// AdvanceTracking records that a skill has been reconciled against upstream
+// commit newSHA without changing its on-disk content. It advances only the
+// version-tracking metadata — the skill's origin CommitSHA and the lock-file
+// source's CommitSHA/ContentHash/FetchedAt — leaving the SKILL.md file and its
+// InstalledHash untouched.
+//
+// Used when a sync skips a locally-edited (drifted) skill: the reviewed
+// upstream version is recorded so it no longer surfaces as an available
+// update, while the user's local edits (and the drift signal that DetectDrift
+// derives from InstalledHash) are preserved.
+func (imp *Importer) AdvanceTracking(ctx context.Context, skillName, newSHA string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if newSHA == "" {
+		return fmt.Errorf("newSHA is required")
+	}
+
+	skillDir := imp.skillDir(skillName)
+	origin, err := ReadOrigin(skillDir)
+	if err != nil {
+		return fmt.Errorf("skill %q has no origin: %w", skillName, err)
+	}
+	origin.CommitSHA = newSHA
+	if err := WriteOrigin(skillDir, origin); err != nil {
+		return fmt.Errorf("writing origin: %w", err)
+	}
+
+	imp.lockfileMu.Lock()
+	defer imp.lockfileMu.Unlock()
+
+	lf, err := ReadLockFile(imp.lockPath)
+	if err != nil {
+		return fmt.Errorf("reading lock file: %w", err)
+	}
+	if srcName, src, found := lf.FindSkillSource(skillName); found {
+		src.CommitSHA = newSHA
+		src.ContentHash = newSHA
+		src.FetchedAt = time.Now().UTC()
+		lf.SetSource(srcName, *src)
+		if err := WriteLockFile(imp.lockPath, lf); err != nil {
+			return fmt.Errorf("writing lock file: %w", err)
+		}
+	}
+	return nil
+}
+
+// BackupSkillFile copies a skill's current SKILL.md to SKILL.md.pre-<shortSHA>
+// next to it before an overwrite, so a forced update of a locally-edited skill
+// stays recoverable. It returns the backup file name (relative to the skill
+// directory). A missing SKILL.md is a no-op that returns an empty name.
+func (imp *Importer) BackupSkillFile(ctx context.Context, skillName, shortSHA string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	skillDir := imp.skillDir(skillName)
+	srcPath := filepath.Join(skillDir, "SKILL.md")
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("reading SKILL.md: %w", err)
+	}
+
+	suffix := shortSHA
+	if suffix == "" {
+		suffix = "local"
+	}
+	backupName := "SKILL.md.pre-" + suffix
+	if err := os.WriteFile(filepath.Join(skillDir, backupName), data, 0644); err != nil {
+		return "", fmt.Errorf("writing backup: %w", err)
+	}
+	return backupName, nil
+}
+
+// Detach makes an imported skill local-only by removing its origin sidecar and
+// its lock-file entry. The SKILL.md and the skill itself remain; it simply no
+// longer tracks an upstream source and will not be touched by sync.
+func (imp *Importer) Detach(ctx context.Context, skillName string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	skillDir := imp.skillDir(skillName)
+	if err := DeleteOrigin(skillDir); err != nil {
+		return fmt.Errorf("removing origin: %w", err)
+	}
+
+	imp.lockfileMu.Lock()
+	defer imp.lockfileMu.Unlock()
+
+	lf, err := ReadLockFile(imp.lockPath)
+	if err != nil {
+		return fmt.Errorf("reading lock file: %w", err)
+	}
+	lf.RemoveSkill(skillName)
+	if err := WriteLockFile(imp.lockPath, lf); err != nil {
+		return fmt.Errorf("writing lock file: %w", err)
+	}
+	return nil
+}

--- a/pkg/skills/reconcile_test.go
+++ b/pkg/skills/reconcile_test.go
@@ -1,0 +1,241 @@
+package skills
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/builder"
+	"github.com/gridctl/gridctl/pkg/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShortSHA(t *testing.T) {
+	assert.Equal(t, "", ShortSHA(""))
+	assert.Equal(t, "abc", ShortSHA("abc"))
+	assert.Equal(t, "abcd1234", ShortSHA("abcd1234"))
+	assert.Equal(t, "abcd1234", ShortSHA("abcd12345678"))
+}
+
+// TestImporter_Update_ForceColdCacheNoPanic is a regression test: with the
+// repo cache evicted, FetchAndCompare returns an empty SHA, and a forced
+// update must not panic on SHA formatting (Constitution Article V).
+func TestImporter_Update_ForceColdCacheNoPanic(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+	repoDir, _ := initSkillRepo(t, "# Test\n\nv1.\n")
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Ref: "master", Trust: true})
+	require.NoError(t, err)
+
+	// Evict the clone cache so FetchAndCompare yields an empty SHA.
+	cacheDir, err := builder.ReposCacheDir()
+	require.NoError(t, err)
+	require.NoError(t, os.RemoveAll(cacheDir))
+
+	require.NotPanics(t, func() {
+		_, _ = imp.Update("test-skill", false, true)
+	})
+}
+
+// driftSkill edits the on-disk SKILL.md of an imported skill so DetectDrift
+// reports it as locally edited, and returns the edited content.
+func driftSkill(t *testing.T, store *registry.Store, skillName, marker string) string {
+	t.Helper()
+	sk, err := store.GetSkill(skillName)
+	require.NoError(t, err)
+	dirName := sk.Dir
+	if dirName == "" {
+		dirName = sk.Name
+	}
+	path := filepath.Join(store.Dir(), "skills", dirName, "SKILL.md")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	edited := string(data) + "\n\n" + marker + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(edited), 0644))
+	return edited
+}
+
+// TestImporter_AdvanceTracking_SkipPreservesFileAndInstalledHash is the central
+// guarantee of the skip path: advancing tracking records the new upstream SHA
+// in the origin and lock file, but the on-disk SKILL.md and its InstalledHash
+// are untouched, so the skill still reads as drifted.
+func TestImporter_AdvanceTracking_SkipPreservesFileAndInstalledHash(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	repoDir, repo := initSkillRepo(t, "# Test\n\nv1.\n")
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Ref: "master", Trust: true})
+	require.NoError(t, err)
+
+	skillDir := imp.skillDir("test-skill")
+	originBefore, err := ReadOrigin(skillDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, originBefore.InstalledHash)
+	oldSHA := originBefore.CommitSHA
+
+	// Local edit → drift.
+	edited := driftSkill(t, store, "test-skill", "Local customization.")
+	drifted, err := DetectDrift(context.Background(), store, lockPath, "")
+	require.NoError(t, err)
+	require.Contains(t, drifted, "test-skill")
+
+	// Upstream moves on.
+	commitChange(t, repo, repoDir, "# Test\n\nv2 upstream.\n")
+	newSHA, changed, err := FetchAndCompare(repoDir, "master", oldSHA, AuthConfig{}, slog.Default())
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.NotEqual(t, oldSHA, newSHA)
+
+	// Skip-advance.
+	require.NoError(t, imp.AdvanceTracking(context.Background(), "test-skill", newSHA))
+
+	// Tracking advanced...
+	originAfter, err := ReadOrigin(skillDir)
+	require.NoError(t, err)
+	assert.Equal(t, newSHA, originAfter.CommitSHA, "origin commit SHA advanced")
+	assert.Equal(t, originBefore.InstalledHash, originAfter.InstalledHash, "InstalledHash untouched")
+
+	lf, err := ReadLockFile(lockPath)
+	require.NoError(t, err)
+	_, src, found := lf.FindSkillSource("test-skill")
+	require.True(t, found)
+	assert.Equal(t, newSHA, src.CommitSHA, "lock commit SHA advanced")
+	assert.Equal(t, newSHA, src.ContentHash, "lock content hash advanced")
+
+	// ...but the file and the drift signal are preserved.
+	onDisk, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	require.NoError(t, err)
+	assert.Equal(t, edited, string(onDisk), "on-disk SKILL.md must be untouched")
+
+	driftedAfter, err := DetectDrift(context.Background(), store, lockPath, "")
+	require.NoError(t, err)
+	assert.Contains(t, driftedAfter, "test-skill", "drift must remain visible after a skip")
+}
+
+func TestImporter_AdvanceTracking_RequiresSHA(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+	repoDir, _ := initSkillRepo(t, "# Test\n\nv1.\n")
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Ref: "master", Trust: true})
+	require.NoError(t, err)
+
+	assert.Error(t, imp.AdvanceTracking(context.Background(), "test-skill", ""))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.Error(t, imp.AdvanceTracking(ctx, "test-skill", "deadbeef"))
+}
+
+func TestImporter_BackupSkillFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+	repoDir, _ := initSkillRepo(t, "# Test\n\nv1.\n")
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Ref: "master", Trust: true})
+	require.NoError(t, err)
+
+	original := driftSkill(t, store, "test-skill", "Edited before backup.")
+
+	name, err := imp.BackupSkillFile(context.Background(), "test-skill", "abc1234")
+	require.NoError(t, err)
+	assert.Equal(t, "SKILL.md.pre-abc1234", name)
+
+	skillDir := imp.skillDir("test-skill")
+	backup, err := os.ReadFile(filepath.Join(skillDir, name))
+	require.NoError(t, err)
+	assert.Equal(t, original, string(backup), "backup captures the pre-overwrite content")
+
+	// Empty SHA falls back to a "local" suffix.
+	name2, err := imp.BackupSkillFile(context.Background(), "test-skill", "")
+	require.NoError(t, err)
+	assert.Equal(t, "SKILL.md.pre-local", name2)
+}
+
+func TestImporter_BackupSkillFile_MissingIsNoOp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, regDir := setupTestRegistry(t)
+	imp := NewImporter(store, regDir, filepath.Join(regDir, "skills.lock.yaml"), slog.Default())
+
+	name, err := imp.BackupSkillFile(context.Background(), "does-not-exist", "sha")
+	require.NoError(t, err)
+	assert.Empty(t, name)
+}
+
+func TestImporter_Detach(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+	repoDir, _ := initSkillRepo(t, "# Test\n\nv1.\n")
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Ref: "master", Trust: true})
+	require.NoError(t, err)
+
+	skillDir := imp.skillDir("test-skill")
+	require.True(t, HasOrigin(skillDir))
+
+	require.NoError(t, imp.Detach(context.Background(), "test-skill"))
+
+	assert.False(t, HasOrigin(skillDir), "origin sidecar removed")
+	_, err = os.Stat(filepath.Join(skillDir, "SKILL.md"))
+	assert.NoError(t, err, "SKILL.md remains on disk")
+	_, err = store.GetSkill("test-skill")
+	assert.NoError(t, err, "skill remains in the registry")
+
+	lf, err := ReadLockFile(lockPath)
+	require.NoError(t, err)
+	_, _, found := lf.FindSkillSource("test-skill")
+	assert.False(t, found, "lock entry removed")
+}
+
+func TestImporter_Diff(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+	repoDir, repo := initSkillRepo(t, "# Test\n\nv1 body.\n")
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Ref: "master", Trust: true})
+	require.NoError(t, err)
+
+	edited := driftSkill(t, store, "test-skill", "Local note.")
+	commitChange(t, repo, repoDir, "# Test\n\nv2 body.\n")
+
+	diff, err := imp.Diff(context.Background(), "test-skill")
+	require.NoError(t, err)
+	assert.Equal(t, "test-skill", diff.Skill)
+	assert.Equal(t, edited, diff.Local, "local side is the current on-disk file")
+	assert.True(t, diff.Drifted, "edited skill reports drift")
+	assert.Contains(t, diff.Upstream, "v2 body.", "upstream side reflects the latest commit")
+	assert.NotContains(t, diff.Upstream, "Local note.", "upstream side excludes local edits")
+
+	// Diff must not mutate on-disk content or tracking.
+	onDisk, err := os.ReadFile(filepath.Join(imp.skillDir("test-skill"), "SKILL.md"))
+	require.NoError(t, err)
+	assert.Equal(t, edited, string(onDisk))
+	origin, err := ReadOrigin(imp.skillDir("test-skill"))
+	require.NoError(t, err)
+	assert.False(t, strings.Contains(origin.CommitSHA, " "))
+}
+
+func TestImporter_Diff_NoOrigin(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, regDir := setupTestRegistry(t)
+	createTestSkill(t, store, "local-only")
+	imp := NewImporter(store, regDir, filepath.Join(regDir, "skills.lock.yaml"), slog.Default())
+
+	_, err := imp.Diff(context.Background(), "local-only")
+	assert.Error(t, err, "a skill without an origin cannot be diffed")
+}


### PR DESCRIPTION
## Description

Stops the web UI from silently overwriting locally-edited git-sourced skills on Sync (the data-loss bug the CLI already guards against), and adds the backend reconciliation API (drift reporting, compare-with-upstream diff, detach, reset). Backend-only; the new fields and endpoints are additive, so it ships safely under the current UI. Part of a two-PR feature (frontend follows).

## Type of Change

- [x] Bug fix (drift-safe sync) + additive feature (reconciliation endpoints)

## Changes Made

- `GET /api/skills/sources` reports drift: `driftedSkills` per source, `hasLocalEdits` per skill.
- Per-source and bulk update accept `{ "force": bool, "skills": [..] }`. A drifted skill is skipped by default (`skipped: "local edits"`) with its version tracking advanced to the latest upstream commit, leaving the on-disk `SKILL.md` and its installed-hash baseline untouched so drift stays visible. `force: true` writes a `SKILL.md.pre-<sha>` backup, then overwrites.
- New per-skill endpoints: `diff` (local vs upstream, no writes), `detach` (scrub origin sidecar + lock entry), `reset` (backup + force-restore).
- `Importer.Update`'s previously-ignored `force` now reinstalls even when the commit is unchanged, so reset/force can discard local edits and restore the tracked version.
- Bumped the Go toolchain to `1.26.4`, clearing the two stdlib `govulncheck` failures (`GO-2026-5037`, `GO-2026-5039`) that were failing the Gatekeeper gate.

## Testing

- `make test` and `go test -race ./...` pass.
- `go test -race -tags=integration ./tests/integration/...` (skills suites) pass.
- `golangci-lint run` clean on touched packages; `scripts/govulncheck.sh` exits 0.
- New unit tests assert a skipped sync advances the lock SHA but leaves the file + InstalledHash untouched (drift remains), backup-before-overwrite, detach, and diff.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Part of #768