### PR TITLE
feat: variables workspace master-detail inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Variables workspace master-detail inspector.** The Variables tab now uses
+  the same list-plus-inspector layout as Library and Tools: a denser,
+  table-like variable list (key, type, set, value preview, and used-by count
+  in aligned columns under a sticky header) with a persistent right-rail
+  inspector for the selected variable. The inspector leads with the stack
+  usage index — every `${var:KEY}` reference site, clickable through to the
+  topology node — followed by a type-aware value view (pretty JSON, list
+  chips, bool/number literals), copy-without-reveal as the primary secret
+  action, edit-in-pane with the full typed editors, set reassignment, and a
+  one-step rotate for string secrets. Selection is URL-synced
+  (`?selected=KEY`) for deep links, arrow keys move it from the list, and
+  with nothing selected the rail shows an at-a-glance overview (counts by
+  type, secrets vs plaintext, unreferenced variables) instead of empty space.
+  Inline row expand/edit is retired in the workspace; the sidebar
+  quick-access panel is unchanged.
+
 - **Per-client model attribution for cost observability.** A new top-level
   `client_models:` map in stack.yaml declares which model each client runs
   (e.g. `claude-code: claude-opus-4-7`), and the gateway prices that client's

--- a/web/src/__tests__/VariableInspector.test.tsx
+++ b/web/src/__tests__/VariableInspector.test.tsx
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { VariableInspector } from '../components/vault/VariableInspector';
+import type { Consumer, Variable } from '../lib/api';
+
+const SECRET_VAR: Variable = {
+  key: 'API_KEY',
+  type: 'string',
+  is_secret: true,
+};
+
+const PLAIN_VAR: Variable = {
+  key: 'IMAGE_TAG',
+  type: 'string',
+  is_secret: false,
+  set: 'dev',
+};
+
+const CONSUMERS: Consumer[] = [
+  { kind: 'mcp-server', name: 'github', field: 'env.API_KEY' },
+  { kind: 'gateway', field: 'auth.token' },
+];
+
+function makeProps(overrides: Partial<Parameters<typeof VariableInspector>[0]> = {}) {
+  return {
+    variable: null as Variable | null,
+    consumers: [] as Consumer[],
+    allVariables: [SECRET_VAR, PLAIN_VAR],
+    usage: { API_KEY: CONSUMERS },
+    setNames: ['dev', 'prod'],
+    locked: false,
+    getValue: vi.fn().mockResolvedValue({ value: 's3cret-value' }),
+    onUpdate: vi.fn().mockResolvedValue(undefined),
+    onAssignSet: vi.fn(),
+    onDelete: vi.fn(),
+    onConsumerClick: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+}
+
+// Flush the microtask queue so reveal/copy promise chains settle.
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('VariableInspector — overview state', () => {
+  it('renders the overview with stats when nothing is selected', () => {
+    render(<VariableInspector {...makeProps()} />);
+    expect(screen.getByText('Variables overview')).toBeInTheDocument();
+    // 2 variables, 1 secret, 1 plaintext, 1 unreferenced (IMAGE_TAG).
+    expect(screen.getByText('Secrets')).toBeInTheDocument();
+    expect(screen.getByText('Unreferenced')).toBeInTheDocument();
+    expect(screen.getByText(/drop a \.env or \.json file/i)).toBeInTheDocument();
+  });
+
+  it('notes the locked vault instead of stats', () => {
+    render(
+      <VariableInspector {...makeProps({ allVariables: null, locked: true })} />,
+    );
+    expect(screen.getByText(/vault is locked/i)).toBeInTheDocument();
+    expect(screen.queryByText('At a glance')).not.toBeInTheDocument();
+  });
+});
+
+describe('VariableInspector — usage section', () => {
+  it('lists all consumers with the summary line', () => {
+    render(
+      <VariableInspector
+        {...makeProps({ variable: SECRET_VAR, consumers: CONSUMERS })}
+      />,
+    );
+    expect(screen.getByText('Referenced in stack')).toBeInTheDocument();
+    expect(screen.getByText(/used by 2 sites/i)).toBeInTheDocument();
+    expect(screen.getByText(/github · env\.API_KEY/)).toBeInTheDocument();
+    expect(screen.getByText(/gateway · auth\.token/)).toBeInTheDocument();
+  });
+
+  it('navigates on consumer click', () => {
+    const props = makeProps({ variable: SECRET_VAR, consumers: CONSUMERS });
+    render(<VariableInspector {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /go to github/i }));
+    expect(props.onConsumerClick).toHaveBeenCalledWith(CONSUMERS[0]);
+  });
+
+  it('shows the hedged orphan callout with a delete shortcut', () => {
+    const props = makeProps({ variable: SECRET_VAR, consumers: [] });
+    render(<VariableInspector {...props} />);
+    expect(screen.getByText(/not referenced by/i)).toBeInTheDocument();
+    expect(screen.getByText(/secrets\.sets/)).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole('button', { name: /delete this variable/i }),
+    );
+    expect(props.onDelete).toHaveBeenCalledWith('API_KEY');
+  });
+});
+
+describe('VariableInspector — value section', () => {
+  it('masks a secret with a fixed-length mask', () => {
+    render(<VariableInspector {...makeProps({ variable: SECRET_VAR })} />);
+    expect(screen.getByLabelText('Value hidden')).toHaveTextContent(
+      '••••••••••',
+    );
+  });
+
+  it('copies the value without revealing it on screen', async () => {
+    const props = makeProps({ variable: SECRET_VAR });
+    render(<VariableInspector {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /copy value/i }));
+    await flush();
+    expect(props.getValue).toHaveBeenCalledWith('API_KEY');
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('s3cret-value');
+    // The mask never leaves the screen.
+    expect(screen.getByLabelText('Value hidden')).toBeInTheDocument();
+    expect(screen.queryByText('s3cret-value')).not.toBeInTheDocument();
+  });
+
+  it('reveals a secret and auto-hides it after 10 seconds', async () => {
+    vi.useFakeTimers();
+    render(<VariableInspector {...makeProps({ variable: SECRET_VAR })} />);
+    fireEvent.click(screen.getByRole('button', { name: /^reveal$/i }));
+    await flush();
+    expect(screen.getByText('s3cret-value')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(screen.queryByText('s3cret-value')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Value hidden')).toBeInTheDocument();
+  });
+
+  it('drops an in-flight reveal when the selection moves away', async () => {
+    let resolveValue: (v: { value: string }) => void = () => {};
+    const getValue = vi.fn().mockImplementation(
+      () =>
+        new Promise<{ value: string }>((res) => {
+          resolveValue = res;
+        }),
+    );
+    const props = makeProps({ variable: SECRET_VAR, getValue });
+    const { rerender } = render(<VariableInspector {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /^reveal$/i }));
+
+    // Switch away while the fetch is in flight, then let it resolve.
+    rerender(<VariableInspector {...props} variable={PLAIN_VAR} />);
+    await act(async () => {
+      resolveValue({ value: 's3cret-value' });
+      await Promise.resolve();
+    });
+
+    // Back on the secret: the late resolution must not have unmasked it.
+    rerender(<VariableInspector {...props} variable={SECRET_VAR} />);
+    expect(screen.queryByText('s3cret-value')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Value hidden')).toBeInTheDocument();
+  });
+
+  it('shows a plaintext value without a reveal step', async () => {
+    render(
+      <VariableInspector
+        {...makeProps({
+          variable: PLAIN_VAR,
+          getValue: vi.fn().mockResolvedValue({ value: 'v1.2.3' }),
+        })}
+      />,
+    );
+    await flush();
+    expect(screen.getByText('v1.2.3')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^reveal$/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('VariableInspector — edit mode', () => {
+  it('saves an edited value through onUpdate and exits edit mode', async () => {
+    const props = makeProps({ variable: SECRET_VAR });
+    render(<VariableInspector {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /edit value/i }));
+
+    const input = screen.getByPlaceholderText('secret value');
+    fireEvent.change(input, { target: { value: 'next-value' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await flush();
+
+    expect(props.onUpdate).toHaveBeenCalledWith('API_KEY', {
+      value: 'next-value',
+      type: 'string',
+      isSecret: true,
+    });
+    expect(
+      screen.queryByPlaceholderText('secret value'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('cancels editing without saving', () => {
+    const props = makeProps({ variable: SECRET_VAR });
+    render(<VariableInspector {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /edit value/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(props.onUpdate).not.toHaveBeenCalled();
+    expect(
+      screen.queryByPlaceholderText('secret value'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('cancels editing on Escape without clearing the selection', () => {
+    const props = makeProps({ variable: SECRET_VAR });
+    render(<VariableInspector {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /edit value/i }));
+    fireEvent.keyDown(screen.getByPlaceholderText('secret value'), {
+      key: 'Escape',
+    });
+    expect(
+      screen.queryByPlaceholderText('secret value'),
+    ).not.toBeInTheDocument();
+    expect(props.onClose).not.toHaveBeenCalled();
+    // Still on the detail view, not the overview.
+    expect(screen.getByRole('heading', { name: 'API_KEY' })).toBeInTheDocument();
+  });
+});
+
+describe('VariableInspector — properties and actions', () => {
+  it('reassigns the set from the move select', () => {
+    const props = makeProps({ variable: PLAIN_VAR });
+    render(<VariableInspector {...props} />);
+    fireEvent.change(screen.getByLabelText('Move to set'), {
+      target: { value: 'prod' },
+    });
+    expect(props.onAssignSet).toHaveBeenCalledWith('IMAGE_TAG', 'prod');
+  });
+
+  it('rotates a string secret behind a confirmation', async () => {
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const props = makeProps({ variable: SECRET_VAR, onUpdate });
+    render(<VariableInspector {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /rotate secret/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /^rotate$/i }));
+    await flush();
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const [key, input] = onUpdate.mock.calls[0] as [
+      string,
+      { value: string; type: string; isSecret: boolean },
+    ];
+    expect(key).toBe('API_KEY');
+    expect(input.type).toBe('string');
+    expect(input.isSecret).toBe(true);
+    expect(input.value).toHaveLength(24);
+  });
+
+  it('offers no rotate action for plaintext variables', async () => {
+    render(<VariableInspector {...makeProps({ variable: PLAIN_VAR })} />);
+    await flush();
+    expect(
+      screen.queryByRole('button', { name: /rotate secret/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('re-masks and resets edit state when the selection changes', async () => {
+    const props = makeProps({ variable: SECRET_VAR });
+    const { rerender } = render(<VariableInspector {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /^reveal$/i }));
+    await flush();
+    expect(screen.getByText('s3cret-value')).toBeInTheDocument();
+
+    rerender(
+      <VariableInspector
+        {...props}
+        variable={PLAIN_VAR}
+        getValue={vi.fn().mockResolvedValue({ value: 'v1.2.3' })}
+      />,
+    );
+    await flush();
+    rerender(<VariableInspector {...props} />);
+    // Back on the secret: it starts masked again.
+    expect(screen.queryByText('s3cret-value')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Value hidden')).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/VaultWorkspace.test.tsx
+++ b/web/src/__tests__/VaultWorkspace.test.tsx
@@ -204,13 +204,151 @@ describe('VaultWorkspace — server filter', () => {
         <VaultWorkspace />
       </MemoryRouter>,
     );
-    // Expand the POSTGRES_URL row, then trigger its Delete action.
-    const row = await screen.findByRole('button', { name: /POSTGRES_URL/i });
+    // Select the POSTGRES_URL row, then delete from the inspector header.
+    const row = await screen.findByRole('option', { name: /POSTGRES_URL/i });
     fireEvent.click(row);
-    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: /delete variable/i }),
+    );
 
     expect(await screen.findByText(/used by 1 consumer/i)).toBeInTheDocument();
     expect(screen.getByText(/may break it/i)).toBeInTheDocument();
+  });
+});
+
+describe('VaultWorkspace — inspector selection', () => {
+  const testVariables = [
+    { key: 'POSTGRES_URL', type: 'string' as const, is_secret: true },
+    { key: 'REDIS_URL', type: 'string' as const, is_secret: true },
+  ];
+  const testUsage = {
+    POSTGRES_URL: [
+      { kind: 'mcp-server' as const, name: 'postgres', field: 'env.POSTGRES_URL' },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.mocked(api.fetchVariableStoreStatus).mockResolvedValue({
+      locked: false,
+      encrypted: false,
+    });
+    vi.mocked(api.fetchVariables).mockResolvedValue(testVariables);
+    vi.mocked(api.fetchVariableSets).mockResolvedValue([]);
+    vi.mocked(api.fetchVariableUsage).mockResolvedValue(testUsage);
+    vi.mocked(api.deleteVariable).mockResolvedValue(undefined);
+    useVaultStore.setState({
+      variables: testVariables,
+      sets: [],
+      usage: testUsage,
+      recentlyEdited: {},
+      loading: false,
+      error: null,
+      locked: false,
+      encrypted: false,
+    });
+  });
+
+  it('shows the overview pane while nothing is selected', async () => {
+    renderWorkspace();
+    expect(await screen.findByText('Variables overview')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'POSTGRES_URL' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('selects a row on click and shows its detail with usage first', async () => {
+    renderWorkspace();
+    const row = await screen.findByRole('option', { name: /POSTGRES_URL/i });
+    fireEvent.click(row);
+
+    expect(
+      await screen.findByRole('option', { name: /POSTGRES_URL/i, selected: true }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'POSTGRES_URL' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Referenced in stack')).toBeInTheDocument();
+    expect(screen.getByText(/used by 1 site/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /go to postgres/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('restores the selection from a ?selected= deep link', async () => {
+    render(
+      <MemoryRouter initialEntries={['/vault?selected=POSTGRES_URL']}>
+        <VaultWorkspace />
+      </MemoryRouter>,
+    );
+    expect(
+      await screen.findByRole('option', { name: /POSTGRES_URL/i, selected: true }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'POSTGRES_URL' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the orphan callout for a variable with no consumers', async () => {
+    renderWorkspace();
+    const row = await screen.findByRole('option', { name: /REDIS_URL/i });
+    fireEvent.click(row);
+    expect(
+      await screen.findByText(/not referenced by/i),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the overview when the selection is filtered out', async () => {
+    // The search query keeps REDIS_URL only, so the selected POSTGRES_URL is
+    // filtered out of the list and the pane shows the overview instead.
+    render(
+      <MemoryRouter initialEntries={['/vault?selected=POSTGRES_URL&q=REDIS']}>
+        <VaultWorkspace />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText('Variables overview')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: /POSTGRES_URL/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('clears the selection after deleting the inspected variable', async () => {
+    renderWorkspace();
+    const row = await screen.findByRole('option', { name: /POSTGRES_URL/i });
+    fireEvent.click(row);
+    fireEvent.click(
+      await screen.findByRole('button', { name: /delete variable/i }),
+    );
+    fireEvent.click(
+      await screen.findByRole('button', { name: /delete "POSTGRES_URL"/i }),
+    );
+
+    expect(await screen.findByText('Variables overview')).toBeInTheDocument();
+    expect(vi.mocked(api.deleteVariable)).toHaveBeenCalledWith('POSTGRES_URL');
+  });
+
+  it('closes the inspector via its close button', async () => {
+    renderWorkspace();
+    fireEvent.click(
+      await screen.findByRole('option', { name: /POSTGRES_URL/i }),
+    );
+    await screen.findByRole('heading', { name: 'POSTGRES_URL' });
+    fireEvent.click(screen.getByRole('button', { name: /close inspector/i }));
+    expect(await screen.findByText('Variables overview')).toBeInTheDocument();
+  });
+
+  it('moves the selection with arrow keys', async () => {
+    renderWorkspace();
+    await screen.findByRole('option', { name: /POSTGRES_URL/i });
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    expect(
+      await screen.findByRole('option', { name: /POSTGRES_URL/i, selected: true }),
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    expect(
+      await screen.findByRole('option', { name: /REDIS_URL/i, selected: true }),
+    ).toBeInTheDocument();
   });
 });
 

--- a/web/src/components/vault/ConsumerList.tsx
+++ b/web/src/components/vault/ConsumerList.tsx
@@ -1,0 +1,95 @@
+import { ArrowUpRight } from 'lucide-react';
+import { isNavigable } from './consumerHelpers';
+import type { Consumer } from '../../lib/api';
+
+// How many consumers to show before collapsing behind a "see all" toggle.
+export const CONSUMER_PREVIEW_LIMIT = 3;
+
+export interface ConsumerListProps {
+  consumers: Consumer[];
+  // Collapsing state is host-owned so it survives re-renders of this list.
+  showAll?: boolean;
+  onToggleShowAll?: () => void;
+  onConsumerClick?: (consumer: Consumer) => void;
+  // Rows beyond this count collapse behind the toggle. Pass null to disable
+  // collapsing entirely (the inspector shows every site).
+  previewLimit?: number | null;
+  // Overrides the default chrome (SecretItem's drill-down panel styling).
+  className?: string;
+}
+
+// ConsumerList renders a variable's reference sites. Server/resource sites
+// are clickable (they navigate to a topology node); other kinds render as
+// plain rows. Long lists collapse behind a "see all" toggle unless the host
+// disables it. Shared by SecretItem (VaultPanel) and VariableInspector.
+export function ConsumerList({
+  consumers,
+  showAll = false,
+  onToggleShowAll,
+  onConsumerClick,
+  previewLimit = CONSUMER_PREVIEW_LIMIT,
+  className,
+}: ConsumerListProps) {
+  const visible =
+    previewLimit === null || showAll
+      ? consumers
+      : consumers.slice(0, previewLimit);
+  const hiddenCount = consumers.length - visible.length;
+  const collapsible =
+    previewLimit !== null && consumers.length > previewLimit;
+
+  return (
+    <div
+      role="group"
+      aria-label="Variables consuming this value"
+      className={
+        className ??
+        'px-3 pb-2 pt-1 border-t border-border-subtle/60 space-y-0.5'
+      }
+    >
+      {visible.map((c, i) => {
+        const label = `${c.name || c.kind} · ${c.field}`;
+        if (isNavigable(c) && onConsumerClick) {
+          return (
+            <button
+              key={`${c.kind}-${c.name}-${c.field}-${i}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onConsumerClick(c);
+              }}
+              aria-label={`Go to ${c.name} (${c.field})`}
+              className="w-full flex items-center gap-1.5 px-2 py-1 rounded text-[10px] font-mono text-text-secondary hover:text-primary hover:bg-surface-highlight/50 transition-colors text-left"
+            >
+              <ArrowUpRight
+                size={10}
+                className="flex-shrink-0 text-text-muted"
+              />
+              <span className="truncate">{label}</span>
+            </button>
+          );
+        }
+        return (
+          <div
+            key={`${c.kind}-${c.name}-${c.field}-${i}`}
+            className="flex items-center gap-1.5 px-2 py-1 text-[10px] font-mono text-text-muted"
+          >
+            <span className="w-2.5 flex-shrink-0 text-center">·</span>
+            <span className="truncate">{label}</span>
+          </div>
+        );
+      })}
+      {collapsible && (hiddenCount > 0 || showAll) && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleShowAll?.();
+          }}
+          className="px-2 py-0.5 text-[10px] text-primary hover:text-primary/80 transition-colors"
+        >
+          {showAll ? 'Show less' : `See all ${consumers.length}`}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/vault/SecretItem.tsx
+++ b/web/src/components/vault/SecretItem.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import {
-  ArrowUpRight,
   ChevronDown,
   ChevronRight,
   Eye,
@@ -11,20 +10,12 @@ import {
 } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { Button } from '../ui/Button';
+import { ConsumerList } from './ConsumerList';
 import { VariableTypeBadge } from './VariableTypeBadge';
 import { VariableVisibilityIcon } from './VariableVisibilityIcon';
 import { SecretGenerator } from './SecretGenerator';
 import { VariableValueInput } from './VariableValueInput';
 import type { Consumer, Variable } from '../../lib/api';
-
-// How many consumers to show before collapsing behind a "see all" toggle.
-const CONSUMER_PREVIEW_LIMIT = 3;
-
-// A consumer is navigable to a topology node only when it is a server or a
-// resource (those are the kinds the graph renders as nodes).
-function isNavigable(c: Consumer): boolean {
-  return c.kind === 'mcp-server' || c.kind === 'resource';
-}
 
 export interface SecretItemProps {
   secret: Variable;
@@ -295,76 +286,3 @@ export function SecretItem({
   );
 }
 
-interface ConsumerListProps {
-  consumers: Consumer[];
-  showAll: boolean;
-  onToggleShowAll: () => void;
-  onConsumerClick?: (consumer: Consumer) => void;
-}
-
-// ConsumerList renders the variable's reference sites. Server/resource sites
-// are clickable (they navigate to a topology node); other kinds render as
-// plain rows. Long lists collapse behind a "see all" toggle.
-function ConsumerList({
-  consumers,
-  showAll,
-  onToggleShowAll,
-  onConsumerClick,
-}: ConsumerListProps) {
-  const visible = showAll
-    ? consumers
-    : consumers.slice(0, CONSUMER_PREVIEW_LIMIT);
-  const hiddenCount = consumers.length - visible.length;
-
-  return (
-    <div
-      role="group"
-      aria-label="Variables consuming this value"
-      className="px-3 pb-2 pt-1 border-t border-border-subtle/60 space-y-0.5"
-    >
-      {visible.map((c, i) => {
-        const label = `${c.name || c.kind} · ${c.field}`;
-        if (isNavigable(c) && onConsumerClick) {
-          return (
-            <button
-              key={`${c.kind}-${c.name}-${c.field}-${i}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onConsumerClick(c);
-              }}
-              aria-label={`Go to ${c.name} (${c.field})`}
-              className="w-full flex items-center gap-1.5 px-2 py-1 rounded text-[10px] font-mono text-text-secondary hover:text-primary hover:bg-surface-highlight/50 transition-colors text-left"
-            >
-              <ArrowUpRight
-                size={10}
-                className="flex-shrink-0 text-text-muted"
-              />
-              <span className="truncate">{label}</span>
-            </button>
-          );
-        }
-        return (
-          <div
-            key={`${c.kind}-${c.name}-${c.field}-${i}`}
-            className="flex items-center gap-1.5 px-2 py-1 text-[10px] font-mono text-text-muted"
-          >
-            <span className="w-2.5 flex-shrink-0 text-center">·</span>
-            <span className="truncate">{label}</span>
-          </div>
-        );
-      })}
-      {(hiddenCount > 0 || showAll) && consumers.length > CONSUMER_PREVIEW_LIMIT && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleShowAll();
-          }}
-          className="px-2 py-0.5 text-[10px] text-primary hover:text-primary/80 transition-colors"
-        >
-          {showAll ? 'Show less' : `See all ${consumers.length}`}
-        </button>
-      )}
-    </div>
-  );
-}

--- a/web/src/components/vault/VariableInspector.tsx
+++ b/web/src/components/vault/VariableInspector.tsx
@@ -1,0 +1,747 @@
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
+import {
+  ArrowUpRight,
+  Copy,
+  Eye,
+  EyeOff,
+  Lock,
+  Pencil,
+  RefreshCw,
+  Trash2,
+} from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { Button } from '../ui/Button';
+import { CodeViewer } from '../ui/CodeViewer';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
+import { IconButton } from '../ui/IconButton';
+import { showToast } from '../ui/Toast';
+import { InspectorHeader } from '../inspector';
+import { generateSecret } from '../../lib/generateSecret';
+import { useRevealedValues } from '../../hooks/useRevealedValues';
+import { ConsumerList } from './ConsumerList';
+import { isNavigable } from './consumerHelpers';
+import { SecretGenerator } from './SecretGenerator';
+import { VariableTypeBadge } from './VariableTypeBadge';
+import { VariableValueInput } from './VariableValueInput';
+import { parseBool, validateVariableInput } from './variableTypeHelpers';
+import type {
+  Consumer,
+  UpdateVariableInput,
+  Variable,
+  VariableType,
+} from '../../lib/api';
+
+// Fixed-length mask for unrevealed secrets — deliberately independent of the
+// real value's length so the mask leaks nothing.
+const SECRET_MASK = '••••••••••';
+
+// Rotated secrets use the generator's defaults: 24 chars, all classes.
+const ROTATE_OPTIONS = {
+  length: 24,
+  upper: true,
+  lower: true,
+  digits: true,
+  symbols: true,
+} as const;
+
+// Converts a stored (normalized) value back into the human form
+// VariableValueInput expects: list values are stored as JSON arrays but edited
+// comma-separated; bool tokens collapse to "true"/"false".
+function toInputForm(type: VariableType, raw: string): string {
+  if (type === 'list') {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed.join(', ');
+    } catch {
+      // Fall through to the raw value.
+    }
+    return raw;
+  }
+  if (type === 'bool') {
+    return parseBool(raw) ? 'true' : 'false';
+  }
+  return raw;
+}
+
+// Splits a stored list value into its items for the chip read view.
+function parseListItems(raw: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed.map(String);
+  } catch {
+    // Fall through to comma splitting.
+  }
+  return raw
+    .split(',')
+    .map((p) => p.trim())
+    .filter((p) => p !== '');
+}
+
+export interface VariableInspectorProps {
+  // The selected variable, or null for the overview state.
+  variable: Variable | null;
+  consumers: Consumer[];
+  // Full variable list + usage index, for the overview stats. Null while the
+  // store hasn't loaded (or the vault is locked).
+  allVariables: Variable[] | null;
+  usage: Record<string, Consumer[]>;
+  // All set names, regardless of the active list filter.
+  setNames: string[];
+  locked: boolean;
+  compact?: boolean;
+  // Increment to request edit mode for the selected variable (keyboard 'e' /
+  // Enter from the list). Ignored when nothing is selected.
+  editSignal?: number;
+  getValue: (key: string) => Promise<{ value: string }>;
+  onUpdate: (key: string, input: UpdateVariableInput) => Promise<void>;
+  onAssignSet: (key: string, set: string) => void;
+  onDelete: (key: string) => void;
+  onConsumerClick?: (consumer: Consumer) => void;
+  onClose: () => void;
+}
+
+/**
+ * VariableInspector fills the Variables workspace right rail with the
+ * selected variable's stack usage, typed value, and properties — selection
+ * lives in the workspace (URL ?selected=). With no selection it renders a
+ * workspace overview instead of dead space. It owns its own reveal map so
+ * secret auto-hide never bleeds into the list's plaintext previews.
+ */
+export function VariableInspector({
+  variable,
+  consumers,
+  allVariables,
+  usage,
+  setNames,
+  locked,
+  compact,
+  editSignal = 0,
+  getValue,
+  onUpdate,
+  onAssignSet,
+  onDelete,
+  onConsumerClick,
+  onClose,
+}: VariableInspectorProps) {
+  const { revealed, reveal, hide } = useRevealedValues();
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const [editValid, setEditValid] = useState(true);
+  const [showEditValue, setShowEditValue] = useState(false);
+  const [confirmRotate, setConfirmRotate] = useState(false);
+
+  const key = variable?.key;
+  const value = key !== undefined ? revealed[key] : undefined;
+  const isRevealed = value !== undefined;
+
+  const startEdit = useCallback(() => {
+    if (!variable) return;
+    const current = revealed[variable.key];
+    setEditValue(
+      current !== undefined ? toInputForm(variable.type, current) : '',
+    );
+    setShowEditValue(!variable.is_secret);
+    setEditing(true);
+  }, [variable, revealed]);
+
+  // Reset transient state when the selection changes, so switching variables
+  // never strands an edit form or a confirm dialog on the previous key.
+  // Adjusting state during render (vs. an effect) avoids a cascading
+  // re-render — same pattern as SkillDetailPanel.
+  const [prevKey, setPrevKey] = useState(key);
+  if (key !== prevKey) {
+    setPrevKey(key);
+    setEditing(false);
+    setEditValue('');
+    setShowEditValue(false);
+    setConfirmRotate(false);
+  }
+
+  // Keyboard 'e' / Enter from the list requests edit mode via a counter prop.
+  const [prevEditSignal, setPrevEditSignal] = useState(editSignal);
+  if (editSignal !== prevEditSignal) {
+    setPrevEditSignal(editSignal);
+    if (variable && !editing) startEdit();
+  }
+
+  // Re-mask when selection moves away: drop the previous key's revealed value
+  // so coming back always starts masked (plaintext is simply refetched).
+  useEffect(() => {
+    if (key === undefined) return;
+    return () => hide(key);
+  }, [key, hide]);
+
+  // Plaintext values display without a Reveal click — fetch eagerly (sticky,
+  // no auto-hide) once the selection lands on a plaintext variable.
+  useEffect(() => {
+    if (!variable || variable.is_secret) return;
+    if (revealed[variable.key] !== undefined) return;
+    void reveal(
+      variable.key,
+      async () => (await getValue(variable.key)).value,
+      false,
+    ).catch(() => {
+      // Read view falls back to the placeholder; no toast for a passive load.
+    });
+  }, [variable, revealed, reveal, getValue]);
+
+  const handleReveal = useCallback(() => {
+    if (!variable) return;
+    void reveal(
+      variable.key,
+      async () => (await getValue(variable.key)).value,
+      true,
+    ).catch(() => showToast('error', `Failed to reveal ${variable.key}`));
+  }, [variable, reveal, getValue]);
+
+  // Copy-without-reveal: fetches the value and puts it on the clipboard while
+  // the on-screen mask stays in place.
+  const handleCopy = useCallback(async () => {
+    if (!variable) return;
+    try {
+      const detail = await getValue(variable.key);
+      await navigator.clipboard.writeText(detail.value);
+      showToast('success', 'Copied');
+    } catch {
+      showToast('error', 'Failed to copy value');
+    }
+  }, [variable, getValue]);
+
+  const cancelEdit = useCallback(() => {
+    setEditing(false);
+    setEditValue('');
+    setShowEditValue(false);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!variable || !editValue) return;
+    const validation = validateVariableInput(variable.type, editValue);
+    if (!validation.ok) {
+      showToast('error', validation.error);
+      return;
+    }
+    try {
+      await onUpdate(variable.key, {
+        value: validation.normalized,
+        type: variable.type,
+        isSecret: variable.is_secret,
+      });
+      setEditing(false);
+      setEditValue('');
+      setShowEditValue(false);
+      // Drop the stale revealed value: secrets re-mask, plaintext refetches.
+      hide(variable.key);
+      showToast('success', `Variable "${variable.key}" updated`);
+    } catch {
+      showToast('error', 'Failed to update variable');
+    }
+  }, [variable, editValue, onUpdate, hide]);
+
+  const handleRotate = useCallback(async () => {
+    if (!variable) return;
+    try {
+      await onUpdate(variable.key, {
+        value: generateSecret(ROTATE_OPTIONS),
+        type: 'string',
+        isSecret: true,
+      });
+      hide(variable.key);
+      showToast('success', `Rotated "${variable.key}"`);
+    } catch {
+      showToast('error', 'Failed to rotate secret');
+    } finally {
+      setConfirmRotate(false);
+    }
+  }, [variable, onUpdate, hide]);
+
+  if (!variable) {
+    return (
+      <aside
+        aria-label="Variable inspector"
+        className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle"
+      >
+        <InspectorOverview
+          variables={allVariables}
+          usage={usage}
+          locked={locked}
+          compact={compact}
+        />
+      </aside>
+    );
+  }
+
+  const canRotate = variable.type === 'string' && variable.is_secret;
+  const navigableConsumer = consumers.find(isNavigable);
+
+  return (
+    <aside
+      aria-label="Variable inspector"
+      className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle"
+    >
+      <InspectorHeader
+        title={variable.key}
+        icon={variable.is_secret ? Lock : Eye}
+        accent="primary"
+        onClose={onClose}
+        subtitle={
+          <div className="flex items-center gap-1.5 flex-wrap mt-0.5">
+            <span className="inline-flex items-center text-[10px] font-medium uppercase tracking-wider px-1.5 py-0.5 rounded-full border border-border/40 bg-surface-elevated text-text-muted">
+              {variable.is_secret ? 'Secret' : 'Plaintext'}
+            </span>
+            {variable.type === 'string' ? (
+              <span className="text-[10px] font-mono text-text-muted/60">
+                string
+              </span>
+            ) : (
+              <VariableTypeBadge type={variable.type} />
+            )}
+            {variable.set && (
+              <span className="inline-flex items-center text-[10px] font-mono px-1.5 py-0.5 rounded bg-surface-elevated text-text-secondary">
+                {variable.set}
+              </span>
+            )}
+          </div>
+        }
+        actions={
+          <div className="flex items-center gap-0.5">
+            <IconButton
+              icon={Pencil}
+              size="sm"
+              variant="ghost"
+              onClick={startEdit}
+              tooltip="Edit variable"
+            />
+            <IconButton
+              icon={Trash2}
+              size="sm"
+              variant="ghost"
+              onClick={() => onDelete(variable.key)}
+              tooltip="Delete variable"
+              className="hover:text-status-error"
+            />
+          </div>
+        }
+      />
+
+      <div
+        className={cn(
+          'flex-1 min-h-0 overflow-y-auto scrollbar-dark',
+          compact ? 'px-3 py-3 space-y-4' : 'px-4 py-4 space-y-5',
+        )}
+      >
+        {/* Usage leads: the consumer index is what no external secret store
+            can show, so it gets the top slot. */}
+        <Section title="Referenced in stack">
+          {consumers.length > 0 ? (
+            <div className="space-y-1">
+              <p className="text-[11px] text-text-secondary">
+                Used by {consumers.length}{' '}
+                {consumers.length === 1 ? 'site' : 'sites'}
+              </p>
+              <ConsumerList
+                consumers={consumers}
+                previewLimit={null}
+                onConsumerClick={onConsumerClick}
+                className="-mx-2 space-y-0.5"
+              />
+            </div>
+          ) : (
+            <div className="rounded-lg border border-border/30 bg-background/40 p-2.5 space-y-1.5">
+              <p className="text-[11px] text-text-secondary leading-relaxed">
+                Not referenced by{' '}
+                <code className="font-mono text-text-primary">
+                  {'${var:…}'}
+                </code>{' '}
+                in the current stack.yaml.
+              </p>
+              <p className="text-[10px] text-text-muted/80 leading-relaxed">
+                Variables injected through <code>secrets.sets</code> may not
+                appear here.
+              </p>
+              <button
+                type="button"
+                onClick={() => onDelete(variable.key)}
+                className="text-[10px] text-status-error hover:text-status-error/80 underline underline-offset-2 transition-colors"
+              >
+                Delete this variable
+              </button>
+            </div>
+          )}
+        </Section>
+
+        <Section title="Value">
+          {editing ? (
+            <div className="space-y-2">
+              <VariableValueInput
+                type={variable.type}
+                value={editValue}
+                onChange={setEditValue}
+                isSecret={variable.is_secret}
+                revealed={showEditValue}
+                onToggleReveal={() => setShowEditValue((v) => !v)}
+                onValidityChange={setEditValid}
+                onRequestSubmit={handleSave}
+                onRequestCancel={cancelEdit}
+                compact={compact}
+                autoFocus
+              />
+              {variable.type === 'string' && (
+                <SecretGenerator
+                  onGenerate={setEditValue}
+                  onReveal={() => setShowEditValue(true)}
+                />
+              )}
+              <div className="flex justify-end gap-1.5">
+                <button
+                  type="button"
+                  onClick={cancelEdit}
+                  className="px-2 py-1 text-[10px] text-text-secondary hover:text-text-primary rounded transition-colors"
+                >
+                  Cancel
+                </button>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={!editValue || !editValid}
+                >
+                  Save
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {isRevealed ? (
+                <ValueReadView type={variable.type} value={value} />
+              ) : (
+                <div
+                  className="text-xs font-mono text-text-muted bg-background/60 px-2 py-1.5 rounded select-none"
+                  aria-label={
+                    variable.is_secret ? 'Value hidden' : 'Value loading'
+                  }
+                >
+                  {variable.is_secret ? SECRET_MASK : '•••'}
+                </div>
+              )}
+              <div className="flex items-center flex-wrap gap-1.5">
+                <Button variant="primary" size="sm" onClick={handleCopy}>
+                  <span className="inline-flex items-center gap-1">
+                    <Copy size={10} /> Copy value
+                  </span>
+                </Button>
+                {variable.is_secret && (
+                  <PillButton
+                    icon={isRevealed ? EyeOff : Eye}
+                    label={isRevealed ? 'Hide' : 'Reveal'}
+                    onClick={handleReveal}
+                  />
+                )}
+                <PillButton icon={Pencil} label="Edit value" onClick={startEdit} />
+              </div>
+            </div>
+          )}
+        </Section>
+
+        <Section title="Properties">
+          <dl className="space-y-1.5">
+            <MetaRow label="Type" value={variable.type} mono />
+            <MetaRow
+              label="Visibility"
+              value={variable.is_secret ? 'Secret' : 'Plaintext'}
+            />
+            <MetaRow
+              label="Set"
+              value={variable.set ?? 'Unassigned'}
+              mono={Boolean(variable.set)}
+            />
+          </dl>
+          {setNames.filter((n) => n !== variable.set).length > 0 && (
+            <select
+              value=""
+              onChange={(e) => {
+                if (e.target.value) onAssignSet(variable.key, e.target.value);
+              }}
+              aria-label="Move to set"
+              className="mt-2 w-full bg-surface border border-border rounded-lg px-2 py-1 text-[10px] text-text-muted focus:outline-none focus:border-primary/40 transition-colors"
+            >
+              <option value="">Move to set…</option>
+              {setNames
+                .filter((n) => n !== variable.set)
+                .map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+            </select>
+          )}
+        </Section>
+      </div>
+
+      {(canRotate || navigableConsumer) && (
+        <div
+          className={cn(
+            'flex-shrink-0 border-t border-border-subtle flex items-center flex-wrap gap-1.5',
+            compact ? 'px-3 py-2' : 'px-4 py-3',
+          )}
+        >
+          {canRotate && (
+            <PillButton
+              icon={RefreshCw}
+              label="Rotate secret"
+              onClick={() => setConfirmRotate(true)}
+            />
+          )}
+          {navigableConsumer && (
+            <PillButton
+              icon={ArrowUpRight}
+              label="Jump to Topology"
+              onClick={() => onConsumerClick?.(navigableConsumer)}
+            />
+          )}
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={confirmRotate}
+        onClose={() => setConfirmRotate(false)}
+        onConfirm={handleRotate}
+        title="Rotate secret"
+        message={
+          <>
+            <p>
+              Generate a new value for{' '}
+              <span className="font-mono text-primary">{variable.key}</span>?
+            </p>
+            <p>
+              The current value is replaced immediately and cannot be
+              recovered. Consumers pick up the new value on their next read.
+            </p>
+          </>
+        }
+        confirmLabel="Rotate"
+        variant="danger"
+      />
+    </aside>
+  );
+}
+
+// Ghost-pill action button shared by the value and footer action rows.
+function PillButton({
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  icon: ComponentType<{ size?: number; className?: string }>;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[10px] font-medium text-text-secondary hover:text-text-primary border border-border/40 hover:border-border transition-colors"
+    >
+      <Icon size={10} /> {label}
+    </button>
+  );
+}
+
+// Type-aware read view for a revealed (or plaintext) value.
+function ValueReadView({ type, value }: { type: VariableType; value: string }) {
+  if (type === 'json') {
+    let pretty = value;
+    try {
+      pretty = JSON.stringify(JSON.parse(value), null, 2);
+    } catch {
+      // Show the raw value when it isn't parseable.
+    }
+    return (
+      <CodeViewer
+        language="json"
+        content={pretty}
+        wrap
+        ariaLabel="Variable value"
+        className="rounded-md border border-border/30 bg-background/60 max-h-[40vh]"
+      />
+    );
+  }
+  if (type === 'list') {
+    return (
+      <div className="flex flex-wrap gap-1">
+        {parseListItems(value).map((item, i) => (
+          <span
+            key={`${item}-${i}`}
+            className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-surface-elevated text-text-secondary border border-border/30"
+          >
+            {item}
+          </span>
+        ))}
+      </div>
+    );
+  }
+  if (type === 'bool') {
+    const truthy = parseBool(value);
+    return (
+      <div
+        className={cn(
+          'text-sm font-mono font-semibold',
+          truthy ? 'text-emerald-300' : 'text-text-muted',
+        )}
+      >
+        {truthy ? 'true' : 'false'}
+      </div>
+    );
+  }
+  if (type === 'number') {
+    return (
+      <div className="text-sm font-mono font-semibold text-emerald-300">
+        {value}
+      </div>
+    );
+  }
+  return (
+    <div className="text-xs font-mono text-text-secondary bg-background/60 px-2 py-1.5 rounded break-all">
+      {value}
+    </div>
+  );
+}
+
+// Overview shown when nothing is selected: a left-aligned block (not a
+// centered hero) with at-a-glance stats and teaching tips, so the rail earns
+// its space even before the first click.
+function InspectorOverview({
+  variables,
+  usage,
+  locked,
+  compact,
+}: {
+  variables: Variable[] | null;
+  usage: Record<string, Consumer[]>;
+  locked: boolean;
+  compact?: boolean;
+}) {
+  const list = variables ?? [];
+  const secretCount = list.filter((v) => v.is_secret).length;
+  const unreferencedCount = list.filter(
+    (v) => (usage[v.key] ?? []).length === 0,
+  ).length;
+  const typeCounts = new Map<VariableType, number>();
+  for (const v of list) {
+    typeCounts.set(v.type, (typeCounts.get(v.type) ?? 0) + 1);
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex-1 min-h-0 overflow-y-auto scrollbar-dark',
+        compact ? 'px-3 py-4 space-y-5' : 'px-4 py-5 space-y-6',
+      )}
+    >
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold text-text-primary">
+          Variables overview
+        </h2>
+        <p className="text-[11px] text-text-muted leading-relaxed">
+          Select a variable to inspect its value, properties, and stack usage.
+        </p>
+      </div>
+
+      {locked ? (
+        <p className="text-[11px] text-text-muted leading-relaxed">
+          Vault is locked — unlock to browse variables and values.
+        </p>
+      ) : (
+        variables !== null && (
+          <Section title="At a glance">
+            <dl className="space-y-1.5">
+              <MetaRow label="Variables" value={String(list.length)} mono />
+              <MetaRow label="Secrets" value={String(secretCount)} mono />
+              <MetaRow
+                label="Plaintext"
+                value={String(list.length - secretCount)}
+                mono
+              />
+              <MetaRow
+                label="Unreferenced"
+                value={String(unreferencedCount)}
+                mono
+              />
+              {[...typeCounts.entries()].map(([type, count]) => (
+                <MetaRow
+                  key={type}
+                  label={`Type: ${type}`}
+                  value={String(count)}
+                  mono
+                />
+              ))}
+            </dl>
+          </Section>
+        )
+      )}
+
+      <Section title="Tips">
+        <ul className="space-y-2">
+          <Tip>
+            Secrets auto-hide 10 seconds after reveal; plaintext values stay
+            visible.
+          </Tip>
+          <Tip>
+            Group variables into sets and inject them in bulk with{' '}
+            <code className="font-mono text-text-secondary">secrets.sets</code>{' '}
+            in stack.yaml.
+          </Tip>
+          <Tip>Drop a .env or .json file anywhere on this page to import.</Tip>
+        </ul>
+      </Section>
+    </div>
+  );
+}
+
+function Tip({ children }: { children: ReactNode }) {
+  return (
+    <li className="text-[11px] text-text-muted leading-relaxed pl-3 relative before:content-['·'] before:absolute before:left-0 before:text-text-muted/60">
+      {children}
+    </li>
+  );
+}
+
+function MetaRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <dt className="text-[11px] text-text-muted flex-shrink-0">{label}</dt>
+      <dd
+        className={cn(
+          'text-[11px] text-text-secondary text-right break-words',
+          mono && 'font-mono',
+        )}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}

--- a/web/src/components/vault/VariableRow.tsx
+++ b/web/src/components/vault/VariableRow.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef } from 'react';
+import { Link2 } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { VariableTypeBadge } from './VariableTypeBadge';
+import { VariableVisibilityIcon } from './VariableVisibilityIcon';
+import type { Variable } from '../../lib/api';
+
+// Shared column template so the sticky header row and every variable row
+// align: Key | Type | Set | Value preview | Used by.
+export const VARIABLE_ROW_GRID =
+  'grid grid-cols-[minmax(0,1.6fr)_4rem_minmax(0,0.8fr)_minmax(0,1.2fr)_3.25rem] items-center gap-2';
+
+export interface VariableRowProps {
+  variable: Variable;
+  selected: boolean;
+  onSelect: () => void;
+  // Pre-computed preview text: the actual value for loaded plaintext, a
+  // fixed-length mask for secrets — never the raw secret.
+  preview: string;
+  consumerCount: number;
+  compact?: boolean;
+}
+
+// VariableRow is the workspace's table-like list row. Unlike SecretItem (the
+// sidebar's expandable card) it carries no inline expand/edit — clicking
+// selects the variable and all depth lives in the right-rail inspector.
+export function VariableRow({
+  variable,
+  selected,
+  onSelect,
+  preview,
+  consumerCount,
+  compact,
+}: VariableRowProps) {
+  const ref = useRef<HTMLButtonElement>(null);
+
+  // Keep the selected row visible when selection moves via keyboard.
+  useEffect(() => {
+    if (selected) ref.current?.scrollIntoView?.({ block: 'nearest' });
+  }, [selected]);
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      role="option"
+      aria-selected={selected}
+      onClick={onSelect}
+      className={cn(
+        'w-full text-left px-6 border-l-2 border-b border-border-subtle/40 transition-colors',
+        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 focus-visible:ring-inset',
+        VARIABLE_ROW_GRID,
+        compact ? 'py-1.5' : 'py-2.5',
+        selected
+          ? 'border-l-primary bg-primary/[0.06]'
+          : 'border-l-transparent hover:bg-surface-highlight/40',
+      )}
+    >
+      <span className="flex items-center gap-2 min-w-0">
+        <VariableVisibilityIcon isSecret={variable.is_secret} />
+        <span className="text-xs font-mono font-medium text-text-primary truncate">
+          {variable.key}
+        </span>
+      </span>
+      <span>
+        {variable.type === 'string' ? (
+          <span className="text-[10px] font-mono text-text-muted/50">
+            string
+          </span>
+        ) : (
+          <VariableTypeBadge type={variable.type} />
+        )}
+      </span>
+      <span className="min-w-0">
+        {variable.set ? (
+          <span className="inline-flex max-w-full items-center text-[10px] font-mono px-1.5 py-0.5 rounded bg-surface-elevated text-text-secondary truncate">
+            {variable.set}
+          </span>
+        ) : (
+          <span className="text-[10px] text-text-muted/40">—</span>
+        )}
+      </span>
+      <span className="text-[10px] font-mono text-text-muted truncate">
+        {preview}
+      </span>
+      <span className="flex justify-end">
+        {consumerCount > 0 && (
+          <span
+            title={`Used by ${consumerCount} ${consumerCount === 1 ? 'consumer' : 'consumers'}`}
+            className="inline-flex items-center gap-1 rounded-md px-1.5 py-px text-[10px] font-mono bg-surface-elevated text-text-muted"
+          >
+            <Link2 size={9} />
+            {consumerCount}
+          </span>
+        )}
+      </span>
+    </button>
+  );
+}

--- a/web/src/components/vault/consumerHelpers.ts
+++ b/web/src/components/vault/consumerHelpers.ts
@@ -1,0 +1,7 @@
+import type { Consumer } from '../../lib/api';
+
+// A consumer is navigable to a topology node only when it is a server or a
+// resource (those are the kinds the graph renders as nodes).
+export function isNavigable(c: Consumer): boolean {
+  return c.kind === 'mcp-server' || c.kind === 'resource';
+}

--- a/web/src/components/vault/variableTypeHelpers.ts
+++ b/web/src/components/vault/variableTypeHelpers.ts
@@ -46,6 +46,12 @@ export function validateVariableInput(
   }
 }
 
+// parseBool interprets a stored bool value's truthy tokens (the subset of
+// what validateVariableInput accepts that means "true").
+export function parseBool(value: string): boolean {
+  return ['true', '1', 'yes', 't'].includes(value.trim().toLowerCase());
+}
+
 // getValuePlaceholder produces an input placeholder that mirrors what
 // validateVariableInput accepts: comma-separated for `list` (not a JSON
 // array), lowercase tokens for `bool`, etc. Visibility only changes the

--- a/web/src/components/workspaces/VaultWorkspace.tsx
+++ b/web/src/components/workspaces/VaultWorkspace.tsx
@@ -24,20 +24,21 @@ import { IconButton } from '../ui/IconButton';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { showToast } from '../ui/Toast';
 import { WorkspaceShell } from '../layout/WorkspaceShell';
-import { SecretItem } from '../vault/SecretItem';
 import { NewSetForm } from '../vault/NewSetForm';
+import { VariableInspector } from '../vault/VariableInspector';
 import { VariableQuickAddForm } from '../vault/VariableQuickAddForm';
+import { VariableRow, VARIABLE_ROW_GRID } from '../vault/VariableRow';
 import { VaultEncryptForm } from '../vault/VaultEncryptForm';
 import { VaultLockPrompt } from '../vault/VaultLockPrompt';
 import { EnvImportModal } from '../vault/EnvImportModal';
 import { useUIStore } from '../../stores/useUIStore';
 import { useStackStore } from '../../stores/useStackStore';
 import { useVaultManager } from '../../hooks/useVaultManager';
+import { useListNav } from '../../hooks/useListNav';
 import { useRevealedValues } from '../../hooks/useRevealedValues';
 import { usePageFileDrop } from '../../hooks/usePageFileDrop';
 import { isImportableFile } from '../../lib/parseFile';
-import { validateVariableInput } from '../vault/variableTypeHelpers';
-import type { Consumer, Variable, VariableType } from '../../lib/api';
+import type { Consumer, Variable } from '../../lib/api';
 
 const ALL_SETS_KEY = '__all__';
 
@@ -130,14 +131,26 @@ export function VaultWorkspace() {
     );
   }, [setSearchParams]);
 
-  // ---- Local UI state -----------------------------------------------------
-  // Edit state — mirrors VaultPanel: validate type on save, preserve is_secret.
-  const [editingKey, setEditingKey] = useState<string | null>(null);
-  const [editValue, setEditValue] = useState('');
-  const [editType, setEditType] = useState<VariableType>('string');
-  const [editIsSecret, setEditIsSecret] = useState(true);
-  const [showEditValue, setShowEditValue] = useState(false);
+  // Inspector selection — the variable shown in the right-rail inspector.
+  // URL-synced as ?selected=<key> (replace history) so reload and deep-links
+  // restore it, mirroring the Library workspace.
+  const selectedKey = searchParams.get('selected');
+  const setSelectedKey = useCallback(
+    (key: string | null) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (key) next.set('selected', key);
+          else next.delete('selected');
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
+  // ---- Local UI state -----------------------------------------------------
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [confirmDeleteSet, setConfirmDeleteSet] = useState<string | null>(null);
 
@@ -196,6 +209,27 @@ export function VaultWorkspace() {
     );
   }, [filteredBySet, searchQuery]);
 
+  // The inspector shows the selection only while it survives the active
+  // filters; a filtered-out key keeps its URL param (the pane falls back to
+  // the overview) so clearing the filter restores the selection.
+  const selectedVariable = useMemo(
+    () => filteredBySearch.find((v) => v.key === selectedKey) ?? null,
+    [filteredBySearch, selectedKey],
+  );
+
+  // A key that no longer exists at all (deleted, vault locked) clears the
+  // param. Guarded on a loaded list so initial load never wipes a deep link.
+  useEffect(() => {
+    if (!selectedKey) return;
+    if (locked) {
+      setSelectedKey(null);
+      return;
+    }
+    if (vaultVariables && !vaultVariables.some((v) => v.key === selectedKey)) {
+      setSelectedKey(null);
+    }
+  }, [selectedKey, locked, vaultVariables, setSelectedKey]);
+
   // ---- Handlers -----------------------------------------------------------
   const handleUnlock = useCallback(
     async (passphrase: string) => {
@@ -215,23 +249,6 @@ export function VaultWorkspace() {
     [lock, encrypted],
   );
 
-  const handleReveal = useCallback(
-    async (key: string) => {
-      const target = allVariables.find((v) => v.key === key);
-      const isPlaintext = target ? !target.is_secret : false;
-      try {
-        await revealedState.reveal(
-          key,
-          async () => (await getVar(key)).value,
-          !isPlaintext,
-        );
-      } catch {
-        showToast('error', `Failed to reveal ${key}`);
-      }
-    },
-    [allVariables, revealedState, getVar],
-  );
-
   const handleCreate = useCallback(
     async (input: Parameters<typeof createVar>[0]) => {
       await createVar(input);
@@ -241,55 +258,18 @@ export function VaultWorkspace() {
     [createVar],
   );
 
-  const handleEdit = useCallback(
-    (key: string) => {
-      const current = allVariables.find((v) => v.key === key);
-      setEditingKey(key);
-      setEditValue('');
-      setEditType(current?.type ?? 'string');
-      setEditIsSecret(current?.is_secret ?? true);
-      setShowEditValue(false);
-    },
-    [allVariables],
-  );
-
-  const handleEditSave = useCallback(async () => {
-    if (!editingKey || !editValue) return;
-    const validation = validateVariableInput(editType, editValue);
-    if (!validation.ok) {
-      showToast('error', validation.error);
-      return;
-    }
-    try {
-      await updateVar(editingKey, {
-        value: validation.normalized,
-        type: editType,
-        isSecret: editIsSecret,
-      });
-      setEditingKey(null);
-      setEditValue('');
-      showToast('success', `Variable "${editingKey}" updated`);
-    } catch {
-      showToast('error', 'Failed to update variable');
-    }
-  }, [editingKey, editValue, editType, editIsSecret, updateVar]);
-
-  const handleEditCancel = useCallback(() => {
-    setEditingKey(null);
-    setEditValue('');
-    setShowEditValue(false);
-  }, []);
-
   const handleDeleteConfirm = useCallback(async () => {
     if (!confirmDelete) return;
     try {
       await deleteVar(confirmDelete);
       setConfirmDelete(null);
+      // The inspector falls back to its overview once its subject is gone.
+      if (confirmDelete === selectedKey) setSelectedKey(null);
       showToast('success', `Variable "${confirmDelete}" deleted`);
     } catch {
       showToast('error', 'Failed to delete variable');
     }
-  }, [confirmDelete, deleteVar]);
+  }, [confirmDelete, deleteVar, selectedKey, setSelectedKey]);
 
   const handleCreateSet = useCallback(async () => {
     const name = newSetName.trim();
@@ -379,6 +359,32 @@ export function VaultWorkspace() {
     onFiles: handleDroppedFiles,
   });
 
+  // ---- Keyboard navigation ------------------------------------------------
+  // Bumping the counter asks the inspector to enter edit mode for the current
+  // selection ('e' / Enter from the list). The inspector ignores it when
+  // nothing is selected.
+  const [editSignal, setEditSignal] = useState(0);
+  const requestInspectorEdit = useCallback(() => {
+    setEditSignal((s) => s + 1);
+  }, []);
+
+  const selectedIndex = useMemo(
+    () => filteredBySearch.findIndex((v) => v.key === selectedKey),
+    [filteredBySearch, selectedKey],
+  );
+
+  useListNav({
+    itemCount: filteredBySearch.length,
+    selectedIndex,
+    setSelectedIndex: (i) => {
+      const next = filteredBySearch[i];
+      if (next) setSelectedKey(next.key);
+    },
+    onEnter: requestInspectorEdit,
+    onEdit: requestInspectorEdit,
+    enabled: !locked && !importOpen,
+  });
+
   const closeImport = useCallback(() => {
     setImportOpen(false);
     setDroppedText('');
@@ -422,14 +428,35 @@ export function VaultWorkspace() {
     />
   );
 
+  const inspector = (
+    <VariableInspector
+      variable={selectedVariable}
+      consumers={selectedVariable ? (usage[selectedVariable.key] ?? []) : []}
+      allVariables={vaultVariables}
+      usage={usage}
+      setNames={setNames}
+      locked={locked}
+      compact={compact}
+      editSignal={editSignal}
+      getValue={getVar}
+      onUpdate={updateVar}
+      onAssignSet={handleAssignSet}
+      onDelete={(key) => setConfirmDelete(key)}
+      onConsumerClick={handleConsumerClick}
+      onClose={() => setSelectedKey(null)}
+    />
+  );
+
   return (
     <div className="absolute inset-0 flex flex-col bg-background text-text-primary overflow-hidden">
       <WorkspaceShell
         workspace="vault"
         defaultLeftPct={20}
-        defaultRightPct={0}
+        defaultRightPct={30}
         left={leftRail}
+        right={inspector}
         minLeftPx={200}
+        minRightPx={300}
       >
         <main className="flex flex-col h-full overflow-hidden">
           <VaultHeader
@@ -535,7 +562,7 @@ export function VaultWorkspace() {
                 )}
 
                 {loading && !vaultVariables && (
-                  <div className="p-6 space-y-3 max-w-3xl">
+                  <div className="p-6 space-y-3">
                     {[1, 2, 3, 4].map((i) => (
                       <div
                         key={i}
@@ -565,19 +592,9 @@ export function VaultWorkspace() {
                     variables={filteredBySearch}
                     revealed={revealedState.revealed}
                     usage={usage}
-                    editingKey={editingKey}
-                    editValue={editValue}
-                    showEditValue={showEditValue}
-                    setNames={setNames}
-                    onReveal={handleReveal}
-                    onEdit={handleEdit}
-                    onDelete={(key) => setConfirmDelete(key)}
-                    onEditValueChange={setEditValue}
-                    onEditToggleShow={() => setShowEditValue(!showEditValue)}
-                    onEditSave={handleEditSave}
-                    onEditCancel={handleEditCancel}
-                    onAssignSet={handleAssignSet}
-                    onConsumerClick={handleConsumerClick}
+                    selectedKey={selectedKey}
+                    onSelect={setSelectedKey}
+                    compact={compact}
                   />
                 )}
               </div>
@@ -965,64 +982,61 @@ function SetPill({
 // Body states
 // ---------------------------------------------------------------------------
 
+// Fixed-length mask for secret previews — independent of the real value's
+// length so the row leaks nothing.
+const SECRET_PREVIEW = '••••••••••';
+
 interface VariableListProps {
   variables: Variable[];
   revealed: Record<string, string>;
   usage: Record<string, Consumer[]>;
-  editingKey: string | null;
-  editValue: string;
-  showEditValue: boolean;
-  setNames: string[];
-  onReveal: (key: string) => void;
-  onEdit: (key: string) => void;
-  onDelete: (key: string) => void;
-  onEditValueChange: (val: string) => void;
-  onEditToggleShow: () => void;
-  onEditSave: () => void;
-  onEditCancel: () => void;
-  onAssignSet: (key: string, set: string) => void;
-  onConsumerClick: (consumer: Consumer) => void;
+  selectedKey: string | null;
+  onSelect: (key: string) => void;
+  compact: boolean;
 }
 
+// Table-like list: aligned columns under a sticky header row, with all depth
+// (value, consumers, actions) living in the right-rail inspector. Rows select;
+// they no longer expand or edit inline.
 function VariableList({
   variables,
   revealed,
   usage,
-  editingKey,
-  editValue,
-  showEditValue,
-  setNames,
-  onReveal,
-  onEdit,
-  onDelete,
-  onEditValueChange,
-  onEditToggleShow,
-  onEditSave,
-  onEditCancel,
-  onAssignSet,
-  onConsumerClick,
+  selectedKey,
+  onSelect,
+  compact,
 }: VariableListProps) {
+  const headerLabel =
+    'text-[9px] uppercase tracking-[0.24em] text-text-muted/50';
   return (
-    <div className="px-6 py-4 space-y-2 max-w-3xl">
+    <div role="listbox" aria-label="Variables" className="pb-4">
+      <div
+        aria-hidden="true"
+        className={cn(
+          'sticky top-0 z-10 px-6 border-l-2 border-l-transparent border-b border-border-subtle bg-background/95 backdrop-blur-sm',
+          VARIABLE_ROW_GRID,
+          compact ? 'py-1' : 'py-1.5',
+        )}
+      >
+        <span className={headerLabel}>key</span>
+        <span className={headerLabel}>type</span>
+        <span className={headerLabel}>set</span>
+        <span className={headerLabel}>value</span>
+        <span className={cn(headerLabel, 'text-right')}>used by</span>
+      </div>
       {variables.map((variable) => (
-        <SecretItem
+        <VariableRow
           key={variable.key}
-          secret={variable}
-          revealed={revealed[variable.key]}
-          consumers={usage[variable.key]}
-          onConsumerClick={onConsumerClick}
-          isEditing={editingKey === variable.key}
-          editValue={editValue}
-          showEditValue={showEditValue}
-          onReveal={() => onReveal(variable.key)}
-          onEdit={() => onEdit(variable.key)}
-          onDelete={() => onDelete(variable.key)}
-          onEditValueChange={onEditValueChange}
-          onEditToggleShow={onEditToggleShow}
-          onEditSave={onEditSave}
-          onEditCancel={onEditCancel}
-          sets={setNames}
-          onAssignSet={(set) => onAssignSet(variable.key, set)}
+          variable={variable}
+          selected={variable.key === selectedKey}
+          onSelect={() => onSelect(variable.key)}
+          preview={
+            variable.is_secret
+              ? SECRET_PREVIEW
+              : (revealed[variable.key] ?? '•••')
+          }
+          consumerCount={(usage[variable.key] ?? []).length}
+          compact={compact}
         />
       ))}
     </div>

--- a/web/src/hooks/useRevealedValues.ts
+++ b/web/src/hooks/useRevealedValues.ts
@@ -25,6 +25,9 @@ const REVEAL_TIMEOUT_MS = 10_000;
 export function useRevealedValues(): UseRevealedValuesResult {
   const [revealed, setRevealed] = useState<Record<string, string>>({});
   const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  // Per-key generation counter: hide() bumps it so an in-flight reveal that
+  // started before the hide can't re-add the value once its fetch resolves.
+  const generations = useRef<Record<string, number>>({});
   const revealedRef = useRef(revealed);
 
   // Mirror the latest revealed map into a ref so callbacks can read it
@@ -50,6 +53,7 @@ export function useRevealedValues(): UseRevealedValuesResult {
 
   const hide = useCallback(
     (key: string) => {
+      generations.current[key] = (generations.current[key] ?? 0) + 1;
       setRevealed((prev) => {
         if (prev[key] === undefined) return prev;
         const next = { ...prev };
@@ -74,7 +78,12 @@ export function useRevealedValues(): UseRevealedValuesResult {
         hide(key);
         return;
       }
+      const generation = generations.current[key] ?? 0;
       const value = await getValue();
+      // A hide() while the fetch was in flight invalidates this reveal —
+      // dropping the result keeps "hidden means hidden" across fast
+      // selection switches.
+      if ((generations.current[key] ?? 0) !== generation) return;
       setRevealed((prev) => ({ ...prev, [key]: value }));
       if (autoHide) {
         timers.current[key] = setTimeout(() => {


### PR DESCRIPTION
## Description

Converts the Variables workspace into a master-detail layout: a denser, table-like variable list plus a persistent right-rail inspector, matching the Library and Tools workspaces. The inspector leads with the stack usage index (every `${var:KEY}` reference site, clickable through to topology), followed by a type-aware value view, copy-without-reveal, edit-in-pane, set reassignment, and one-step rotate for string secrets.

Closes #775

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Enable the right rail in `VaultWorkspace` (`defaultRightPct={30}`, `minRightPx={300}`) with URL-synced selection (`?selected=KEY`), arrow-key list navigation, and a filtered-out-selection fallback to the overview pane
- New `VariableInspector`: usage section first (full consumer list, hedged orphan callout), type-aware value views (pretty JSON via CodeViewer, list chips, bool/number literals), fixed-length secret masking, copy-without-reveal as the primary action, reveal with 10s auto-hide, edit-in-pane via the existing `VariableValueInput`, set reassignment, rotate behind a confirm, and an at-a-glance overview when nothing is selected
- New `VariableRow`: aligned table columns (key, type, set, value preview, used-by count) under a sticky header, with the Tools-style selected-row accent; inline row expand/edit removed from the workspace
- Extract `ConsumerList` from `SecretItem` into a shared component (sidebar `VaultPanel` behavior unchanged)
- Harden `useRevealedValues` against a race where an in-flight reveal could re-add a value after `hide()` (per-key generation counter)
- Tests: new `VariableInspector` suite (17 tests) plus workspace selection-flow coverage; changelog entry

## Testing

- `cd web && npm test` — 990 tests pass, including new coverage for selection via click and deep link, usage rendering and consumer navigation, copy-without-reveal, reveal auto-hide, edit save/cancel, rotate, delete-clears-selection, and the mid-reveal selection-switch race
- `cd web && npm run build` and lint clean on all touched files
- Manual: select/inspect/edit/rotate flows on wide and narrow viewports; `]` collapses the rail and the preference persists

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed