### PR TITLE
feat: per-client model attribution for cost observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Per-client model attribution for cost observability.** A new top-level
+  `client_models:` map in stack.yaml declares which model each client runs
+  (e.g. `claude-code: claude-opus-4-7`), and the gateway prices that client's
+  tool calls at those rates ahead of the per-server `model:` and
+  `gateway.default_model` tiers — so multi-client stacks (Claude Code on Opus,
+  Gemini CLI on Gemini, sharing the same servers) get correctly attributed
+  per-client cost. The map is pricing-only and access-inert: it never requires
+  a `clients:` block and never restricts any client. Edits hot-reload without
+  restarting servers. The Metrics tab's Top Clients panel gains a Model column
+  showing each declared client's model with provenance and inline editing
+  backed by the new `GET /api/pricing/models` known-models list and a
+  dedicated `PUT /api/clients/{slug}/model` endpoint (atomic, comment-
+  preserving YAML writes). `gridctl validate` now warns (never errors) on
+  model IDs unknown to the pricing snapshot and on `client_models` keys that
+  are not normalized client IDs. Stacks without the map behave exactly as
+  before; anonymous calls keep pricing via the server/default tiers.
+
 - **Reconcile and edit git-sourced skills in the Library.** The Library now
   surfaces local edits to imported skills and lets you reconcile them. Skill
   cards, the detail panel, and the editor show a "Modified" badge when a tracked

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -740,6 +740,44 @@ policy (deny); the editor warns before that happens. Finer tool-level
 allow-lists (`tools:`) are enforced by the gateway but edited directly in
 stack.yaml.
 
+Declaring which model a client runs for cost estimates is a separate,
+access-inert concern — see [Client Models](#client-models-pricing-attribution)
+below.
+
+---
+
+## Client Models (pricing attribution)
+
+The optional top-level `client_models:` map declares which model each
+connecting client runs, purely for cost attribution: tool calls from a
+declared client are priced at that model's rates. This is **pricing, not
+access** — the map never requires a `clients:` block, never restricts any
+client, and has zero effect on the access policy described in
+[Clients](#clients-per-client-access-scoping) above (which is access, not
+pricing).
+
+```yaml
+gateway:
+  default_model: claude-haiku-4-5   # pricing floor for anything not declared
+
+client_models:
+  claude-code: claude-opus-4-7
+  gemini-cli: gemini-2.5-pro
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `client_models` | map | No | - | Stable client identifier → model ID used to price that client's tool calls. Keys are the same identifiers used by `clients.profiles` and shown on the topology (e.g. `claude-code`). Values are model IDs from the embedded LiteLLM pricing snapshot (e.g. `claude-opus-4-7`) |
+
+Pricing resolution per tool call, highest precedence first: call-level usage
+metadata (when a server reports one) > the calling client's `client_models`
+entry > the target server's `model:` > `gateway.default_model`. Unknown model
+IDs and keys that are not normalized client IDs surface as validation
+warnings (never errors) and price as zero. Edits hot-reload without
+restarting any server. The Metrics tab's Top Clients panel shows each
+declared client's model and lets you edit it inline; see
+[Cost Observability](cost-observability.md) for semantics and limitations.
+
 ---
 
 ## Skill Sources

--- a/docs/cost-observability.md
+++ b/docs/cost-observability.md
@@ -4,23 +4,36 @@ Gridctl prices every observed tool call against an embedded snapshot of LiteLLM'
 
 ## Model attribution (required for cost data)
 
-Pricing a call requires knowing which model the tokens are billed against. The gateway sits below the LLM client and cannot observe the client's model choice, so attribution is declared in `stack.yaml`: a per-server `model` field, with a stack-wide `gateway.default_model` fallback for servers that do not set their own.
+Pricing a call requires knowing which model the tokens are billed against. The gateway sits below the LLM client and cannot observe the client's model choice — and the MCP protocol never carries it — so attribution is declared in `stack.yaml`. Resolution per tool call, highest precedence first:
+
+| Precedence | Source | Declared where |
+|---|---|---|
+| 1 | Call-level usage metadata | Reported by the MCP server per call (no standardized wire shape yet; inert today) |
+| 2 | Calling client's model | Top-level `client_models:` map |
+| 3 | Target server's model | `model:` on the server entry |
+| 4 | Stack-wide default | `gateway.default_model` |
+
+The client tier exists because a model is a property of the calling client's session, not the tool server: when Claude Code on Opus and Gemini CLI on Gemini share the same servers, only a per-client declaration prices both correctly. `client_models:` is purely a pricing declaration — it never creates or implies access restrictions (that is the separate `clients:` block).
 
 ```yaml
 gateway:
-  default_model: claude-haiku-4-5   # prices any server without its own model
+  default_model: claude-haiku-4-5   # floor for anything not declared below
+
+client_models:
+  claude-code: claude-opus-4-7      # this client's calls price as Opus
+  gemini-cli: gemini-2.5-pro        # regardless of which server they hit
 
 mcp-servers:
   - name: jira
     image: mcp/atlassian:latest
-    model: claude-opus-4-7          # overrides the default for this server
+    model: claude-opus-4-7          # prices undeclared clients' calls to this server
 ```
 
-Without attribution, tokens and latency record normally but cost stays zero, and the dashboard's cost card shows a configuration hint instead of a number. Resolution is per server: the server's own `model` wins, then `gateway.default_model`, then no attribution (pricing skipped for that server's calls). Edits to either field hot-reload through the file watcher without restarting any server; subsequent calls price against the updated mapping.
+Without any attribution, tokens and latency record normally but cost stays zero, and the dashboard's cost card shows a configuration hint instead of a number. Anonymous calls (no client identity on the session) skip the client tier and resolve via the server tier. Edits to any of these fields hot-reload through the file watcher without restarting any server; subsequent calls price against the updated mapping. The Metrics tab's Top Clients panel shows each declared client's model with `· client` provenance and supports inline editing backed by the known-models list (`GET /api/pricing/models`); clients without a declaration aggregate whatever server/default rates their calls hit, so no single model is shown for them.
 
-A tool result that carries its own model in usage metadata takes precedence over the configured mapping at the call level. The MCP wire shape for that metadata is not yet standardized, so configured attribution is the operative path today.
+Two limitations to keep expectations honest. A declared client model is a session-level default: the gateway cannot see a mid-session model switch (e.g. `/model` in Claude Code), so calls keep pricing at the declared model until the declaration changes. And validation is soft by design: model IDs unknown to the pricing snapshot, or `client_models` keys that are not normalized client IDs (`gridctl validate` warns and suggests the canonical form), produce warnings — never errors — and price as zero.
 
-Cost figures are estimates — tokenizer-approximated counts multiplied by published list rates. They are built for comparing servers, spotting waste, and trending over time, not for reconciling invoices.
+Cost figures are estimates — tokenizer-approximated counts multiplied by published list rates. They are built for comparing servers and clients, spotting waste, and trending over time, not for reconciling invoices.
 
 ## Refreshing pricing data
 

--- a/examples/access-control/per-client-scoping.yaml
+++ b/examples/access-control/per-client-scoping.yaml
@@ -59,3 +59,12 @@ clients:
         - "Custom Agent"
       servers:
         - gitlab
+
+# Cost attribution (pricing, not access): declare which model each client
+# runs so its tool calls are priced at that model's rates. Keys are the same
+# stable client IDs the profiles above use. This map is independent of the
+# clients: block — it never restricts anything, and works in stacks with no
+# clients: block at all.
+client_models:
+  claude-code: claude-opus-4-7
+  cursor: claude-sonnet-4-6

--- a/examples/getting-started/mcp-basic.yaml
+++ b/examples/getting-started/mcp-basic.yaml
@@ -12,10 +12,16 @@
 version: "1"
 name: mcp-basic
 
-# Cost attribution: declaring which model your client runs lets the gateway
-# price tool calls against embedded LiteLLM rates (estimates, not billing
-# truth). default_model covers every server; a per-server `model:` overrides
-# it. Omit both and cost stays zero (tokens still record).
+# Cost attribution: declaring a model lets the gateway price tool calls
+# against embedded LiteLLM rates (estimates, not billing truth). Omit every
+# model declaration and cost stays zero (tokens still record).
+# default_model covers every server; a per-server `model:` overrides it. With
+# multiple clients on different model tiers, declare per client instead via a
+# top-level `client_models:` map (it outranks both and never affects access):
+#
+# client_models:
+#   claude-code: claude-opus-4-7
+#   gemini-cli: gemini-2.5-pro
 gateway:
   default_model: claude-opus-4-7
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -53,9 +53,15 @@ type Server struct {
 	tokenizerName string // active tokenizer mode: "embedded" or "api"
 
 	// modelAttribution returns the server -> model mapping used to price
-	// tool calls. Nil (or an empty map) means no cost attribution is
-	// configured. Must be safe for concurrent calls.
+	// tool calls. Nil (or an empty map) means no server-level cost
+	// attribution is configured. Must be safe for concurrent calls.
 	modelAttribution func() map[string]string
+
+	// clientModelAttribution returns the client ID -> model mapping
+	// (stack.yaml client_models) used to price tool calls by calling
+	// client. Nil (or an empty map) means no client-level attribution is
+	// configured. Must be safe for concurrent calls.
+	clientModelAttribution func() map[string]string
 
 	// startWatcher, when set, starts a file watcher on the given stack path.
 	// Injected by GatewayBuilder so POST /api/stack/initialize can activate live reload.
@@ -191,6 +197,15 @@ func (s *Server) SetModelAttribution(get func() map[string]string) {
 	s.modelAttribution = get
 }
 
+// SetClientModelAttribution sets a getter for the client ID -> model mapping
+// (stack.yaml client_models) used to price tool calls by calling client.
+// Same contract as SetModelAttribution: the getter follows hot reloads and
+// must be safe for concurrent calls. Feeds the /api/status client_models
+// exposure, the cost_attribution flag, and the /api/clients model field.
+func (s *Server) SetClientModelAttribution(get func() map[string]string) {
+	s.clientModelAttribution = get
+}
+
 // modelAttributionMap returns the current server -> model mapping, or nil
 // when no attribution getter is wired or nothing is configured.
 func (s *Server) modelAttributionMap() map[string]string {
@@ -198,6 +213,15 @@ func (s *Server) modelAttributionMap() map[string]string {
 		return nil
 	}
 	return s.modelAttribution()
+}
+
+// clientModelAttributionMap returns the current client -> model mapping, or
+// nil when no attribution getter is wired or nothing is configured.
+func (s *Server) clientModelAttributionMap() map[string]string {
+	if s.clientModelAttribution == nil {
+		return nil
+	}
+	return s.clientModelAttribution()
 }
 
 // SetStartWatcher sets a callback that activates live-reload file watching for
@@ -267,7 +291,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/traces/{traceId}", s.handleTraces)
 	mux.HandleFunc("POST /api/clients/{slug}/scope/preview", s.handleClientScopePreview)
 	mux.HandleFunc("PUT /api/clients/{slug}/scope", s.handleSetClientScope)
+	mux.HandleFunc("PUT /api/clients/{slug}/model", s.handleSetClientModel)
 	mux.HandleFunc("/api/clients", s.handleClients)
+	mux.HandleFunc("GET /api/pricing/models", s.handlePricingModels)
 	mux.HandleFunc("/api/reload", s.handleReload)
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("/ready", s.handleReady)
@@ -405,11 +431,16 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		CodeMode   string                   `json:"code_mode,omitempty"`
 		TokenUsage *metrics.TokenUsage      `json:"token_usage,omitempty"`
 		Cost       *metrics.CostUsage       `json:"cost,omitempty"`
-		// CostAttribution reports whether any server has a model configured
-		// for pricing. False lets the UI explain why cost stays empty
-		// (set `model:` in stack.yaml) instead of showing a bare $0.00.
-		CostAttribution bool   `json:"cost_attribution,omitempty"`
-		StackName       string `json:"stack_name,omitempty"`
+		// CostAttribution reports whether any client or server has a model
+		// configured for pricing. False lets the UI explain why cost stays
+		// empty (set `client_models:` or `model:` in stack.yaml) instead of
+		// showing a bare $0.00.
+		CostAttribution bool `json:"cost_attribution,omitempty"`
+		// ClientModels is the declared client ID -> model pricing map from
+		// stack.yaml client_models. Omitted when empty. The UI uses it to
+		// label per-client cost with the model it was priced as.
+		ClientModels map[string]string `json:"client_models,omitempty"`
+		StackName    string            `json:"stack_name,omitempty"`
 	}{
 		Gateway: ServerInfo{
 			Name:      s.gateway.ServerInfo().Name,
@@ -440,7 +471,8 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 			status.Cost = &cost
 		}
 	}
-	status.CostAttribution = len(s.modelAttributionMap()) > 0
+	status.ClientModels = s.clientModelAttributionMap()
+	status.CostAttribution = len(s.modelAttributionMap()) > 0 || len(status.ClientModels) > 0
 
 	writeJSON(w, status)
 }
@@ -1022,6 +1054,10 @@ type ClientStatus struct {
 	Linked     bool   `json:"linked"`
 	Transport  string `json:"transport"`
 	ConfigPath string `json:"configPath,omitempty"`
+	// Model is the client's declared pricing model from stack.yaml
+	// client_models, when present. Pricing attribution only — it carries no
+	// access-control meaning and is independent of EffectiveScope.
+	Model string `json:"model,omitempty"`
 	// EffectiveScope is the backend-computed per-client tool access scope when a
 	// `clients:` block is configured: the servers and prefixed tools this client
 	// can reach. nil when no access scoping is in effect, so the frontend can
@@ -1048,6 +1084,7 @@ func (s *Server) handleClients(w http.ResponseWriter, r *http.Request) {
 	}
 
 	scopingOn := s.gateway != nil && s.gateway.ClientAccessConfigured()
+	clientModels := s.clientModelAttributionMap()
 
 	infos := s.provisioners.AllClientInfo(serverName)
 	statuses := make([]ClientStatus, 0, len(infos))
@@ -1059,6 +1096,7 @@ func (s *Server) handleClients(w http.ResponseWriter, r *http.Request) {
 			Linked:     info.Linked,
 			Transport:  info.Transport,
 			ConfigPath: info.ConfigPath,
+			Model:      clientModels[info.Slug],
 		}
 		// Surface the backend-computed effective scope keyed on the client's
 		// stable identifier (its slug, which is what `gridctl link` assigns and

--- a/internal/api/clients_model.go
+++ b/internal/api/clients_model.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// setClientModelRequest is the wire shape for PUT /api/clients/{slug}/model.
+// Model is the pricing model ID for this client (e.g. "claude-opus-4-7");
+// an empty string removes the client's entry from client_models. Unknown
+// model IDs are accepted — pricing is best-effort and validation surfaces
+// them as load-time warnings, never hard errors.
+type setClientModelRequest struct {
+	Model string `json:"model"`
+}
+
+// setClientModelResponse is the success payload.
+type setClientModelResponse struct {
+	Client     string `json:"client"`
+	ProfileKey string `json:"profileKey"`
+	Model      string `json:"model"`
+	Reloaded   bool   `json:"reloaded"`
+	ReloadedAt string `json:"reloadedAt,omitempty"`
+}
+
+// handleSetClientModel writes a single client's pricing model into the live
+// stack YAML's top-level `client_models:` map and triggers a hot reload.
+// This is deliberately a separate path from the access-scope endpoint: a
+// model declaration is pricing attribution only and must never create or
+// touch a `clients:` block (whose presence flips the stack into default-deny
+// access semantics). The YAML write is atomic and conflict-detected: an
+// external edit between read and write surfaces as 409 so the UI can
+// re-fetch.
+//
+// PUT /api/clients/{slug}/model
+func (s *Server) handleSetClientModel(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	if slug == "" {
+		writeJSONError(w, "Client slug is required", http.StatusBadRequest)
+		return
+	}
+	clientKey := mcp.NormalizeClientID(slug)
+	if clientKey == "" {
+		writeStructuredError(w, http.StatusBadRequest, errCodeInvalidClient,
+			"Client identifier is empty after normalization.",
+			"Provide a non-empty client slug.")
+		return
+	}
+
+	if s.stackFile == "" {
+		writeJSONError(w, "No stack file configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, setToolsRequestMaxBytes))
+	if err != nil {
+		writeJSONError(w, "Failed to read request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	var req setClientModelRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	switch err := setClientModel(s.stackFile, clientKey, req.Model); {
+	case err == nil:
+		// proceed
+	case errors.Is(err, errStackModified):
+		writeStructuredError(w, http.StatusConflict, errCodeStackModified,
+			"The stack file was modified outside the canvas.",
+			"Reload the file to see the latest contents, then re-apply your changes.")
+		return
+	default:
+		slog.Default().Warn("client model write failed", "client", clientKey, "error", err)
+		writeJSONError(w, "Failed to update stack: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	slog.Default().Info("client pricing model updated", "client", clientKey, "model", req.Model)
+
+	resp := setClientModelResponse{
+		Client:     slug,
+		ProfileKey: clientKey,
+		Model:      req.Model,
+	}
+
+	if s.reloadHandler != nil {
+		result, err := s.reloadHandler.Reload(r.Context())
+		if err != nil {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed, err.Error(),
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+		if !result.Success {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed, result.Message,
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+		resp.Reloaded = true
+		resp.ReloadedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	writeJSON(w, resp)
+}
+
+// setClientModel writes (or removes, when model is empty) the pricing model
+// for clientKey in the stack YAML's top-level `client_models:` map at path.
+// It mirrors setClientScope: it serializes concurrent callers on the same
+// path, detects external edits via a pre-read hash vs. pre-write re-read,
+// and writes atomically. Comments, ordering, and unrelated keys survive the
+// yaml.Node round-trip.
+func setClientModel(path, clientKey, model string) error {
+	if path == "" {
+		return errStackFileEmpty
+	}
+
+	mu := stackFileLock(path)
+	mu.Lock()
+	defer mu.Unlock()
+
+	original, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read stack file: %w", err)
+	}
+	originalHash := sha256.Sum256(original)
+
+	updated, err := patchClientModels(original, clientKey, model)
+	if err != nil {
+		return err
+	}
+
+	fireBetweenReadsHook()
+
+	current, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("re-read stack file: %w", err)
+	}
+	if sha256.Sum256(current) != originalHash {
+		return errStackModified
+	}
+
+	return atomicWrite(path, updated)
+}
+
+// patchClientModels rewrites the YAML source so the top-level
+// `client_models:` map carries (or drops) the given client's model. An empty
+// model deletes the client's key — never writing `model: ""` — and removes
+// the whole `client_models:` mapping when it empties, so a fully cleared
+// stack round-trips back to its pre-feature shape. The `clients:` access
+// block is never touched.
+func patchClientModels(source []byte, clientKey, model string) ([]byte, error) {
+	if clientKey == "" {
+		return nil, fmt.Errorf("client key must not be empty")
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(source, &root); err != nil {
+		return nil, fmt.Errorf("parse stack yaml: %w", err)
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil, fmt.Errorf("parse stack yaml: not a document")
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse stack yaml: top-level not a mapping")
+	}
+
+	if model == "" {
+		// Removal path: nothing to do when the map (or the key) is absent.
+		modelsNode := findMappingValue(doc, "client_models")
+		if modelsNode != nil && modelsNode.Kind == yaml.MappingNode {
+			removeMappingKey(modelsNode, clientKey)
+			if len(modelsNode.Content) == 0 {
+				removeMappingKey(doc, "client_models")
+			}
+		}
+	} else {
+		modelsNode, err := ensureChildMapping(doc, "client_models")
+		if err != nil {
+			return nil, err
+		}
+		replaceOrInsertScalar(modelsNode, clientKey, model)
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// replaceOrInsertScalar sets mapping[key] to a string scalar, replacing an
+// existing value or appending the key.
+func replaceOrInsertScalar(mapping *yaml.Node, key, value string) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			mapping.Content[i+1] = scalarNode(value)
+			return
+		}
+	}
+	mapping.Content = append(mapping.Content, scalarNode(key), scalarNode(value))
+}
+
+// removeMappingKey deletes key (and its value) from a mapping node. No-op
+// when the key is absent.
+func removeMappingKey(mapping *yaml.Node, key string) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			mapping.Content = append(mapping.Content[:i], mapping.Content[i+2:]...)
+			return
+		}
+	}
+}

--- a/internal/api/clients_model_test.go
+++ b/internal/api/clients_model_test.go
@@ -1,0 +1,274 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestPatchClientModels_InsertIntoFreshMap(t *testing.T) {
+	source := []byte(`# my stack
+name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+    port: 3000
+`)
+	out, err := patchClientModels(source, "claude-code", "claude-opus-4-7")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "client_models:") || !strings.Contains(got, "claude-code: claude-opus-4-7") {
+		t.Errorf("expected client_models entry; got:\n%s", got)
+	}
+	if !strings.Contains(got, "# my stack") {
+		t.Errorf("comment lost:\n%s", got)
+	}
+	if strings.Contains(got, "clients:") {
+		t.Errorf("model patch must never create a clients: access block:\n%s", got)
+	}
+}
+
+func TestPatchClientModels_ReplaceExisting(t *testing.T) {
+	source := []byte(`name: test
+client_models:
+  claude-code: claude-opus-4-7   # primary client
+  gemini-cli: gemini-2.5-pro
+`)
+	out, err := patchClientModels(source, "claude-code", "claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "claude-code: claude-haiku-4-5") {
+		t.Errorf("expected replaced model; got:\n%s", got)
+	}
+	if !strings.Contains(got, "gemini-cli: gemini-2.5-pro") {
+		t.Errorf("sibling entry lost:\n%s", got)
+	}
+}
+
+func TestPatchClientModels_ClearDeletesKey(t *testing.T) {
+	source := []byte(`name: test
+client_models:
+  claude-code: claude-opus-4-7
+  gemini-cli: gemini-2.5-pro
+`)
+	out, err := patchClientModels(source, "claude-code", "")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "claude-code") {
+		t.Errorf("cleared key must be deleted, never written as empty:\n%s", got)
+	}
+	if !strings.Contains(got, "gemini-cli: gemini-2.5-pro") {
+		t.Errorf("sibling entry lost:\n%s", got)
+	}
+}
+
+func TestPatchClientModels_ClearLastEntryDropsMap(t *testing.T) {
+	source := []byte(`name: test
+client_models:
+  claude-code: claude-opus-4-7
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+    port: 3000
+`)
+	out, err := patchClientModels(source, "claude-code", "")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "client_models") {
+		t.Errorf("emptied client_models map must be removed entirely:\n%s", got)
+	}
+	// The result must remain a loadable stack with siblings intact.
+	var roundTrip map[string]any
+	if err := yaml.Unmarshal(out, &roundTrip); err != nil {
+		t.Fatalf("output is not valid YAML: %v", err)
+	}
+	if roundTrip["name"] != "test" {
+		t.Errorf("sibling keys lost: %v", roundTrip)
+	}
+}
+
+func TestPatchClientModels_ClearAbsentKeyIsNoOp(t *testing.T) {
+	source := []byte("name: test\n")
+	out, err := patchClientModels(source, "claude-code", "")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if strings.Contains(string(out), "client_models") {
+		t.Errorf("clearing an absent key must not create the map:\n%s", out)
+	}
+}
+
+func TestHandleSetClientModel_RoundTrip(t *testing.T) {
+	srv := newTestServer(t)
+	stackFile := writeTempStack(t, `name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+    port: 3000
+`)
+	srv.SetStackFile(stackFile)
+	handler := srv.Handler()
+
+	// Set.
+	req := httptest.NewRequest(http.MethodPut, "/api/clients/claude-code/model",
+		strings.NewReader(`{"model":"claude-opus-4-7"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp setClientModelResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ProfileKey != "claude-code" || resp.Model != "claude-opus-4-7" {
+		t.Errorf("response = %+v", resp)
+	}
+	assertStackContains(t, stackFile, "claude-code: claude-opus-4-7")
+
+	// Clear.
+	req = httptest.NewRequest(http.MethodPut, "/api/clients/claude-code/model",
+		strings.NewReader(`{"model":""}`))
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertStackNotContains(t, stackFile, "client_models")
+}
+
+func TestHandleSetClientModel_NormalizesSlug(t *testing.T) {
+	srv := newTestServer(t)
+	stackFile := writeTempStack(t, "name: test\n")
+	srv.SetStackFile(stackFile)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/clients/Claude%20Code/model",
+		strings.NewReader(`{"model":"claude-opus-4-7"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertStackContains(t, stackFile, "claude-code: claude-opus-4-7")
+}
+
+func TestHandleSetClientModel_NoStackFile(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/clients/claude-code/model",
+		strings.NewReader(`{"model":"claude-opus-4-7"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestHandlePricingModels(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/pricing/models", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var resp pricingModelsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Source == "" {
+		t.Error("expected a source name")
+	}
+	if resp.Models == nil {
+		t.Error("models must be a JSON array, never null")
+	}
+	// The embedded LiteLLM snapshot backs the default source; a flagship
+	// Anthropic ID should always be present.
+	found := false
+	for _, m := range resp.Models {
+		if strings.HasPrefix(m, "claude-") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected at least one claude-* model in %d models", len(resp.Models))
+	}
+}
+
+func TestHandleStatus_ClientModelsAndCostAttribution(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	srv.SetClientModelAttribution(func() map[string]string {
+		return map[string]string{"claude-code": "claude-opus-4-7"}
+	})
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var resp struct {
+		CostAttribution bool              `json:"cost_attribution"`
+		ClientModels    map[string]string `json:"client_models"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.CostAttribution {
+		t.Error("cost_attribution must be true when only client models are configured")
+	}
+	if resp.ClientModels["claude-code"] != "claude-opus-4-7" {
+		t.Errorf("client_models = %v", resp.ClientModels)
+	}
+}
+
+// writeTempStack writes a stack YAML into a temp dir and returns its path.
+func writeTempStack(t *testing.T, content string) string {
+	t.Helper()
+	path := t.TempDir() + "/stack.yaml"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp stack: %v", err)
+	}
+	return path
+}
+
+func assertStackContains(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read stack: %v", err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Errorf("stack file missing %q:\n%s", want, data)
+	}
+}
+
+func assertStackNotContains(t *testing.T, path, unwanted string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read stack: %v", err)
+	}
+	if strings.Contains(string(data), unwanted) {
+		t.Errorf("stack file unexpectedly contains %q:\n%s", unwanted, data)
+	}
+}

--- a/internal/api/optimize_test.go
+++ b/internal/api/optimize_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 
 	"github.com/gridctl/gridctl/pkg/metrics"
@@ -202,6 +203,15 @@ type staticPricingSource struct {
 func (s staticPricingSource) Lookup(model string) (pricing.Rates, bool) {
 	r, ok := s.rates[model]
 	return r, ok
+}
+
+func (s staticPricingSource) Models() []string {
+	models := make([]string, 0, len(s.rates))
+	for id := range s.rates {
+		models = append(models, id)
+	}
+	sort.Strings(models)
+	return models
 }
 
 func (s staticPricingSource) Name() string { return "api-test-fixture" }

--- a/internal/api/pricing.go
+++ b/internal/api/pricing.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gridctl/gridctl/pkg/pricing"
+)
+
+// pricingModelsResponse is the payload for GET /api/pricing/models.
+type pricingModelsResponse struct {
+	// Source is the active pricing source's short name (e.g. "litellm").
+	Source string `json:"source"`
+	// Models is the sorted list of canonical model IDs the source can
+	// price. Used to populate the model combobox in the UI; free-text IDs
+	// outside this list are still accepted everywhere (best-effort pricing).
+	Models []string `json:"models"`
+}
+
+// handlePricingModels returns the canonical model IDs known to the active
+// pricing source, for UI pickers. The list is computed once per source at
+// construction, so this handler is a cheap snapshot read.
+//
+// GET /api/pricing/models
+func (s *Server) handlePricingModels(w http.ResponseWriter, r *http.Request) {
+	models := pricing.KnownModels()
+	if models == nil {
+		models = []string{}
+	}
+	writeJSON(w, pricingModelsResponse{
+		Source: pricing.CurrentSource().Name(),
+		Models: models,
+	})
+}

--- a/pkg/config/clientmodels.go
+++ b/pkg/config/clientmodels.go
@@ -1,0 +1,74 @@
+package config
+
+import "strings"
+
+// clientNameAliases mirrors the alias table in pkg/mcp/clientid.go so the
+// validation layer can warn about client_models keys that would never match
+// the wire identity (e.g. "claude-ai" normalizes to "claude-desktop").
+//
+// pkg/config deliberately does not import pkg/mcp: config is a foundational
+// package and pulling in the MCP stack for one function would freeze the
+// dependency direction. The copy is small and drift-guarded by
+// TestNormalizedClientModelKeyParity (clientmodels_parity_test.go), an
+// external test that imports both packages and asserts they agree.
+var clientNameAliases = map[string]string{
+	"claude-ai":      "claude-desktop",
+	"claude desktop": "claude-desktop",
+	"claude code":    "claude-code",
+	"claude-code":    "claude-code",
+	"cursor":         "cursor",
+	"cursor-ide":     "cursor",
+	"windsurf":       "windsurf",
+	"continue":       "continue",
+	"continue.dev":   "continue",
+	"cline":          "cline",
+	"zed":            "zed",
+	"goose":          "goose",
+}
+
+// normalizedClientModelKey returns the canonical client ID for a raw
+// client_models key, mirroring mcp.NormalizeClientID: alias variants map to
+// short canonical IDs, everything else slugifies to lowercase hyphenated
+// form. Used only to warn when a configured key differs from the form the
+// gateway resolves at call time — the cost path itself never re-normalizes.
+func normalizedClientModelKey(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	lower := strings.ToLower(trimmed)
+	if alias, ok := clientNameAliases[lower]; ok {
+		return alias
+	}
+	return slugifyClientModelKey(lower)
+}
+
+// slugifyClientModelKey mirrors slugifyClientName in pkg/mcp/clientid.go:
+// lowercase letters, digits, and dots pass through, runs of any other rune
+// collapse to a single hyphen, and leading/trailing hyphens are stripped.
+func slugifyClientModelKey(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	prevSep := true
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.':
+			b.WriteRune(r)
+			prevSep = false
+		default:
+			if !prevSep {
+				b.WriteRune('-')
+				prevSep = true
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
+}
+
+// NormalizedClientModelKeyForTest exposes normalizedClientModelKey to the
+// external parity test (clientmodels_parity_test.go), which asserts this
+// package's copy of the normalization logic matches mcp.NormalizeClientID.
+// Not for production use — the cost path never re-normalizes keys.
+func NormalizedClientModelKeyForTest(raw string) string {
+	return normalizedClientModelKey(raw)
+}

--- a/pkg/config/clientmodels_parity_test.go
+++ b/pkg/config/clientmodels_parity_test.go
@@ -1,0 +1,36 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+// TestNormalizedClientModelKeyParity guards the deliberate copy of the
+// client-ID normalization logic in pkg/config/clientmodels.go against drift
+// from its source of truth, mcp.NormalizeClientID. pkg/config cannot import
+// pkg/mcp in production code (it would invert the foundational-package
+// layering), but this external test package can import both. If this test
+// fails, sync pkg/config/clientmodels.go with pkg/mcp/clientid.go.
+func TestNormalizedClientModelKeyParity(t *testing.T) {
+	samples := []string{
+		// alias-table entries (the high-risk drift surface)
+		"claude-ai", "claude desktop", "claude code", "claude-code",
+		"cursor", "cursor-ide", "windsurf", "continue", "continue.dev",
+		"cline", "zed", "goose",
+		// case and whitespace variants
+		"Claude Code", "  CURSOR  ", "Claude-AI",
+		// slug-path inputs
+		"gemini-cli", "Gemini CLI", "grok_build", "My Custom Agent v2",
+		"continue.dev nightly", "weird//name__here", "-leading-trailing-",
+		"", "   ", "日本語クライアント",
+	}
+	for _, raw := range samples {
+		want := mcp.NormalizeClientID(raw)
+		got := config.NormalizedClientModelKeyForTest(raw)
+		if got != want {
+			t.Errorf("normalization drift for %q: config=%q mcp=%q — sync pkg/config/clientmodels.go with pkg/mcp/clientid.go", raw, got, want)
+		}
+	}
+}

--- a/pkg/config/health.go
+++ b/pkg/config/health.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/gridctl/gridctl/pkg/pricing"
 )
 
 // IssueSeverity represents the severity level of a validation issue.
@@ -166,6 +168,48 @@ func (r *ValidationResult) addWarnings(s *Stack) {
 			Severity: SeverityWarning,
 		})
 		r.WarningCount++
+	}
+
+	r.addModelWarnings(s)
+}
+
+// addModelWarnings flags cost-attribution declarations that would silently
+// price as zero: model IDs unknown to the active pricing source, and
+// client_models keys that differ from the normalized client identity the
+// gateway resolves at call time. Warnings only — unknown models are
+// best-effort by design (single runtime WARN, zero cost), so a typo or a
+// model newer than the embedded pricing snapshot never blocks a deploy.
+func (r *ValidationResult) addModelWarnings(s *Stack) {
+	warnUnknown := func(field, model string) {
+		if model == "" {
+			return
+		}
+		if _, ok := pricing.Lookup(model); !ok {
+			r.Issues = append(r.Issues, ValidationIssue{
+				Field:    field,
+				Message:  fmt.Sprintf("model %q is unknown to the pricing snapshot; calls will record tokens but cost as zero (refresh with `make update-pricing` or check the ID)", model),
+				Severity: SeverityWarning,
+			})
+			r.WarningCount++
+		}
+	}
+
+	if s.Gateway != nil {
+		warnUnknown("gateway.default_model", s.Gateway.DefaultModel)
+	}
+	for i, srv := range s.MCPServers {
+		warnUnknown(fmt.Sprintf("mcp-servers[%d].model", i), srv.Model)
+	}
+	for client, model := range s.ClientModels {
+		warnUnknown(fmt.Sprintf("client_models.%s", client), model)
+		if normalized := normalizedClientModelKey(client); normalized != client {
+			r.Issues = append(r.Issues, ValidationIssue{
+				Field:    fmt.Sprintf("client_models.%s", client),
+				Message:  fmt.Sprintf("key %q is not a normalized client ID and will never match a connecting client; use %q", client, normalized),
+				Severity: SeverityWarning,
+			})
+			r.WarningCount++
+		}
 	}
 }
 

--- a/pkg/config/health_test.go
+++ b/pkg/config/health_test.go
@@ -3,10 +3,13 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gridctl/gridctl/pkg/pricing"
 )
 
 func TestValidateWithIssues_ValidStack(t *testing.T) {
@@ -68,7 +71,6 @@ func TestValidateWithIssues_WarningNoAuth(t *testing.T) {
 	}
 	assert.True(t, found, "expected warning about missing auth")
 }
-
 
 func TestValidateWithIssues_MixedErrorsAndWarnings(t *testing.T) {
 	stack := &Stack{
@@ -201,4 +203,73 @@ func TestValidationResult_Counts(t *testing.T) {
 
 	assert.Equal(t, 2, result.ErrorCount)
 	assert.Equal(t, 1, result.WarningCount)
+}
+
+// modelWarningSource is a deterministic pricing.Source for warning tests.
+type modelWarningSource struct{ known map[string]bool }
+
+func (s modelWarningSource) Lookup(model string) (pricing.Rates, bool) {
+	if s.known[model] {
+		return pricing.Rates{InputPerToken: 1e-6}, true
+	}
+	return pricing.Rates{}, false
+}
+
+func (s modelWarningSource) Models() []string { return nil }
+
+func (s modelWarningSource) Name() string { return "health-test-fixture" }
+
+func TestValidateWithIssues_ModelWarnings(t *testing.T) {
+	prev := pricing.CurrentSource()
+	t.Cleanup(func() { pricing.SetSource(prev) })
+	pricing.SetSource(modelWarningSource{known: map[string]bool{"known-model": true}})
+
+	stack := &Stack{
+		Version: "1",
+		Name:    "test",
+		Network: Network{Name: "test-net"},
+		Gateway: &GatewayConfig{DefaultModel: "unknown-default"},
+		MCPServers: []MCPServer{
+			{Name: "a", Image: "img", Port: 3000, Model: "unknown-server-model"},
+			{Name: "b", Image: "img", Port: 3001, Model: "known-model"},
+		},
+		ClientModels: map[string]string{
+			"claude-code": "known-model",
+			"gemini-cli":  "unknown-client-model",
+			"Claude Code": "known-model", // non-normalized key
+		},
+	}
+
+	result := ValidateWithIssues(stack)
+
+	warnings := map[string]string{}
+	for _, issue := range result.Issues {
+		if issue.Severity == SeverityWarning {
+			warnings[issue.Field] = issue.Message
+		}
+	}
+
+	for _, field := range []string{
+		"gateway.default_model",
+		"mcp-servers[0].model",
+		"client_models.gemini-cli",
+		"client_models.Claude Code",
+	} {
+		if _, ok := warnings[field]; !ok {
+			t.Errorf("expected warning for %s; got %v", field, warnings)
+		}
+	}
+	if msg, ok := warnings["client_models.Claude Code"]; ok && !strings.Contains(msg, `"claude-code"`) {
+		t.Errorf("non-normalized key warning should name the canonical form; got %q", msg)
+	}
+	if _, ok := warnings["mcp-servers[1].model"]; ok {
+		t.Error("known model must not warn")
+	}
+	if _, ok := warnings["client_models.claude-code"]; ok {
+		t.Error("known model on normalized key must not warn")
+	}
+	// Warnings never flip validity.
+	if !result.Valid {
+		t.Error("model warnings must not invalidate the stack")
+	}
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -20,6 +20,16 @@ type Stack struct {
 	Resources  []Resource       `yaml:"resources,omitempty"`
 	Clients    *ClientsConfig   `yaml:"clients,omitempty"` // Optional per-client access scoping (NetworkPolicy semantics)
 
+	// ClientModels declares which model each connecting client runs, purely
+	// for cost attribution: tool calls from a declared client are priced at
+	// that model's rates ahead of any per-server model or gateway
+	// default_model. Keys are stable client identifiers (the same form used
+	// by clients.profiles and shown on the topology — e.g. "claude-code").
+	// The map has zero effect on access policy: declaring a model never
+	// requires a clients: block and never restricts an unlisted client.
+	// Empty (the default) disables the client pricing tier.
+	ClientModels map[string]string `yaml:"client_models,omitempty" json:"client_models,omitempty"`
+
 	// References is the variable-usage index, derived during expandStackVars:
 	// which consumers reference each ${var:KEY}/${vault:KEY} key. It is computed
 	// from the stack, not persisted with it — the yaml/json "-" tags keep it out
@@ -290,6 +300,30 @@ type MCPServer struct {
 	// zero. Unknown model IDs are best-effort — they log a single WARN and
 	// price as zero rather than failing validation.
 	Model string `yaml:"model,omitempty" json:"model,omitempty"`
+}
+
+// ClientModelAttribution returns the client ID -> model mapping used to
+// price tool calls by calling client, the highest-precedence configured tier
+// (a call-level model reported by the server still wins over it). Entries
+// with empty values are skipped. Returns nil when nothing is configured,
+// which keeps the client pricing tier inert. Keys are NOT re-normalized:
+// they must already be canonical client IDs (see NormalizeClientID in
+// pkg/mcp/clientid.go); ValidateWithIssues warns on keys that are not.
+func (s *Stack) ClientModelAttribution() map[string]string {
+	if s == nil || len(s.ClientModels) == 0 {
+		return nil
+	}
+	var out map[string]string
+	for client, model := range s.ClientModels {
+		if client == "" || model == "" {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string, len(s.ClientModels))
+		}
+		out[client] = model
+	}
+	return out
 }
 
 // ModelAttribution builds the server name -> effective model mapping used to

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -303,3 +303,113 @@ func TestMCPServer_ModelYAMLRoundTrip(t *testing.T) {
 		t.Errorf("zero-value Model serialized: %s", raw)
 	}
 }
+
+func TestStack_ClientModelAttribution(t *testing.T) {
+	tests := []struct {
+		name  string
+		stack *Stack
+		want  map[string]string
+	}{
+		{
+			name:  "nil stack",
+			stack: nil,
+			want:  nil,
+		},
+		{
+			name:  "no client models",
+			stack: &Stack{MCPServers: []MCPServer{{Name: "a"}}},
+			want:  nil,
+		},
+		{
+			name: "declared clients",
+			stack: &Stack{ClientModels: map[string]string{
+				"claude-code": "claude-opus-4-7",
+				"gemini-cli":  "gemini-2.5-pro",
+			}},
+			want: map[string]string{
+				"claude-code": "claude-opus-4-7",
+				"gemini-cli":  "gemini-2.5-pro",
+			},
+		},
+		{
+			name: "empty values skipped",
+			stack: &Stack{ClientModels: map[string]string{
+				"claude-code": "claude-opus-4-7",
+				"gemini-cli":  "",
+			}},
+			want: map[string]string{"claude-code": "claude-opus-4-7"},
+		},
+		{
+			name:  "all values empty returns nil",
+			stack: &Stack{ClientModels: map[string]string{"gemini-cli": ""}},
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.stack.ClientModelAttribution()
+			if len(got) != len(tt.want) {
+				t.Fatalf("ClientModelAttribution() = %v, want %v", got, tt.want)
+			}
+			for client, model := range tt.want {
+				if got[client] != model {
+					t.Errorf("ClientModelAttribution()[%q] = %q, want %q", client, got[client], model)
+				}
+			}
+		})
+	}
+}
+
+func TestStack_ClientModelsYAMLRoundTrip(t *testing.T) {
+	in := Stack{
+		Name:         "test",
+		ClientModels: map[string]string{"claude-code": "claude-opus-4-7"},
+	}
+	raw, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out Stack
+	if err := yaml.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.ClientModels["claude-code"] != "claude-opus-4-7" {
+		t.Errorf("ClientModels round-trip = %v", out.ClientModels)
+	}
+
+	// A stack without client models must not serialize the key (Article IX:
+	// the zero value is indistinguishable from a pre-feature stack.yaml).
+	raw, err = yaml.Marshal(Stack{Name: "plain"})
+	if err != nil {
+		t.Fatalf("marshal plain: %v", err)
+	}
+	if strings.Contains(string(raw), "client_models") {
+		t.Errorf("zero-value ClientModels serialized: %s", raw)
+	}
+}
+
+// TestStack_ClientModelsAccessInert pins the design constraint that drove
+// the top-level client_models map: declaring pricing models must never
+// create or imply an access policy. The clients: block stays nil.
+func TestStack_ClientModelsAccessInert(t *testing.T) {
+	src := `
+name: pricing-only
+client_models:
+  claude-code: claude-opus-4-7
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+    port: 3000
+`
+	var stack Stack
+	if err := yaml.Unmarshal([]byte(src), &stack); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stack.Clients != nil {
+		t.Error("client_models must not materialize a clients: access block")
+	}
+	if stack.ClientModelAttribution()["claude-code"] != "claude-opus-4-7" {
+		t.Errorf("attribution = %v", stack.ClientModelAttribution())
+	}
+}

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -77,11 +77,23 @@ type GatewayBuilder struct {
 	// time. Nil when no server in the stack opts in.
 	telemetry *telemetryWiring
 
-	// modelAttribution holds the server -> effective model mapping used to
+	// modelAttribution holds the client and server model mappings used to
 	// price tool calls. Stored behind an atomic pointer so the hot-reload
-	// hook can swap the mapping without racing in-flight observations; the
-	// observer's resolver closure reads through it on every call.
-	modelAttribution atomic.Pointer[map[string]string]
+	// hook can swap both mappings together without racing in-flight
+	// observations; the observer's resolver closure reads through it on
+	// every call.
+	modelAttribution atomic.Pointer[modelAttribution]
+}
+
+// modelAttribution is the resolved cost-attribution state derived from a
+// stack: clients maps normalized client IDs to their declared models
+// (stack.yaml client_models), servers maps server names to their effective
+// models (per-server model: with gateway default_model folded in). The
+// resolver consults clients first — the model is a property of the calling
+// client's session; the server tier is the coarser fallback.
+type modelAttribution struct {
+	clients map[string]string
+	servers map[string]string
 }
 
 // telemetryWiring bundles the three per-signal writers + the otlptrace
@@ -799,28 +811,47 @@ func (b *GatewayBuilder) buildTokenCounter() (token.Counter, error) {
 }
 
 // wireModelAttribution installs the cost-attribution model resolver on the
-// observer and exposes the same mapping to the API server (for the optimize
-// model stats and the /api/status cost_attribution flag). The resolver is
-// always installed: an empty mapping resolves every server to "", which keeps
-// the observer's cost path inert exactly as if no resolver were set, while
-// letting a hot reload activate attribution later without an unsynchronized
-// SetModelResolver swap racing in-flight observations.
+// observer and exposes the underlying mappings to the API server (for the
+// optimize model stats, the /api/status cost_attribution flag, and the
+// client_models exposure). The resolver is always installed: empty mappings
+// resolve every call to "", which keeps the observer's cost path inert
+// exactly as if no resolver were set, while letting a hot reload activate
+// attribution later without an unsynchronized SetModelResolver swap racing
+// in-flight observations.
+//
+// Resolution precedence within the resolver: the calling client's declared
+// model (client_models) wins over the server's effective model. An empty
+// clientID — anonymous sessions and the legacy ObserveToolCall path — skips
+// the client tier and lands on the server tier, preserving pre-client
+// behavior exactly.
 func (b *GatewayBuilder) wireModelAttribution(observer *metrics.Observer, apiServer *api.Server) {
 	b.refreshModelAttribution(b.stack)
-	observer.SetModelResolver(func(serverName string) string {
-		return (*b.modelAttribution.Load())[serverName]
+	observer.SetModelResolver(func(serverName, clientID string) string {
+		attribution := b.modelAttribution.Load()
+		if clientID != "" {
+			if model := attribution.clients[clientID]; model != "" {
+				return model
+			}
+		}
+		return attribution.servers[serverName]
 	})
 	apiServer.SetModelAttribution(func() map[string]string {
-		return *b.modelAttribution.Load()
+		return b.modelAttribution.Load().servers
+	})
+	apiServer.SetClientModelAttribution(func() map[string]string {
+		return b.modelAttribution.Load().clients
 	})
 }
 
-// refreshModelAttribution re-resolves the server -> model mapping from the
-// given stack. Called at build time and from the hot-reload hook so `model:`
-// and `default_model:` edits take effect on the next observed call.
+// refreshModelAttribution re-resolves the client and server model mappings
+// from the given stack. Called at build time and from the hot-reload hook so
+// `client_models:`, `model:`, and `default_model:` edits take effect on the
+// next observed call.
 func (b *GatewayBuilder) refreshModelAttribution(cfg *config.Stack) {
-	attribution := cfg.ModelAttribution()
-	b.modelAttribution.Store(&attribution)
+	b.modelAttribution.Store(&modelAttribution{
+		clients: cfg.ClientModelAttribution(),
+		servers: cfg.ModelAttribution(),
+	})
 }
 
 // buildTracingConfig extracts tracing config from gateway config with defaults.
@@ -874,8 +905,8 @@ func (b *GatewayBuilder) setupHotReload(ctx context.Context, inst *GatewayInstan
 		// Re-resolve the per-client access policy from the reloaded config so a
 		// `clients:` change takes effect on the next tools/list and tools/call.
 		inst.Gateway.SetClientAccessPolicy(mcp.NewClientAccessPolicy(clientAccessSpec(newCfg)))
-		// Re-resolve cost attribution so `model:` / `default_model:` edits
-		// price subsequent calls without a restart.
+		// Re-resolve cost attribution so `client_models:`, `model:`, and
+		// `default_model:` edits price subsequent calls without a restart.
 		b.refreshModelAttribution(newCfg)
 		b.applyTelemetryConfig(inst.APIServer, handler)
 	})

--- a/pkg/controller/model_attribution_test.go
+++ b/pkg/controller/model_attribution_test.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"context"
+	"sort"
 	"testing"
 
 	"github.com/gridctl/gridctl/internal/api"
@@ -22,6 +24,15 @@ func (s staticPricingSource) Lookup(model string) (pricing.Rates, bool) {
 	return r, ok
 }
 
+func (s staticPricingSource) Models() []string {
+	models := make([]string, 0, len(s.rates))
+	for id := range s.rates {
+		models = append(models, id)
+	}
+	sort.Strings(models)
+	return models
+}
+
 func (s staticPricingSource) Name() string { return "controller-test-fixture" }
 
 func newAttributionFixture(t *testing.T, stack *config.Stack) (*GatewayBuilder, *metrics.Observer, *metrics.Accumulator, *api.Server) {
@@ -31,6 +42,7 @@ func newAttributionFixture(t *testing.T, stack *config.Stack) (*GatewayBuilder, 
 	pricing.SetSource(staticPricingSource{rates: map[string]pricing.Rates{
 		"claude-fixture": {InputPerToken: 3e-6, OutputPerToken: 15e-6},
 		"fallback-model": {InputPerToken: 1e-6, OutputPerToken: 5e-6},
+		"client-fixture": {InputPerToken: 30e-6, OutputPerToken: 150e-6},
 	}})
 
 	builder := NewGatewayBuilder(Config{}, stack, "/path/stack.yaml", nil, &runtime.UpResult{})
@@ -44,6 +56,17 @@ func newAttributionFixture(t *testing.T, stack *config.Stack) (*GatewayBuilder, 
 func observeCall(observer *metrics.Observer, serverName string) {
 	observer.ObserveToolCall(serverName, -1, map[string]any{"q": "hello"},
 		&mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent("response")}})
+}
+
+func observeClientCall(observer *metrics.Observer, serverName, clientID string) mcp.ToolCallSummary {
+	return observer.ObserveToolCallWithClient(context.Background(), mcp.ToolCallObservation{
+		ServerName: serverName,
+		ReplicaID:  -1,
+		ClientID:   clientID,
+		ToolName:   "demo",
+		Arguments:  map[string]any{"q": "hello"},
+		Result:     &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent("response")}},
+	})
 }
 
 // TestWireModelAttribution_RecordsCostWithoutManualWiring is the regression
@@ -145,4 +168,145 @@ func TestRefreshModelAttribution_HotReload(t *testing.T) {
 	if acc.CostSnapshot().PerServer["b"].TotalUSD <= 0 {
 		t.Error("expected reloaded model: to price subsequent calls")
 	}
+}
+
+// TestWireModelAttribution_ClientBeatsServer pins the resolution precedence:
+// a calling client's declared model (client_models) outranks the target
+// server's model. The rates differ by 10x so a precedence regression cannot
+// hide in rounding.
+func TestWireModelAttribution_ClientBeatsServer(t *testing.T) {
+	stack := &config.Stack{
+		Name:         "test",
+		MCPServers:   []config.MCPServer{{Name: "a", Model: "claude-fixture"}},
+		ClientModels: map[string]string{"claude-code": "client-fixture"},
+	}
+	_, observer, acc, _ := newAttributionFixture(t, stack)
+
+	summary := observeClientCall(observer, "a", "claude-code")
+	if summary.Model != "client-fixture" {
+		t.Fatalf("resolved model = %q, want client-fixture (client tier must beat server tier)", summary.Model)
+	}
+
+	// The recorded per-client cost reflects the client rate, not the server's.
+	clientCost := acc.CostSnapshot().PerClient["claude-code"]
+	inputTokens := summary.InputTokens
+	wantInput := float64(inputTokens) * 30e-6
+	if !approxUSD(clientCost.InputUSD, wantInput) {
+		t.Errorf("PerClient InputUSD = %v, want %v (client-fixture rate)", clientCost.InputUSD, wantInput)
+	}
+}
+
+// TestWireModelAttribution_UndeclaredClientFallsToServer verifies the second
+// tier: a client with no client_models entry prices against the target
+// server's effective model.
+func TestWireModelAttribution_UndeclaredClientFallsToServer(t *testing.T) {
+	stack := &config.Stack{
+		Name:         "test",
+		MCPServers:   []config.MCPServer{{Name: "a", Model: "claude-fixture"}},
+		ClientModels: map[string]string{"gemini-cli": "client-fixture"},
+	}
+	_, observer, acc, _ := newAttributionFixture(t, stack)
+
+	summary := observeClientCall(observer, "a", "claude-code")
+	if summary.Model != "claude-fixture" {
+		t.Fatalf("resolved model = %q, want claude-fixture (server tier)", summary.Model)
+	}
+	if acc.CostSnapshot().PerClient["claude-code"].TotalUSD <= 0 {
+		t.Error("expected per-client cost recorded at the server rate")
+	}
+}
+
+// TestWireModelAttribution_AnonymousSkipsClientTier pins the #772
+// behavior-preservation guarantee: an empty ClientID (anonymous sessions,
+// the legacy ObserveToolCall path) never consults client_models and lands on
+// the server tier exactly as before this feature.
+func TestWireModelAttribution_AnonymousSkipsClientTier(t *testing.T) {
+	stack := &config.Stack{
+		Name:         "test",
+		MCPServers:   []config.MCPServer{{Name: "a", Model: "claude-fixture"}},
+		ClientModels: map[string]string{"claude-code": "client-fixture"},
+	}
+	_, observer, acc, _ := newAttributionFixture(t, stack)
+
+	// Legacy path: no client attribution at all.
+	observeCall(observer, "a")
+	srv := acc.CostSnapshot().PerServer["a"]
+	tokens := acc.Snapshot().PerServer["a"]
+	wantInput := float64(tokens.InputTokens) * 3e-6
+	if !approxUSD(srv.InputUSD, wantInput) {
+		t.Errorf("anonymous InputUSD = %v, want %v (server rate, never the client rate)", srv.InputUSD, wantInput)
+	}
+}
+
+// TestWireModelAttribution_ClientOnlyStack verifies the pricing-only
+// configuration: client_models with no server models and no default_model
+// prices declared clients and leaves everything else at zero cost.
+func TestWireModelAttribution_ClientOnlyStack(t *testing.T) {
+	stack := &config.Stack{
+		Name:         "test",
+		MCPServers:   []config.MCPServer{{Name: "a"}},
+		ClientModels: map[string]string{"claude-code": "client-fixture"},
+	}
+	_, observer, acc, _ := newAttributionFixture(t, stack)
+
+	observeClientCall(observer, "a", "claude-code")
+	if acc.CostSnapshot().PerClient["claude-code"].TotalUSD <= 0 {
+		t.Error("expected declared client to be priced with no server attribution present")
+	}
+
+	before := acc.CostSnapshot().Session.TotalUSD
+	observeClientCall(observer, "a", "gemini-cli")
+	if after := acc.CostSnapshot().Session.TotalUSD; after != before {
+		t.Errorf("undeclared client on unattributed server moved cost: %v -> %v", before, after)
+	}
+}
+
+// TestRefreshModelAttribution_ClientModelsHotReload verifies the
+// onConfigApplied path for the client tier: a reloaded stack with a changed
+// client_models entry prices subsequent calls against the new mapping.
+func TestRefreshModelAttribution_ClientModelsHotReload(t *testing.T) {
+	stack := &config.Stack{
+		Name:       "test",
+		MCPServers: []config.MCPServer{{Name: "a"}},
+	}
+	builder, observer, acc, _ := newAttributionFixture(t, stack)
+
+	observeClientCall(observer, "a", "claude-code")
+	if got := acc.CostSnapshot().Session.TotalUSD; got != 0 {
+		t.Fatalf("expected zero cost before client attribution; got %v", got)
+	}
+
+	builder.refreshModelAttribution(&config.Stack{
+		Name:         "test",
+		MCPServers:   []config.MCPServer{{Name: "a"}},
+		ClientModels: map[string]string{"claude-code": "client-fixture"},
+	})
+
+	observeClientCall(observer, "a", "claude-code")
+	if acc.CostSnapshot().PerClient["claude-code"].TotalUSD <= 0 {
+		t.Error("expected reloaded client_models to price subsequent calls")
+	}
+}
+
+// TestClientModelsAccessInert pins the design constraint that drove the
+// top-level map: a stack declaring only client_models produces no access
+// policy spec, so no client is denied anything.
+func TestClientModelsAccessInert(t *testing.T) {
+	stack := &config.Stack{
+		Name:         "test",
+		MCPServers:   []config.MCPServer{{Name: "a"}},
+		ClientModels: map[string]string{"claude-code": "client-fixture"},
+	}
+	if spec := clientAccessSpec(stack); spec != nil {
+		t.Errorf("client_models must not create an access spec; got %+v", spec)
+	}
+}
+
+// approxUSD mirrors the metrics package's float comparison for USD values.
+func approxUSD(a, b float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < 1e-9
 }

--- a/pkg/metrics/observer.go
+++ b/pkg/metrics/observer.go
@@ -8,11 +8,13 @@ import (
 	"github.com/gridctl/gridctl/pkg/token"
 )
 
-// ModelResolver returns the configured model ID for a server, or "" when
-// the server has no model attribution. Used by the Observer when a tool
-// result does not carry a model in its CallUsage metadata. Resolvers must
-// be safe for concurrent calls.
-type ModelResolver func(serverName string) string
+// ModelResolver returns the configured model ID for a call, or "" when no
+// attribution is configured. Used by the Observer when a tool result does
+// not carry a model in its CallUsage metadata. clientID is the normalized
+// calling-client identifier ("" for anonymous or legacy observation paths);
+// resolvers consult client-level attribution first and fall back to
+// server-level. Resolvers must be safe for concurrent calls.
+type ModelResolver func(serverName, clientID string) string
 
 // Observer implements mcp.ToolCallObserver and mcp.ClientObserver by
 // counting tokens, pricing the call against the active pricing.Source,
@@ -35,10 +37,10 @@ func NewObserver(counter token.Counter, accumulator *Accumulator) *Observer {
 	}
 }
 
-// SetModelResolver installs the server -> model resolver used as a fallback
-// when a tool result does not carry a model in its CallUsage. Passing nil
-// clears the resolver, after which only call-level model attribution is
-// honored.
+// SetModelResolver installs the client/server -> model resolver used as a
+// fallback when a tool result does not carry a model in its CallUsage.
+// Passing nil clears the resolver, after which only call-level model
+// attribution is honored.
 func (o *Observer) SetModelResolver(r ModelResolver) {
 	o.modelResolver = r
 }
@@ -99,7 +101,7 @@ func (o *Observer) observe(serverName string, replicaID int, clientID, toolName 
 		summary.CacheCreationTokens = usageMeta.CacheCreationTokens
 	}
 
-	model := o.resolveModel(serverName, usageMeta)
+	model := o.resolveModel(serverName, clientID, usageMeta)
 	if model == "" {
 		return summary
 	}
@@ -127,13 +129,14 @@ func (o *Observer) observe(serverName string, replicaID int, clientID, toolName 
 }
 
 // resolveModel picks the model ID for a call: the call-level model wins,
-// then the server-level resolver fallback, then "" (skip pricing).
-func (o *Observer) resolveModel(serverName string, usage *mcp.CallUsage) string {
+// then the configured resolver (client-level attribution before
+// server-level, per the resolver contract), then "" (skip pricing).
+func (o *Observer) resolveModel(serverName, clientID string, usage *mcp.CallUsage) string {
 	if usage != nil && usage.Model != "" {
 		return usage.Model
 	}
 	if o.modelResolver != nil {
-		return o.modelResolver(serverName)
+		return o.modelResolver(serverName, clientID)
 	}
 	return ""
 }

--- a/pkg/metrics/observer_test.go
+++ b/pkg/metrics/observer_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/gridctl/gridctl/pkg/mcp"
@@ -122,7 +123,7 @@ func TestObserver_RecordsCostWithCacheTokens(t *testing.T) {
 	counter := token.NewHeuristicCounter(4)
 	acc := NewAccumulator(100)
 	obs := NewObserver(counter, acc)
-	obs.SetModelResolver(func(string) string { return "claude-fixture" })
+	obs.SetModelResolver(func(string, string) string { return "claude-fixture" })
 
 	args := map[string]any{"q": "hello"}
 	result := &mcp.ToolCallResult{
@@ -231,7 +232,7 @@ func TestObserver_CallLevelModelOverridesResolver(t *testing.T) {
 	counter := token.NewHeuristicCounter(4)
 	acc := NewAccumulator(100)
 	obs := NewObserver(counter, acc)
-	obs.SetModelResolver(func(string) string { return "server-model" })
+	obs.SetModelResolver(func(string, string) string { return "server-model" })
 
 	result := &mcp.ToolCallResult{
 		Content: []mcp.Content{mcp.NewTextContent("x")},
@@ -263,6 +264,16 @@ func (s staticSource) Lookup(model string) (pricing.Rates, bool) {
 	r, ok := s.rates[model]
 	return r, ok
 }
+
+func (s staticSource) Models() []string {
+	models := make([]string, 0, len(s.rates))
+	for id := range s.rates {
+		models = append(models, id)
+	}
+	sort.Strings(models)
+	return models
+}
+
 func (s staticSource) Name() string { return s.name }
 
 func approxUSDEq(a, b float64) bool {

--- a/pkg/pricing/litellm.go
+++ b/pkg/pricing/litellm.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -30,8 +31,9 @@ type litellmEntry struct {
 // model_prices_and_context_window.json. The full file is parsed once at
 // construction and held in memory; lookups are constant-time map reads.
 type LiteLLMSource struct {
-	rates map[string]Rates // canonical model ID -> rates
-	warn  warnOnce         // logs unknown models a single time per ID
+	rates  map[string]Rates // canonical model ID -> rates
+	models []string         // sorted canonical model IDs (cached for Models)
+	warn   warnOnce         // logs unknown models a single time per ID
 }
 
 // NewLiteLLMSource parses the embedded LiteLLM pricing data and returns a
@@ -41,11 +43,20 @@ type LiteLLMSource struct {
 // malformed.
 func NewLiteLLMSource() *LiteLLMSource {
 	rates := parseLiteLLMRates(rawModelPrices)
-	return &LiteLLMSource{rates: rates}
+	models := make([]string, 0, len(rates))
+	for id := range rates {
+		models = append(models, id)
+	}
+	sort.Strings(models)
+	return &LiteLLMSource{rates: rates, models: models}
 }
 
 // Name returns "litellm".
 func (s *LiteLLMSource) Name() string { return "litellm" }
+
+// Models returns the sorted canonical model IDs in the rate table, computed
+// once at construction. Callers must not mutate the returned slice.
+func (s *LiteLLMSource) Models() []string { return s.models }
 
 // Lookup returns the per-token rates for the given model ID. Probes the
 // rate table in order from most specific to most general:

--- a/pkg/pricing/pricing.go
+++ b/pkg/pricing/pricing.go
@@ -59,10 +59,13 @@ func (c Cost) Total() float64 {
 }
 
 // Source is the abstraction for a per-model rate table. Implementations are
-// expected to be safe for concurrent Lookup. Name is a short identifier
-// (e.g. "litellm") used in logs and diagnostic output.
+// expected to be safe for concurrent Lookup and Models. Name is a short
+// identifier (e.g. "litellm") used in logs and diagnostic output. Models
+// returns the sorted canonical model IDs the source can price — used to
+// populate pickers in the UI; callers must not mutate the returned slice.
 type Source interface {
 	Lookup(model string) (Rates, bool)
+	Models() []string
 	Name() string
 }
 
@@ -101,6 +104,12 @@ func CurrentSource() Source {
 // the model is unknown.
 func Lookup(model string) (Rates, bool) {
 	return activeSource.Load().s.Lookup(model)
+}
+
+// KnownModels returns the sorted canonical model IDs the active Source can
+// price. Callers must not mutate the returned slice.
+func KnownModels() []string {
+	return activeSource.Load().s.Models()
 }
 
 // Calculate returns the total USD cost for a tool call. When the model has

--- a/pkg/pricing/pricing_test.go
+++ b/pkg/pricing/pricing_test.go
@@ -1,6 +1,7 @@
 package pricing
 
 import (
+	"sort"
 	"sync"
 	"testing"
 )
@@ -14,6 +15,15 @@ type fakeSource struct {
 func (s *fakeSource) Lookup(model string) (Rates, bool) {
 	r, ok := s.rates[model]
 	return r, ok
+}
+
+func (s *fakeSource) Models() []string {
+	models := make([]string, 0, len(s.rates))
+	for id := range s.rates {
+		models = append(models, id)
+	}
+	sort.Strings(models)
+	return models
 }
 
 func (s *fakeSource) Name() string { return s.name }
@@ -213,4 +223,28 @@ func approxEqual(a, b float64) bool {
 		d = -d
 	}
 	return d < eps
+}
+
+func TestKnownModels(t *testing.T) {
+	// Against a deterministic source: sorted, complete, and matching Models().
+	src := &fakeSource{name: "fixture", rates: map[string]Rates{
+		"zeta-model":  {InputPerToken: 1},
+		"alpha-model": {InputPerToken: 2},
+	}}
+	withSource(t, src, func() {
+		got := KnownModels()
+		want := []string{"alpha-model", "zeta-model"}
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Errorf("KnownModels() = %v, want %v", got, want)
+		}
+	})
+
+	// Against the embedded LiteLLM source: non-empty and sorted.
+	models := NewLiteLLMSource().Models()
+	if len(models) == 0 {
+		t.Fatal("embedded source returned no models")
+	}
+	if !sort.StringsAreSorted(models) {
+		t.Error("Models() must return a sorted slice")
+	}
 }

--- a/pkg/reload/diff.go
+++ b/pkg/reload/diff.go
@@ -17,11 +17,12 @@ type ConfigDiff struct {
 	// It needs an in-memory policy refresh (via the reload's onConfigApplied hook)
 	// but no container or network work, so it must still mark the diff non-empty.
 	ClientsChanged bool
-	// ModelAttributionChanged indicates the server -> model mapping used for
-	// cost attribution changed (a server's `model:` or the gateway's
-	// `default_model:`). Like ClientsChanged it needs only an in-memory
-	// refresh via the onConfigApplied hook — pricing metadata never warrants
-	// a container restart — but it must still mark the diff non-empty.
+	// ModelAttributionChanged indicates the server and/or client model
+	// mappings used for cost attribution changed (a server's `model:`, the
+	// gateway's `default_model:`, or a `client_models:` entry). Like
+	// ClientsChanged it needs only an in-memory refresh via the
+	// onConfigApplied hook — pricing metadata never warrants a container
+	// restart — but it must still mark the diff non-empty.
 	ModelAttributionChanged bool
 }
 
@@ -87,18 +88,20 @@ func ComputeDiff(old, new *config.Stack) *ConfigDiff {
 	// Detect per-client access (`clients:`) changes
 	diff.ClientsChanged = clientsChanged(old, new)
 
-	// Detect cost-attribution (`model:` / `default_model:`) changes
+	// Detect cost-attribution (`client_models:` / `model:` / `default_model:`) changes
 	diff.ModelAttributionChanged = modelAttributionChanged(old, new)
 
 	return diff
 }
 
-// modelAttributionChanged reports whether the effective server -> model
-// mapping differs between two stacks. Comparing the resolved maps (rather
-// than raw fields) means a no-op edit — e.g. adding a per-server model:
-// identical to the gateway default_model — does not mark the diff non-empty.
+// modelAttributionChanged reports whether the effective cost-attribution
+// mappings — server -> model and client -> model — differ between two
+// stacks. Comparing the resolved maps (rather than raw fields) means a
+// no-op edit — e.g. adding a per-server model: identical to the gateway
+// default_model — does not mark the diff non-empty.
 func modelAttributionChanged(old, new *config.Stack) bool {
-	return !maps.Equal(old.ModelAttribution(), new.ModelAttribution())
+	return !maps.Equal(old.ModelAttribution(), new.ModelAttribution()) ||
+		!maps.Equal(old.ClientModelAttribution(), new.ClientModelAttribution())
 }
 
 // clientsChanged reports whether the per-client access (`clients:`) block
@@ -406,4 +409,3 @@ func openAPIEqual(a, b *config.OpenAPIConfig) bool {
 	}
 	return true
 }
-

--- a/pkg/reload/diff_test.go
+++ b/pkg/reload/diff_test.go
@@ -160,7 +160,6 @@ func TestComputeDiff_NetworkChanged(t *testing.T) {
 	}
 }
 
-
 func TestComputeDiff_ResourceChanges(t *testing.T) {
 	old := &config.Stack{
 		Name: "test",
@@ -474,5 +473,61 @@ func TestComputeDiff_RedundantPerServerModelIsNoOp(t *testing.T) {
 
 	if diff.ModelAttributionChanged {
 		t.Error("redundant per-server model must not flag a change")
+	}
+}
+
+func TestComputeDiff_ClientModelsOnlyChange(t *testing.T) {
+	servers := []config.MCPServer{{Name: "github", Image: "image1", Port: 3000}}
+	old := &config.Stack{Name: "test", MCPServers: servers}
+	new := &config.Stack{
+		Name:         "test",
+		MCPServers:   servers,
+		ClientModels: map[string]string{"claude-code": "claude-opus-4-7"},
+	}
+
+	diff := ComputeDiff(old, new)
+
+	if !diff.ModelAttributionChanged {
+		t.Error("expected ModelAttributionChanged for a client_models-only edit")
+	}
+	if diff.IsEmpty() {
+		t.Error("client_models-only edit must mark the diff non-empty so onConfigApplied fires")
+	}
+	if len(diff.MCPServers.Modified) != 0 {
+		t.Errorf("Modified = %d, want 0 (pricing metadata must not restart servers)",
+			len(diff.MCPServers.Modified))
+	}
+	if diff.ClientsChanged {
+		t.Error("client_models must not flag ClientsChanged (access stays separate)")
+	}
+}
+
+func TestComputeDiff_ClientModelsUnchanged(t *testing.T) {
+	servers := []config.MCPServer{{Name: "github", Image: "image1", Port: 3000}}
+	models := map[string]string{"claude-code": "claude-opus-4-7"}
+	old := &config.Stack{Name: "test", MCPServers: servers, ClientModels: models}
+	new := &config.Stack{Name: "test", MCPServers: servers, ClientModels: map[string]string{"claude-code": "claude-opus-4-7"}}
+
+	diff := ComputeDiff(old, new)
+
+	if diff.ModelAttributionChanged {
+		t.Error("identical client_models must not flag a change")
+	}
+	if !diff.IsEmpty() {
+		t.Error("identical stacks must produce an empty diff")
+	}
+}
+
+func TestComputeDiff_ClientModelValueChange(t *testing.T) {
+	servers := []config.MCPServer{{Name: "github", Image: "image1", Port: 3000}}
+	old := &config.Stack{Name: "test", MCPServers: servers,
+		ClientModels: map[string]string{"claude-code": "claude-opus-4-7"}}
+	new := &config.Stack{Name: "test", MCPServers: servers,
+		ClientModels: map[string]string{"claude-code": "claude-haiku-4-5"}}
+
+	diff := ComputeDiff(old, new)
+
+	if !diff.ModelAttributionChanged {
+		t.Error("expected ModelAttributionChanged when a client's model changes")
 	}
 }

--- a/tests/integration/codemode_cost_test.go
+++ b/tests/integration/codemode_cost_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -59,7 +60,7 @@ func TestCodeMode_CostAttributionThroughSandbox(t *testing.T) {
 	counter := token.NewHeuristicCounter(4)
 	acc := metrics.NewAccumulator(100)
 	obs := metrics.NewObserver(counter, acc)
-	obs.SetModelResolver(func(string) string { return "test-model" })
+	obs.SetModelResolver(func(string, string) string { return "test-model" })
 	gw.SetToolCallObserver(obs)
 
 	cm := mcp.NewCodeMode(5 * time.Second)
@@ -142,6 +143,15 @@ type staticPricingSource struct {
 func (s staticPricingSource) Lookup(model string) (pricing.Rates, bool) {
 	r, ok := s.rates[model]
 	return r, ok
+}
+
+func (s staticPricingSource) Models() []string {
+	models := make([]string, 0, len(s.rates))
+	for id := range s.rates {
+		models = append(models, id)
+	}
+	sort.Strings(models)
+	return models
 }
 
 func (s staticPricingSource) Name() string { return "integration-fixture" }

--- a/web/src/components/metrics/MetricsTab.tsx
+++ b/web/src/components/metrics/MetricsTab.tsx
@@ -18,7 +18,7 @@ import { IconButton } from '../ui/IconButton';
 import { PopoutButton } from '../ui/PopoutButton';
 import { useUIStore } from '../../stores/useUIStore';
 import { useStackStore } from '../../stores/useStackStore';
-import { fetchTokenMetrics, clearTokenMetrics, fetchCostMetrics } from '../../lib/api';
+import { fetchTokenMetrics, clearTokenMetrics, fetchCostMetrics, fetchPricingModels, updateClientModel } from '../../lib/api';
 import { useWindowManager } from '../../hooks/useWindowManager';
 import { formatCompactNumber, formatUSD } from '../../lib/format';
 import { POLLING } from '../../lib/constants';
@@ -45,6 +45,7 @@ export function MetricsTab() {
   const tokenUsage = useStackStore((s) => s.tokenUsage);
   const costUsage = useStackStore((s) => s.costUsage);
   const costAttribution = useStackStore((s) => s.costAttribution);
+  const clientModels = useStackStore((s) => s.clientModels);
   const metricsDetached = useUIStore((s) => s.metricsDetached);
   const { openDetachedWindow } = useWindowManager();
   const [timeRange, setTimeRange] = useState<TimeRange>('live');
@@ -497,6 +498,7 @@ export function MetricsTab() {
                   <thead>
                     <tr className="border-b border-border/30">
                       <ClientSortableHeader label="Client" column="name" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} />
+                      <th className="px-3 py-1.5 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">Model</th>
                       <ClientSortableHeader label="Input" column="input" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
                       <ClientSortableHeader label="Output" column="output" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
                       <ClientSortableHeader label="Total" column="total" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
@@ -507,6 +509,13 @@ export function MetricsTab() {
                     {sortedClients.map((client) => (
                       <tr key={client.name} className="border-b border-border/20 last:border-0 hover:bg-surface-highlight/30 transition-colors">
                         <td className="px-3 py-2 font-medium text-text-primary font-mono">{client.name}</td>
+                        <td className="px-3 py-2">
+                          <ClientModelCell
+                            client={client.name}
+                            declaredModel={clientModels[client.name]}
+                            costAttribution={costAttribution}
+                          />
+                        </td>
                         <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(client.input)}</td>
                         <td className="px-3 py-2 text-right text-primary tabular-nums">{formatCompactNumber(client.output)}</td>
                         <td className="px-3 py-2 text-right text-text-primary font-semibold tabular-nums">{formatCompactNumber(client.total)}</td>
@@ -630,6 +639,154 @@ function CostKPICard({
         </span>
       )}
     </div>
+  );
+}
+
+// pricingModelsCache memoizes the known-models list for the lifetime of the
+// page: the embedded pricing snapshot only changes on a gateway rebuild, so
+// one fetch (triggered by the first edit) serves every cell.
+let pricingModelsCache: string[] | null = null;
+
+const MODEL_PRECEDENCE_HINT =
+  'Pricing precedence: client model (client_models) > server model > gateway default_model. ' +
+  'A declared client model is a session-level default — it cannot track mid-session model switches.';
+
+// ClientModelCell shows which model a client's calls are priced as and lets
+// the operator set it inline. A pill with "· client" provenance renders only
+// for clients explicitly declared in client_models; non-declaring clients
+// aggregate heterogeneous per-server/default rates, so they get a muted
+// "per-server" (when any attribution is configured) rather than an invented
+// single model. Clicking opens a combobox backed by /api/pricing/models;
+// free text is allowed (unknown IDs price as zero, best-effort).
+function ClientModelCell({
+  client,
+  declaredModel,
+  costAttribution,
+}: {
+  client: string;
+  declaredModel?: string;
+  costAttribution: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [models, setModels] = useState<string[]>(pricingModelsCache ?? []);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const openEditor = useCallback(() => {
+    setDraft(declaredModel ?? '');
+    setSaveError(null);
+    setEditing(true);
+    if (pricingModelsCache === null) {
+      fetchPricingModels()
+        .then((resp) => {
+          pricingModelsCache = resp.models;
+          setModels(resp.models);
+        })
+        .catch(() => {
+          // Combobox degrades to free text; pricing is best-effort anyway.
+        });
+    }
+  }, [declaredModel]);
+
+  const save = useCallback(async () => {
+    const model = draft.trim();
+    if (model === (declaredModel ?? '')) {
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await updateClientModel(client, model);
+      // Optimistic store update so the pill reflects the save before the
+      // next status poll lands; the poll then confirms from the backend.
+      const current = useStackStore.getState().clientModels;
+      const next = { ...current };
+      if (model === '') {
+        delete next[client];
+      } else {
+        next[client] = model;
+      }
+      useStackStore.setState({ clientModels: next });
+      setEditing(false);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }, [client, draft, declaredModel]);
+
+  if (editing) {
+    const datalistId = `pricing-models-${client}`;
+    return (
+      <span className="inline-flex items-center gap-1">
+        <input
+          autoFocus
+          list={datalistId}
+          value={draft}
+          disabled={saving}
+          placeholder="claude-opus-4-7"
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') void save();
+            if (e.key === 'Escape') setEditing(false);
+          }}
+          title={saveError ?? 'Enter to save, Esc to cancel. Clear and save to remove.'}
+          className={cn(
+            'w-44 rounded bg-surface-highlight/60 border px-1.5 py-0.5 text-[11px] font-mono',
+            'text-text-primary placeholder:text-text-muted/50 focus:outline-none',
+            saveError ? 'border-status-error/60' : 'border-border/50 focus:border-primary/50',
+          )}
+        />
+        <datalist id={datalistId}>
+          {models.map((m) => (
+            <option key={m} value={m} />
+          ))}
+        </datalist>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => void save()}
+          className="text-[10px] text-primary hover:text-primary/80 disabled:opacity-50"
+        >
+          {saving ? '…' : 'save'}
+        </button>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => setEditing(false)}
+          className="text-[10px] text-text-muted hover:text-text-secondary disabled:opacity-50"
+        >
+          cancel
+        </button>
+      </span>
+    );
+  }
+
+  if (declaredModel) {
+    return (
+      <button
+        type="button"
+        onClick={openEditor}
+        title={MODEL_PRECEDENCE_HINT}
+        className="inline-flex items-center gap-1 rounded-full bg-surface-highlight/60 border border-border/40 px-2 py-0.5 hover:border-primary/40 transition-colors"
+      >
+        <span className="text-[10px] font-mono text-text-primary">{declaredModel}</span>
+        <span className="text-[9px] text-text-muted/70">· client</span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={openEditor}
+      title={MODEL_PRECEDENCE_HINT}
+      className="text-[10px] text-text-muted/60 hover:text-text-secondary transition-colors"
+    >
+      {costAttribution ? 'per-server' : 'set model'}
+    </button>
   );
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, SkillUsageResponse, RegistryStatus, AgentSkill, ItemState, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SourceSyncSummary, SkillSyncResult, SkillDiffResponse, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention } from '../types';
+import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, SkillUsageResponse, RegistryStatus, AgentSkill, ItemState, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SourceSyncSummary, SkillSyncResult, SkillDiffResponse, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention, PricingModelsResponse, UpdateClientModelResponse } from '../types';
 
 // Base URL for API calls - empty for same origin
 const API_BASE = '';
@@ -521,6 +521,51 @@ export interface LogEntry {
  * Fetch structured gateway logs
  * GET /api/logs
  */
+/**
+ * Fetch the canonical model IDs known to the active pricing source.
+ * GET /api/pricing/models
+ */
+export async function fetchPricingModels(): Promise<PricingModelsResponse> {
+  return fetchJSON<PricingModelsResponse>('/api/pricing/models');
+}
+
+/**
+ * Set (or clear, with an empty string) a client's pricing model in the
+ * stack's client_models map. Pricing attribution only — never touches the
+ * clients: access block.
+ * PUT /api/clients/{slug}/model
+ */
+export async function updateClientModel(
+  slug: string,
+  model: string,
+): Promise<UpdateClientModelResponse> {
+  const response = await fetch(
+    `${API_BASE}/api/clients/${encodeURIComponent(slug)}/model`,
+    {
+      method: 'PUT',
+      headers: buildHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ model }),
+    },
+  );
+
+  if (response.status === 401) throw new AuthError('Authentication required');
+
+  const data = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const err = data?.error;
+    const msg =
+      err && typeof err === 'object' && typeof err.message === 'string'
+        ? err.message
+        : typeof err === 'string'
+          ? err
+          : `Update client model failed: ${response.status} ${response.statusText}`;
+    throw new Error(msg);
+  }
+
+  return data as UpdateClientModelResponse;
+}
+
 export async function fetchGatewayLogs(lines = 100, level?: string): Promise<LogEntry[]> {
   let url = `${API_BASE}/api/logs?lines=${lines}`;
   if (level) {

--- a/web/src/stores/useStackStore.ts
+++ b/web/src/stores/useStackStore.ts
@@ -60,7 +60,8 @@ interface StackState {
   codeMode: string | null;  // Gateway code mode status ("on" when active)
   tokenUsage: TokenUsage | null; // Token usage metrics from status response
   costUsage: CostUsage | null;   // USD cost snapshot; null when no cost recorded
-  costAttribution: boolean; // True when any server has a model: configured for pricing
+  costAttribution: boolean; // True when any client or server has a pricing model configured
+  clientModels: Record<string, string>; // Declared client -> model pricing map (client_models)
   stackName: string;        // Active stack name; empty string in stackless mode
 
   // === React Flow State ===
@@ -119,6 +120,7 @@ export const useStackStore = create<StackState>()(
     tokenUsage: null,
     costUsage: null,
     costAttribution: false,
+    clientModels: {},
     stackName: '',
     nodes: [],
     edges: [],
@@ -152,6 +154,7 @@ export const useStackStore = create<StackState>()(
         tokenUsage: status.token_usage ?? null,
         costUsage: status.cost ?? null,
         costAttribution: status.cost_attribution ?? false,
+        clientModels: status.client_models ?? {},
         stackName: status.stack_name || '',
         autoscaleHistory: folded.history,
         autoscaleDecisions: folded.decisions,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -105,6 +105,7 @@ export interface ClientStatus {
   linked: boolean;    // Whether gridctl entry exists in client config
   transport: string;  // "native SSE", "native HTTP", or "mcp-remote bridge"
   configPath?: string; // Config file path (only if detected)
+  model?: string;     // Declared pricing model from client_models (pricing only, not access)
   effectiveScope?: ClientScopeResult; // Per-client access scope (when scoping is configured)
 }
 
@@ -217,8 +218,24 @@ export interface GatewayStatus {
   code_mode?: string;      // "on" when code mode is active (omitted when off)
   token_usage?: TokenUsage; // Token usage metrics (omitted if no accumulator)
   cost?: CostUsage;        // Cost snapshot (omitted until any cost is recorded)
-  cost_attribution?: boolean; // True when any server has a model: configured for pricing
+  cost_attribution?: boolean; // True when any client or server has a pricing model configured
+  client_models?: Record<string, string>; // Declared client -> model pricing map (client_models)
   stack_name?: string;     // Active stack name; omitted in stackless mode
+}
+
+// Response from GET /api/pricing/models
+export interface PricingModelsResponse {
+  source: string;   // Active pricing source name (e.g. "litellm")
+  models: string[]; // Sorted canonical model IDs the source can price
+}
+
+// Response from PUT /api/clients/{slug}/model
+export interface UpdateClientModelResponse {
+  client: string;
+  profileKey: string;
+  model: string;
+  reloaded: boolean;
+  reloadedAt?: string;
 }
 
 // Tool definition matching mcp.Tool


### PR DESCRIPTION
## Description

Adds a top-level `client_models:` map to stack.yaml declaring which model each client runs, purely for cost attribution. The resolver prices tool calls by the calling client's model ahead of the per-server tier from #772, so multi-client stacks (Claude Code on Opus, Gemini CLI on Gemini, sharing the same servers) get correctly attributed per-client cost. The map is access-inert by design: declaring a pricing model never creates a `clients:` block and never restricts any client (the block's default-deny semantics made profile-colocated models a footgun).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `client_models:` stack field + `Stack.ClientModelAttribution()`; resolution precedence: call-level usage metadata (future) > client > server `model:` > `gateway.default_model`; anonymous calls skip the client tier, preserving existing behavior exactly
- `metrics.ModelResolver` widens to `(serverName, clientID)`; both maps live in one struct behind the existing atomic pointer, so hot reloads swap them race-free — a `client_models`-only edit reloads with no container restart (generalized `ModelAttributionChanged`; `ClientsChanged` untouched)
- Dedicated `PUT /api/clients/{slug}/model` endpoint with an atomic, comment-preserving YAML patcher (clearing deletes the key and drops the empty map; never writes `model: ""`); the access-scope path has zero diff
- `pricing.Source.Models()` + `pricing.KnownModels()` and `GET /api/pricing/models`; `/api/status` exposes `client_models` and broadens `cost_attribution`; `ClientStatus` gains `model`
- Metrics tab Top Clients gains a Model column: provenance pill (`model · client`) for declared clients, muted "per-server" otherwise, inline combobox editor backed by the known-models list
- `gridctl validate` warns (never errors) on model IDs unknown to the pricing snapshot and on non-normalized `client_models` keys, suggesting the canonical form; normalization parity with `pkg/mcp` is guarded by a cross-package test (`pkg/mcp` itself has no diff)
- Docs: new top-level "Client Models (pricing attribution)" config-schema section cross-linked with the access section, cost-observability rewritten around a precedence table with the mid-session model-switch limitation stated, both examples updated, changelog entry

## Testing

- 24 new tests: attribution helper and YAML round-trips, precedence (client beats server, undeclared falls to server, anonymous skips client tier, client-only stacks), access-inertness, hot reload, diff detection, YAML patcher edge cases (clear, drop-empty-map, comments), endpoints, validation warnings, normalization parity, known-models listing
- `go test ./...`, `golangci-lint run` (0 issues), `tsc --noEmit`, 965 frontend tests, and `make build` all pass; both touched example stacks validated via `gridctl validate`
- Verify manually: add `client_models: {claude-code: claude-opus-4-7}` to a stack, make tool calls from Claude Code, check the Top Clients cost column and model pill

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #773