### PR TITLE
fix: wire cost model attribution so cost data populates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,23 @@ All notable changes to gridctl will be documented in this file.
 
 ### Fixed
 
+- **Cost observability now produces data.** The cost pipeline (pricing engine,
+  accumulator, REST API, UI cost card, optimize heuristics, `gen_ai.cost.usd`
+  spans) was fully built but its trigger was never wired: no production code
+  installed a model resolver on the metrics observer, so every deployment
+  recorded zero cost forever while tokens recorded normally. Stack YAML gains
+  an optional per-server `model:` field plus a `gateway.default_model`
+  fallback; when set, the gateway prices each observed call against the
+  embedded LiteLLM rates and cost flows through every existing surface
+  (`/api/status`, `/api/metrics/cost`, the Metrics tab, per-client
+  attribution, metrics persistence, traces, and the
+  `expensive_model_on_cheap_task` heuristic, which can now name the model).
+  Both fields hot-reload without restarting servers — pricing metadata never
+  warrants a container restart. Stacks without a model behave exactly as
+  before (tokens recorded, zero cost), and the dashboard cost card now shows
+  a "set `model:` to enable estimates" hint instead of a bare $0.00 when
+  attribution is not configured.
+
 - **The web UI no longer silently overwrites locally-edited skills on sync.**
   Both sync paths (`POST /api/skills/sources/{name}/update` and the bulk `POST
   /api/skills/sources/update`) called the importer with no drift check, so

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -63,6 +63,7 @@ gateway:
 | `auth` | object | No | - | Authentication configuration |
 | `code_mode` | string | No | `"off"` | Enable code mode: `"on"` or `"off"` *(experimental)* |
 | `code_mode_timeout` | int | No | `30` | Code mode execution timeout in seconds. Must be >= 0 *(experimental)* |
+| `default_model` | string | No | - | Model ID used to price tool calls for servers without their own `model` field (e.g. `"claude-opus-4-7"`). Enables cost observability; figures are estimates from the embedded LiteLLM rates, not billing truth. Empty disables cost attribution for servers without a per-server `model` |
 | `output_format` | string | No | `"json"` | Default output format for tool call results: `"json"`, `"toon"`, `"csv"`, or `"text"`. Per-server `output_format` overrides this value |
 | `maxToolResultBytes` | int | No | `65536` | Maximum size of a tool result in bytes before truncation. Results over the limit are truncated with a suffix noting the original size. `0` uses the default (64 KB) |
 | `security` | object | No | - | Security settings (see [Security](#security)) |
@@ -455,6 +456,7 @@ mcp-servers:
 | `replica_policy` | string | No | `"round-robin"` | Dispatch policy when `replicas > 1` or `autoscale` is set: `"round-robin"` or `"least-connections"` |
 | `autoscale` | object | No | - | Reactive autoscaling block. Mutually exclusive with `replicas`. Not supported for external URL or OpenAPI transports. See [Autoscale](#autoscale) |
 | `telemetry` | object | No | - | Per-server telemetry persistence overrides. See [Per-server Overrides](#per-server-overrides) |
+| `model` | string | No | - | Model ID used to price this server's tool calls (e.g. `"claude-opus-4-7"`). Overrides `gateway.default_model`. Enables cost observability for this server; figures are estimates from the embedded LiteLLM rates. Unknown model IDs log a single WARN and price as zero. Edits hot-reload without restarting the server. See [Cost Observability](cost-observability.md) |
 
 **Type determination rules:**
 - Must have exactly one of: `image`, `source`, `url`, `command` (alone), `ssh` + `command`, or `openapi`

--- a/docs/cost-observability.md
+++ b/docs/cost-observability.md
@@ -1,6 +1,26 @@
 # Cost Observability
 
-Gridctl prices every observed tool call against an embedded snapshot of LiteLLM's [`model_prices_and_context_window.json`](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json). The cost layer lives in `pkg/pricing` (rate table + normalization) and `pkg/metrics` (parallel cost counters alongside the existing token counters). Surfacing cost in the REST API, Web UI, and `gridctl optimize` CLI ships in follow-up PRs; this document describes the foundation that landed first.
+Gridctl prices every observed tool call against an embedded snapshot of LiteLLM's [`model_prices_and_context_window.json`](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json). The cost layer lives in `pkg/pricing` (rate table + normalization) and `pkg/metrics` (parallel cost counters alongside the existing token counters). Cost surfaces in the REST API (`/api/status`, `/api/metrics/cost`), the Web UI Metrics tab, the `gridctl optimize` CLI, opt-in metrics persistence, and the `gen_ai.cost.usd` span attribute on tool-call traces.
+
+## Model attribution (required for cost data)
+
+Pricing a call requires knowing which model the tokens are billed against. The gateway sits below the LLM client and cannot observe the client's model choice, so attribution is declared in `stack.yaml`: a per-server `model` field, with a stack-wide `gateway.default_model` fallback for servers that do not set their own.
+
+```yaml
+gateway:
+  default_model: claude-haiku-4-5   # prices any server without its own model
+
+mcp-servers:
+  - name: jira
+    image: mcp/atlassian:latest
+    model: claude-opus-4-7          # overrides the default for this server
+```
+
+Without attribution, tokens and latency record normally but cost stays zero, and the dashboard's cost card shows a configuration hint instead of a number. Resolution is per server: the server's own `model` wins, then `gateway.default_model`, then no attribution (pricing skipped for that server's calls). Edits to either field hot-reload through the file watcher without restarting any server; subsequent calls price against the updated mapping.
+
+A tool result that carries its own model in usage metadata takes precedence over the configured mapping at the call level. The MCP wire shape for that metadata is not yet standardized, so configured attribution is the operative path today.
+
+Cost figures are estimates — tokenizer-approximated counts multiplied by published list rates. They are built for comparing servers, spotting waste, and trending over time, not for reconciling invoices.
 
 ## Refreshing pricing data
 

--- a/examples/getting-started/mcp-basic.yaml
+++ b/examples/getting-started/mcp-basic.yaml
@@ -4,12 +4,20 @@
 # - Multiple MCP servers with different transports
 # - Server-level tool filtering
 # - Environment variable expansion
+# - Cost attribution via model IDs
 #
 # Usage:
 #   gridctl apply examples/getting-started/mcp-basic.yaml
 #
 version: "1"
 name: mcp-basic
+
+# Cost attribution: declaring which model your client runs lets the gateway
+# price tool calls against embedded LiteLLM rates (estimates, not billing
+# truth). default_model covers every server; a per-server `model:` overrides
+# it. Omit both and cost stays zero (tokens still record).
+gateway:
+  default_model: claude-opus-4-7
 
 network:
   name: mcp-basic-net
@@ -38,6 +46,7 @@ mcp-servers:
     command: ["sh", "-c", "while true; do sleep 3600; done"]
     description: "Primary tools server"
     tools: ["read", "list", "search"]  # Only these tools are exposed to clients
+    # model: claude-haiku-4-5   # per-server pricing override of gateway.default_model
     # telemetry:
     #   persist:
     #     traces: false   # explicit override: skip traces for this server only

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -52,6 +52,11 @@ type Server struct {
 	gatewayAddr   string // e.g. "http://localhost:8180" — used to build MCP config for CLI proxy
 	tokenizerName string // active tokenizer mode: "embedded" or "api"
 
+	// modelAttribution returns the server -> model mapping used to price
+	// tool calls. Nil (or an empty map) means no cost attribution is
+	// configured. Must be safe for concurrent calls.
+	modelAttribution func() map[string]string
+
 	// startWatcher, when set, starts a file watcher on the given stack path.
 	// Injected by GatewayBuilder so POST /api/stack/initialize can activate live reload.
 	startWatcher func(stackPath string)
@@ -175,6 +180,24 @@ func (s *Server) SetGatewayAddr(addr string) {
 // SetTokenizerName sets the active tokenizer mode for display in /api/status.
 func (s *Server) SetTokenizerName(name string) {
 	s.tokenizerName = name
+}
+
+// SetModelAttribution sets a getter for the server -> model mapping used to
+// price tool calls. The getter (rather than a static map) lets hot reloads of
+// `model:` / `default_model:` reach handlers without re-wiring; it must be
+// safe for concurrent calls. Feeds the optimize model stats and the
+// /api/status cost_attribution flag.
+func (s *Server) SetModelAttribution(get func() map[string]string) {
+	s.modelAttribution = get
+}
+
+// modelAttributionMap returns the current server -> model mapping, or nil
+// when no attribution getter is wired or nothing is configured.
+func (s *Server) modelAttributionMap() map[string]string {
+	if s.modelAttribution == nil {
+		return nil
+	}
+	return s.modelAttribution()
 }
 
 // SetStartWatcher sets a callback that activates live-reload file watching for
@@ -382,7 +405,11 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		CodeMode   string                   `json:"code_mode,omitempty"`
 		TokenUsage *metrics.TokenUsage      `json:"token_usage,omitempty"`
 		Cost       *metrics.CostUsage       `json:"cost,omitempty"`
-		StackName  string                   `json:"stack_name,omitempty"`
+		// CostAttribution reports whether any server has a model configured
+		// for pricing. False lets the UI explain why cost stays empty
+		// (set `model:` in stack.yaml) instead of showing a bare $0.00.
+		CostAttribution bool   `json:"cost_attribution,omitempty"`
+		StackName       string `json:"stack_name,omitempty"`
 	}{
 		Gateway: ServerInfo{
 			Name:      s.gateway.ServerInfo().Name,
@@ -413,6 +440,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 			status.Cost = &cost
 		}
 	}
+	status.CostAttribution = len(s.modelAttributionMap()) > 0
 
 	writeJSON(w, status)
 }

--- a/internal/api/optimize.go
+++ b/internal/api/optimize.go
@@ -111,7 +111,7 @@ func (s *Server) optimizeStats() optimize.Stats {
 		}
 		stats.ServerCallCount = computeServerCallCount(acc.ToolUsageSnapshot())
 	}
-	stats.ModelStats = lookupModelStats(stats.Servers)
+	stats.ModelStats = lookupModelStats(s.modelAttributionMap())
 	return stats
 }
 
@@ -191,19 +191,32 @@ func computeServerCallCount(toolUsage map[string]map[string]metrics.ToolStat) ma
 	return out
 }
 
-// lookupModelStats consults the active pricing.Source for a default
-// model attribution per server. The current gateway has no per-server
-// model resolver wired into a public accessor, so this returns an
-// empty map for now — the expensive_model_on_cheap_task heuristic
-// falls back to inferring rate from observed cost÷tokens, which still
-// correctly identifies Opus-tier traffic.
-//
-// When a future PR exposes per-server model attribution, populate the
-// returned map here so the heuristic can name the model in its
-// summary instead of saying "an Opus-tier model."
-func lookupModelStats(_ []optimize.ServerInfo) map[string]optimize.ModelStat {
-	_ = pricing.CurrentSource()
-	return nil
+// lookupModelStats resolves per-token rates from the active pricing.Source
+// for each server with model attribution (a `model:` field or the gateway
+// `default_model:`), so expensive_model_on_cheap_task can read the rate
+// directly and name the model in its summary. Servers without attribution —
+// or whose model is unknown to the pricing source — are omitted; the
+// heuristic falls back to inferring rate from observed cost÷tokens.
+func lookupModelStats(models map[string]string) map[string]optimize.ModelStat {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make(map[string]optimize.ModelStat, len(models))
+	for server, model := range models {
+		rates, ok := pricing.Lookup(model)
+		if !ok {
+			continue
+		}
+		out[server] = optimize.ModelStat{
+			Model:             model,
+			InputUSDPerToken:  rates.InputPerToken,
+			OutputUSDPerToken: rates.OutputPerToken,
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // parseFloatQuery returns the float64 value of a query parameter, or 0

--- a/internal/api/optimize_test.go
+++ b/internal/api/optimize_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gridctl/gridctl/pkg/metrics"
 	"github.com/gridctl/gridctl/pkg/optimize"
+	"github.com/gridctl/gridctl/pkg/pricing"
 )
 
 func TestHandleOptimize_NoAccumulator_503(t *testing.T) {
@@ -190,5 +191,73 @@ func TestHandleOptimize_MinImpactRespected(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200; got %d", rec.Code)
+	}
+}
+
+// staticPricingSource is a deterministic pricing.Source for model-stat tests.
+type staticPricingSource struct {
+	rates map[string]pricing.Rates
+}
+
+func (s staticPricingSource) Lookup(model string) (pricing.Rates, bool) {
+	r, ok := s.rates[model]
+	return r, ok
+}
+
+func (s staticPricingSource) Name() string { return "api-test-fixture" }
+
+func TestLookupModelStats(t *testing.T) {
+	prev := pricing.CurrentSource()
+	t.Cleanup(func() { pricing.SetSource(prev) })
+	pricing.SetSource(staticPricingSource{rates: map[string]pricing.Rates{
+		"claude-opus-4-7": {InputPerToken: 15e-6, OutputPerToken: 75e-6},
+	}})
+
+	t.Run("nil attribution returns nil", func(t *testing.T) {
+		if got := lookupModelStats(nil); got != nil {
+			t.Errorf("lookupModelStats(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("attributed server resolves rates and names the model", func(t *testing.T) {
+		got := lookupModelStats(map[string]string{"jira": "claude-opus-4-7"})
+		stat, ok := got["jira"]
+		if !ok {
+			t.Fatalf("expected stat for jira; got %v", got)
+		}
+		if stat.Model != "claude-opus-4-7" {
+			t.Errorf("Model = %q, want claude-opus-4-7", stat.Model)
+		}
+		if stat.InputUSDPerToken != 15e-6 {
+			t.Errorf("InputUSDPerToken = %v, want 15e-6", stat.InputUSDPerToken)
+		}
+		if stat.OutputUSDPerToken != 75e-6 {
+			t.Errorf("OutputUSDPerToken = %v, want 75e-6", stat.OutputUSDPerToken)
+		}
+	})
+
+	t.Run("unknown model is omitted", func(t *testing.T) {
+		got := lookupModelStats(map[string]string{"jira": "not-in-pricing-table"})
+		if got != nil {
+			t.Errorf("expected nil for pricing-unknown model; got %v", got)
+		}
+	})
+}
+
+func TestOptimizeStats_ModelStats_FromAttribution(t *testing.T) {
+	prev := pricing.CurrentSource()
+	t.Cleanup(func() { pricing.SetSource(prev) })
+	pricing.SetSource(staticPricingSource{rates: map[string]pricing.Rates{
+		"claude-opus-4-7": {InputPerToken: 15e-6, OutputPerToken: 75e-6},
+	}})
+
+	srv := newTestServerWithMetrics(t)
+	srv.SetModelAttribution(func() map[string]string {
+		return map[string]string{"jira": "claude-opus-4-7"}
+	})
+
+	stats := srv.optimizeStats()
+	if stats.ModelStats["jira"].Model != "claude-opus-4-7" {
+		t.Errorf("ModelStats[jira].Model = %q, want claude-opus-4-7", stats.ModelStats["jira"].Model)
 	}
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -187,6 +187,13 @@ type GatewayConfig struct {
 	// Security configures security features such as schema pinning. When nil, defaults apply.
 	Security *GatewaySecurityConfig `yaml:"security,omitempty" json:"security,omitempty"`
 
+	// DefaultModel is the model ID used to price tool calls for servers that
+	// do not set their own model field (e.g. "claude-opus-4-7"). Rates come
+	// from the embedded LiteLLM pricing snapshot; resulting figures are
+	// estimates, not billing truth. Empty (the default) disables cost
+	// attribution for servers without a per-server model.
+	DefaultModel string `yaml:"default_model,omitempty" json:"default_model,omitempty"`
+
 	// Tokenizer selects the token counting strategy.
 	// Values: "embedded" (default) uses the cl100k_base BPE vocabulary (pure Go, no network).
 	// "api" uses Anthropic's count_tokens endpoint for exact counts — Anthropic-specific,
@@ -275,6 +282,43 @@ type MCPServer struct {
 	// Telemetry, when set, overrides stack-global telemetry persistence for
 	// this server. nil fields inherit; *bool fields explicitly opt in or out.
 	Telemetry *MCPServerTelemetry `yaml:"telemetry,omitempty" json:"telemetry,omitempty"`
+
+	// Model is the model ID used to price this server's tool calls against
+	// the embedded LiteLLM pricing snapshot (e.g. "claude-opus-4-7").
+	// Overrides gateway.default_model for this server. Empty (the default)
+	// means no cost attribution: tokens are still recorded but cost stays
+	// zero. Unknown model IDs are best-effort — they log a single WARN and
+	// price as zero rather than failing validation.
+	Model string `yaml:"model,omitempty" json:"model,omitempty"`
+}
+
+// ModelAttribution builds the server name -> effective model mapping used to
+// price tool calls: a server's own Model field wins, then the gateway-level
+// DefaultModel. Servers with no effective model are omitted. Returns nil when
+// no attribution is configured anywhere, which keeps the cost path inert.
+func (s *Stack) ModelAttribution() map[string]string {
+	if s == nil {
+		return nil
+	}
+	var defaultModel string
+	if s.Gateway != nil {
+		defaultModel = s.Gateway.DefaultModel
+	}
+	var out map[string]string
+	for _, server := range s.MCPServers {
+		model := server.Model
+		if model == "" {
+			model = defaultModel
+		}
+		if model == "" {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string, len(s.MCPServers))
+		}
+		out[server.Name] = model
+	}
+	return out
 }
 
 // AutoscaleConfig controls reactive autoscaling of a ReplicaSet. All fields are

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -209,5 +210,96 @@ func TestStack_NonContainerWorkloads(t *testing.T) {
 	workloads := stack.NonContainerWorkloads()
 	if len(workloads) != 2 {
 		t.Fatalf("expected 2 non-container workloads, got %d", len(workloads))
+	}
+}
+
+func TestStack_ModelAttribution(t *testing.T) {
+	tests := []struct {
+		name  string
+		stack *Stack
+		want  map[string]string
+	}{
+		{
+			name:  "nil stack",
+			stack: nil,
+			want:  nil,
+		},
+		{
+			name:  "no models configured",
+			stack: &Stack{MCPServers: []MCPServer{{Name: "a"}, {Name: "b"}}},
+			want:  nil,
+		},
+		{
+			name: "per-server model only",
+			stack: &Stack{MCPServers: []MCPServer{
+				{Name: "a", Model: "claude-opus-4-7"},
+				{Name: "b"},
+			}},
+			want: map[string]string{"a": "claude-opus-4-7"},
+		},
+		{
+			name: "default model fills unset servers",
+			stack: &Stack{
+				Gateway: &GatewayConfig{DefaultModel: "claude-haiku-4-5"},
+				MCPServers: []MCPServer{
+					{Name: "a", Model: "claude-opus-4-7"},
+					{Name: "b"},
+				},
+			},
+			want: map[string]string{
+				"a": "claude-opus-4-7",
+				"b": "claude-haiku-4-5",
+			},
+		},
+		{
+			name: "default model only",
+			stack: &Stack{
+				Gateway:    &GatewayConfig{DefaultModel: "claude-haiku-4-5"},
+				MCPServers: []MCPServer{{Name: "a"}, {Name: "b"}},
+			},
+			want: map[string]string{
+				"a": "claude-haiku-4-5",
+				"b": "claude-haiku-4-5",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.stack.ModelAttribution()
+			if len(got) != len(tt.want) {
+				t.Fatalf("ModelAttribution() = %v, want %v", got, tt.want)
+			}
+			for server, model := range tt.want {
+				if got[server] != model {
+					t.Errorf("ModelAttribution()[%q] = %q, want %q", server, got[server], model)
+				}
+			}
+		})
+	}
+}
+
+func TestMCPServer_ModelYAMLRoundTrip(t *testing.T) {
+	in := MCPServer{Name: "priced", Image: "mcp/priced:latest", Model: "claude-opus-4-7"}
+	raw, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out MCPServer
+	if err := yaml.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Model != "claude-opus-4-7" {
+		t.Errorf("Model round-trip = %q, want %q", out.Model, "claude-opus-4-7")
+	}
+
+	// A server without a model must not serialize the field (Article IX:
+	// the zero value is indistinguishable from a pre-model stack.yaml).
+	raw, err = yaml.Marshal(MCPServer{Name: "plain"})
+	if err != nil {
+		t.Fatalf("marshal plain: %v", err)
+	}
+	if strings.Contains(string(raw), "model:") {
+		t.Errorf("zero-value Model serialized: %s", raw)
 	}
 }

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
@@ -75,6 +76,12 @@ type GatewayBuilder struct {
 	// telemetry holds the opt-in disk-persistence writers wired at Build
 	// time. Nil when no server in the stack opts in.
 	telemetry *telemetryWiring
+
+	// modelAttribution holds the server -> effective model mapping used to
+	// price tool calls. Stored behind an atomic pointer so the hot-reload
+	// hook can swap the mapping without racing in-flight observations; the
+	// observer's resolver closure reads through it on every call.
+	modelAttribution atomic.Pointer[map[string]string]
 }
 
 // telemetryWiring bundles the three per-signal writers + the otlptrace
@@ -487,6 +494,7 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 	}
 	accumulator := metrics.NewAccumulator(10000)
 	observer := metrics.NewObserver(counter, accumulator)
+	b.wireModelAttribution(observer, server)
 	gateway.SetToolCallObserver(observer)
 	gateway.SetPromptGetObserver(observer)
 	gateway.SetTokenCounter(counter)
@@ -790,6 +798,31 @@ func (b *GatewayBuilder) buildTokenCounter() (token.Counter, error) {
 	}
 }
 
+// wireModelAttribution installs the cost-attribution model resolver on the
+// observer and exposes the same mapping to the API server (for the optimize
+// model stats and the /api/status cost_attribution flag). The resolver is
+// always installed: an empty mapping resolves every server to "", which keeps
+// the observer's cost path inert exactly as if no resolver were set, while
+// letting a hot reload activate attribution later without an unsynchronized
+// SetModelResolver swap racing in-flight observations.
+func (b *GatewayBuilder) wireModelAttribution(observer *metrics.Observer, apiServer *api.Server) {
+	b.refreshModelAttribution(b.stack)
+	observer.SetModelResolver(func(serverName string) string {
+		return (*b.modelAttribution.Load())[serverName]
+	})
+	apiServer.SetModelAttribution(func() map[string]string {
+		return *b.modelAttribution.Load()
+	})
+}
+
+// refreshModelAttribution re-resolves the server -> model mapping from the
+// given stack. Called at build time and from the hot-reload hook so `model:`
+// and `default_model:` edits take effect on the next observed call.
+func (b *GatewayBuilder) refreshModelAttribution(cfg *config.Stack) {
+	attribution := cfg.ModelAttribution()
+	b.modelAttribution.Store(&attribution)
+}
+
 // buildTracingConfig extracts tracing config from gateway config with defaults.
 func buildTracingConfig(gw *config.GatewayConfig) *tracing.Config {
 	cfg := tracing.DefaultConfig()
@@ -841,6 +874,9 @@ func (b *GatewayBuilder) setupHotReload(ctx context.Context, inst *GatewayInstan
 		// Re-resolve the per-client access policy from the reloaded config so a
 		// `clients:` change takes effect on the next tools/list and tools/call.
 		inst.Gateway.SetClientAccessPolicy(mcp.NewClientAccessPolicy(clientAccessSpec(newCfg)))
+		// Re-resolve cost attribution so `model:` / `default_model:` edits
+		// price subsequent calls without a restart.
+		b.refreshModelAttribution(newCfg)
 		b.applyTelemetryConfig(inst.APIServer, handler)
 	})
 	inst.APIServer.SetReloadHandler(reloadHandler)

--- a/pkg/controller/model_attribution_test.go
+++ b/pkg/controller/model_attribution_test.go
@@ -1,0 +1,148 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/gridctl/gridctl/internal/api"
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/metrics"
+	"github.com/gridctl/gridctl/pkg/pricing"
+	"github.com/gridctl/gridctl/pkg/runtime"
+	"github.com/gridctl/gridctl/pkg/token"
+)
+
+// staticPricingSource is a deterministic pricing.Source for wiring tests.
+type staticPricingSource struct {
+	rates map[string]pricing.Rates
+}
+
+func (s staticPricingSource) Lookup(model string) (pricing.Rates, bool) {
+	r, ok := s.rates[model]
+	return r, ok
+}
+
+func (s staticPricingSource) Name() string { return "controller-test-fixture" }
+
+func newAttributionFixture(t *testing.T, stack *config.Stack) (*GatewayBuilder, *metrics.Observer, *metrics.Accumulator, *api.Server) {
+	t.Helper()
+	prev := pricing.CurrentSource()
+	t.Cleanup(func() { pricing.SetSource(prev) })
+	pricing.SetSource(staticPricingSource{rates: map[string]pricing.Rates{
+		"claude-fixture": {InputPerToken: 3e-6, OutputPerToken: 15e-6},
+		"fallback-model": {InputPerToken: 1e-6, OutputPerToken: 5e-6},
+	}})
+
+	builder := NewGatewayBuilder(Config{}, stack, "/path/stack.yaml", nil, &runtime.UpResult{})
+	acc := metrics.NewAccumulator(100)
+	observer := metrics.NewObserver(token.NewHeuristicCounter(4), acc)
+	apiServer := api.NewServer(mcp.NewGateway(), nil)
+	builder.wireModelAttribution(observer, apiServer)
+	return builder, observer, acc, apiServer
+}
+
+func observeCall(observer *metrics.Observer, serverName string) {
+	observer.ObserveToolCall(serverName, -1, map[string]any{"q": "hello"},
+		&mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent("response")}})
+}
+
+// TestWireModelAttribution_RecordsCostWithoutManualWiring is the regression
+// test for the original defect: production code never called
+// SetModelResolver, so cost stayed zero in every deployment. A tool call
+// observed through the builder-wired observer must record cost with no
+// test-side resolver setup.
+func TestWireModelAttribution_RecordsCostWithoutManualWiring(t *testing.T) {
+	stack := &config.Stack{
+		Name: "test",
+		MCPServers: []config.MCPServer{
+			{Name: "a", Model: "claude-fixture"},
+			{Name: "b"},
+		},
+	}
+	_, observer, acc, _ := newAttributionFixture(t, stack)
+
+	observeCall(observer, "a")
+
+	snap := acc.CostSnapshot()
+	if snap.Session.TotalUSD <= 0 {
+		t.Fatal("expected non-zero session cost for a model-attributed server")
+	}
+	if snap.PerServer["a"].TotalUSD <= 0 {
+		t.Error("expected non-zero per-server cost for server a")
+	}
+
+	// Server b has no attribution: tokens record, cost does not move.
+	before := snap.Session.TotalUSD
+	observeCall(observer, "b")
+	after := acc.CostSnapshot().Session.TotalUSD
+	if after != before {
+		t.Errorf("unattributed server moved session cost: %v -> %v", before, after)
+	}
+	if acc.Snapshot().PerServer["b"].TotalTokens == 0 {
+		t.Error("expected tokens recorded for unattributed server b")
+	}
+}
+
+// TestWireModelAttribution_DefaultModelFallback verifies a server without
+// its own model: prices against gateway.default_model.
+func TestWireModelAttribution_DefaultModelFallback(t *testing.T) {
+	stack := &config.Stack{
+		Name:       "test",
+		Gateway:    &config.GatewayConfig{DefaultModel: "fallback-model"},
+		MCPServers: []config.MCPServer{{Name: "b"}},
+	}
+	_, observer, acc, _ := newAttributionFixture(t, stack)
+
+	observeCall(observer, "b")
+
+	if acc.CostSnapshot().PerServer["b"].TotalUSD <= 0 {
+		t.Error("expected default_model to price calls for servers without model:")
+	}
+}
+
+// TestWireModelAttribution_NoModelsPreservesZeroCost pins Article IX: a
+// stack with no model configuration behaves exactly as before the fix —
+// tokens recorded, zero cost.
+func TestWireModelAttribution_NoModelsPreservesZeroCost(t *testing.T) {
+	stack := &config.Stack{
+		Name:       "test",
+		MCPServers: []config.MCPServer{{Name: "a"}, {Name: "b"}},
+	}
+	_, observer, acc, _ := newAttributionFixture(t, stack)
+
+	observeCall(observer, "a")
+	observeCall(observer, "b")
+
+	if got := acc.CostSnapshot().Session.TotalUSD; got != 0 {
+		t.Errorf("expected zero cost without attribution; got %v", got)
+	}
+	if acc.Snapshot().Session.TotalTokens == 0 {
+		t.Error("expected tokens recorded even without attribution")
+	}
+}
+
+// TestRefreshModelAttribution_HotReload verifies the onConfigApplied path: a
+// reloaded stack with a changed model prices subsequent calls against the
+// new mapping without rebuilding the observer.
+func TestRefreshModelAttribution_HotReload(t *testing.T) {
+	stack := &config.Stack{
+		Name:       "test",
+		MCPServers: []config.MCPServer{{Name: "b"}},
+	}
+	builder, observer, acc, _ := newAttributionFixture(t, stack)
+
+	observeCall(observer, "b")
+	if got := acc.CostSnapshot().Session.TotalUSD; got != 0 {
+		t.Fatalf("expected zero cost before attribution; got %v", got)
+	}
+
+	builder.refreshModelAttribution(&config.Stack{
+		Name:       "test",
+		MCPServers: []config.MCPServer{{Name: "b", Model: "claude-fixture"}},
+	})
+
+	observeCall(observer, "b")
+	if acc.CostSnapshot().PerServer["b"].TotalUSD <= 0 {
+		t.Error("expected reloaded model: to price subsequent calls")
+	}
+}

--- a/pkg/reload/diff.go
+++ b/pkg/reload/diff.go
@@ -1,6 +1,7 @@
 package reload
 
 import (
+	"maps"
 	"reflect"
 
 	"github.com/gridctl/gridctl/pkg/config"
@@ -16,6 +17,12 @@ type ConfigDiff struct {
 	// It needs an in-memory policy refresh (via the reload's onConfigApplied hook)
 	// but no container or network work, so it must still mark the diff non-empty.
 	ClientsChanged bool
+	// ModelAttributionChanged indicates the server -> model mapping used for
+	// cost attribution changed (a server's `model:` or the gateway's
+	// `default_model:`). Like ClientsChanged it needs only an in-memory
+	// refresh via the onConfigApplied hook — pricing metadata never warrants
+	// a container restart — but it must still mark the diff non-empty.
+	ModelAttributionChanged bool
 }
 
 // MCPServerDiff contains changes to MCP servers.
@@ -60,7 +67,8 @@ func (d *ConfigDiff) IsEmpty() bool {
 		len(d.Resources.Removed) == 0 &&
 		len(d.Resources.Modified) == 0 &&
 		!d.NetworkChanged &&
-		!d.ClientsChanged
+		!d.ClientsChanged &&
+		!d.ModelAttributionChanged
 }
 
 // ComputeDiff computes the differences between two stack configurations.
@@ -79,7 +87,18 @@ func ComputeDiff(old, new *config.Stack) *ConfigDiff {
 	// Detect per-client access (`clients:`) changes
 	diff.ClientsChanged = clientsChanged(old, new)
 
+	// Detect cost-attribution (`model:` / `default_model:`) changes
+	diff.ModelAttributionChanged = modelAttributionChanged(old, new)
+
 	return diff
+}
+
+// modelAttributionChanged reports whether the effective server -> model
+// mapping differs between two stacks. Comparing the resolved maps (rather
+// than raw fields) means a no-op edit — e.g. adding a per-server model:
+// identical to the gateway default_model — does not mark the diff non-empty.
+func modelAttributionChanged(old, new *config.Stack) bool {
+	return !maps.Equal(old.ModelAttribution(), new.ModelAttribution())
 }
 
 // clientsChanged reports whether the per-client access (`clients:`) block

--- a/pkg/reload/diff_test.go
+++ b/pkg/reload/diff_test.go
@@ -401,3 +401,78 @@ func TestComputeDiff_AutoscaleWithUnrelatedChangeIsRestart(t *testing.T) {
 	}
 }
 
+func TestComputeDiff_ModelAttributionOnlyChange(t *testing.T) {
+	servers := func(model string) []config.MCPServer {
+		return []config.MCPServer{{Name: "github", Image: "image1", Port: 3000, Model: model}}
+	}
+	old := &config.Stack{Name: "test", MCPServers: servers("")}
+	new := &config.Stack{Name: "test", MCPServers: servers("claude-opus-4-7")}
+
+	diff := ComputeDiff(old, new)
+
+	if !diff.ModelAttributionChanged {
+		t.Error("expected ModelAttributionChanged for a model-only edit")
+	}
+	if diff.IsEmpty() {
+		t.Error("model-only edit must mark the diff non-empty so onConfigApplied fires")
+	}
+	if len(diff.MCPServers.Modified) != 0 {
+		t.Errorf("Modified = %d, want 0 (pricing metadata must not restart the server)",
+			len(diff.MCPServers.Modified))
+	}
+}
+
+func TestComputeDiff_DefaultModelChange(t *testing.T) {
+	servers := []config.MCPServer{{Name: "github", Image: "image1", Port: 3000}}
+	old := &config.Stack{Name: "test", MCPServers: servers}
+	new := &config.Stack{
+		Name:       "test",
+		MCPServers: servers,
+		Gateway:    &config.GatewayConfig{DefaultModel: "claude-haiku-4-5"},
+	}
+
+	diff := ComputeDiff(old, new)
+
+	if !diff.ModelAttributionChanged {
+		t.Error("expected ModelAttributionChanged for a default_model edit")
+	}
+	if diff.IsEmpty() {
+		t.Error("default_model edit must mark the diff non-empty")
+	}
+}
+
+func TestComputeDiff_ModelAttributionUnchanged(t *testing.T) {
+	servers := []config.MCPServer{{Name: "github", Image: "image1", Port: 3000, Model: "claude-opus-4-7"}}
+	old := &config.Stack{Name: "test", MCPServers: servers}
+	new := &config.Stack{Name: "test", MCPServers: servers}
+
+	diff := ComputeDiff(old, new)
+
+	if diff.ModelAttributionChanged {
+		t.Error("identical model attribution must not flag a change")
+	}
+	if !diff.IsEmpty() {
+		t.Error("identical stacks must produce an empty diff")
+	}
+}
+
+func TestComputeDiff_RedundantPerServerModelIsNoOp(t *testing.T) {
+	// Adding a per-server model identical to the gateway default does not
+	// change the effective mapping, so the diff stays empty.
+	old := &config.Stack{
+		Name:       "test",
+		MCPServers: []config.MCPServer{{Name: "github", Image: "image1", Port: 3000}},
+		Gateway:    &config.GatewayConfig{DefaultModel: "claude-opus-4-7"},
+	}
+	new := &config.Stack{
+		Name:       "test",
+		MCPServers: []config.MCPServer{{Name: "github", Image: "image1", Port: 3000, Model: "claude-opus-4-7"}},
+		Gateway:    &config.GatewayConfig{DefaultModel: "claude-opus-4-7"},
+	}
+
+	diff := ComputeDiff(old, new)
+
+	if diff.ModelAttributionChanged {
+		t.Error("redundant per-server model must not flag a change")
+	}
+}

--- a/web/src/components/metrics/MetricsTab.tsx
+++ b/web/src/components/metrics/MetricsTab.tsx
@@ -44,6 +44,7 @@ export function MetricsTab() {
   const bottomPanelTab = useUIStore((s) => s.bottomPanelTab);
   const tokenUsage = useStackStore((s) => s.tokenUsage);
   const costUsage = useStackStore((s) => s.costUsage);
+  const costAttribution = useStackStore((s) => s.costAttribution);
   const metricsDetached = useUIStore((s) => s.metricsDetached);
   const { openDetachedWindow } = useWindowManager();
   const [timeRange, setTimeRange] = useState<TimeRange>('live');
@@ -188,6 +189,10 @@ export function MetricsTab() {
   // displaying "—" then matches the UX spec ("never a fabricated number").
   const sessionCostUSD = costUsage?.session.total_usd;
   const hasCost = sessionCostUSD !== undefined;
+  // Without model attribution the gateway cannot price calls, so cost stays
+  // absent or $0.00 forever. Surface the config hint instead of leaving the
+  // user to wonder whether traffic is free.
+  const showAttributionHint = !costAttribution && !(sessionCostUSD && sessionCostUSD > 0);
 
   const hasData =
     sessionTotal > 0 ||
@@ -400,7 +405,7 @@ export function MetricsTab() {
               <KPICard label="Input Tokens" value={sessionInput} colorClass="text-secondary" />
               <KPICard label="Output Tokens" value={sessionOutput} colorClass="text-primary" />
               <KPICard label="Total Tokens" value={sessionTotal} colorClass="text-text-primary" />
-              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} />
+              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} showHint={showAttributionHint} />
               {savingsPercent > 0 && (
                 <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
                   <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Format Savings</span>
@@ -593,8 +598,18 @@ function KPICard({ label, value, colorClass }: { label: string; value: number; c
 // hasn't priced any calls yet (per the UX spec: never show a fabricated
 // number). The icon stays muted-by-default; the value carries the accent
 // so the card reads as "cost-flavored" without competing with the amber
-// Output KPI to its left.
-function CostKPICard({ usd, hasCost }: { usd: number | undefined; hasCost: boolean }) {
+// Output KPI to its left. When no server has model attribution configured
+// (showHint), a one-line pointer explains how to enable estimates — without
+// it, cost can never populate and the dash/$0.00 reads as "free."
+function CostKPICard({
+  usd,
+  hasCost,
+  showHint,
+}: {
+  usd: number | undefined;
+  hasCost: boolean;
+  showHint?: boolean;
+}) {
   return (
     <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
       <span className="text-[10px] text-text-muted uppercase tracking-wider flex items-center gap-1 mb-1">
@@ -609,6 +624,11 @@ function CostKPICard({ usd, hasCost }: { usd: number | undefined; hasCost: boole
       >
         {hasCost ? formatUSD(usd ?? 0) : '—'}
       </span>
+      {showHint && (
+        <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
+          Set <code className="font-mono">model:</code> in stack.yaml to enable estimates
+        </span>
+      )}
     </div>
   );
 }

--- a/web/src/pages/DetachedMetricsPage.tsx
+++ b/web/src/pages/DetachedMetricsPage.tsx
@@ -84,6 +84,7 @@ const TIME_RANGES: { value: TimeRange; label: string }[] = [
 function DetachedMetricsPageContent() {
   const [tokenUsage, setTokenUsage] = useState<TokenUsage | null>(null);
   const [costUsage, setCostUsage] = useState<CostUsage | null>(null);
+  const [costAttribution, setCostAttribution] = useState(false);
   const [timeRange, setTimeRange] = useState<TimeRange>('live');
   const [isPaused, setIsPaused] = useState(false);
   const [metricsData, setMetricsData] = useState<TokenMetricsResponse | null>(null);
@@ -108,6 +109,7 @@ function DetachedMetricsPageContent() {
         const status: GatewayStatus = await fetchStatus();
         setTokenUsage(status.token_usage ?? null);
         setCostUsage(status.cost ?? null);
+        setCostAttribution(status.cost_attribution ?? false);
       } catch {
         // Ignore status errors
       }
@@ -209,6 +211,9 @@ function DetachedMetricsPageContent() {
   const savedTokens = tokenUsage?.format_savings.saved_tokens ?? 0;
   const sessionCostUSD = costUsage?.session.total_usd;
   const hasCost = sessionCostUSD !== undefined;
+  // Mirrors MetricsTab: without model attribution the gateway cannot price
+  // calls, so explain the config requirement instead of a bare dash/$0.00.
+  const showAttributionHint = !costAttribution && !(sessionCostUSD && sessionCostUSD > 0);
   const hasData =
     sessionTotal > 0 ||
     (metricsData?.data_points?.length ?? 0) > 0 ||
@@ -434,7 +439,7 @@ function DetachedMetricsPageContent() {
               <KPICard label="Input Tokens" value={sessionInput} colorClass="text-secondary" />
               <KPICard label="Output Tokens" value={sessionOutput} colorClass="text-primary" />
               <KPICard label="Total Tokens" value={sessionTotal} colorClass="text-text-primary" />
-              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} />
+              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} showHint={showAttributionHint} />
               {savingsPercent > 0 && (
                 <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
                   <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Format Savings</span>
@@ -600,7 +605,15 @@ function KPICard({ label, value, colorClass }: { label: string; value: number; c
   );
 }
 
-function CostKPICard({ usd, hasCost }: { usd: number | undefined; hasCost: boolean }) {
+function CostKPICard({
+  usd,
+  hasCost,
+  showHint,
+}: {
+  usd: number | undefined;
+  hasCost: boolean;
+  showHint?: boolean;
+}) {
   return (
     <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
       <span className="text-[10px] text-text-muted uppercase tracking-wider flex items-center gap-1 mb-1">
@@ -615,6 +628,11 @@ function CostKPICard({ usd, hasCost }: { usd: number | undefined; hasCost: boole
       >
         {hasCost ? formatUSD(usd ?? 0) : '—'}
       </span>
+      {showHint && (
+        <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
+          Set <code className="font-mono">model:</code> in stack.yaml to enable estimates
+        </span>
+      )}
     </div>
   );
 }

--- a/web/src/stores/useStackStore.ts
+++ b/web/src/stores/useStackStore.ts
@@ -60,6 +60,7 @@ interface StackState {
   codeMode: string | null;  // Gateway code mode status ("on" when active)
   tokenUsage: TokenUsage | null; // Token usage metrics from status response
   costUsage: CostUsage | null;   // USD cost snapshot; null when no cost recorded
+  costAttribution: boolean; // True when any server has a model: configured for pricing
   stackName: string;        // Active stack name; empty string in stackless mode
 
   // === React Flow State ===
@@ -117,6 +118,7 @@ export const useStackStore = create<StackState>()(
     codeMode: null,
     tokenUsage: null,
     costUsage: null,
+    costAttribution: false,
     stackName: '',
     nodes: [],
     edges: [],
@@ -149,6 +151,7 @@ export const useStackStore = create<StackState>()(
         codeMode: status.code_mode || null,
         tokenUsage: status.token_usage ?? null,
         costUsage: status.cost ?? null,
+        costAttribution: status.cost_attribution ?? false,
         stackName: status.stack_name || '',
         autoscaleHistory: folded.history,
         autoscaleDecisions: folded.decisions,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -217,6 +217,7 @@ export interface GatewayStatus {
   code_mode?: string;      // "on" when code mode is active (omitted when off)
   token_usage?: TokenUsage; // Token usage metrics (omitted if no accumulator)
   cost?: CostUsage;        // Cost snapshot (omitted until any cost is recorded)
+  cost_attribution?: boolean; // True when any server has a model: configured for pricing
   stack_name?: string;     // Active stack name; omitted in stackless mode
 }
 


### PR DESCRIPTION
## Description

Cost observability never produced data: the pricing pipeline (rates, accumulator, API, UI, optimize heuristics, cost spans) was fully built, but no production code ever installed a model resolver on the metrics observer, so every deployment recorded zero cost forever. This PR adds the missing attribution trigger: an optional per-server `model:` field plus a `gateway.default_model` fallback in stack.yaml, wired into the observer at gateway build time.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `model:` (per server) and `gateway.default_model` stack.yaml fields; `Stack.ModelAttribution()` resolves the effective server-to-model map (server field wins, then default, then no attribution)
- Gateway builder installs the resolver on the metrics observer behind an atomic pointer; the hot-reload `onConfigApplied` hook swaps the mapping without racing in-flight observations
- `ModelAttributionChanged` diff flag: model edits hot-reload via in-memory refresh with no container restart (same pattern as `clients:` changes), which also makes `default_model` hot-reloadable
- `lookupModelStats` stub implemented so `expensive_model_on_cheap_task` reads real rates and names the model
- `/api/status` gains an additive `cost_attribution` boolean; the Metrics tab cost card (and detached popout) show a "set `model:` to enable estimates" hint instead of a bare dash/$0.00 when unconfigured
- Docs: config schema rows, cost-observability attribution section (stale "ships in follow-up PRs" framing removed), example stack, changelog entry

Stacks without a model behave exactly as before: tokens recorded, zero cost (pinned by test).

## Testing

- New regression test proves a builder-wired observer records non-zero cost with no test-side `SetModelResolver` (the original defect)
- Tests for default-model fallback, zero-config back-compat, hot-reload re-pricing, diff detection (including redundant-model no-op), YAML round-trip, and model-stats lookup
- `go test ./...`, `golangci-lint run` (0 issues), `tsc --noEmit`, and 965 frontend tests pass; `make build` succeeds
- Verify manually: set `model: claude-opus-4-7` on a server, make tool calls, check `cost` in `GET /api/status` and the Metrics tab cost KPI

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #771