### PR TITLE
feat: skills editor UX and drift reconciliation UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ All notable changes to gridctl will be documented in this file.
   by default for existing skills, the split defaults to a body-heavy ratio, the
   preview/ratio/frontmatter state persists across reopens, a minimal markdown
   toolbar inserts at the cursor, the preview pane scroll-follows the editor, and
-  the file tree is demoted behind a "Files (N)" pill. None of this changes the
-  bytes served to agents.
+  the file tree is demoted behind a "Files (N)" pill. The modal's expand toggle
+  (previously a no-op for the editor) now steps it up to a near-fullscreen view,
+  and the editor body grows with the panel. None of this changes the bytes
+  served to agents.
 
 - **Reconciliation API for git-sourced skills.** The skills HTTP API gained the
   building blocks for editing imported skills safely. `GET /api/skills/sources`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Reconcile and edit git-sourced skills in the Library.** The Library now
+  surfaces local edits to imported skills and lets you reconcile them. Skill
+  cards, the detail panel, and the editor show a "Modified" badge when a tracked
+  `SKILL.md` has local edits. Clicking Sync on a source (or the workspace-wide
+  Sync) that has edited skills opens a confirm listing them, with "keep my edits
+  (skip these)" and "overwrite local edits" choices instead of silently
+  clobbering them; toasts report updated, kept, and overwritten counts. The
+  skill editor grew a provenance strip (tracked-from owner/repo@sha, last synced)
+  with Compare-with-upstream (a local-vs-upstream diff with Keep mine / Take
+  upstream), Reset to upstream, Detach from source, and Fork-as actions. The
+  editor also opens body-first now: frontmatter collapses to a one-line summary
+  by default for existing skills, the split defaults to a body-heavy ratio, the
+  preview/ratio/frontmatter state persists across reopens, a minimal markdown
+  toolbar inserts at the cursor, and the file tree is demoted behind a "Files (N)"
+  pill. None of this changes the bytes served to agents.
+
 - **Reconciliation API for git-sourced skills.** The skills HTTP API gained the
   building blocks for editing imported skills safely. `GET /api/skills/sources`
   now reports drift (`driftedSkills` per source, `hasLocalEdits` per skill). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ All notable changes to gridctl will be documented in this file.
   editor also opens body-first now: frontmatter collapses to a one-line summary
   by default for existing skills, the split defaults to a body-heavy ratio, the
   preview/ratio/frontmatter state persists across reopens, a minimal markdown
-  toolbar inserts at the cursor, and the file tree is demoted behind a "Files (N)"
-  pill. None of this changes the bytes served to agents.
+  toolbar inserts at the cursor, the preview pane scroll-follows the editor, and
+  the file tree is demoted behind a "Files (N)" pill. None of this changes the
+  bytes served to agents.
 
 - **Reconciliation API for git-sourced skills.** The skills HTTP API gained the
   building blocks for editing imported skills safely. `GET /api/skills/sources`

--- a/web/src/__tests__/DriftAwareSync.test.tsx
+++ b/web/src/__tests__/DriftAwareSync.test.tsx
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { SourceGroupHeader } from '../components/registry/SourceGroupHeader';
+import { updateSkillSource } from '../lib/api';
+import type { SkillSourceStatus } from '../types';
+
+vi.mock('../lib/api', () => ({ updateSkillSource: vi.fn().mockResolvedValue({ source: 'src', results: [] }) }));
+vi.mock('../components/ui/Toast', () => ({ showToast: vi.fn() }));
+
+const updateMock = vi.mocked(updateSkillSource);
+
+function makeSource(overrides: Partial<SkillSourceStatus> = {}): SkillSourceStatus {
+  return {
+    name: 'src',
+    repo: 'https://github.com/org/repo',
+    autoUpdate: false,
+    updateInterval: '',
+    skills: [],
+    updateAvailable: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  updateMock.mockClear();
+  Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    configurable: true,
+    get() {
+      return this.parentNode;
+    },
+  });
+});
+afterEach(() => cleanup());
+
+describe('SourceGroupHeader drift-aware sync', () => {
+  it('syncs immediately (no confirm) when there are no local edits', async () => {
+    render(
+      <SourceGroupHeader source={makeSource()} count={1} hasSearch={false} isActive={false} onToggle={() => {}} />,
+    );
+    fireEvent.click(screen.getByTitle('Update available, pull latest'));
+    await waitFor(() => expect(updateMock).toHaveBeenCalledTimes(1));
+    // Clean sync sends no force flag.
+    expect(updateMock).toHaveBeenCalledWith('src', undefined);
+  });
+
+  it('opens a confirm listing drifted skills instead of syncing immediately', () => {
+    render(
+      <SourceGroupHeader
+        source={makeSource({ driftedSkills: ['edited-skill'] })}
+        count={1}
+        hasSearch={false}
+        isActive={false}
+        onToggle={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTitle('Update available, pull latest'));
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(screen.getByText('edited-skill')).toBeInTheDocument();
+    expect(screen.getByText(/local edits that a/i)).toBeInTheDocument();
+  });
+
+  it('"keep my edits" syncs without force; "overwrite" syncs with force', async () => {
+    const { rerender } = render(
+      <SourceGroupHeader
+        source={makeSource({ driftedSkills: ['edited-skill'] })}
+        count={1}
+        hasSearch={false}
+        isActive={false}
+        onToggle={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTitle('Update available, pull latest'));
+    fireEvent.click(screen.getByRole('button', { name: /keep my edits/i }));
+    await waitFor(() => expect(updateMock).toHaveBeenCalledWith('src', undefined));
+
+    updateMock.mockClear();
+    rerender(
+      <SourceGroupHeader
+        source={makeSource({ driftedSkills: ['edited-skill'] })}
+        count={1}
+        hasSearch={false}
+        isActive={false}
+        onToggle={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTitle('Update available, pull latest'));
+    fireEvent.click(screen.getByRole('button', { name: /overwrite local edits/i }));
+    await waitFor(() => expect(updateMock).toHaveBeenCalledWith('src', { force: true }));
+  });
+});

--- a/web/src/__tests__/LibraryWorkspace.test.tsx
+++ b/web/src/__tests__/LibraryWorkspace.test.tsx
@@ -563,7 +563,7 @@ describe('LibraryWorkspace', () => {
       renderAt('/library');
       fireEvent.click(screen.getByRole('button', { name: /sync sources from git/i }));
       await waitFor(() =>
-        expect(showToast).toHaveBeenCalledWith('success', 'Synced 1 source, 1 skill updated'),
+        expect(showToast).toHaveBeenCalledWith('success', 'Sync complete: 1 updated'),
       );
     });
 

--- a/web/src/__tests__/ModalExpand.test.tsx
+++ b/web/src/__tests__/ModalExpand.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { Modal } from '../components/ui/Modal';
+
+afterEach(() => cleanup());
+
+function panel() {
+  return screen.getByRole('dialog');
+}
+
+describe('Modal expand toggle', () => {
+  it('steps a full-size panel up to fullscreen and back', () => {
+    render(
+      <Modal isOpen onClose={() => {}} title="Editor" expandable size="full">
+        <div>body</div>
+      </Modal>,
+    );
+    expect(panel().className).toContain('max-w-5xl');
+
+    fireEvent.click(screen.getByTitle('Expanded view'));
+    expect(panel().className).toContain('max-w-[96vw]');
+    expect(panel().className).toContain('h-[94vh]');
+
+    fireEvent.click(screen.getByTitle('Compact view'));
+    expect(panel().className).toContain('max-w-5xl');
+  });
+
+  it('keeps the legacy default-to-wide step when no size is forced', () => {
+    render(
+      <Modal isOpen onClose={() => {}} title="Plain" expandable>
+        <div>body</div>
+      </Modal>,
+    );
+    expect(panel().className).toContain('max-w-lg');
+    fireEvent.click(screen.getByTitle('Expanded view'));
+    expect(panel().className).toContain('max-w-3xl');
+  });
+
+  it('hides the toggle when there is no larger size to expand to', () => {
+    render(
+      <Modal isOpen onClose={() => {}} title="Max" expandable size="fullscreen">
+        <div>body</div>
+      </Modal>,
+    );
+    expect(screen.queryByTitle('Expanded view')).toBeNull();
+  });
+});

--- a/web/src/__tests__/editorPrefs.test.ts
+++ b/web/src/__tests__/editorPrefs.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useUIStore, EDITOR_PREFS_DEFAULTS } from '../stores/useUIStore';
+
+describe('useUIStore editor prefs slice', () => {
+  beforeEach(() => {
+    useUIStore.setState({ editorPrefs: { ...EDITOR_PREFS_DEFAULTS } });
+  });
+
+  it('defaults to a collapsed frontmatter, visible preview, body-heavy split', () => {
+    const prefs = useUIStore.getState().editorPrefs;
+    expect(prefs.showFrontmatter).toBe(false);
+    expect(prefs.showPreview).toBe(true);
+    expect(prefs.splitRatio).toBeGreaterThan(0.5);
+  });
+
+  it('setEditorPrefs merges partial updates without dropping other keys', () => {
+    useUIStore.getState().setEditorPrefs({ showFrontmatter: true });
+    expect(useUIStore.getState().editorPrefs).toEqual({
+      ...EDITOR_PREFS_DEFAULTS,
+      showFrontmatter: true,
+    });
+
+    useUIStore.getState().setEditorPrefs({ splitRatio: 0.4 });
+    expect(useUIStore.getState().editorPrefs).toEqual({
+      ...EDITOR_PREFS_DEFAULTS,
+      showFrontmatter: true,
+      splitRatio: 0.4,
+    });
+  });
+});

--- a/web/src/__tests__/markdownEdit.test.ts
+++ b/web/src/__tests__/markdownEdit.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { applyMarkdownAction } from '../lib/markdownEdit';
+
+describe('applyMarkdownAction', () => {
+  it('wraps the selection in bold markers and reselects the inner text', () => {
+    const r = applyMarkdownAction('hello world', 0, 5, 'bold');
+    expect(r.value).toBe('**hello** world');
+    expect(r.value.slice(r.selStart, r.selEnd)).toBe('hello');
+  });
+
+  it('uses placeholder text for an empty bold selection', () => {
+    const r = applyMarkdownAction('', 0, 0, 'bold');
+    expect(r.value).toBe('**bold text**');
+  });
+
+  it('prefixes the current line with a heading marker', () => {
+    const r = applyMarkdownAction('line one\nline two', 9, 9, 'heading');
+    expect(r.value).toBe('line one\n## line two');
+  });
+
+  it('prefixes the current line with a list marker', () => {
+    const r = applyMarkdownAction('item', 0, 0, 'list');
+    expect(r.value).toBe('- item');
+  });
+
+  it('wraps the selection in a fenced code block', () => {
+    const r = applyMarkdownAction('x = 1', 0, 5, 'code');
+    expect(r.value).toBe('```\nx = 1\n```');
+    expect(r.value.slice(r.selStart, r.selEnd)).toBe('x = 1');
+  });
+});

--- a/web/src/__tests__/skillReconcileApi.test.ts
+++ b/web/src/__tests__/skillReconcileApi.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  updateSkillSource,
+  syncAllSources,
+  fetchSkillDiff,
+  detachSkill,
+  resetSkill,
+} from '../lib/api';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockJSON(payload: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => payload });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('drift-safe sync api', () => {
+  it('updateSkillSource omits a body when no options are given', async () => {
+    const fetchMock = mockJSON({ source: 'src', results: [] });
+    await updateSkillSource('my source');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/skills/sources/my%20source/update');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('updateSkillSource sends force/skills when provided', async () => {
+    const fetchMock = mockJSON({ source: 'src', results: [{ skill: 'a', backup: 'SKILL.md.pre-abc' }] });
+    const res = await updateSkillSource('src', { force: true, skills: ['a'] });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ force: true, skills: ['a'] });
+    expect(res.results[0].backup).toBe('SKILL.md.pre-abc');
+  });
+
+  it('syncAllSources sends a body only when forcing', async () => {
+    const fetchMock = mockJSON({ sources: [], syncedSources: 0, updatedSkills: 0, failedSources: 0, pinnedSources: 0 });
+    await syncAllSources();
+    expect(fetchMock.mock.calls[0][1].body).toBeUndefined();
+
+    await syncAllSources({ force: true });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ force: true });
+  });
+
+  it('fetchSkillDiff GETs the per-skill diff endpoint', async () => {
+    const payload = { skill: 'a', local: 'x', upstream: 'y', unifiedDiff: '@@', drifted: true };
+    const fetchMock = mockJSON(payload);
+    const res = await fetchSkillDiff('src', 'a');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/skills/sources/src/skills/a/diff');
+    // GET requests carry no method override body
+    expect(init?.method ?? 'GET').toBe('GET');
+    expect(res).toEqual(payload);
+  });
+
+  it('detachSkill POSTs to the detach endpoint', async () => {
+    const fetchMock = mockJSON({ detached: 'a' });
+    const res = await detachSkill('src', 'a');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/skills/sources/src/skills/a/detach');
+    expect(init.method).toBe('POST');
+    expect(res.detached).toBe('a');
+  });
+
+  it('resetSkill POSTs to the reset endpoint', async () => {
+    const fetchMock = mockJSON({ skill: 'a', imported: 1, backup: 'SKILL.md.pre-abc' });
+    const res = await resetSkill('src', 'a');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/skills/sources/src/skills/a/reset');
+    expect(init.method).toBe('POST');
+    expect(res.backup).toBe('SKILL.md.pre-abc');
+  });
+});

--- a/web/src/__tests__/skillSync.test.ts
+++ b/web/src/__tests__/skillSync.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeSkillResults, addCounts, syncCountsMessage } from '../lib/skillSync';
+
+describe('summarizeSkillResults', () => {
+  it('buckets each outcome by its distinguishing field', () => {
+    const counts = summarizeSkillResults([
+      { skill: 'a', imported: 1 },
+      { skill: 'b', skipped: 'local edits' },
+      { skill: 'c', imported: 1, backup: 'SKILL.md.pre-abc' },
+      { skill: 'd', error: 'boom' },
+      { skill: 'e', imported: 0 },
+    ]);
+    expect(counts).toEqual({ updated: 1, skipped: 1, overwritten: 1, failed: 1 });
+  });
+
+  it('treats undefined results as empty', () => {
+    expect(summarizeSkillResults(undefined)).toEqual({ updated: 0, skipped: 0, overwritten: 0, failed: 0 });
+  });
+});
+
+describe('addCounts', () => {
+  it('sums two count buckets', () => {
+    expect(
+      addCounts(
+        { updated: 1, skipped: 2, overwritten: 0, failed: 1 },
+        { updated: 3, skipped: 0, overwritten: 1, failed: 0 },
+      ),
+    ).toEqual({ updated: 4, skipped: 2, overwritten: 1, failed: 1 });
+  });
+});
+
+describe('syncCountsMessage', () => {
+  it('renders only non-zero buckets', () => {
+    expect(syncCountsMessage({ updated: 2, skipped: 1, overwritten: 0, failed: 0 })).toBe('2 updated, 1 kept');
+    expect(syncCountsMessage({ updated: 0, skipped: 0, overwritten: 3, failed: 1 })).toBe('3 overwritten, 1 failed');
+  });
+
+  it('is empty when nothing changed (caller falls back to up-to-date)', () => {
+    expect(syncCountsMessage({ updated: 0, skipped: 0, overwritten: 0, failed: 0 })).toBe('');
+  });
+});

--- a/web/src/components/registry/DriftSyncDialog.tsx
+++ b/web/src/components/registry/DriftSyncDialog.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useId } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+
+interface DriftSyncDialogProps {
+  isOpen: boolean;
+  /** Dialog title, e.g. `Sync "owner/repo"`. */
+  title: string;
+  /** Names of the locally-edited skills a sync would otherwise overwrite. */
+  driftedSkills: string[];
+  busy?: boolean;
+  /** Dismiss without syncing. */
+  onCancel: () => void;
+  /** Sync, skipping drifted skills (keeps local edits). */
+  onSkip: () => void;
+  /** Sync, overwriting drifted skills (a backup is written server-side). */
+  onOverwrite: () => void;
+}
+
+/**
+ * Three-way confirm shown before syncing a source that has locally-edited
+ * skills. Mirrors ConfirmDialog's chrome but offers Cancel / keep-my-edits /
+ * overwrite, since a plain confirm cannot express the skip-vs-overwrite choice.
+ * Default focus lands on the safe "keep my edits" action.
+ */
+export function DriftSyncDialog({
+  isOpen,
+  title,
+  driftedSkills,
+  busy = false,
+  onCancel,
+  onSkip,
+  onOverwrite,
+}: DriftSyncDialogProps) {
+  const titleId = useId();
+  const descId = useId();
+  const panelRef = useFocusTrap<HTMLDivElement>({ active: isOpen });
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onCancel();
+      }
+    },
+    [onCancel],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, handleKeyDown]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 z-[60] animate-fade-in-scale',
+        'bg-background/80 backdrop-blur-sm flex items-center justify-center',
+      )}
+    >
+      <div className="absolute inset-0" onClick={onCancel} />
+
+      <div
+        ref={panelRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        className="relative glass-panel-elevated rounded-xl p-5 max-w-md w-full mx-4 space-y-3 shadow-lg"
+      >
+        <h2 id={titleId} className="flex items-center gap-2 text-sm font-semibold text-text-primary">
+          <AlertTriangle size={15} className="text-amber-300" />
+          {title}
+        </h2>
+        <div id={descId} className="text-xs text-text-muted space-y-2">
+          <p>
+            {driftedSkills.length === 1 ? 'This skill has' : 'These skills have'} local edits that a
+            sync would overwrite:
+          </p>
+          <ul className="max-h-40 overflow-y-auto scrollbar-dark rounded-lg border border-border/40 bg-background/40 divide-y divide-border/20">
+            {driftedSkills.map((name) => (
+              <li key={name} className="px-3 py-1.5 font-mono text-[11px] text-text-secondary">
+                {name}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="flex flex-wrap justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className={cn(
+              'px-3 py-1.5 text-xs rounded-lg transition-colors',
+              'text-text-secondary hover:text-text-primary bg-surface-elevated hover:bg-surface-highlight',
+              'focus:outline-none focus:ring-2 focus:ring-primary/30 focus:ring-offset-2 focus:ring-offset-background',
+              busy && 'opacity-50 cursor-not-allowed',
+            )}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onOverwrite}
+            disabled={busy}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium rounded-lg transition-colors',
+              'text-status-error bg-status-error/10 hover:bg-status-error/20 border border-status-error/30',
+              'focus:outline-none focus:ring-2 focus:ring-status-error/40 focus:ring-offset-2 focus:ring-offset-background',
+              busy && 'opacity-50 cursor-not-allowed',
+            )}
+          >
+            Overwrite local edits
+          </button>
+          <button
+            type="button"
+            autoFocus
+            onClick={onSkip}
+            disabled={busy}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium rounded-lg transition-colors',
+              'bg-primary text-background hover:bg-primary-light',
+              'focus:outline-none focus:ring-2 focus:ring-primary/40 focus:ring-offset-2 focus:ring-offset-background',
+              busy && 'opacity-50 cursor-not-allowed',
+            )}
+          >
+            Keep my edits (skip these)
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/registry/SkillCard.tsx
+++ b/web/src/components/registry/SkillCard.tsx
@@ -55,6 +55,7 @@ export const SkillCard = memo(({
   // Scannability signals, both derived from fields the skill already carries.
   const category = skillCategory(skill.dir);
   const metaSummary = skillMetaSummary(skill).join(' · ');
+  const hasLocalEdits = source?.driftedSkills?.includes(skill.name) ?? false;
 
   return (
     <div
@@ -133,6 +134,14 @@ export const SkillCard = memo(({
               className="flex-shrink-0 inline-flex items-center text-text-muted/50 transition-colors group-hover:text-text-muted/80 mt-0.5"
             >
               <GitBranch size={12} />
+            </span>
+          )}
+          {hasLocalEdits && (
+            <span
+              title="Edited locally; a sync will skip this unless you overwrite"
+              className="flex-shrink-0 text-[9px] font-medium uppercase tracking-wider px-1.5 py-0.5 rounded-full border border-amber-400/30 bg-amber-400/10 text-amber-300 mt-0.5"
+            >
+              Modified
             </span>
           )}
           <StateBadge state={skill.state} />

--- a/web/src/components/registry/SkillCompareDialog.tsx
+++ b/web/src/components/registry/SkillCompareDialog.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useState } from 'react';
+import { AlertCircle, GitCompareArrows, Loader2 } from 'lucide-react';
+import { Modal } from '../ui/Modal';
+import { showToast } from '../ui/Toast';
+import { cn } from '../../lib/cn';
+import { fetchSkillDiff, resetSkill } from '../../lib/api';
+import type { SkillDiffResponse } from '../../types';
+
+interface SkillCompareDialogProps {
+  isOpen: boolean;
+  /** Source (lock) name the skill is tracked under. */
+  sourceName: string;
+  skillName: string;
+  onClose: () => void;
+  /** Called after "Take upstream" overwrites the local copy, so the caller can
+   *  refresh and (typically) close the editor. */
+  onTookUpstream: () => void;
+}
+
+/**
+ * Compare a tracked skill's local SKILL.md against the latest upstream content.
+ * Read-only by default; "Take upstream" force-restores the skill (the server
+ * writes a backup first) behind an inline confirm. "Keep mine" simply closes.
+ * The diff fetch failing surfaces inline rather than blocking.
+ */
+export function SkillCompareDialog({
+  isOpen,
+  sourceName,
+  skillName,
+  onClose,
+  onTookUpstream,
+}: SkillCompareDialogProps) {
+  const [diff, setDiff] = useState<SkillDiffResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  // Reset the result on (re)open or target change during render rather than in
+  // an effect, so the effect only performs the fetch and its async callbacks.
+  const target = `${sourceName}/${skillName}`;
+  const [loadedFor, setLoadedFor] = useState<string | null>(null);
+  if (isOpen && loadedFor !== target) {
+    setLoadedFor(target);
+    setDiff(null);
+    setError(null);
+    setConfirming(false);
+  }
+  // Loading is derived: open, fetched for this target, no result or error yet.
+  const loading = isOpen && diff === null && error === null;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    fetchSkillDiff(sourceName, skillName)
+      .then((d) => {
+        if (!cancelled) {
+          setError(null);
+          setDiff(d);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setDiff(null);
+          setError(err instanceof Error ? err.message : 'Failed to load diff');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, sourceName, skillName]);
+
+  const handleTakeUpstream = async () => {
+    setBusy(true);
+    try {
+      await resetSkill(sourceName, skillName);
+      showToast('success', `"${skillName}" reset to upstream`);
+      onTookUpstream();
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'Reset failed');
+    } finally {
+      setBusy(false);
+      setConfirming(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={`Compare: ${skillName}`} size="wide">
+      <div className="flex flex-col gap-3 min-h-[40vh]">
+        <p className="text-xs text-text-muted flex items-center gap-1.5">
+          <GitCompareArrows size={13} className="text-primary" />
+          Your local SKILL.md vs the latest upstream content.
+        </p>
+
+        {loading && (
+          <div className="flex-1 flex items-center justify-center text-text-muted text-xs gap-2 py-10">
+            <Loader2 size={14} className="animate-spin" /> Fetching upstream…
+          </div>
+        )}
+
+        {error && (
+          <div className="flex items-start gap-2 rounded-lg border border-status-error/30 bg-status-error/10 px-3 py-2.5 text-xs text-status-error">
+            <AlertCircle size={14} className="flex-shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {!loading && !error && diff && <DiffBody diff={diff} />}
+
+        <div className="flex flex-wrap items-center justify-end gap-2 border-t border-border/30 pt-3">
+          {confirming ? (
+            <>
+              <span className="text-xs text-text-muted mr-auto">
+                Overwrite your local edits with upstream? A backup is kept.
+              </span>
+              <button
+                type="button"
+                onClick={() => setConfirming(false)}
+                disabled={busy}
+                className="px-3 py-1.5 text-xs rounded-lg text-text-secondary hover:text-text-primary bg-surface-elevated hover:bg-surface-highlight transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleTakeUpstream()}
+                disabled={busy}
+                className={cn(
+                  'px-3 py-1.5 text-xs font-medium rounded-lg transition-colors',
+                  'text-status-error bg-status-error/10 hover:bg-status-error/20 border border-status-error/30',
+                  busy && 'opacity-50 cursor-not-allowed',
+                )}
+              >
+                {busy ? 'Overwriting…' : 'Confirm overwrite'}
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-xs font-medium rounded-lg bg-primary text-background hover:bg-primary-light transition-colors"
+              >
+                Keep mine
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirming(true)}
+                disabled={loading || !!error}
+                className={cn(
+                  'px-3 py-1.5 text-xs rounded-lg transition-colors',
+                  'text-text-secondary hover:text-text-primary bg-surface-elevated hover:bg-surface-highlight',
+                  (loading || !!error) && 'opacity-50 cursor-not-allowed',
+                )}
+              >
+                Take upstream
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function DiffBody({ diff }: { diff: SkillDiffResponse }) {
+  if (diff.unifiedDiff) {
+    return (
+      <div className="flex-1 overflow-auto scrollbar-dark rounded-lg border border-border/30 bg-background/40">
+        <pre className="text-[11px] font-mono leading-relaxed p-3 whitespace-pre">
+          {diff.unifiedDiff.split('\n').map((line, i) => (
+            <div key={i} className={cn('px-1 -mx-1', diffLineClass(line))}>
+              {line || ' '}
+            </div>
+          ))}
+        </pre>
+      </div>
+    );
+  }
+  // No textual diff: either identical, or only whitespace changes.
+  return (
+    <div className="flex-1 flex items-center justify-center text-xs text-text-muted py-10">
+      {diff.drifted
+        ? 'No line-level differences against upstream.'
+        : 'This skill matches upstream; no local edits.'}
+    </div>
+  );
+}
+
+function diffLineClass(line: string): string {
+  if (line.startsWith('@@')) return 'text-primary/80 bg-primary/5';
+  if (line.startsWith('+')) return 'text-emerald-300 bg-emerald-500/5';
+  if (line.startsWith('-')) return 'text-status-error bg-status-error/5';
+  return 'text-text-secondary';
+}

--- a/web/src/components/registry/SkillDetailPanel.tsx
+++ b/web/src/components/registry/SkillDetailPanel.tsx
@@ -105,6 +105,7 @@ export function SkillDetailPanel({
   };
 
   const repoInfo = source ? extractRepoInfo(source.repo) : null;
+  const hasLocalEdits = source?.driftedSkills?.includes(skill.name) ?? false;
 
   return (
     <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle">
@@ -123,6 +124,14 @@ export function SkillDetailPanel({
               >
                 <GitBranch size={10} />
                 {repoInfo ? `${repoInfo.owner}/${repoInfo.repo}` : source.name}
+              </span>
+            )}
+            {hasLocalEdits && (
+              <span
+                title="Edited locally; a sync will skip this unless you overwrite"
+                className="inline-flex items-center text-[10px] font-medium uppercase tracking-wider px-1.5 py-0.5 rounded-full border border-amber-400/30 bg-amber-400/10 text-amber-300"
+              >
+                Modified
               </span>
             )}
           </div>

--- a/web/src/components/registry/SkillEditor.tsx
+++ b/web/src/components/registry/SkillEditor.tsx
@@ -407,6 +407,7 @@ export function SkillEditor({
   const isNew = !skill;
   const idCounter = useRef(0);
   const bodyRef = useRef<HTMLTextAreaElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
   const originalBodyRef = useRef('');
 
   // Persisted editor view preferences (frontmatter/preview/split).
@@ -654,6 +655,22 @@ export function SkillEditor({
       ta.setSelectionRange(next.selStart, next.selEnd);
     });
   }, [body]);
+
+  // --- Scroll sync: the preview follows the editor proportionally ---
+
+  // Proportional (fraction-of-scrollable-height) mapping. The rendered preview
+  // is taller or shorter than the source, so an exact line mapping is not
+  // possible without a source map; fraction tracking keeps both panes aligned
+  // closely enough to feel tethered.
+  const handleEditorScroll = useCallback((e: React.UIEvent<HTMLTextAreaElement>) => {
+    const ta = e.currentTarget;
+    const preview = previewRef.current;
+    if (!preview) return;
+    const srcMax = ta.scrollHeight - ta.clientHeight;
+    if (srcMax <= 0) return;
+    const dstMax = preview.scrollHeight - preview.clientHeight;
+    preview.scrollTop = (ta.scrollTop / srcMax) * dstMax;
+  }, []);
 
   // --- Reconciliation actions (remote skills only) ---
 
@@ -1043,6 +1060,7 @@ export function SkillEditor({
               ref={bodyRef}
               value={body}
               onChange={(e) => setBody(e.target.value)}
+              onScroll={handleEditorScroll}
               placeholder={'# Skill Instructions\n\nWrite markdown instructions that the agent will follow...\n\n## Steps\n\n1. First step\n2. Second step'}
               className="flex-1 w-full bg-background/40 px-5 py-4 text-sm font-mono text-text-primary placeholder:text-text-muted/30 resize-none focus:outline-none leading-relaxed"
               spellCheck={false}
@@ -1065,7 +1083,7 @@ export function SkillEditor({
                 <div className="px-4 py-2 border-b border-border/20 flex-shrink-0">
                   <span className="text-xs text-text-muted uppercase tracking-wider">Preview</span>
                 </div>
-                <div className="flex-1 overflow-y-auto scrollbar-dark">
+                <div ref={previewRef} className="flex-1 overflow-y-auto scrollbar-dark">
                   <div className="px-5 py-4">
                     <MarkdownPreview content={body} />
                   </div>

--- a/web/src/components/registry/SkillEditor.tsx
+++ b/web/src/components/registry/SkillEditor.tsx
@@ -769,7 +769,10 @@ export function SkillEditor({
       onPopout={onPopout}
       popoutDisabled={popoutDisabled}
     >
-      <div className="flex flex-col h-[calc(85vh-3.5rem)] -mx-6 -my-4">
+      {/* Fill the modal's padded content box (100% + the cancelled py-4) so the
+          editor grows with the panel: 85vh base, 94vh expanded, full viewport
+          when detached. */}
+      <div className="flex flex-col h-[calc(100%+2rem)] -mx-6 -my-4">
         {/* Header bar with state toggle, preview toggle, and save */}
         <div className="flex items-center justify-between px-5 py-3 border-b border-border/50 bg-surface-elevated/30 flex-shrink-0">
           <div className="flex items-center gap-3 min-w-0">

--- a/web/src/components/registry/SkillEditor.tsx
+++ b/web/src/components/registry/SkillEditor.tsx
@@ -12,15 +12,40 @@ import {
   GripVertical,
   Eye,
   EyeOff,
+  Bold,
+  List,
+  Code2,
+  Heading,
+  Files,
+  GitBranch,
+  GitCompareArrows,
+  RotateCcw,
+  Unlink,
+  GitFork,
 } from 'lucide-react';
 import { Modal } from '../ui/Modal';
 import { showToast } from '../ui/Toast';
 import { SkillFileTree } from './SkillFileTree';
 import { MarkdownPreview } from './MarkdownPreview';
-import { createRegistrySkill, updateRegistrySkill, validateSkillContent } from '../../lib/api';
+import { SkillCompareDialog } from './SkillCompareDialog';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
+import {
+  createRegistrySkill,
+  updateRegistrySkill,
+  validateSkillContent,
+  resetSkill,
+  detachSkill,
+} from '../../lib/api';
 import { parseAcceptanceCriterion } from '../../lib/skillCriteria';
+import { extractRepoInfo } from '../../lib/repo';
+import { applyMarkdownAction, type MarkdownAction } from '../../lib/markdownEdit';
 import { cn } from '../../lib/cn';
-import type { AgentSkill, ItemState, SkillValidationResult } from '../../types';
+import { useUIStore } from '../../stores/useUIStore';
+import type { AgentSkill, ItemState, SkillSourceStatus, SkillValidationResult } from '../../types';
+
+// One-time hint shown the first time a user saves an edit to a remote skill,
+// explaining that the edit becomes a local customization sync will preserve.
+const LOCAL_EDIT_NOTE_KEY = 'gridctl-skill-local-edit-note-seen';
 
 // --- Types ---
 
@@ -127,10 +152,13 @@ function createDebouncedValidator(
 
 // --- Resizable split pane hook ---
 
-function useSplitPane(defaultRatio = 0.5, minRatio = 0.25, maxRatio = 0.75) {
+function useSplitPane(defaultRatio = 0.5, minRatio = 0.25, maxRatio = 0.75, onCommit?: (ratio: number) => void) {
   const [ratio, setRatio] = useState(defaultRatio);
   const [isDragging, setIsDragging] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Latest ratio during a drag, read on mouse-up so the committed value (which
+  // we persist) is the final position rather than a stale render snapshot.
+  const ratioRef = useRef(defaultRatio);
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -144,6 +172,7 @@ function useSplitPane(defaultRatio = 0.5, minRatio = 0.25, maxRatio = 0.75) {
         const rect = containerRef.current.getBoundingClientRect();
         const x = moveEvent.clientX - rect.left;
         const newRatio = Math.min(maxRatio, Math.max(minRatio, x / rect.width));
+        ratioRef.current = newRatio;
         setRatio(newRatio);
       };
 
@@ -153,12 +182,13 @@ function useSplitPane(defaultRatio = 0.5, minRatio = 0.25, maxRatio = 0.75) {
         document.body.style.userSelect = '';
         document.removeEventListener('mousemove', handleMouseMove);
         document.removeEventListener('mouseup', handleMouseUp);
+        onCommit?.(ratioRef.current);
       };
 
       document.addEventListener('mousemove', handleMouseMove);
       document.addEventListener('mouseup', handleMouseUp);
     },
-    [minRatio, maxRatio],
+    [minRatio, maxRatio, onCommit],
   );
 
   return { ratio, containerRef, handleMouseDown, isDragging };
@@ -354,6 +384,9 @@ interface SkillEditorProps {
   onClose: () => void;
   onSaved: () => void;
   skill?: AgentSkill;
+  /** Owning git source, when this skill was imported. Drives the provenance
+   *  strip and reconciliation actions (compare/reset/detach/fork). */
+  source?: SkillSourceStatus;
   onPopout?: () => void;
   popoutDisabled?: boolean;
   size?: 'default' | 'wide' | 'full';
@@ -365,6 +398,7 @@ export function SkillEditor({
   onClose,
   onSaved,
   skill,
+  source,
   onPopout,
   popoutDisabled,
   size,
@@ -372,6 +406,23 @@ export function SkillEditor({
 }: SkillEditorProps) {
   const isNew = !skill;
   const idCounter = useRef(0);
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
+  const originalBodyRef = useRef('');
+
+  // Persisted editor view preferences (frontmatter/preview/split).
+  const editorPrefs = useUIStore((s) => s.editorPrefs);
+  const setEditorPrefs = useUIStore((s) => s.setEditorPrefs);
+
+  // Provenance / reconciliation
+  const repoInfo = source ? extractRepoInfo(source.repo) : null;
+  const isRemote = !!source && !isNew;
+  const hasLocalEdits = (source?.driftedSkills?.includes(skill?.name ?? '') ?? false) && !isNew;
+  const [showCompare, setShowCompare] = useState(false);
+  const [pendingAction, setPendingAction] = useState<'reset' | 'detach' | null>(null);
+  const [forking, setForking] = useState(false);
+  const [forkName, setForkName] = useState('');
+  const [reconciling, setReconciling] = useState(false);
+  const [showFiles, setShowFiles] = useState(false);
 
   // Editor state
   const [name, setName] = useState('');
@@ -384,19 +435,51 @@ export function SkillEditor({
   const [state, setState] = useState<ItemState>('draft');
   const [body, setBody] = useState('');
 
-  // UI state
-  const [showFrontmatter, setShowFrontmatter] = useState(true);
-  const [showPreview, setShowPreview] = useState(true);
+  // UI state. Existing skills open with frontmatter collapsed (body-first); a
+  // new skill always opens it so its required fields are reachable. Preview and
+  // split ratio come from persisted prefs.
+  const [showFrontmatter, setShowFrontmatter] = useState(isNew ? true : editorPrefs.showFrontmatter);
+  const [showPreview, setShowPreview] = useState(editorPrefs.showPreview);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [validation, setValidation] = useState<SkillValidationResult | null>(null);
 
-  // Resizable split pane
-  const { ratio, containerRef, handleMouseDown: handleSplitMouseDown, isDragging: splitDragging } = useSplitPane(0.5, 0.25, 0.75);
+  const toggleFrontmatter = useCallback(() => {
+    setShowFrontmatter((prev) => {
+      const next = !prev;
+      setEditorPrefs({ showFrontmatter: next });
+      return next;
+    });
+  }, [setEditorPrefs]);
+
+  const togglePreview = useCallback(() => {
+    setShowPreview((prev) => {
+      const next = !prev;
+      setEditorPrefs({ showPreview: next });
+      return next;
+    });
+  }, [setEditorPrefs]);
+
+  // Resizable split pane: body-heavy by default; committed ratio persisted.
+  const persistRatio = useCallback((r: number) => setEditorPrefs({ splitRatio: r }), [setEditorPrefs]);
+  const { ratio, containerRef, handleMouseDown: handleSplitMouseDown, isDragging: splitDragging } = useSplitPane(editorPrefs.splitRatio, 0.25, 0.75, persistRatio);
 
   // Computed
   const lineCount = useMemo(() => body.split('\n').length, [body]);
   const charCount = body.length;
+
+  // One-line frontmatter summary shown while the section is collapsed.
+  const frontmatterSummary = useMemo(() => {
+    const metaCount = metadata.filter((m) => m.key).length;
+    const criteriaCount = criteria.filter((c) => c.given && c.when && c.then).length;
+    const parts = [
+      license || 'no license',
+      `${metaCount} metadata`,
+      `${criteriaCount} criteria`,
+      state,
+    ];
+    return parts.join(' · ');
+  }, [license, metadata, criteria, state]);
 
   // --- Initialize from skill prop ---
 
@@ -428,6 +511,7 @@ export function SkillEditor({
       );
       setState(skill.state);
       setBody(skill.body ?? '');
+      originalBodyRef.current = skill.body ?? '';
     } else {
       setName('');
       setDescription('');
@@ -438,9 +522,19 @@ export function SkillEditor({
       setCriteria([{ id: ++idCounter.current, given: '', when: 'the skill is called', then: '' }]);
       setState('draft');
       setBody('');
+      originalBodyRef.current = '';
     }
     setError(null);
     setValidation(null);
+    // A new skill always opens with frontmatter expanded (its required fields
+    // must be reachable); an existing skill honors the persisted preference.
+    setShowFrontmatter(skill ? useUIStore.getState().editorPrefs.showFrontmatter : true);
+    // Reset transient reconciliation UI when the open skill changes.
+    setShowCompare(false);
+    setPendingAction(null);
+    setForking(false);
+    setForkName('');
+    setShowFiles(false);
   }, [skill, isOpen]);
 
   // --- Metadata management ---
@@ -520,6 +614,22 @@ export function SkillEditor({
       } else {
         await updateRegistrySkill(skill!.name, skillData);
         showToast('success', `Skill "${name}" updated`);
+        // First time a tracked skill is edited, explain that the change becomes
+        // a local customization that future syncs will preserve.
+        if (isRemote && body !== originalBodyRef.current) {
+          try {
+            if (!localStorage.getItem(LOCAL_EDIT_NOTE_KEY)) {
+              localStorage.setItem(LOCAL_EDIT_NOTE_KEY, '1');
+              showToast(
+                'warning',
+                'Saved as a local customization. Future syncs will skip this skill unless you overwrite.',
+                { duration: 6000 },
+              );
+            }
+          } catch {
+            // localStorage unavailable (private mode): skip the one-time note.
+          }
+        }
       }
       onSaved();
       onClose();
@@ -530,7 +640,92 @@ export function SkillEditor({
     } finally {
       setSaving(false);
     }
-  }, [saving, name, description, metadata, criteria, body, state, skill, license, compatibility, allowedTools, isNew, onSaved, onClose]);
+  }, [saving, name, description, metadata, criteria, body, state, skill, license, compatibility, allowedTools, isNew, isRemote, onSaved, onClose]);
+
+  // --- Markdown toolbar ---
+
+  const applyMarkdown = useCallback((action: MarkdownAction) => {
+    const ta = bodyRef.current;
+    if (!ta) return;
+    const next = applyMarkdownAction(body, ta.selectionStart, ta.selectionEnd, action);
+    setBody(next.value);
+    requestAnimationFrame(() => {
+      ta.focus();
+      ta.setSelectionRange(next.selStart, next.selEnd);
+    });
+  }, [body]);
+
+  // --- Reconciliation actions (remote skills only) ---
+
+  const handleReset = useCallback(async () => {
+    if (!source || !skill) return;
+    setReconciling(true);
+    try {
+      await resetSkill(source.name, skill.name);
+      showToast('success', `"${skill.name}" reset to upstream`);
+      onSaved();
+      onClose();
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'Reset failed');
+    } finally {
+      setReconciling(false);
+      setPendingAction(null);
+    }
+  }, [source, skill, onSaved, onClose]);
+
+  const handleDetach = useCallback(async () => {
+    if (!source || !skill) return;
+    setReconciling(true);
+    try {
+      await detachSkill(source.name, skill.name);
+      showToast('success', `"${skill.name}" detached; now a local skill`);
+      onSaved();
+      onClose();
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'Detach failed');
+    } finally {
+      setReconciling(false);
+      setPendingAction(null);
+    }
+  }, [source, skill, onSaved, onClose]);
+
+  const handleFork = useCallback(async () => {
+    const newName = forkName.trim();
+    if (!newName) return;
+    setReconciling(true);
+    try {
+      const metadataRecord: Record<string, string> = {};
+      for (const entry of metadata) {
+        if (entry.key) metadataRecord[entry.key] = entry.value;
+      }
+      const criteriaStrings = criteria
+        .filter((c) => c.given && c.when && c.then)
+        .map((c) => `GIVEN ${c.given} WHEN ${c.when} THEN ${c.then}`);
+      // A fork is a brand-new local skill (no origin) seeded from the current
+      // editor fields, so it captures any unsaved local edits.
+      const copy: AgentSkill = {
+        name: newName,
+        description,
+        body,
+        state,
+        fileCount: 0,
+        ...(license && { license }),
+        ...(compatibility && { compatibility }),
+        ...(Object.keys(metadataRecord).length > 0 && { metadata: metadataRecord }),
+        ...(allowedTools && { allowedTools }),
+        ...(criteriaStrings.length > 0 && { acceptanceCriteria: criteriaStrings }),
+      };
+      await createRegistrySkill(copy);
+      showToast('success', `Forked as "${newName}"`);
+      onSaved();
+      onClose();
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'Fork failed (name may already exist)');
+    } finally {
+      setReconciling(false);
+      setForking(false);
+    }
+  }, [forkName, description, body, state, license, compatibility, metadata, allowedTools, criteria, onSaved, onClose]);
 
   // --- Keyboard shortcut: Cmd/Ctrl+S to save ---
 
@@ -569,7 +764,7 @@ export function SkillEditor({
           <div className="flex items-center gap-3">
             {/* Preview toggle */}
             <button
-              onClick={() => setShowPreview(!showPreview)}
+              onClick={togglePreview}
               title={showPreview ? 'Hide preview' : 'Show preview'}
               className={cn(
                 'p-1.5 rounded-lg transition-all duration-200 group',
@@ -614,17 +809,95 @@ export function SkillEditor({
           </div>
         )}
 
-        {/* Frontmatter helpers (collapsible, scrollable) */}
+        {/* Provenance strip: only for skills tracked from a git source */}
+        {isRemote && source && (
+          <div className="flex items-center justify-between gap-3 flex-wrap px-5 py-2 border-b border-border/30 bg-surface/40 flex-shrink-0">
+            <div className="flex items-center gap-2 min-w-0 text-[11px] text-text-muted">
+              <GitBranch size={12} className="text-text-muted/70 flex-shrink-0" />
+              <span className="truncate">
+                Tracked from{' '}
+                <span className="font-mono text-text-secondary">
+                  {repoInfo ? `${repoInfo.owner}/${repoInfo.repo}` : source.name}
+                </span>
+                {source.commitSha && (
+                  <span className="font-mono text-text-muted/70">@{source.commitSha.slice(0, 7)}</span>
+                )}
+                {source.lastFetched && (
+                  <span className="text-text-muted/70">
+                    {' '}· synced {new Date(source.lastFetched).toLocaleDateString()}
+                  </span>
+                )}
+              </span>
+              {hasLocalEdits && (
+                <span
+                  title="Edited locally; a sync will skip this unless you overwrite"
+                  className="flex-shrink-0 text-[9px] font-medium uppercase tracking-wider px-1.5 py-0.5 rounded-full border border-amber-400/30 bg-amber-400/10 text-amber-300"
+                >
+                  Local edits
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-1 flex-shrink-0">
+              <ProvenanceAction icon={GitCompareArrows} label="Compare" onClick={() => setShowCompare(true)} disabled={reconciling} />
+              <ProvenanceAction icon={RotateCcw} label="Reset" onClick={() => setPendingAction('reset')} disabled={reconciling} />
+              <ProvenanceAction icon={Unlink} label="Detach" onClick={() => setPendingAction('detach')} disabled={reconciling} />
+              <ProvenanceAction icon={GitFork} label="Fork as…" onClick={() => { setForkName(`${skill!.name}-local`); setForking(true); }} disabled={reconciling} />
+            </div>
+          </div>
+        )}
+
+        {/* Fork-as inline input */}
+        {forking && (
+          <div className="flex items-center gap-2 px-5 py-2 border-b border-border/30 bg-background/40 flex-shrink-0">
+            <span className="text-[11px] text-text-muted flex-shrink-0">Fork as a new local skill:</span>
+            <input
+              autoFocus
+              value={forkName}
+              onChange={(e) => setForkName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleFork(); if (e.key === 'Escape') setForking(false); }}
+              placeholder="new-skill-name"
+              className="flex-1 max-w-xs bg-background/60 border border-border/40 rounded-lg px-3 py-1.5 text-xs font-mono text-text-primary placeholder:text-text-muted/50 focus:outline-none focus:border-primary/50 transition-colors"
+            />
+            <button
+              onClick={handleFork}
+              disabled={!forkName.trim() || reconciling}
+              className={cn(
+                'px-3 py-1.5 text-xs font-medium rounded-lg bg-primary text-background hover:bg-primary-light transition-colors',
+                (!forkName.trim() || reconciling) && 'opacity-50 cursor-not-allowed',
+              )}
+            >
+              Fork
+            </button>
+            <button
+              onClick={() => setForking(false)}
+              className="px-3 py-1.5 text-xs rounded-lg text-text-secondary hover:text-text-primary bg-surface-elevated hover:bg-surface-highlight transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+
+        {/* Frontmatter helpers (collapsible, scrollable). Collapsed by default
+            for existing skills so the body gets the room; a one-line summary
+            keeps the key fields glanceable, with "Edit metadata" to expand. */}
         <div className="border-b border-border/30 flex-shrink-0">
           <button
-            onClick={() => setShowFrontmatter(!showFrontmatter)}
-            className="w-full flex items-center justify-between px-5 py-2.5 text-xs text-text-muted hover:text-text-secondary transition-colors"
+            onClick={toggleFrontmatter}
+            className="w-full flex items-center justify-between gap-3 px-5 py-2.5 text-xs text-text-muted hover:text-text-secondary transition-colors"
           >
-            <span className="flex items-center gap-2">
-              <Settings size={14} />
-              <span className="uppercase tracking-wider">Frontmatter</span>
+            <span className="flex items-center gap-2 min-w-0">
+              <Settings size={14} className="flex-shrink-0" />
+              <span className="uppercase tracking-wider flex-shrink-0">Frontmatter</span>
+              {!showFrontmatter && (
+                <span className="truncate text-text-muted/70 normal-case tracking-normal">
+                  {frontmatterSummary}
+                </span>
+              )}
             </span>
-            {showFrontmatter ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+            <span className="flex items-center gap-1.5 flex-shrink-0">
+              {!showFrontmatter && <span className="text-[10px] text-primary/80">Edit metadata</span>}
+              {showFrontmatter ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+            </span>
           </button>
 
           {showFrontmatter && (
@@ -718,14 +991,29 @@ export function SkillEditor({
           )}
         </div>
 
-        {/* File tree (only for existing skills) */}
+        {/* File tree (existing skills), demoted behind a pill so it no longer
+            crowds the editor; expands on demand. */}
         {!isNew && skill && (
-          <SkillFileTree
-            skillName={skill.name}
-            onSelectFile={(path) => {
-              showToast('success', `Selected: ${path}`);
-            }}
-          />
+          <div className="border-b border-border/30 flex-shrink-0">
+            <button
+              onClick={() => setShowFiles((v) => !v)}
+              className="flex items-center gap-1.5 px-5 py-1.5 text-[11px] text-text-muted hover:text-text-secondary transition-colors"
+            >
+              <Files size={12} />
+              <span>Files ({skill.fileCount})</span>
+              {showFiles ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+            </button>
+            {showFiles && (
+              <div className="max-h-[22vh] overflow-y-auto scrollbar-dark border-t border-border/20">
+                <SkillFileTree
+                  skillName={skill.name}
+                  onSelectFile={(path) => {
+                    showToast('success', `Selected: ${path}`);
+                  }}
+                />
+              </div>
+            )}
+          </div>
         )}
 
         {/* Editor area: split pane when preview on, full-width when off */}
@@ -741,10 +1029,18 @@ export function SkillEditor({
             )}
             style={showPreview ? { width: `${ratio * 100}%` } : { width: '100%' }}
           >
-            <div className="px-4 py-2 border-b border-border/20 flex-shrink-0">
+            <div className="flex items-center justify-between gap-2 px-4 py-1.5 border-b border-border/20 flex-shrink-0">
               <span className="text-xs text-text-muted uppercase tracking-wider">Markdown</span>
+              {/* Minimal formatting toolbar: inserts at the textarea cursor */}
+              <div className="flex items-center gap-0.5">
+                <ToolbarButton icon={Bold} label="Bold" onClick={() => applyMarkdown('bold')} />
+                <ToolbarButton icon={Heading} label="Heading" onClick={() => applyMarkdown('heading')} />
+                <ToolbarButton icon={List} label="List item" onClick={() => applyMarkdown('list')} />
+                <ToolbarButton icon={Code2} label="Code block" onClick={() => applyMarkdown('code')} />
+              </div>
             </div>
             <textarea
+              ref={bodyRef}
               value={body}
               onChange={(e) => setBody(e.target.value)}
               placeholder={'# Skill Instructions\n\nWrite markdown instructions that the agent will follow...\n\n## Steps\n\n1. First step\n2. Second step'}
@@ -808,6 +1104,103 @@ export function SkillEditor({
           </div>
         </div>
       </div>
+
+      {/* Reconciliation: compare-with-upstream and reset/detach confirms */}
+      {isRemote && source && skill && (
+        <SkillCompareDialog
+          isOpen={showCompare}
+          sourceName={source.name}
+          skillName={skill.name}
+          onClose={() => setShowCompare(false)}
+          onTookUpstream={() => { setShowCompare(false); onSaved(); onClose(); }}
+        />
+      )}
+
+      <ConfirmDialog
+        isOpen={pendingAction === 'reset'}
+        onClose={() => setPendingAction(null)}
+        onConfirm={handleReset}
+        title="Reset to upstream"
+        message={
+          <>
+            <p>
+              Replace <span className="font-mono text-primary">{skill?.name}</span> with the latest
+              upstream content?
+            </p>
+            <p>Your local edits are backed up next to the skill before they are overwritten.</p>
+          </>
+        }
+        confirmLabel="Reset to upstream"
+        autoFocus="cancel"
+      />
+
+      <ConfirmDialog
+        isOpen={pendingAction === 'detach'}
+        onClose={() => setPendingAction(null)}
+        onConfirm={handleDetach}
+        title="Detach from source"
+        message={
+          <>
+            <p>
+              Stop tracking <span className="font-mono text-primary">{skill?.name}</span> from its
+              source?
+            </p>
+            <p>The skill and your edits stay; it becomes a local skill that sync no longer touches.</p>
+          </>
+        }
+        confirmLabel="Detach"
+      />
     </Modal>
+  );
+}
+
+// --- Small toolbar / provenance action buttons ---
+
+function ToolbarButton({
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  icon: typeof Bold;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      className="p-1.5 rounded-md text-text-muted hover:text-primary hover:bg-primary/10 transition-colors"
+    >
+      <Icon size={13} />
+    </button>
+  );
+}
+
+function ProvenanceAction({
+  icon: Icon,
+  label,
+  onClick,
+  disabled,
+}: {
+  icon: typeof Bold;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'inline-flex items-center gap-1 px-2 py-1 text-[11px] font-medium rounded-md transition-colors',
+        'text-text-secondary hover:text-text-primary bg-surface-elevated hover:bg-surface-highlight border border-border/40',
+        disabled && 'opacity-50 cursor-not-allowed',
+      )}
+    >
+      <Icon size={11} /> {label}
+    </button>
   );
 }

--- a/web/src/components/registry/SourceGroupHeader.tsx
+++ b/web/src/components/registry/SourceGroupHeader.tsx
@@ -4,6 +4,8 @@ import { cn } from '../../lib/cn';
 import { showToast } from '../ui/Toast';
 import { updateSkillSource } from '../../lib/api';
 import { extractRepoInfo } from '../../lib/repo';
+import { summarizeSkillResults, syncCountsMessage } from '../../lib/skillSync';
+import { DriftSyncDialog } from './DriftSyncDialog';
 import type { SkillSourceStatus } from '../../types';
 
 interface SourceGroupHeaderProps {
@@ -36,24 +38,43 @@ export function SourceGroupHeader({
   onUpdated,
 }: SourceGroupHeaderProps) {
   const [updating, setUpdating] = useState(false);
+  const [confirmDrift, setConfirmDrift] = useState(false);
 
   const repoInfo = source ? extractRepoInfo(source.repo) : null;
   const label = source ? (repoInfo ? `${repoInfo.owner}/${repoInfo.repo}` : source.name) : 'My Skills';
   const shortSha = source?.commitSha ? source.commitSha.slice(0, 7) : null;
+  const drifted = source?.driftedSkills ?? [];
 
-  const handleUpdate = async (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const runSync = async (force: boolean) => {
     if (!source || updating) return;
     setUpdating(true);
     try {
-      await updateSkillSource(source.name);
-      showToast('success', `Synced "${source.name}"`);
+      const { results } = await updateSkillSource(source.name, force ? { force } : undefined);
+      const counts = summarizeSkillResults(results);
+      const detail = syncCountsMessage(counts);
+      showToast(
+        counts.failed > 0 ? 'warning' : 'success',
+        detail ? `Synced "${source.name}": ${detail}` : `"${source.name}" is up to date`,
+      );
       onUpdated?.();
     } catch (err) {
       showToast('error', err instanceof Error ? err.message : 'Sync failed');
     } finally {
       setUpdating(false);
+      setConfirmDrift(false);
     }
+  };
+
+  // Sync clean sources silently; warn before a sync that would touch
+  // locally-edited skills so the user picks skip vs overwrite.
+  const handleUpdate = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!source || updating) return;
+    if (drifted.length > 0) {
+      setConfirmDrift(true);
+      return;
+    }
+    void runSync(false);
   };
 
   return (
@@ -116,6 +137,17 @@ export function SourceGroupHeader({
         </span>
       </div>
       <div className="border-b border-border/30" />
+      {source && (
+        <DriftSyncDialog
+          isOpen={confirmDrift}
+          title={`Sync ${label}`}
+          driftedSkills={drifted}
+          busy={updating}
+          onCancel={() => setConfirmDrift(false)}
+          onSkip={() => void runSync(false)}
+          onOverwrite={() => void runSync(true)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -3,30 +3,38 @@ import { X, Maximize2, Minimize2, ExternalLink } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 
-type ModalSize = 'default' | 'wide' | 'full';
+type ModalSize = 'default' | 'wide' | 'full' | 'fullscreen';
 
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   title: string;
   children: ReactNode;
-  /** Allow user to toggle between default and wide sizes */
+  /** Show an expand toggle that steps the panel up one size from its base
+   *  (default -> wide, wide -> full, full -> fullscreen). */
   expandable?: boolean;
   /** Callback to pop out into a new window */
   onPopout?: () => void;
   /** Disable popout button (e.g., already detached) */
   popoutDisabled?: boolean;
-  /** Force a specific size (overrides internal expand toggle) */
+  /** Base size of the panel (the expand toggle steps up from here) */
   size?: ModalSize;
   /** Flush mode: panel fills the entire viewport (for detached windows) */
   flush?: boolean;
 }
 
+// 'full' and 'fullscreen' pin the panel height (rather than letting content
+// drive it) so full-height children like the skill editor can size with
+// percentages and actually grow when the panel does.
 const sizeClasses: Record<ModalSize, string> = {
-  default: 'max-w-lg',
-  wide: 'max-w-3xl',
-  full: 'max-w-5xl',
+  default: 'max-w-lg max-h-[85vh]',
+  wide: 'max-w-3xl max-h-[85vh]',
+  full: 'max-w-5xl h-[85vh]',
+  fullscreen: 'max-w-[96vw] h-[94vh]',
 };
+
+// Expansion ladder for the expand toggle.
+const SIZE_ORDER: ModalSize[] = ['default', 'wide', 'full', 'fullscreen'];
 
 export function Modal({
   isOpen,
@@ -71,7 +79,12 @@ export function Modal({
 
   if (!isOpen) return null;
 
-  const currentSize = forcedSize ?? (expanded ? 'wide' : 'default');
+  // The expand toggle steps one size up from the base; a base already at the
+  // top of the ladder has nothing to expand to, so the button is hidden.
+  const baseSize = forcedSize ?? 'default';
+  const expandedSize = SIZE_ORDER[Math.min(SIZE_ORDER.indexOf(baseSize) + 1, SIZE_ORDER.length - 1)];
+  const canExpand = !!expandable && expandedSize !== baseSize && !flush;
+  const currentSize = expanded && canExpand ? expandedSize : baseSize;
 
   return (
     <div
@@ -96,8 +109,8 @@ export function Modal({
           flush
             ? 'flex-1 min-h-0 bg-surface-elevated'
             : cn(
-                'glass-panel-elevated rounded-xl w-full mx-4 max-h-[85vh] shadow-lg',
-                'transition-[max-width] duration-300 ease-out',
+                'glass-panel-elevated rounded-xl w-full mx-4 shadow-lg',
+                'transition-[max-width,height] duration-300 ease-out',
                 sizeClasses[currentSize],
               ),
         )}
@@ -106,7 +119,7 @@ export function Modal({
         <div className="flex items-center justify-between px-6 py-4 border-b border-border/30 flex-shrink-0">
           <h2 id={titleId} className="text-sm font-medium text-text-primary">{title}</h2>
           <div className="flex items-center gap-1">
-            {expandable && (
+            {canExpand && (
               <button
                 onClick={() => setExpanded(!expanded)}
                 title={expanded ? 'Compact view' : 'Expanded view'}

--- a/web/src/components/workspaces/LibraryWorkspace.tsx
+++ b/web/src/components/workspaces/LibraryWorkspace.tsx
@@ -23,9 +23,11 @@ import { SkillCardSkeleton } from '../registry/SkillCardSkeleton';
 import { LibraryGrid, type GroupMode } from '../registry/LibraryGrid';
 import { LibraryTable } from '../registry/LibraryTable';
 import { SkillDetailPanel } from '../registry/SkillDetailPanel';
+import { DriftSyncDialog } from '../registry/DriftSyncDialog';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { Modal } from '../ui/Modal';
 import { showToast } from '../ui/Toast';
+import { summarizeSkillResults, syncCountsMessage, addCounts, type SyncCounts } from '../../lib/skillSync';
 import { useFuzzySearch } from '../../hooks/useFuzzySearch';
 import { useSkillUsage } from '../../hooks/useSkillUsage';
 import { useWindowManager } from '../../hooks/useWindowManager';
@@ -299,6 +301,7 @@ export function LibraryWorkspace() {
   // failure list is captured for the Details overlay opened from the toast.
   const [syncing, setSyncing] = useState(false);
   const [syncFailures, setSyncFailures] = useState<SourceSyncResult[] | null>(null);
+  const [confirmSyncDrift, setConfirmSyncDrift] = useState(false);
 
   // Multi-select state. Names only (not skill objects) so the selection
   // survives filter, sort, group, and refresh; stale names are pruned at the
@@ -393,40 +396,60 @@ export function LibraryWorkspace() {
     }
   }, [refreshRegistry]);
 
+  // Aggregate the locally-edited skills across every source, for the bulk-sync
+  // drift warning and to decide whether a sync needs confirmation.
+  const driftedAcrossSources = useMemo(
+    () => (sources ?? []).flatMap((s) => s.driftedSkills ?? []),
+    [sources],
+  );
+
   // Bulk sync every imported source via the aggregate backend endpoint.
   // Surfaces an aggregated toast; failures expose a Details action that
   // opens an overlay listing the per-source error messages.
-  const handleSyncAll = useCallback(async () => {
-    if (syncing) return;
-    setSyncing(true);
-    try {
-      const summary = await syncAllSources();
-      await refreshAll();
-      const failures = summary.sources.filter((s) => s.error || s.skills?.some((k) => k.error));
-      if (failures.length === 0) {
-        if (summary.updatedSkills === 0) {
-          showToast('success', 'All sources up to date');
+  const runSyncAll = useCallback(
+    async (force: boolean) => {
+      if (syncing) return;
+      setSyncing(true);
+      setConfirmSyncDrift(false);
+      try {
+        const summary = await syncAllSources(force ? { force } : undefined);
+        await refreshAll();
+        const counts = (summary.sources ?? []).reduce<SyncCounts>(
+          (acc, s) => addCounts(acc, summarizeSkillResults(s.skills)),
+          { updated: 0, skipped: 0, overwritten: 0, failed: 0 },
+        );
+        const failures = summary.sources.filter((s) => s.error || s.skills?.some((k) => k.error));
+        if (failures.length === 0) {
+          const detail = syncCountsMessage(counts);
+          showToast('success', detail ? `Sync complete: ${detail}` : 'All sources up to date');
         } else {
+          const okCount = summary.syncedSources;
+          const failCount = failures.length;
           showToast(
-            'success',
-            `Synced ${summary.syncedSources} source${summary.syncedSources === 1 ? '' : 's'}, ${summary.updatedSkills} skill${summary.updatedSkills === 1 ? '' : 's'} updated`,
+            'warning',
+            `Synced ${okCount} of ${okCount + failCount} sources. ${failCount} failed`,
+            { action: { label: 'Details', onClick: () => setSyncFailures(failures) }, duration: 6000 },
           );
         }
-      } else {
-        const okCount = summary.syncedSources;
-        const failCount = failures.length;
-        showToast(
-          'warning',
-          `Synced ${okCount} of ${okCount + failCount} sources. ${failCount} failed`,
-          { action: { label: 'Details', onClick: () => setSyncFailures(failures) }, duration: 6000 },
-        );
+      } catch (err) {
+        showToast('error', err instanceof Error ? err.message : 'Sync failed');
+      } finally {
+        setSyncing(false);
       }
-    } catch (err) {
-      showToast('error', err instanceof Error ? err.message : 'Sync failed');
-    } finally {
-      setSyncing(false);
+    },
+    [syncing, refreshAll],
+  );
+
+  // Sync clean sources silently; when any source has local edits, warn first so
+  // the user chooses to keep or overwrite them.
+  const handleSyncAll = useCallback(() => {
+    if (syncing) return;
+    if (driftedAcrossSources.length > 0) {
+      setConfirmSyncDrift(true);
+      return;
     }
-  }, [syncing, refreshAll]);
+    void runSyncAll(false);
+  }, [syncing, driftedAcrossSources, runSyncAll]);
 
   const handleEnable = useCallback(async (skill: AgentSkill) => {
     try {
@@ -882,8 +905,19 @@ export function LibraryWorkspace() {
       <SkillEditor
         isOpen={showEditor}
         onClose={handleEditorClose}
-        onSaved={refreshRegistry}
+        onSaved={refreshAll}
         skill={editingSkill}
+        source={editingSkill ? sourceMap.get(editingSkill.name) : undefined}
+      />
+
+      <DriftSyncDialog
+        isOpen={confirmSyncDrift}
+        title="Sync all sources"
+        driftedSkills={driftedAcrossSources}
+        busy={syncing}
+        onCancel={() => setConfirmSyncDrift(false)}
+        onSkip={() => void runSyncAll(false)}
+        onOverwrite={() => void runSyncAll(true)}
       />
 
       {syncFailures && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, SkillUsageResponse, RegistryStatus, AgentSkill, ItemState, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SourceSyncSummary, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
+import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, SkillUsageResponse, RegistryStatus, AgentSkill, ItemState, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SourceSyncSummary, SkillSyncResult, SkillDiffResponse, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
 
 // Base URL for API calls - empty for same origin
 const API_BASE = '';
@@ -1204,25 +1204,72 @@ export async function checkSkillSource(name: string): Promise<SourceUpdateCheck>
 }
 
 /**
- * Apply available updates for a source
+ * Apply available updates for a source. Without `force`, locally-edited
+ * (drifted) skills are skipped and reported as `skipped: "local edits"`; with
+ * `force` they are overwritten (the server writes a SKILL.md.pre-<sha> backup
+ * first). An optional `skills` filter restricts the operation to named skills.
  * POST /api/skills/sources/{name}/update
  */
-export async function updateSkillSource(name: string): Promise<{ source: string; results: unknown[] }> {
-  return mutateJSON<{ source: string; results: unknown[] }>(
+export async function updateSkillSource(
+  name: string,
+  opts?: { force?: boolean; skills?: string[] },
+): Promise<{ source: string; results: SkillSyncResult[] }> {
+  return mutateJSON<{ source: string; results: SkillSyncResult[] }>(
     `/api/skills/sources/${encodeURIComponent(name)}/update`,
     'POST',
+    opts && (opts.force || opts.skills?.length) ? opts : undefined,
   );
 }
 
 /**
  * Sync every imported source in one server-side fan-out. Pinned sources
- * (refs shaped like v1.0.0 or full commit SHAs) are silently skipped. The
+ * (refs shaped like v1.0.0 or full commit SHAs) are silently skipped. Without
+ * `force`, drifted skills are skipped; with `force` they are overwritten. The
  * response carries per-source results plus aggregate counters.
  *
  * POST /api/skills/sources/update
  */
-export async function syncAllSources(): Promise<SourceSyncSummary> {
-  return mutateJSON<SourceSyncSummary>('/api/skills/sources/update', 'POST');
+export async function syncAllSources(opts?: { force?: boolean }): Promise<SourceSyncSummary> {
+  return mutateJSON<SourceSyncSummary>(
+    '/api/skills/sources/update',
+    'POST',
+    opts?.force ? opts : undefined,
+  );
+}
+
+/**
+ * Compare a tracked skill's on-disk SKILL.md against the latest upstream
+ * content. Read-only: nothing is written to disk and no SHAs change.
+ * GET /api/skills/sources/{name}/skills/{skill}/diff
+ */
+export async function fetchSkillDiff(source: string, skill: string): Promise<SkillDiffResponse> {
+  return fetchJSON<SkillDiffResponse>(
+    `/api/skills/sources/${encodeURIComponent(source)}/skills/${encodeURIComponent(skill)}/diff`,
+  );
+}
+
+/**
+ * Detach a skill from its source: removes the origin sidecar and lock entry so
+ * the skill becomes local-only and is no longer touched by sync.
+ * POST /api/skills/sources/{name}/skills/{skill}/detach
+ */
+export async function detachSkill(source: string, skill: string): Promise<{ detached: string }> {
+  return mutateJSON<{ detached: string }>(
+    `/api/skills/sources/${encodeURIComponent(source)}/skills/${encodeURIComponent(skill)}/detach`,
+    'POST',
+  );
+}
+
+/**
+ * Reset a single skill to its upstream content. The server backs up the
+ * current (possibly edited) SKILL.md before force-restoring it.
+ * POST /api/skills/sources/{name}/skills/{skill}/reset
+ */
+export async function resetSkill(source: string, skill: string): Promise<SkillSyncResult> {
+  return mutateJSON<SkillSyncResult>(
+    `/api/skills/sources/${encodeURIComponent(source)}/skills/${encodeURIComponent(skill)}/reset`,
+    'POST',
+  );
 }
 
 /**

--- a/web/src/lib/markdownEdit.ts
+++ b/web/src/lib/markdownEdit.ts
@@ -1,0 +1,38 @@
+export type MarkdownAction = 'bold' | 'list' | 'code' | 'heading';
+
+/**
+ * Apply a lightweight markdown transform at a textarea's current selection and
+ * return the new value plus the caret/selection to restore. Pure (no DOM) so
+ * the SkillEditor toolbar can stay thin and the behavior is unit-testable.
+ */
+export function applyMarkdownAction(
+  value: string,
+  selStart: number,
+  selEnd: number,
+  action: MarkdownAction,
+): { value: string; selStart: number; selEnd: number } {
+  const selected = value.slice(selStart, selEnd);
+  const lineStart = value.lastIndexOf('\n', selStart - 1) + 1;
+
+  switch (action) {
+    case 'bold': {
+      const text = selected || 'bold text';
+      const next = value.slice(0, selStart) + `**${text}**` + value.slice(selEnd);
+      return { value: next, selStart: selStart + 2, selEnd: selStart + 2 + text.length };
+    }
+    case 'code': {
+      const text = selected || 'code';
+      const block = '```\n' + text + '\n```';
+      const next = value.slice(0, selStart) + block + value.slice(selEnd);
+      return { value: next, selStart: selStart + 4, selEnd: selStart + 4 + text.length };
+    }
+    case 'heading': {
+      const next = value.slice(0, lineStart) + '## ' + value.slice(lineStart);
+      return { value: next, selStart: selStart + 3, selEnd: selEnd + 3 };
+    }
+    case 'list': {
+      const next = value.slice(0, lineStart) + '- ' + value.slice(lineStart);
+      return { value: next, selStart: selStart + 2, selEnd: selEnd + 2 };
+    }
+  }
+}

--- a/web/src/lib/skillSync.ts
+++ b/web/src/lib/skillSync.ts
@@ -1,0 +1,49 @@
+import type { SkillSyncResult } from '../types';
+
+export interface SyncCounts {
+  updated: number;
+  skipped: number;
+  overwritten: number;
+  failed: number;
+}
+
+/**
+ * Tally per-skill sync outcomes into discrete buckets. A force-overwritten
+ * skill carries a backup file name (and would also report `imported`), so it is
+ * counted as overwritten rather than a plain update; a skipped skill carries a
+ * `skipped` reason; the rest with `imported > 0` are plain updates.
+ */
+export function summarizeSkillResults(results: SkillSyncResult[] | undefined): SyncCounts {
+  const c: SyncCounts = { updated: 0, skipped: 0, overwritten: 0, failed: 0 };
+  for (const r of results ?? []) {
+    if (r.error) c.failed++;
+    else if (r.skipped) c.skipped++;
+    else if (r.backup) c.overwritten++;
+    else if (r.imported) c.updated++;
+  }
+  return c;
+}
+
+/** Add b into a, returning a new total. */
+export function addCounts(a: SyncCounts, b: SyncCounts): SyncCounts {
+  return {
+    updated: a.updated + b.updated,
+    skipped: a.skipped + b.skipped,
+    overwritten: a.overwritten + b.overwritten,
+    failed: a.failed + b.failed,
+  };
+}
+
+/**
+ * Human phrase for a set of sync counts, e.g. "2 updated, 1 kept, 1
+ * overwritten". Returns an empty string when nothing changed, so callers can
+ * fall back to an "up to date" message.
+ */
+export function syncCountsMessage(c: SyncCounts): string {
+  const parts: string[] = [];
+  if (c.updated) parts.push(`${c.updated} updated`);
+  if (c.overwritten) parts.push(`${c.overwritten} overwritten`);
+  if (c.skipped) parts.push(`${c.skipped} kept`);
+  if (c.failed) parts.push(`${c.failed} failed`);
+  return parts.join(', ');
+}

--- a/web/src/stores/useUIStore.ts
+++ b/web/src/stores/useUIStore.ts
@@ -70,10 +70,29 @@ function normalizeCompactMode(raw: unknown): CompactModeMap {
   return out;
 }
 
+// Skill editor view preferences, persisted so the editor reopens the way the
+// user left it. Body-heavy split and collapsed frontmatter are the defaults for
+// existing skills (a new skill forces frontmatter open so its fields are fillable).
+export interface EditorPrefs {
+  showFrontmatter: boolean;
+  showPreview: boolean;
+  splitRatio: number;
+}
+
+export const EDITOR_PREFS_DEFAULTS: EditorPrefs = {
+  showFrontmatter: false,
+  showPreview: true,
+  splitRatio: 0.62,
+};
+
 interface UIState extends WorkspaceSlice, CompactModeSlice {
   sidebarOpen: boolean;
   activeTab: SidebarTab;
   edgeStyle: EdgeStyle;
+
+  // Skill editor view preferences
+  editorPrefs: EditorPrefs;
+  setEditorPrefs: (prefs: Partial<EditorPrefs>) => void;
 
   // Compact card mode
   compactCards: boolean;
@@ -161,6 +180,11 @@ export const useUIStore = create<UIState>()(
       sidebarOpen: false,
       activeTab: 'details',
       edgeStyle: 'default', // Bezier curves
+
+      // Skill editor view preferences
+      editorPrefs: { ...EDITOR_PREFS_DEFAULTS },
+      setEditorPrefs: (prefs) =>
+        set((s) => ({ editorPrefs: { ...s.editorPrefs, ...prefs } })),
 
       // Compact cards default
       compactCards: false,
@@ -255,6 +279,7 @@ export const useUIStore = create<UIState>()(
         edgeStyle: state.edgeStyle,
         compactCards: state.compactCards,
         compactMode: state.compactMode,
+        editorPrefs: state.editorPrefs,
       }),
       merge: (persisted, current) => ({
         ...current,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -507,6 +507,8 @@ export interface SkillSourceEntry {
   state: string;
   isRemote: boolean;
   contentHash?: string;
+  /** True when the on-disk SKILL.md diverges from the last installed snapshot. */
+  hasLocalEdits?: boolean;
 }
 
 export interface SkillSourceStatus {
@@ -520,6 +522,8 @@ export interface SkillSourceStatus {
   lastFetched?: string;
   commitSha?: string;
   updateAvailable: boolean;
+  /** Names of skills in this source with local edits a sync would overwrite. */
+  driftedSkills?: string[];
 }
 
 export interface SkillPreview {
@@ -582,6 +586,19 @@ export interface SkillSyncResult {
   imported?: number;
   warnings?: string[];
   error?: string;
+  /** Reason a drifted skill was left untouched (e.g. "local edits"). */
+  skipped?: string;
+  /** File name of the pre-overwrite backup written when force-overwritten. */
+  backup?: string;
+}
+
+/** Local vs upstream comparison for a single tracked skill (no writes). */
+export interface SkillDiffResponse {
+  skill: string;
+  local: string;
+  upstream: string;
+  unifiedDiff?: string;
+  drifted: boolean;
 }
 
 export interface SourceSyncResult {
@@ -596,6 +613,7 @@ export interface SourceSyncSummary {
   sources: SourceSyncResult[];
   syncedSources: number;
   updatedSkills: number;
+  skippedSkills?: number;
   failedSources: number;
   pinnedSources: number;
 }


### PR DESCRIPTION
## Description

Frontend half of the drift-safe skill reconciliation work (backend merged in #769). Surfaces local edits to git-sourced skills, makes Sync ask before touching them, and adds a provenance strip with compare/reset/detach/fork plus editor breathing room.

## Type of Change

- [x] Feature (frontend; consumes the additive API from #769)

## Changes Made

- "Modified" drift badge on skill cards, the detail panel, and the editor for tracked skills with local edits.
- Drift-aware Sync: clean sources sync silently; a source (or the workspace-wide Sync) with edited skills opens a confirm listing them with keep-my-edits (skip) or overwrite choices. Toasts report updated, kept, and overwritten counts.
- Editor provenance strip (tracked-from owner/repo@sha, last synced) with Compare-with-upstream (local-vs-upstream diff, Keep mine / Take upstream), Reset to upstream, Detach from source, and Fork-as.
- Editor breathing room: frontmatter collapsed to a one-line summary by default for existing skills, body-heavy split, persisted preview/ratio/frontmatter prefs, a markdown toolbar (bold/heading/list/code), and the file tree demoted behind a "Files (N)" pill. Stays on the textarea (CodeMirror deferred).
- api.ts: force/skills params on update + sync-all, and diff/detach/reset functions; new source/skill/diff types.

## Testing

- `npm run build`, `npx tsc --noEmit`, and `npm test` (962 passing) all green.
- New Vitest coverage: the reconciliation api functions, the drift-aware Sync gating (skip vs overwrite), the sync-result summarizer, the markdown toolbar transform, and the persisted editor prefs.
- Lint is clean on touched files apart from two pre-existing `react-hooks/set-state-in-effect` errors in the editor init and skill-resolver effects (unchanged by this PR).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #768