### PR TITLE
feat: in-UI cost model editing across all three pricing tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **In-UI pricing model editing across all three attribution tiers.** Cost
+  attribution no longer requires hand-editing stack.yaml: the per-server
+  `model:` and `gateway.default_model` tiers join `client_models:` as
+  editable from the web UI, through new `PUT /api/mcp-servers/{name}/model`
+  and `PUT /api/gateway/default-model` endpoints (atomic, comment-preserving
+  YAML writes with 409 conflict detection and hot reload, mirroring the
+  client-model endpoint). The old datalist editor is replaced by a shared
+  searchable model picker over the embedded LiteLLM snapshot — provider
+  grouping, keyboard navigation, virtualized for the full ~2,700-ID list,
+  free text allowed with a soft "prices as $0" note for unknown IDs. A new
+  "Pricing models" slide-over manager lists all three tiers in precedence
+  order and opens from the Metrics toolbar, the sidebar inspector's new
+  Pricing section (clients and servers show their priced-as model with
+  provenance), or the command palette ("Edit pricing models"). The Metrics
+  per-server table gains a Model column with `· server` pills and muted
+  `default:` inheritance, the creation wizard gains pricing fields
+  (`gateway.default_model` in a Pricing section, per-server model under
+  Advanced), and `/api/status` now exposes `server_models`, `default_model`,
+  and each server's declared `model` for the UI.
+
 - **Variables workspace master-detail inspector.** The Variables tab now uses
   the same list-plus-inspector layout as Library and Tools: a denser,
   table-like variable list (key, type, set, value preview, and used-by count
@@ -254,6 +274,12 @@ All notable changes to gridctl will be documented in this file.
   web UI client list. This is gridctl's first TOML-based client provisioner.
 
 ### Fixed
+
+- **Detached metrics window missing the client Model column.** The popout
+  `/metrics` window now has full parity with the Metrics tab: the Top Clients
+  Model column with inline editing, the per-server Model column, and the
+  pricing manager. The stale cost hint ("Set `model:` in stack.yaml") in both
+  surfaces is replaced with copy that points at the in-UI edit path.
 
 - **Cost observability now produces data.** The cost pipeline (pricing engine,
   accumulator, REST API, UI cost card, optimize heuristics, `gen_ai.cost.usd`

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -774,8 +774,9 @@ metadata (when a server reports one) > the calling client's `client_models`
 entry > the target server's `model:` > `gateway.default_model`. Unknown model
 IDs and keys that are not normalized client IDs surface as validation
 warnings (never errors) and price as zero. Edits hot-reload without
-restarting any server. The Metrics tab's Top Clients panel shows each
-declared client's model and lets you edit it inline; see
+restarting any server. All three tiers are editable in the web UI: inline in
+the Metrics tab's client and server tables, or through the "Pricing models"
+manager (Metrics toolbar, sidebar inspector, or command palette); see
 [Cost Observability](cost-observability.md) for semantics and limitations.
 
 ---

--- a/docs/cost-observability.md
+++ b/docs/cost-observability.md
@@ -29,7 +29,17 @@ mcp-servers:
     model: claude-opus-4-7          # prices undeclared clients' calls to this server
 ```
 
-Without any attribution, tokens and latency record normally but cost stays zero, and the dashboard's cost card shows a configuration hint instead of a number. Anonymous calls (no client identity on the session) skip the client tier and resolve via the server tier. Edits to any of these fields hot-reload through the file watcher without restarting any server; subsequent calls price against the updated mapping. The Metrics tab's Top Clients panel shows each declared client's model with `· client` provenance and supports inline editing backed by the known-models list (`GET /api/pricing/models`); clients without a declaration aggregate whatever server/default rates their calls hit, so no single model is shown for them.
+Without any attribution, tokens and latency record normally but cost stays zero, and the dashboard's cost card shows a configuration hint instead of a number. Anonymous calls (no client identity on the session) skip the client tier and resolve via the server tier. Edits to any of these fields hot-reload through the file watcher without restarting any server; subsequent calls price against the updated mapping.
+
+### Editing attribution in the UI
+
+All three declared tiers are editable in the web UI without touching `stack.yaml`. The shared model picker is a searchable, provider-grouped combobox over the known-models list (`GET /api/pricing/models`); free-text IDs outside the list are accepted (best-effort pricing, soft warning, $0).
+
+- **Metrics tab** (and the detached `/metrics` window): the Top Clients panel shows each declared client's model with `· client` provenance and edits inline; the per-server table shows `· server` pills or muted `default: <id>` inheritance and edits inline. Clients without a declaration aggregate whatever server/default rates their calls hit, so no single model is shown for them.
+- **Pricing models manager**: a slide-over listing all three tiers in precedence order (clients, servers, gateway default). Opened from the Metrics toolbar's `$` button, the sidebar inspector's Pricing section, or the command palette ("Edit pricing models").
+- **Creation wizard**: `gateway.default_model` (Pricing section) and per-server `model:` (Advanced section) can be set before the first apply.
+
+Writes go through dedicated pricing endpoints (`PUT /api/clients/{slug}/model`, `PUT /api/mcp-servers/{name}/model`, `PUT /api/gateway/default-model`) that patch only the relevant key, preserve comments and ordering, and never create or touch a `clients:` access block. A concurrent external edit surfaces as a 409 conflict so the UI can re-fetch; successful saves hot-reload immediately.
 
 Two limitations to keep expectations honest. A declared client model is a session-level default: the gateway cannot see a mid-session model switch (e.g. `/model` in Claude Code), so calls keep pricing at the declared model until the declaration changes. And validation is soft by design: model IDs unknown to the pricing snapshot, or `client_models` keys that are not normalized client IDs (`gridctl validate` warns and suggests the canonical form), produce warnings — never errors — and price as zero.
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -63,6 +63,16 @@ type Server struct {
 	// configured. Must be safe for concurrent calls.
 	clientModelAttribution func() map[string]string
 
+	// declaredServerModels returns the server -> model mapping as DECLARED
+	// in stack.yaml (per-server model: only, no default_model folded in).
+	// The UI needs the declared value as the edit baseline; the effective
+	// value comes from modelAttribution. Must be safe for concurrent calls.
+	declaredServerModels func() map[string]string
+
+	// defaultModel returns the gateway-level default_model from stack.yaml,
+	// or "" when none is configured. Must be safe for concurrent calls.
+	defaultModel func() string
+
 	// startWatcher, when set, starts a file watcher on the given stack path.
 	// Injected by GatewayBuilder so POST /api/stack/initialize can activate live reload.
 	startWatcher func(stackPath string)
@@ -224,6 +234,39 @@ func (s *Server) clientModelAttributionMap() map[string]string {
 	return s.clientModelAttribution()
 }
 
+// SetDeclaredServerModels sets a getter for the server -> model mapping as
+// declared in stack.yaml (per-server model: only). Same contract as
+// SetModelAttribution: the getter follows hot reloads and must be safe for
+// concurrent calls. Feeds the /api/status server model exposure.
+func (s *Server) SetDeclaredServerModels(get func() map[string]string) {
+	s.declaredServerModels = get
+}
+
+// SetDefaultModel sets a getter for the gateway-level default_model. The
+// getter follows hot reloads and must be safe for concurrent calls. Feeds
+// the /api/status default_model exposure.
+func (s *Server) SetDefaultModel(get func() string) {
+	s.defaultModel = get
+}
+
+// declaredServerModelsMap returns the current declared server -> model
+// mapping, or nil when no getter is wired or nothing is configured.
+func (s *Server) declaredServerModelsMap() map[string]string {
+	if s.declaredServerModels == nil {
+		return nil
+	}
+	return s.declaredServerModels()
+}
+
+// defaultModelValue returns the current gateway default_model, or "" when no
+// getter is wired or none is configured.
+func (s *Server) defaultModelValue() string {
+	if s.defaultModel == nil {
+		return ""
+	}
+	return s.defaultModel()
+}
+
 // SetStartWatcher sets a callback that activates live-reload file watching for
 // the given stack path. Called by POST /api/stack/initialize after cold-loading.
 func (s *Server) SetStartWatcher(fn func(stackPath string)) {
@@ -278,6 +321,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /api/mcp-servers/{name}/restart", s.handleMCPServerRestart)
 	mux.HandleFunc("PUT /api/mcp-servers/tools", s.handleSetServerToolsBatch)
 	mux.HandleFunc("PUT /api/mcp-servers/{name}/tools", s.handleSetServerTools)
+	mux.HandleFunc("PUT /api/mcp-servers/{name}/model", s.handleSetServerModel)
+	mux.HandleFunc("PUT /api/gateway/default-model", s.handleSetDefaultModel)
 	mux.HandleFunc("/api/mcp-servers", s.handleMCPServers)
 	mux.HandleFunc("/api/tools", s.handleTools)
 	mux.HandleFunc("GET /api/tools/catalog", s.handleToolsCatalog)
@@ -440,7 +485,16 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		// stack.yaml client_models. Omitted when empty. The UI uses it to
 		// label per-client cost with the model it was priced as.
 		ClientModels map[string]string `json:"client_models,omitempty"`
-		StackName    string            `json:"stack_name,omitempty"`
+		// ServerModels is the EFFECTIVE server -> model pricing map (a
+		// server's own model: with gateway default_model folded in).
+		// Omitted when no server-tier attribution is configured. The
+		// declared per-server value rides on each MCPServerStatus.Model.
+		ServerModels map[string]string `json:"server_models,omitempty"`
+		// DefaultModel is the gateway-level default_model from stack.yaml.
+		// Omitted when not configured. Lets the UI render "inherits
+		// default: <id>" provenance for servers without their own model.
+		DefaultModel string `json:"default_model,omitempty"`
+		StackName    string `json:"stack_name,omitempty"`
 	}{
 		Gateway: ServerInfo{
 			Name:      s.gateway.ServerInfo().Name,
@@ -472,7 +526,9 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	status.ClientModels = s.clientModelAttributionMap()
-	status.CostAttribution = len(s.modelAttributionMap()) > 0 || len(status.ClientModels) > 0
+	status.ServerModels = s.modelAttributionMap()
+	status.DefaultModel = s.defaultModelValue()
+	status.CostAttribution = len(status.ServerModels) > 0 || len(status.ClientModels) > 0
 
 	writeJSON(w, status)
 }
@@ -562,6 +618,10 @@ type MCPServerStatus struct {
 	LastCheck     *string  `json:"lastCheck,omitempty"`
 	HealthError   string   `json:"healthError,omitempty"`
 	ToolWhitelist []string `json:"toolWhitelist,omitempty"`
+	// Model is the pricing model DECLARED on this server in stack.yaml
+	// (model: field only — a gateway default_model is not folded in here).
+	// Empty when the server inherits the default or has no attribution.
+	Model string `json:"model,omitempty"`
 
 	Replicas  []mcp.ReplicaStatus  `json:"replicas,omitempty"`
 	Autoscale *mcp.AutoscaleStatus `json:"autoscale,omitempty"`
@@ -569,6 +629,7 @@ type MCPServerStatus struct {
 
 func (s *Server) getMCPServerStatuses() []MCPServerStatus {
 	mcpStatuses := s.gateway.Status()
+	declaredModels := s.declaredServerModelsMap()
 	statuses := make([]MCPServerStatus, len(mcpStatuses))
 	for i, ms := range mcpStatuses {
 		status := MCPServerStatus{
@@ -588,6 +649,7 @@ func (s *Server) getMCPServerStatuses() []MCPServerStatus {
 			Healthy:       ms.Healthy,
 			HealthError:   ms.HealthError,
 			ToolWhitelist: ms.ToolWhitelist,
+			Model:         declaredModels[ms.Name],
 			Replicas:      ms.Replicas,
 			Autoscale:     ms.Autoscale,
 		}

--- a/internal/api/clients_model.go
+++ b/internal/api/clients_model.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -195,16 +194,7 @@ func patchClientModels(source []byte, clientKey, model string) ([]byte, error) {
 		replaceOrInsertScalar(modelsNode, clientKey, model)
 	}
 
-	var buf bytes.Buffer
-	enc := yaml.NewEncoder(&buf)
-	enc.SetIndent(2)
-	if err := enc.Encode(&root); err != nil {
-		return nil, fmt.Errorf("marshal stack yaml: %w", err)
-	}
-	if err := enc.Close(); err != nil {
-		return nil, fmt.Errorf("marshal stack yaml: %w", err)
-	}
-	return buf.Bytes(), nil
+	return encodeStackYAML(&root)
 }
 
 // replaceOrInsertScalar sets mapping[key] to a string scalar, replacing an

--- a/internal/api/gateway_model.go
+++ b/internal/api/gateway_model.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// setDefaultModelRequest is the wire shape for PUT /api/gateway/default-model.
+// Model is the stack-wide fallback pricing model ID; an empty string removes
+// gateway.default_model. Unknown model IDs are accepted — pricing is
+// best-effort and validation surfaces them as load-time warnings, never hard
+// errors.
+type setDefaultModelRequest struct {
+	Model string `json:"model"`
+}
+
+// setDefaultModelResponse is the success payload.
+type setDefaultModelResponse struct {
+	Model      string `json:"model"`
+	Reloaded   bool   `json:"reloaded"`
+	ReloadedAt string `json:"reloadedAt,omitempty"`
+}
+
+// handleSetDefaultModel writes gateway.default_model into the live stack YAML
+// and triggers a hot reload. Pricing attribution only: the gateway: block is
+// created when absent and removed again when clearing default_model empties
+// a block this endpoint created, so a fully cleared stack round-trips back to
+// its pre-feature shape. The YAML write is atomic and conflict-detected: an
+// external edit between read and write surfaces as 409 so the UI can
+// re-fetch.
+//
+// PUT /api/gateway/default-model
+func (s *Server) handleSetDefaultModel(w http.ResponseWriter, r *http.Request) {
+	if s.stackFile == "" {
+		writeJSONError(w, "No stack file configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, setToolsRequestMaxBytes))
+	if err != nil {
+		writeJSONError(w, "Failed to read request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	var req setDefaultModelRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	switch err := setGatewayDefaultModel(s.stackFile, req.Model); {
+	case err == nil:
+		// proceed
+	case errors.Is(err, errStackModified):
+		writeStructuredError(w, http.StatusConflict, errCodeStackModified,
+			"The stack file was modified outside the canvas.",
+			"Reload the file to see the latest contents, then re-apply your changes.")
+		return
+	default:
+		slog.Default().Warn("gateway default model write failed", "error", err)
+		writeJSONError(w, "Failed to update stack: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	slog.Default().Info("gateway default pricing model updated", "model", req.Model)
+
+	resp := setDefaultModelResponse{Model: req.Model}
+
+	if s.reloadHandler != nil {
+		result, err := s.reloadHandler.Reload(r.Context())
+		if err != nil {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed, err.Error(),
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+		if !result.Success {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed, result.Message,
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+		resp.Reloaded = true
+		resp.ReloadedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	writeJSON(w, resp)
+}
+
+// setGatewayDefaultModel writes (or removes, when model is empty) the
+// gateway.default_model scalar in the stack YAML at path. Same atomic
+// read-verify-write discipline as setClientModel and setServerModel.
+func setGatewayDefaultModel(path, model string) error {
+	if path == "" {
+		return errStackFileEmpty
+	}
+
+	mu := stackFileLock(path)
+	mu.Lock()
+	defer mu.Unlock()
+
+	original, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read stack file: %w", err)
+	}
+	originalHash := sha256.Sum256(original)
+
+	updated, err := patchGatewayDefaultModel(original, model)
+	if err != nil {
+		return err
+	}
+
+	fireBetweenReadsHook()
+
+	current, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("re-read stack file: %w", err)
+	}
+	if sha256.Sum256(current) != originalHash {
+		return errStackModified
+	}
+
+	return atomicWrite(path, updated)
+}
+
+// patchGatewayDefaultModel rewrites the YAML source so the gateway: block
+// carries (or drops) default_model. An empty model deletes the key — never
+// writing `default_model: ""` — and removes the gateway: block only when the
+// key removal emptied it, so a gateway block that carried only default_model
+// round-trips away cleanly while a block with other keys (auth, code_mode,
+// ...) is left intact. Clearing when nothing is set is a no-op.
+func patchGatewayDefaultModel(source []byte, model string) ([]byte, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(source, &root); err != nil {
+		return nil, fmt.Errorf("parse stack yaml: %w", err)
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil, fmt.Errorf("parse stack yaml: not a document")
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse stack yaml: top-level not a mapping")
+	}
+
+	if model == "" {
+		gw := findMappingValue(doc, "gateway")
+		if gw == nil || gw.Kind != yaml.MappingNode {
+			// Absent (or a bare `gateway:` null) — nothing to clear. A bare
+			// block was not created by this endpoint, so it is left alone.
+			return encodeStackYAML(&root)
+		}
+		hadKey := findMappingValue(gw, "default_model") != nil
+		removeMappingKey(gw, "default_model")
+		// Drop the block only when removing OUR key emptied it: that shape
+		// is exactly what the set path creates from scratch. A pre-existing
+		// empty mapping (no key removed) stays untouched.
+		if hadKey && len(gw.Content) == 0 {
+			removeMappingKey(doc, "gateway")
+		}
+	} else {
+		gw, err := ensureChildMapping(doc, "gateway")
+		if err != nil {
+			return nil, err
+		}
+		replaceOrInsertScalar(gw, "default_model", model)
+	}
+
+	return encodeStackYAML(&root)
+}

--- a/internal/api/gateway_model_test.go
+++ b/internal/api/gateway_model_test.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestPatchGatewayDefaultModel_CreatesGatewayBlock(t *testing.T) {
+	source := []byte(`# my stack
+name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+`)
+	out, err := patchGatewayDefaultModel(source, "claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "gateway:") || !strings.Contains(got, "default_model: claude-haiku-4-5") {
+		t.Errorf("expected gateway.default_model; got:\n%s", got)
+	}
+	if !strings.Contains(got, "# my stack") {
+		t.Errorf("comment lost:\n%s", got)
+	}
+}
+
+func TestPatchGatewayDefaultModel_ReplaceExisting(t *testing.T) {
+	source := []byte(`name: test
+gateway:
+  default_model: claude-haiku-4-5   # stack floor
+  code_mode: on
+`)
+	out, err := patchGatewayDefaultModel(source, "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "default_model: claude-sonnet-4-6") {
+		t.Errorf("expected replaced model; got:\n%s", got)
+	}
+	if !strings.Contains(got, "code_mode:") {
+		t.Errorf("sibling gateway key lost:\n%s", got)
+	}
+}
+
+func TestPatchGatewayDefaultModel_ClearRemovesKeyKeepsBlock(t *testing.T) {
+	source := []byte(`name: test
+gateway:
+  default_model: claude-haiku-4-5
+  code_mode: on
+`)
+	out, err := patchGatewayDefaultModel(source, "")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "default_model") {
+		t.Errorf("cleared key must be deleted:\n%s", got)
+	}
+	if !strings.Contains(got, "gateway:") || !strings.Contains(got, "code_mode:") {
+		t.Errorf("gateway block with other keys must survive:\n%s", got)
+	}
+}
+
+func TestPatchGatewayDefaultModel_ClearLastKeyDropsBlock(t *testing.T) {
+	source := []byte(`name: test
+gateway:
+  default_model: claude-haiku-4-5
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+`)
+	out, err := patchGatewayDefaultModel(source, "")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "gateway") {
+		t.Errorf("a gateway block emptied by the clear must be removed:\n%s", got)
+	}
+	var roundTrip map[string]any
+	if err := yaml.Unmarshal(out, &roundTrip); err != nil {
+		t.Fatalf("output is not valid YAML: %v", err)
+	}
+	if roundTrip["name"] != "test" {
+		t.Errorf("sibling keys lost: %v", roundTrip)
+	}
+}
+
+func TestPatchGatewayDefaultModel_ClearAbsentIsNoOp(t *testing.T) {
+	source := []byte("name: test\n")
+	out, err := patchGatewayDefaultModel(source, "")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if strings.Contains(string(out), "gateway") {
+		t.Errorf("clearing with no gateway block must not create one:\n%s", out)
+	}
+}
+
+func TestPatchGatewayDefaultModel_ClearPreservesPreexistingEmptyBlock(t *testing.T) {
+	// A bare `gateway:` line (explicit null) was not created by this
+	// endpoint; a clear must leave it alone rather than deleting user YAML.
+	source := []byte("name: test\ngateway:\n")
+	out, err := patchGatewayDefaultModel(source, "")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if !strings.Contains(string(out), "gateway:") {
+		t.Errorf("pre-existing bare gateway block must survive a clear:\n%s", out)
+	}
+}
+
+func TestHandleSetDefaultModel_RoundTrip(t *testing.T) {
+	srv := newTestServer(t)
+	stackFile := writeTempStack(t, `name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+`)
+	srv.SetStackFile(stackFile)
+	handler := srv.Handler()
+
+	// Set.
+	req := httptest.NewRequest(http.MethodPut, "/api/gateway/default-model",
+		strings.NewReader(`{"model":"claude-haiku-4-5"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp setDefaultModelResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Model != "claude-haiku-4-5" {
+		t.Errorf("response = %+v", resp)
+	}
+	assertStackContains(t, stackFile, "default_model: claude-haiku-4-5")
+
+	// Clear — the gateway block this endpoint created must round-trip away.
+	req = httptest.NewRequest(http.MethodPut, "/api/gateway/default-model",
+		strings.NewReader(`{"model":""}`))
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertStackNotContains(t, stackFile, "gateway")
+}
+
+func TestHandleSetDefaultModel_NoStackFile(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/gateway/default-model",
+		strings.NewReader(`{"model":"claude-haiku-4-5"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+}

--- a/internal/api/server_model.go
+++ b/internal/api/server_model.go
@@ -1,0 +1,195 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// setServerModelRequest is the wire shape for PUT /api/mcp-servers/{name}/model.
+// Model is the pricing model ID for this server (e.g. "claude-opus-4-7"); an
+// empty string removes the server's model: key so it falls back to
+// gateway.default_model (or no attribution). Unknown model IDs are accepted —
+// pricing is best-effort and validation surfaces them as load-time warnings,
+// never hard errors.
+type setServerModelRequest struct {
+	Model string `json:"model"`
+}
+
+// setServerModelResponse is the success payload.
+type setServerModelResponse struct {
+	Server     string `json:"server"`
+	Model      string `json:"model"`
+	Reloaded   bool   `json:"reloaded"`
+	ReloadedAt string `json:"reloadedAt,omitempty"`
+}
+
+// handleSetServerModel writes a single MCP server's pricing model into the
+// live stack YAML and triggers a hot reload. Like the client-model endpoint
+// this is pricing attribution only: it touches the server's model: scalar
+// and nothing else. The YAML write is atomic and conflict-detected: an
+// external edit between read and write surfaces as 409 so the UI can
+// re-fetch.
+//
+// PUT /api/mcp-servers/{name}/model
+func (s *Server) handleSetServerModel(w http.ResponseWriter, r *http.Request) {
+	serverName := r.PathValue("name")
+	if serverName == "" {
+		writeJSONError(w, "Server name is required", http.StatusBadRequest)
+		return
+	}
+
+	if s.stackFile == "" {
+		writeJSONError(w, "No stack file configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, setToolsRequestMaxBytes))
+	if err != nil {
+		writeJSONError(w, "Failed to read request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	var req setServerModelRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	switch err := setServerModel(s.stackFile, serverName, req.Model); {
+	case err == nil:
+		// proceed
+	case errors.Is(err, errServerNotFound):
+		writeJSONError(w, "MCP server not found: "+serverName, http.StatusNotFound)
+		return
+	case errors.Is(err, errStackModified):
+		writeStructuredError(w, http.StatusConflict, errCodeStackModified,
+			"The stack file was modified outside the canvas.",
+			"Reload the file to see the latest contents, then re-apply your changes.")
+		return
+	default:
+		slog.Default().Warn("server model write failed", "server", serverName, "error", err)
+		writeJSONError(w, "Failed to update stack: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	slog.Default().Info("server pricing model updated", "server", serverName, "model", req.Model)
+
+	resp := setServerModelResponse{
+		Server: serverName,
+		Model:  req.Model,
+	}
+
+	if s.reloadHandler != nil {
+		result, err := s.reloadHandler.Reload(r.Context())
+		if err != nil {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed, err.Error(),
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+		if !result.Success {
+			writeStructuredError(w, http.StatusBadGateway, errCodeReloadFailed, result.Message,
+				"The stack file was saved but the hot reload failed. Check gridctl logs.")
+			return
+		}
+		resp.Reloaded = true
+		resp.ReloadedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	writeJSON(w, resp)
+}
+
+// setServerModel writes (or removes, when model is empty) the pricing model
+// for the named server in the stack YAML at path. It mirrors setClientModel:
+// it serializes concurrent callers on the same path, detects external edits
+// via a pre-read hash vs. pre-write re-read, and writes atomically. Comments,
+// ordering, and unrelated keys survive the yaml.Node round-trip.
+func setServerModel(path, serverName, model string) error {
+	if path == "" {
+		return errStackFileEmpty
+	}
+
+	mu := stackFileLock(path)
+	mu.Lock()
+	defer mu.Unlock()
+
+	original, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read stack file: %w", err)
+	}
+	originalHash := sha256.Sum256(original)
+
+	updated, err := patchServerModel(original, serverName, model)
+	if err != nil {
+		return err
+	}
+
+	fireBetweenReadsHook()
+
+	current, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("re-read stack file: %w", err)
+	}
+	if sha256.Sum256(current) != originalHash {
+		return errStackModified
+	}
+
+	return atomicWrite(path, updated)
+}
+
+// patchServerModel rewrites the YAML source so the named entry in the
+// mcp-servers: sequence carries (or drops) the given model: scalar. An empty
+// model deletes the key — never writing `model: ""` — so a cleared server
+// round-trips back to its pre-attribution shape. Returns errServerNotFound
+// when the server is absent from the stack.
+func patchServerModel(source []byte, serverName, model string) ([]byte, error) {
+	if serverName == "" {
+		return nil, fmt.Errorf("server name must not be empty")
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(source, &root); err != nil {
+		return nil, fmt.Errorf("parse stack yaml: %w", err)
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil, fmt.Errorf("parse stack yaml: not a document")
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parse stack yaml: top-level not a mapping")
+	}
+
+	serversSeq := findMappingValue(doc, "mcp-servers")
+	if serversSeq == nil || serversSeq.Kind != yaml.SequenceNode {
+		return nil, errServerNotFound
+	}
+
+	var target *yaml.Node
+	for _, entry := range serversSeq.Content {
+		if entry.Kind != yaml.MappingNode {
+			continue
+		}
+		if nameNode := findMappingValue(entry, "name"); nameNode != nil && nameNode.Value == serverName {
+			target = entry
+			break
+		}
+	}
+	if target == nil {
+		return nil, errServerNotFound
+	}
+
+	if model == "" {
+		removeMappingKey(target, "model")
+	} else {
+		replaceOrInsertScalar(target, "model", model)
+	}
+
+	return encodeStackYAML(&root)
+}

--- a/internal/api/server_model_test.go
+++ b/internal/api/server_model_test.go
@@ -1,0 +1,243 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestPatchServerModel_InsertIntoServer(t *testing.T) {
+	source := []byte(`# my stack
+name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+    port: 3000
+  - name: gitlab
+    image: mcp/gitlab:latest
+    port: 3001
+`)
+	out, err := patchServerModel(source, "github", "claude-opus-4-7")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "model: claude-opus-4-7") {
+		t.Errorf("expected model entry; got:\n%s", got)
+	}
+	if !strings.Contains(got, "# my stack") {
+		t.Errorf("comment lost:\n%s", got)
+	}
+	if !strings.Contains(got, "name: gitlab") {
+		t.Errorf("sibling server lost:\n%s", got)
+	}
+	// The sibling must not gain a model.
+	if strings.Count(got, "model:") != 1 {
+		t.Errorf("expected exactly one model: key; got:\n%s", got)
+	}
+}
+
+func TestPatchServerModel_ReplaceExisting(t *testing.T) {
+	source := []byte(`name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+    model: claude-opus-4-7   # priced as opus
+`)
+	out, err := patchServerModel(source, "github", "claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "model: claude-haiku-4-5") {
+		t.Errorf("expected replaced model; got:\n%s", got)
+	}
+	if strings.Contains(got, "claude-opus-4-7") {
+		t.Errorf("old model survived:\n%s", got)
+	}
+}
+
+func TestPatchServerModel_ClearDeletesKey(t *testing.T) {
+	source := []byte(`name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+    model: claude-opus-4-7
+    port: 3000
+`)
+	out, err := patchServerModel(source, "github", "")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "model") {
+		t.Errorf("cleared key must be deleted, never written as empty:\n%s", got)
+	}
+	if !strings.Contains(got, "port: 3000") {
+		t.Errorf("sibling field lost:\n%s", got)
+	}
+	// The result must remain a loadable stack.
+	var roundTrip map[string]any
+	if err := yaml.Unmarshal(out, &roundTrip); err != nil {
+		t.Fatalf("output is not valid YAML: %v", err)
+	}
+}
+
+func TestPatchServerModel_ClearAbsentKeyIsNoOp(t *testing.T) {
+	source := []byte(`name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+`)
+	out, err := patchServerModel(source, "github", "")
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if strings.Contains(string(out), "model") {
+		t.Errorf("clearing an absent key must not create it:\n%s", out)
+	}
+}
+
+func TestPatchServerModel_ServerNotFound(t *testing.T) {
+	source := []byte(`name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+`)
+	_, err := patchServerModel(source, "missing", "claude-opus-4-7")
+	if !errors.Is(err, errServerNotFound) {
+		t.Errorf("err = %v, want errServerNotFound", err)
+	}
+}
+
+func TestHandleSetServerModel_RoundTrip(t *testing.T) {
+	srv := newTestServer(t)
+	stackFile := writeTempStack(t, `name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+    port: 3000
+`)
+	srv.SetStackFile(stackFile)
+	handler := srv.Handler()
+
+	// Set.
+	req := httptest.NewRequest(http.MethodPut, "/api/mcp-servers/github/model",
+		strings.NewReader(`{"model":"claude-opus-4-7"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp setServerModelResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Server != "github" || resp.Model != "claude-opus-4-7" {
+		t.Errorf("response = %+v", resp)
+	}
+	assertStackContains(t, stackFile, "model: claude-opus-4-7")
+
+	// Clear.
+	req = httptest.NewRequest(http.MethodPut, "/api/mcp-servers/github/model",
+		strings.NewReader(`{"model":""}`))
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	assertStackNotContains(t, stackFile, "model:")
+}
+
+func TestHandleSetServerModel_UnknownServer(t *testing.T) {
+	srv := newTestServer(t)
+	stackFile := writeTempStack(t, `name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+`)
+	srv.SetStackFile(stackFile)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/mcp-servers/missing/model",
+		strings.NewReader(`{"model":"claude-opus-4-7"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleSetServerModel_NoStackFile(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/mcp-servers/github/model",
+		strings.NewReader(`{"model":"claude-opus-4-7"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestSetServerModel_ConflictOnExternalEdit(t *testing.T) {
+	stackFile := writeTempStack(t, `name: test
+mcp-servers:
+  - name: github
+    image: mcp/github:latest
+`)
+	swapBetweenReadsHook(func() {
+		// Simulate an external editor landing a change between our initial
+		// read and the pre-write re-read.
+		_ = os.WriteFile(stackFile, []byte("name: test\n# externally edited\n"), 0o600)
+	})
+	defer swapBetweenReadsHook(nil)
+
+	err := setServerModel(stackFile, "github", "claude-opus-4-7")
+	if !errors.Is(err, errStackModified) {
+		t.Errorf("err = %v, want errStackModified", err)
+	}
+}
+
+func TestHandleStatus_ServerModelsAndDefaultModel(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	srv.SetModelAttribution(func() map[string]string {
+		return map[string]string{"github": "claude-opus-4-7", "gitlab": "claude-haiku-4-5"}
+	})
+	srv.SetDeclaredServerModels(func() map[string]string {
+		return map[string]string{"github": "claude-opus-4-7"}
+	})
+	srv.SetDefaultModel(func() string { return "claude-haiku-4-5" })
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var resp struct {
+		CostAttribution bool              `json:"cost_attribution"`
+		ServerModels    map[string]string `json:"server_models"`
+		DefaultModel    string            `json:"default_model"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.CostAttribution {
+		t.Error("cost_attribution must be true when server models are configured")
+	}
+	if resp.ServerModels["github"] != "claude-opus-4-7" || resp.ServerModels["gitlab"] != "claude-haiku-4-5" {
+		t.Errorf("server_models = %v", resp.ServerModels)
+	}
+	if resp.DefaultModel != "claude-haiku-4-5" {
+		t.Errorf("default_model = %q", resp.DefaultModel)
+	}
+}

--- a/internal/api/stack_edit.go
+++ b/internal/api/stack_edit.go
@@ -342,6 +342,22 @@ func toolsSequenceNode(tools []string) *yaml.Node {
 	return seq
 }
 
+// encodeStackYAML marshals a patched document with the package-standard
+// two-space indent. Shared by every yaml.Node patcher so the round-trip
+// encoding never drifts between endpoints.
+func encodeStackYAML(root *yaml.Node) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(root); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("marshal stack yaml: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
 // atomicWrite writes data to path via a same-directory temp file + fsync +
 // rename. A mid-write crash leaves the original file intact; a mid-rename
 // crash on a POSIX filesystem leaves either the old or the new file at path,

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -91,9 +91,14 @@ type GatewayBuilder struct {
 // models (per-server model: with gateway default_model folded in). The
 // resolver consults clients first — the model is a property of the calling
 // client's session; the server tier is the coarser fallback.
+// declaredServers and defaultModel carry the raw (un-folded) declarations so
+// the API can show provenance: which servers set their own model and what
+// the gateway default is.
 type modelAttribution struct {
-	clients map[string]string
-	servers map[string]string
+	clients         map[string]string
+	servers         map[string]string
+	declaredServers map[string]string
+	defaultModel    string
 }
 
 // telemetryWiring bundles the three per-signal writers + the otlptrace
@@ -841,6 +846,12 @@ func (b *GatewayBuilder) wireModelAttribution(observer *metrics.Observer, apiSer
 	apiServer.SetClientModelAttribution(func() map[string]string {
 		return b.modelAttribution.Load().clients
 	})
+	apiServer.SetDeclaredServerModels(func() map[string]string {
+		return b.modelAttribution.Load().declaredServers
+	})
+	apiServer.SetDefaultModel(func() string {
+		return b.modelAttribution.Load().defaultModel
+	})
 }
 
 // refreshModelAttribution re-resolves the client and server model mappings
@@ -849,9 +860,38 @@ func (b *GatewayBuilder) wireModelAttribution(observer *metrics.Observer, apiSer
 // next observed call.
 func (b *GatewayBuilder) refreshModelAttribution(cfg *config.Stack) {
 	b.modelAttribution.Store(&modelAttribution{
-		clients: cfg.ClientModelAttribution(),
-		servers: cfg.ModelAttribution(),
+		clients:         cfg.ClientModelAttribution(),
+		servers:         cfg.ModelAttribution(),
+		declaredServers: declaredServerModels(cfg),
+		defaultModel:    gatewayDefaultModel(cfg),
 	})
+}
+
+// declaredServerModels collects the raw per-server model: declarations
+// (no gateway default folded in). Returns nil when nothing is declared.
+func declaredServerModels(cfg *config.Stack) map[string]string {
+	if cfg == nil {
+		return nil
+	}
+	var out map[string]string
+	for _, server := range cfg.MCPServers {
+		if server.Model == "" {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string, len(cfg.MCPServers))
+		}
+		out[server.Name] = server.Model
+	}
+	return out
+}
+
+// gatewayDefaultModel returns gateway.default_model, or "" when unset.
+func gatewayDefaultModel(cfg *config.Stack) string {
+	if cfg == nil || cfg.Gateway == nil {
+		return ""
+	}
+	return cfg.Gateway.DefaultModel
 }
 
 // buildTracingConfig extracts tracing config from gateway config with defaults.

--- a/pkg/controller/model_attribution_test.go
+++ b/pkg/controller/model_attribution_test.go
@@ -302,6 +302,49 @@ func TestClientModelsAccessInert(t *testing.T) {
 	}
 }
 
+// TestRefreshModelAttribution_DeclaredAndDefaultExposed verifies the raw
+// declarations ride alongside the effective maps: declaredServers carries
+// only per-server model: fields (no default folded in) and defaultModel
+// carries gateway.default_model, both following hot reloads. These feed the
+// /api/status provenance exposure.
+func TestRefreshModelAttribution_DeclaredAndDefaultExposed(t *testing.T) {
+	stack := &config.Stack{
+		Name:    "test",
+		Gateway: &config.GatewayConfig{DefaultModel: "fallback-model"},
+		MCPServers: []config.MCPServer{
+			{Name: "a", Model: "claude-fixture"},
+			{Name: "b"},
+		},
+	}
+	builder, _, _, _ := newAttributionFixture(t, stack)
+
+	attribution := builder.modelAttribution.Load()
+	if attribution.defaultModel != "fallback-model" {
+		t.Errorf("defaultModel = %q, want fallback-model", attribution.defaultModel)
+	}
+	if got := attribution.declaredServers["a"]; got != "claude-fixture" {
+		t.Errorf("declaredServers[a] = %q, want claude-fixture", got)
+	}
+	if _, ok := attribution.declaredServers["b"]; ok {
+		t.Error("declaredServers must not fold the gateway default into undeclared servers")
+	}
+	// The effective map DOES fold the default in.
+	if got := attribution.servers["b"]; got != "fallback-model" {
+		t.Errorf("servers[b] = %q, want fallback-model (effective map folds default)", got)
+	}
+
+	// A hot reload that drops everything clears both exposures.
+	builder.refreshModelAttribution(&config.Stack{
+		Name:       "test",
+		MCPServers: []config.MCPServer{{Name: "a"}, {Name: "b"}},
+	})
+	attribution = builder.modelAttribution.Load()
+	if attribution.defaultModel != "" || len(attribution.declaredServers) != 0 {
+		t.Errorf("cleared stack must clear declared exposure; got default=%q declared=%v",
+			attribution.defaultModel, attribution.declaredServers)
+	}
+}
+
 // approxUSD mirrors the metrics package's float comparison for USD values.
 func approxUSD(a, b float64) bool {
 	d := a - b

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,6 +17,7 @@
         "@rjsf/core": "^6.6.1",
         "@rjsf/utils": "^6.5.2",
         "@rjsf/validator-ajv8": "^6.6.1",
+        "@tanstack/react-virtual": "^3.14.2",
         "@uiw/react-codemirror": "^4.25.10",
         "@xyflow/react": "^12.10.2",
         "clsx": "^2.1.1",
@@ -4273,6 +4274,33 @@
         "@tailwindcss/oxide": "4.3.0",
         "postcss": "^8.5.10",
         "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.2.tgz",
+      "integrity": "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz",
+      "integrity": "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "@rjsf/core": "^6.6.1",
     "@rjsf/utils": "^6.5.2",
     "@rjsf/validator-ajv8": "^6.6.1",
+    "@tanstack/react-virtual": "^3.14.2",
     "@uiw/react-codemirror": "^4.25.10",
     "@xyflow/react": "^12.10.2",
     "clsx": "^2.1.1",

--- a/web/src/__tests__/ClientModelCell.test.tsx
+++ b/web/src/__tests__/ClientModelCell.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ClientModelCell } from '../components/pricing/ClientModelCell';
+import { resetPricingModelsCacheForTests } from '../hooks/usePricingModels';
+import * as apiModule from '../lib/api';
+
+vi.mock('../components/ui/Toast', () => ({
+  showToast: vi.fn(),
+}));
+
+beforeEach(() => {
+  resetPricingModelsCacheForTests();
+  vi.restoreAllMocks();
+  vi.spyOn(apiModule, 'fetchPricingModels').mockResolvedValue({
+    source: 'litellm',
+    models: ['claude-haiku-4-5', 'claude-opus-4-7'],
+  });
+});
+
+describe('ClientModelCell', () => {
+  it('renders the declared model as a pill with client provenance', () => {
+    render(
+      <ClientModelCell
+        client="claude-code"
+        declaredModel="claude-opus-4-7"
+        costAttribution
+        onSaved={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('claude-opus-4-7')).toBeInTheDocument();
+    expect(screen.getByText('· client')).toBeInTheDocument();
+  });
+
+  it('renders per-server for undeclared clients when attribution exists', () => {
+    render(
+      <ClientModelCell client="goose" costAttribution onSaved={vi.fn()} />,
+    );
+    expect(screen.getByText('per-server')).toBeInTheDocument();
+  });
+
+  it('saves a committed model and reports it to the host', async () => {
+    const onSaved = vi.fn();
+    const update = vi.spyOn(apiModule, 'updateClientModel').mockResolvedValue({
+      client: 'claude-code',
+      profileKey: 'claude-code',
+      model: 'claude-haiku-4-5',
+      reloaded: true,
+    });
+    render(
+      <ClientModelCell client="claude-code" costAttribution={false} onSaved={onSaved} />,
+    );
+
+    fireEvent.click(screen.getByText('set model'));
+    const input = await screen.findByRole('combobox', { name: 'Pricing model' });
+    fireEvent.change(input, { target: { value: 'claude-haiku-4-5' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalledWith('claude-code', 'claude-haiku-4-5');
+      expect(onSaved).toHaveBeenCalledWith('claude-code', 'claude-haiku-4-5');
+    });
+    // Editor closes back to the pill state on success.
+    await waitFor(() => {
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the editor open and surfaces the message on save failure', async () => {
+    const onSaved = vi.fn();
+    vi.spyOn(apiModule, 'updateClientModel').mockRejectedValue(
+      new Error('The stack file was modified outside the canvas.'),
+    );
+    render(
+      <ClientModelCell client="claude-code" costAttribution={false} onSaved={onSaved} />,
+    );
+
+    fireEvent.click(screen.getByText('set model'));
+    const input = await screen.findByRole('combobox', { name: 'Pricing model' });
+    fireEvent.change(input, { target: { value: 'claude-haiku-4-5' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it('does not call the API when the committed value is unchanged', async () => {
+    const update = vi.spyOn(apiModule, 'updateClientModel');
+    render(
+      <ClientModelCell
+        client="claude-code"
+        declaredModel="claude-opus-4-7"
+        costAttribution
+        onSaved={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('claude-opus-4-7'));
+    const input = await screen.findByRole('combobox', { name: 'Pricing model' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/ModelPicker.test.tsx
+++ b/web/src/__tests__/ModelPicker.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ModelPicker } from '../components/pricing/ModelPicker';
+import { resetPricingModelsCacheForTests } from '../hooks/usePricingModels';
+import * as apiModule from '../lib/api';
+
+const MODELS = [
+  'claude-haiku-4-5',
+  'claude-opus-4-7',
+  'claude-sonnet-4-6',
+  'gpt-4o',
+  'anthropic/claude-opus-4-7',
+  'groq/llama-3.3-70b',
+];
+
+beforeEach(() => {
+  resetPricingModelsCacheForTests();
+  vi.restoreAllMocks();
+  vi.spyOn(apiModule, 'fetchPricingModels').mockResolvedValue({
+    source: 'litellm',
+    models: MODELS,
+  });
+});
+
+function getInput(): HTMLInputElement {
+  return screen.getByRole('combobox', { name: 'Pricing model' });
+}
+
+describe('ModelPicker', () => {
+  it('filters options live on substring input', async () => {
+    render(<ModelPicker value="" onCommit={vi.fn()} autoFocus />);
+    await waitFor(() => expect(apiModule.fetchPricingModels).toHaveBeenCalled());
+
+    fireEvent.change(getInput(), { target: { value: 'opus' } });
+    await waitFor(() => {
+      const options = screen.getAllByRole('option');
+      expect(options.map((o) => o.textContent)).toEqual([
+        'claude-opus-4-7',
+        'anthropic/claude-opus-4-7',
+      ]);
+    });
+  });
+
+  it('groups provider-prefixed IDs under their provider', async () => {
+    render(<ModelPicker value="" onCommit={vi.fn()} autoFocus />);
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(MODELS.length));
+    // Bare IDs lead under "models"; prefixed IDs group alphabetically.
+    expect(screen.getByText('models')).toBeInTheDocument();
+    expect(screen.getByText('anthropic')).toBeInTheDocument();
+    expect(screen.getByText('groq')).toBeInTheDocument();
+  });
+
+  it('commits the active option on Enter after arrow navigation', async () => {
+    const onCommit = vi.fn();
+    render(<ModelPicker value="" onCommit={onCommit} autoFocus />);
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(MODELS.length));
+
+    const input = getInput();
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith('claude-opus-4-7');
+  });
+
+  it('passes free text through on Enter when nothing is highlighted', async () => {
+    const onCommit = vi.fn();
+    render(<ModelPicker value="" onCommit={onCommit} autoFocus />);
+    await waitFor(() => expect(apiModule.fetchPricingModels).toHaveBeenCalled());
+
+    fireEvent.change(getInput(), { target: { value: 'my-custom-model' } });
+    fireEvent.keyDown(getInput(), { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith('my-custom-model');
+  });
+
+  it('shows the soft unknown-model note for IDs outside the snapshot', async () => {
+    render(<ModelPicker value="" onCommit={vi.fn()} autoFocus />);
+    await waitFor(() => expect(apiModule.fetchPricingModels).toHaveBeenCalled());
+
+    fireEvent.change(getInput(), { target: { value: 'my-custom-model' } });
+    await waitFor(() => {
+      expect(screen.getByText(/prices as \$0/)).toBeInTheDocument();
+    });
+  });
+
+  it('cancels on Escape without committing', async () => {
+    const onCommit = vi.fn();
+    const onCancel = vi.fn();
+    render(<ModelPicker value="claude-opus-4-7" onCommit={onCommit} onCancel={onCancel} autoFocus />);
+    await waitFor(() => expect(apiModule.fetchPricingModels).toHaveBeenCalled());
+
+    fireEvent.keyDown(getInput(), { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('commits an option on mouse selection', async () => {
+    const onCommit = vi.fn();
+    render(<ModelPicker value="" onCommit={onCommit} autoFocus />);
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(MODELS.length));
+
+    fireEvent.mouseDown(screen.getByRole('option', { name: 'gpt-4o' }));
+    expect(onCommit).toHaveBeenCalledWith('gpt-4o');
+  });
+
+  it('clears the draft via the clear affordance', async () => {
+    render(<ModelPicker value="claude-opus-4-7" onCommit={vi.fn()} autoFocus />);
+    await waitFor(() => expect(apiModule.fetchPricingModels).toHaveBeenCalled());
+
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'Clear model' }));
+    expect(getInput().value).toBe('');
+  });
+});

--- a/web/src/__tests__/StackForm.test.tsx
+++ b/web/src/__tests__/StackForm.test.tsx
@@ -354,6 +354,44 @@ describe('StackForm Gateway Advanced section', () => {
   });
 });
 
+describe('YAML serialization — pricing fields', () => {
+  it('serializes gateway default_model when set', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: {
+        name: 'my-stack',
+        gateway: { defaultModel: 'claude-haiku-4-5' },
+      },
+    });
+    expect(yaml).toContain('gateway:');
+    expect(yaml).toContain('default_model: claude-haiku-4-5');
+  });
+
+  it('omits default_model when unset', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: { name: 'my-stack', gateway: { codeMode: 'on' } },
+    });
+    expect(yaml).not.toContain('default_model');
+  });
+
+  it('serializes per-server model when set', () => {
+    const yaml = buildYAML({
+      type: 'stack',
+      data: {
+        name: 'my-stack',
+        mcpServers: [
+          { name: 'github', serverType: 'container', image: 'mcp/github:latest', model: 'claude-opus-4-7' },
+          { name: 'gitlab', serverType: 'container', image: 'mcp/gitlab:latest' },
+        ],
+      },
+    });
+    expect(yaml).toContain('model: claude-opus-4-7');
+    // The model-less sibling must not gain a model key.
+    expect(yaml.match(/ model:/g)).toHaveLength(1);
+  });
+});
+
 describe('YAML serialization — gateway advanced fields', () => {
   it('serializes api_key auth with header', () => {
     const yaml = buildYAML({

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   ArrowUpRight,
   ShieldCheck,
   SlidersHorizontal,
+  DollarSign,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { cn } from '../../lib/cn';
@@ -48,6 +49,10 @@ export function Sidebar() {
   const autoscaleDecisions = useStackStore((s) => s.autoscaleDecisions);
   const clients = useStackStore((s) => s.clients);
   const mcpServers = useStackStore((s) => s.mcpServers);
+  const clientModels = useStackStore((s) => s.clientModels);
+  const defaultModel = useStackStore((s) => s.defaultModel);
+  const costAttribution = useStackStore((s) => s.costAttribution);
+  const setPricingManagerOpen = useUIStore((s) => s.setPricingManagerOpen);
   const enableAccessLens = useAccessLensStore((s) => s.setEnabled);
   const openAccessLensEditor = useAccessLensStore((s) => s.openSlideOver);
   const { openDetachedWindow } = useWindowManager();
@@ -393,6 +398,54 @@ export function Sidebar() {
                 >
                   <SlidersHorizontal size={14} />
                   Edit Scope
+                </button>
+              </div>
+            </InspectorSection>
+          );
+        })()}
+
+        {/* Pricing Section (clients and MCP servers) — which model this
+            node's calls are priced as, with a path into the manager. */}
+        {(isClient || isServer) && (() => {
+          const declared = isClient
+            ? clientModels[clientData?.slug ?? '']
+            : mcpServers.find((s) => s.name === data.name)?.model;
+          return (
+            <InspectorSection title="Pricing" icon={DollarSign}>
+              <div className="space-y-3">
+                <div className="flex justify-between items-center gap-3">
+                  <span className="text-sm text-text-muted">
+                    {isClient ? 'Priced as' : 'Pricing model'}
+                  </span>
+                  {declared ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-surface-highlight/60 border border-border/40 px-2 py-0.5">
+                      <span className="text-[10px] font-mono text-text-primary">{declared}</span>
+                      <span className="text-[9px] text-text-muted/70">
+                        {isClient ? '· client' : '· server'}
+                      </span>
+                    </span>
+                  ) : !isClient && defaultModel ? (
+                    <span className="text-[10px] font-mono text-text-muted/70">
+                      default: {defaultModel}
+                    </span>
+                  ) : (
+                    <span className="text-[10px] text-text-muted/60">
+                      {isClient && costAttribution ? 'per-server' : 'not configured'}
+                    </span>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setPricingManagerOpen(true)}
+                  className={cn(
+                    'w-full inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg text-xs font-medium transition-all',
+                    'bg-surface-elevated/60 border border-border/50',
+                    'hover:bg-surface-highlight hover:border-text-muted/30',
+                    'text-text-secondary hover:text-text-primary',
+                  )}
+                >
+                  <DollarSign size={12} />
+                  Edit Pricing Models
                 </button>
               </div>
             </InspectorSection>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -425,11 +425,11 @@ export function Sidebar() {
                       </span>
                     </span>
                   ) : !isClient && defaultModel ? (
-                    <span className="text-[10px] font-mono text-text-muted/70">
+                    <span className="text-xs font-mono text-text-muted">
                       default: {defaultModel}
                     </span>
                   ) : (
-                    <span className="text-[10px] text-text-muted/60">
+                    <span className="text-xs text-text-muted">
                       {isClient && costAttribution ? 'per-server' : 'not configured'}
                     </span>
                   )}

--- a/web/src/components/metrics/MetricsTab.tsx
+++ b/web/src/components/metrics/MetricsTab.tsx
@@ -18,12 +18,15 @@ import { IconButton } from '../ui/IconButton';
 import { PopoutButton } from '../ui/PopoutButton';
 import { useUIStore } from '../../stores/useUIStore';
 import { useStackStore } from '../../stores/useStackStore';
-import { fetchTokenMetrics, clearTokenMetrics, fetchCostMetrics, fetchPricingModels, updateClientModel } from '../../lib/api';
+import { fetchTokenMetrics, clearTokenMetrics, fetchCostMetrics } from '../../lib/api';
 import { useWindowManager } from '../../hooks/useWindowManager';
 import { formatCompactNumber, formatUSD } from '../../lib/format';
 import { POLLING } from '../../lib/constants';
 import { AreaChart } from '../chart/AreaChart';
 import { PersistedFromMarker } from '../telemetry/PersistedFromMarker';
+import { ClientModelCell } from '../pricing/ClientModelCell';
+import { ServerModelCell } from '../pricing/ServerModelCell';
+import { ATTRIBUTION_HINT } from '../pricing/constants';
 import type { TokenMetricsResponse, CostMetricsResponse } from '../../types';
 
 type TimeRange = 'live' | '1h' | '6h' | '24h' | '7d';
@@ -46,7 +49,12 @@ export function MetricsTab() {
   const costUsage = useStackStore((s) => s.costUsage);
   const costAttribution = useStackStore((s) => s.costAttribution);
   const clientModels = useStackStore((s) => s.clientModels);
+  const mcpServers = useStackStore((s) => s.mcpServers);
+  const defaultModel = useStackStore((s) => s.defaultModel);
+  const setClientModelLocal = useStackStore((s) => s.setClientModelLocal);
+  const setServerModelLocal = useStackStore((s) => s.setServerModelLocal);
   const metricsDetached = useUIStore((s) => s.metricsDetached);
+  const setPricingManagerOpen = useUIStore((s) => s.setPricingManagerOpen);
   const { openDetachedWindow } = useWindowManager();
   const [timeRange, setTimeRange] = useState<TimeRange>('live');
   const [isPaused, setIsPaused] = useState(false);
@@ -166,6 +174,16 @@ export function MetricsTab() {
       total: counts.total_tokens,
     }));
   }, [tokenUsage]);
+
+  // Declared per-server models (model: field only, no default folded in) for
+  // the Model column's provenance pills.
+  const declaredServerModels = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const s of mcpServers) {
+      if (s.model) out[s.name] = s.model;
+    }
+    return out;
+  }, [mcpServers]);
 
   // Sort per-server entries
   const sortedServers = useMemo(() => {
@@ -343,6 +361,14 @@ export function MetricsTab() {
             )}
           </div>
 
+          <IconButton
+            icon={DollarSign}
+            onClick={() => setPricingManagerOpen(true)}
+            tooltip="Edit pricing models"
+            size="sm"
+            variant="ghost"
+          />
+
           <div className="w-px h-4 bg-border/50 mx-0.5" />
           <PopoutButton
             onClick={() => openDetachedWindow('metrics')}
@@ -514,6 +540,7 @@ export function MetricsTab() {
                             client={client.name}
                             declaredModel={clientModels[client.name]}
                             costAttribution={costAttribution}
+                            onSaved={setClientModelLocal}
                           />
                         </td>
                         <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(client.input)}</td>
@@ -542,6 +569,7 @@ export function MetricsTab() {
                         sortDirection={sortDirection}
                         onSort={handleSort}
                       />
+                      <th className="px-3 py-1.5 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">Model</th>
                       <SortableHeader
                         label="Input"
                         column="input"
@@ -572,6 +600,14 @@ export function MetricsTab() {
                     {sortedServers.map((server) => (
                       <tr key={server.name} className="border-b border-border/20 hover:bg-surface-highlight/30 transition-colors">
                         <td className="px-3 py-2 font-medium text-text-primary font-mono">{server.name}</td>
+                        <td className="px-3 py-2">
+                          <ServerModelCell
+                            server={server.name}
+                            declaredModel={declaredServerModels[server.name]}
+                            defaultModel={defaultModel}
+                            onSaved={setServerModelLocal}
+                          />
+                        </td>
                         <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(server.input)}</td>
                         <td className="px-3 py-2 text-right text-primary tabular-nums">{formatCompactNumber(server.output)}</td>
                         <td className="px-3 py-2 text-right text-text-primary font-semibold tabular-nums">{formatCompactNumber(server.total)}</td>
@@ -635,158 +671,10 @@ function CostKPICard({
       </span>
       {showHint && (
         <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
-          Set <code className="font-mono">model:</code> in stack.yaml to enable estimates
+          {ATTRIBUTION_HINT}
         </span>
       )}
     </div>
-  );
-}
-
-// pricingModelsCache memoizes the known-models list for the lifetime of the
-// page: the embedded pricing snapshot only changes on a gateway rebuild, so
-// one fetch (triggered by the first edit) serves every cell.
-let pricingModelsCache: string[] | null = null;
-
-const MODEL_PRECEDENCE_HINT =
-  'Pricing precedence: client model (client_models) > server model > gateway default_model. ' +
-  'A declared client model is a session-level default — it cannot track mid-session model switches.';
-
-// ClientModelCell shows which model a client's calls are priced as and lets
-// the operator set it inline. A pill with "· client" provenance renders only
-// for clients explicitly declared in client_models; non-declaring clients
-// aggregate heterogeneous per-server/default rates, so they get a muted
-// "per-server" (when any attribution is configured) rather than an invented
-// single model. Clicking opens a combobox backed by /api/pricing/models;
-// free text is allowed (unknown IDs price as zero, best-effort).
-function ClientModelCell({
-  client,
-  declaredModel,
-  costAttribution,
-}: {
-  client: string;
-  declaredModel?: string;
-  costAttribution: boolean;
-}) {
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState('');
-  const [models, setModels] = useState<string[]>(pricingModelsCache ?? []);
-  const [saving, setSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
-
-  const openEditor = useCallback(() => {
-    setDraft(declaredModel ?? '');
-    setSaveError(null);
-    setEditing(true);
-    if (pricingModelsCache === null) {
-      fetchPricingModels()
-        .then((resp) => {
-          pricingModelsCache = resp.models;
-          setModels(resp.models);
-        })
-        .catch(() => {
-          // Combobox degrades to free text; pricing is best-effort anyway.
-        });
-    }
-  }, [declaredModel]);
-
-  const save = useCallback(async () => {
-    const model = draft.trim();
-    if (model === (declaredModel ?? '')) {
-      setEditing(false);
-      return;
-    }
-    setSaving(true);
-    setSaveError(null);
-    try {
-      await updateClientModel(client, model);
-      // Optimistic store update so the pill reflects the save before the
-      // next status poll lands; the poll then confirms from the backend.
-      const current = useStackStore.getState().clientModels;
-      const next = { ...current };
-      if (model === '') {
-        delete next[client];
-      } else {
-        next[client] = model;
-      }
-      useStackStore.setState({ clientModels: next });
-      setEditing(false);
-    } catch (err) {
-      setSaveError(err instanceof Error ? err.message : 'Save failed');
-    } finally {
-      setSaving(false);
-    }
-  }, [client, draft, declaredModel]);
-
-  if (editing) {
-    const datalistId = `pricing-models-${client}`;
-    return (
-      <span className="inline-flex items-center gap-1">
-        <input
-          autoFocus
-          list={datalistId}
-          value={draft}
-          disabled={saving}
-          placeholder="claude-opus-4-7"
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') void save();
-            if (e.key === 'Escape') setEditing(false);
-          }}
-          title={saveError ?? 'Enter to save, Esc to cancel. Clear and save to remove.'}
-          className={cn(
-            'w-44 rounded bg-surface-highlight/60 border px-1.5 py-0.5 text-[11px] font-mono',
-            'text-text-primary placeholder:text-text-muted/50 focus:outline-none',
-            saveError ? 'border-status-error/60' : 'border-border/50 focus:border-primary/50',
-          )}
-        />
-        <datalist id={datalistId}>
-          {models.map((m) => (
-            <option key={m} value={m} />
-          ))}
-        </datalist>
-        <button
-          type="button"
-          disabled={saving}
-          onClick={() => void save()}
-          className="text-[10px] text-primary hover:text-primary/80 disabled:opacity-50"
-        >
-          {saving ? '…' : 'save'}
-        </button>
-        <button
-          type="button"
-          disabled={saving}
-          onClick={() => setEditing(false)}
-          className="text-[10px] text-text-muted hover:text-text-secondary disabled:opacity-50"
-        >
-          cancel
-        </button>
-      </span>
-    );
-  }
-
-  if (declaredModel) {
-    return (
-      <button
-        type="button"
-        onClick={openEditor}
-        title={MODEL_PRECEDENCE_HINT}
-        className="inline-flex items-center gap-1 rounded-full bg-surface-highlight/60 border border-border/40 px-2 py-0.5 hover:border-primary/40 transition-colors"
-      >
-        <span className="text-[10px] font-mono text-text-primary">{declaredModel}</span>
-        <span className="text-[9px] text-text-muted/70">· client</span>
-      </button>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={openEditor}
-      title={MODEL_PRECEDENCE_HINT}
-      className="text-[10px] text-text-muted/60 hover:text-text-secondary transition-colors"
-    >
-      {costAttribution ? 'per-server' : 'set model'}
-    </button>
   );
 }
 

--- a/web/src/components/pricing/ClientModelCell.tsx
+++ b/web/src/components/pricing/ClientModelCell.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useState } from 'react';
+import { updateClientModel } from '../../lib/api';
+import { showToast } from '../ui/Toast';
+import { ModelPicker } from './ModelPicker';
+import { MODEL_PRECEDENCE_HINT } from './constants';
+
+// ClientModelCell shows which model a client's calls are priced as and lets
+// the operator set it inline. A pill with "· client" provenance renders only
+// for clients explicitly declared in client_models; non-declaring clients
+// aggregate heterogeneous per-server/default rates, so they get a muted
+// "per-server" (when any attribution is configured) rather than an invented
+// single model. Clicking opens the shared ModelPicker combobox; free text is
+// allowed (unknown IDs price as zero, best-effort).
+//
+// State stays with the host: `declaredModel` is the saved value and
+// `onSaved` reports a successful write so the main window can update its
+// store optimistically while the detached window updates local state.
+export function ClientModelCell({
+  client,
+  declaredModel,
+  costAttribution,
+  onSaved,
+}: {
+  client: string;
+  declaredModel?: string;
+  costAttribution: boolean;
+  onSaved: (client: string, model: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const save = useCallback(
+    async (model: string) => {
+      if (model === (declaredModel ?? '')) {
+        setEditing(false);
+        return;
+      }
+      setSaving(true);
+      setSaveError(null);
+      try {
+        const resp = await updateClientModel(client, model);
+        onSaved(client, model);
+        setEditing(false);
+        showToast('success', model === '' ? `Pricing model cleared for ${client}` : `Pricing model saved for ${client}`);
+        if (resp.reloaded === false) {
+          showToast('warning', 'Stack updated. Run "gridctl reload" or restart with --watch to apply.');
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Save failed';
+        setSaveError(msg);
+        showToast('error', msg);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [client, declaredModel, onSaved],
+  );
+
+  if (editing) {
+    return (
+      <span className="inline-flex items-center gap-1">
+        <ModelPicker
+          value={declaredModel ?? ''}
+          onCommit={(model) => void save(model)}
+          onCancel={() => setEditing(false)}
+          disabled={saving}
+          autoFocus
+          widthClass="w-52"
+          error={saveError}
+        />
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => setEditing(false)}
+          className="text-[10px] text-text-muted hover:text-text-secondary disabled:opacity-50"
+        >
+          cancel
+        </button>
+      </span>
+    );
+  }
+
+  if (declaredModel) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setSaveError(null);
+          setEditing(true);
+        }}
+        title={MODEL_PRECEDENCE_HINT}
+        className="inline-flex items-center gap-1 rounded-full bg-surface-highlight/60 border border-border/40 px-2 py-0.5 hover:border-primary/40 transition-colors"
+      >
+        <span className="text-[10px] font-mono text-text-primary">{declaredModel}</span>
+        <span className="text-[9px] text-text-muted/70">· client</span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setSaveError(null);
+        setEditing(true);
+      }}
+      title={MODEL_PRECEDENCE_HINT}
+      className="text-[10px] text-text-muted/60 hover:text-text-secondary transition-colors"
+    >
+      {costAttribution ? 'per-server' : 'set model'}
+    </button>
+  );
+}
+
+export default ClientModelCell;

--- a/web/src/components/pricing/ClientModelCell.tsx
+++ b/web/src/components/pricing/ClientModelCell.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { cn } from '../../lib/cn';
 import { updateClientModel } from '../../lib/api';
 import { showToast } from '../ui/Toast';
 import { ModelPicker } from './ModelPicker';
@@ -106,7 +107,15 @@ export function ClientModelCell({
         setEditing(true);
       }}
       title={MODEL_PRECEDENCE_HINT}
-      className="text-[10px] text-text-muted/60 hover:text-text-secondary transition-colors"
+      className={cn(
+        'text-[10px] transition-colors',
+        costAttribution
+          ? // Informational state that happens to be clickable: stays quiet
+            // in dense tables, brightens to the accent on hover.
+            'text-text-muted/70 hover:text-secondary'
+          : // Empty-state CTA: the house interactive-text pattern.
+            'text-secondary hover:text-secondary-light',
+      )}
     >
       {costAttribution ? 'per-server' : 'set model'}
     </button>

--- a/web/src/components/pricing/ModelPicker.tsx
+++ b/web/src/components/pricing/ModelPicker.tsx
@@ -1,0 +1,317 @@
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { X } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { usePricingModels } from '../../hooks/usePricingModels';
+import { UNKNOWN_MODEL_NOTE } from './constants';
+
+// Above this many visible rows the option list renders through
+// @tanstack/react-virtual. The unfiltered LiteLLM snapshot is ~2,700 IDs —
+// past cmdk's documented unvirtualized ceiling — but a few keystrokes of
+// filtering lands well under the threshold, where plain rendering keeps
+// jsdom-testable, zero-overhead behavior.
+const VIRTUALIZE_AT = 150;
+
+const ITEM_HEIGHT = 26;
+const HEADER_HEIGHT = 22;
+
+// The option list groups model IDs by provider. Provider-prefixed IDs
+// ("anthropic/claude-...") group under their prefix; bare IDs ("gpt-4o",
+// "claude-opus-4-7") form the leading "models" group, which carries the
+// flagship aliases users reach for most.
+type Row =
+  | { kind: 'header'; label: string }
+  | { kind: 'item'; id: string };
+
+function buildRows(models: string[], query: string): Row[] {
+  const q = query.trim().toLowerCase();
+  const filtered = q === '' ? models : models.filter((m) => m.toLowerCase().includes(q));
+
+  const bare: string[] = [];
+  const byProvider = new Map<string, string[]>();
+  for (const id of filtered) {
+    const slash = id.indexOf('/');
+    if (slash <= 0) {
+      bare.push(id);
+    } else {
+      const provider = id.slice(0, slash);
+      const group = byProvider.get(provider);
+      if (group) group.push(id);
+      else byProvider.set(provider, [id]);
+    }
+  }
+
+  const rows: Row[] = [];
+  if (bare.length > 0) {
+    rows.push({ kind: 'header', label: 'models' });
+    for (const id of bare) rows.push({ kind: 'item', id });
+  }
+  for (const provider of [...byProvider.keys()].sort()) {
+    rows.push({ kind: 'header', label: provider });
+    for (const id of byProvider.get(provider)!) rows.push({ kind: 'item', id });
+  }
+  return rows;
+}
+
+export interface ModelPickerProps {
+  /** The currently saved model ID; empty string means none declared. */
+  value: string;
+  /** Called with the chosen ID on Enter or option click; '' clears. */
+  onCommit: (model: string) => void;
+  /** Called on Escape. The parent usually closes the editor. */
+  onCancel?: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+  autoFocus?: boolean;
+  /** Width class for the input; defaults to the metrics-cell width. */
+  widthClass?: string;
+  /** Non-null renders the error state (red border + title). */
+  error?: string | null;
+  /**
+   * Commit the draft when focus leaves the input (form-field semantics, used
+   * by the wizard). Inline cells keep the default Enter-to-save semantics.
+   */
+  commitOnBlur?: boolean;
+}
+
+/**
+ * ModelPicker is the shared combobox over the pricing snapshot's canonical
+ * model IDs (GET /api/pricing/models): live substring filtering, provider
+ * grouping, full keyboard control (arrows, Enter, Escape), and free-text
+ * pass-through — unknown IDs are valid everywhere, they just price as $0.
+ * The list virtualizes above VIRTUALIZE_AT rows so the full ~2,700-ID
+ * snapshot stays responsive.
+ */
+export function ModelPicker({
+  value,
+  onCommit,
+  onCancel,
+  placeholder = 'claude-opus-4-7',
+  disabled = false,
+  autoFocus = false,
+  widthClass = 'w-52',
+  error = null,
+  commitOnBlur = false,
+}: ModelPickerProps) {
+  const models = usePricingModels();
+  const [draft, setDraft] = useState(value);
+  const [open, setOpen] = useState(autoFocus);
+  const [active, setActive] = useState(-1);
+  const listId = useId();
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const rows = useMemo(() => buildRows(models, draft), [models, draft]);
+  const knownSet = useMemo(() => new Set(models), [models]);
+  const isUnknown = draft.trim() !== '' && models.length > 0 && !knownSet.has(draft.trim());
+
+  const virtualize = rows.length > VIRTUALIZE_AT;
+  const virtualizer = useVirtualizer({
+    count: virtualize ? rows.length : 0,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (index) => (rows[index]?.kind === 'header' ? HEADER_HEIGHT : ITEM_HEIGHT),
+    overscan: 8,
+  });
+
+  // Clamp the active row when filtering shrinks the list.
+  useEffect(() => {
+    if (active >= rows.length) setActive(-1);
+  }, [rows.length, active]);
+
+  const move = useCallback(
+    (dir: 1 | -1) => {
+      if (rows.length === 0) return;
+      setOpen(true);
+      let next = active;
+      for (let step = 0; step < rows.length; step++) {
+        next += dir;
+        if (next < 0) next = rows.length - 1;
+        if (next >= rows.length) next = 0;
+        if (rows[next].kind === 'item') break;
+      }
+      setActive(next);
+      if (virtualize) {
+        virtualizer.scrollToIndex(next);
+      } else {
+        document.getElementById(`${listId}-row-${next}`)?.scrollIntoView({ block: 'nearest' });
+      }
+    },
+    [rows, active, virtualize, virtualizer, listId],
+  );
+
+  const commit = useCallback(
+    (model: string) => {
+      setOpen(false);
+      onCommit(model.trim());
+    },
+    [onCommit],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        move(1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        move(-1);
+        break;
+      case 'Enter': {
+        e.preventDefault();
+        const activeRow = open && active >= 0 ? rows[active] : undefined;
+        if (activeRow && activeRow.kind === 'item') {
+          commit(activeRow.id);
+        } else {
+          commit(draft);
+        }
+        break;
+      }
+      case 'Escape':
+        e.preventDefault();
+        // Stop the keydown here so a host SlideOver's document-level Escape
+        // listener does not also close the whole panel.
+        e.stopPropagation();
+        setOpen(false);
+        onCancel?.();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const renderRow = (row: Row, index: number, style?: React.CSSProperties) => {
+    if (row.kind === 'header') {
+      return (
+        <div
+          key={`h-${row.label}-${index}`}
+          id={`${listId}-row-${index}`}
+          style={style}
+          className="px-2 pt-1.5 pb-0.5 text-[9px] uppercase tracking-wider text-text-muted/60 select-none"
+        >
+          {row.label}
+        </div>
+      );
+    }
+    const isActive = index === active;
+    const isSelected = row.id === value;
+    return (
+      <div
+        key={row.id}
+        id={`${listId}-row-${index}`}
+        role="option"
+        aria-selected={isSelected}
+        style={style}
+        onMouseDown={(e) => {
+          // Commit before the input's blur fires so the parent save flow
+          // sees the click, not a cancel.
+          e.preventDefault();
+          commit(row.id);
+        }}
+        onMouseMove={() => {
+          if (!isActive) setActive(index);
+        }}
+        className={cn(
+          'px-2 py-1 text-[11px] font-mono cursor-pointer truncate',
+          isActive ? 'bg-primary/[0.12] text-text-primary' : 'text-text-secondary',
+          isSelected && !isActive && 'bg-primary/[0.04]',
+        )}
+        title={row.id}
+      >
+        {row.id}
+      </div>
+    );
+  };
+
+  return (
+    <div className={cn('relative inline-block text-left', widthClass)}>
+      <div className="flex items-center gap-1">
+        <input
+          autoFocus={autoFocus}
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listId}
+          aria-activedescendant={active >= 0 ? `${listId}-row-${active}` : undefined}
+          aria-label="Pricing model"
+          value={draft}
+          disabled={disabled}
+          placeholder={placeholder}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            setActive(-1);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => {
+            setOpen(false);
+            if (commitOnBlur && draft.trim() !== value) {
+              onCommit(draft.trim());
+            }
+          }}
+          onKeyDown={handleKeyDown}
+          title={error ?? 'Enter to save, Esc to cancel. Clear and save to remove.'}
+          className={cn(
+            'w-full rounded bg-surface-highlight/60 border px-1.5 py-0.5 text-[11px] font-mono',
+            'text-text-primary placeholder:text-text-muted/50 focus:outline-none',
+            error ? 'border-status-error/60' : 'border-border/50 focus:border-primary/50',
+          )}
+        />
+        {draft !== '' && !disabled && (
+          <button
+            type="button"
+            aria-label="Clear model"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              setDraft('');
+              setActive(-1);
+              setOpen(true);
+            }}
+            className="p-0.5 text-text-muted hover:text-text-secondary transition-colors flex-shrink-0"
+          >
+            <X size={10} />
+          </button>
+        )}
+      </div>
+
+      {open && rows.length > 0 && (
+        <div
+          className="absolute left-0 right-0 top-full mt-1 z-50 rounded-md border border-border/50 bg-surface-elevated shadow-xl overflow-hidden"
+        >
+          <div
+            ref={scrollRef}
+            id={listId}
+            role="listbox"
+            aria-label="Known pricing models"
+            className="overflow-y-auto scrollbar-dark"
+            style={{ maxHeight: 240 }}
+          >
+            {virtualize ? (
+              <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+                {virtualizer.getVirtualItems().map((v) =>
+                  renderRow(rows[v.index], v.index, {
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    height: v.size,
+                    transform: `translateY(${v.start}px)`,
+                  }),
+                )}
+              </div>
+            ) : (
+              rows.map((row, i) => renderRow(row, i))
+            )}
+          </div>
+          <div className="px-2 py-1 border-t border-border/30 text-[9px] text-text-muted/60 select-none">
+            {models.length > 0 ? `${models.length} models · LiteLLM snapshot` : 'Loading models…'}
+          </div>
+        </div>
+      )}
+
+      {isUnknown && (
+        <p className="mt-0.5 text-[9px] leading-snug text-status-pending/80">{UNKNOWN_MODEL_NOTE}</p>
+      )}
+    </div>
+  );
+}
+
+export default ModelPicker;

--- a/web/src/components/pricing/ModelPicker.tsx
+++ b/web/src/components/pricing/ModelPicker.tsx
@@ -308,7 +308,7 @@ export function ModelPicker({
       )}
 
       {isUnknown && (
-        <p className="mt-0.5 text-[9px] leading-snug text-status-pending/80">{UNKNOWN_MODEL_NOTE}</p>
+        <p className="mt-0.5 text-[10px] leading-snug text-status-pending">{UNKNOWN_MODEL_NOTE}</p>
       )}
     </div>
   );

--- a/web/src/components/pricing/PricingManagerHost.tsx
+++ b/web/src/components/pricing/PricingManagerHost.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import { useStackStore } from '../../stores/useStackStore';
+import { useUIStore } from '../../stores/useUIStore';
+import { PricingManagerSlideOver } from './PricingManagerSlideOver';
+
+// PricingManagerHost wires the canonical pricing manager to the main
+// window's stores: visibility from useUIStore (so Metrics, the inspector,
+// and the command palette can all open it), data and optimistic updates
+// from useStackStore. The detached metrics window hosts the same slide-over
+// from its own local state instead.
+export function PricingManagerHost() {
+  const open = useUIStore((s) => s.pricingManagerOpen);
+  const setOpen = useUIStore((s) => s.setPricingManagerOpen);
+
+  const mcpServers = useStackStore((s) => s.mcpServers);
+  const defaultModel = useStackStore((s) => s.defaultModel);
+  const clientModels = useStackStore((s) => s.clientModels);
+  const costUsage = useStackStore((s) => s.costUsage);
+  const tokenUsage = useStackStore((s) => s.tokenUsage);
+  const costAttribution = useStackStore((s) => s.costAttribution);
+  const setClientModelLocal = useStackStore((s) => s.setClientModelLocal);
+  const setServerModelLocal = useStackStore((s) => s.setServerModelLocal);
+  const setDefaultModelLocal = useStackStore((s) => s.setDefaultModelLocal);
+
+  const servers = useMemo(
+    () =>
+      [...mcpServers]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((s) => ({ name: s.name, declaredModel: s.model })),
+    [mcpServers],
+  );
+
+  // Declared clients plus clients observed in token/cost data, so a client
+  // that has called through the gateway is configurable before anyone
+  // declares it.
+  const clients = useMemo(() => {
+    const names = new Set<string>(Object.keys(clientModels));
+    for (const name of Object.keys(tokenUsage?.per_client ?? {})) names.add(name);
+    for (const name of Object.keys(costUsage?.per_client ?? {})) names.add(name);
+    return [...names].sort().map((name) => ({ name, declaredModel: clientModels[name] }));
+  }, [clientModels, tokenUsage, costUsage]);
+
+  return (
+    <PricingManagerSlideOver
+      open={open}
+      onClose={() => setOpen(false)}
+      defaultModel={defaultModel}
+      servers={servers}
+      clients={clients}
+      costAttribution={costAttribution}
+      onClientSaved={setClientModelLocal}
+      onServerSaved={setServerModelLocal}
+      onDefaultSaved={setDefaultModelLocal}
+    />
+  );
+}
+
+export default PricingManagerHost;

--- a/web/src/components/pricing/PricingManagerSlideOver.tsx
+++ b/web/src/components/pricing/PricingManagerSlideOver.tsx
@@ -104,8 +104,8 @@ export function PricingManagerSlideOver({
         </TierSection>
 
         <div className="border-t border-border/30 pt-3 space-y-1.5">
-          <p className="text-[9px] text-text-muted/60 leading-relaxed">{SNAPSHOT_NOTE}</p>
-          <p className="text-[9px] text-text-muted/60 leading-relaxed">
+          <p className="text-[10px] text-text-muted leading-relaxed">{SNAPSHOT_NOTE}</p>
+          <p className="text-[10px] text-text-muted leading-relaxed">
             Unknown IDs record tokens but price as $0. A declared client model is a session
             default and cannot observe mid-session model switches.
           </p>
@@ -130,9 +130,9 @@ function TierSection({
     <section>
       <div className="flex items-center gap-1.5 mb-1">
         {icon}
-        <h3 className="text-[11px] font-medium text-text-secondary">{title}</h3>
+        <h3 className="text-xs font-medium text-text-secondary">{title}</h3>
       </div>
-      <p className="text-[9px] text-text-muted/60 mb-2 leading-relaxed">{note}</p>
+      <p className="text-[11px] text-text-muted mb-2 leading-relaxed">{note}</p>
       <div className="space-y-1.5">{children}</div>
     </section>
   );
@@ -141,7 +141,7 @@ function TierSection({
 function TierRow({ name, children }: { name: string; children: React.ReactNode }) {
   return (
     <div className="flex items-center justify-between gap-3 min-h-[26px]">
-      <span className="text-[11px] font-mono text-text-primary truncate" title={name}>
+      <span className="text-xs font-mono text-text-primary truncate" title={name}>
         {name}
       </span>
       <div className="flex-shrink-0">{children}</div>
@@ -239,7 +239,7 @@ function DefaultModelRow({
         setEditing(true);
       }}
       title={MODEL_PRECEDENCE_HINT}
-      className="text-[10px] text-text-muted/60 hover:text-text-secondary transition-colors"
+      className="text-[10px] text-secondary hover:text-secondary-light transition-colors"
     >
       set default model
     </button>

--- a/web/src/components/pricing/PricingManagerSlideOver.tsx
+++ b/web/src/components/pricing/PricingManagerSlideOver.tsx
@@ -1,0 +1,249 @@
+import { useCallback, useState } from 'react';
+import { Users, Server, Globe } from 'lucide-react';
+import { SlideOver } from '../ui/SlideOver';
+import { showToast } from '../ui/Toast';
+import { updateDefaultModel } from '../../lib/api';
+import { ModelPicker } from './ModelPicker';
+import { ClientModelCell } from './ClientModelCell';
+import { ServerModelCell } from './ServerModelCell';
+import { MODEL_PRECEDENCE_HINT, SNAPSHOT_NOTE } from './constants';
+
+export interface PricingManagerSlideOverProps {
+  open: boolean;
+  onClose: () => void;
+  /** Gateway-level default_model; empty when not configured. */
+  defaultModel: string;
+  /** Every server in the stack with its DECLARED model (model: field only). */
+  servers: Array<{ name: string; declaredModel?: string }>;
+  /** Declared clients plus clients observed in cost/token data. */
+  clients: Array<{ name: string; declaredModel?: string }>;
+  costAttribution: boolean;
+  onClientSaved: (client: string, model: string) => void;
+  onServerSaved: (server: string, model: string) => void;
+  onDefaultSaved: (model: string) => void;
+}
+
+/**
+ * PricingManagerSlideOver is the canonical editor for all three pricing
+ * attribution tiers, listed in precedence order: client models, server
+ * models, gateway default. Each row is the same inline editor the metrics
+ * tables use, so a save here behaves identically (optimistic update via the
+ * host's onSaved, hot reload, 409 surfacing). Data flows in through props so
+ * the main window can host it from the store while the detached metrics
+ * window hosts it from local state.
+ *
+ * Non-modal by design (no focus trap, no backdrop): the canvas and the cost
+ * chart stay live behind it so an edit's effect is visible on the next poll.
+ */
+export function PricingManagerSlideOver({
+  open,
+  onClose,
+  defaultModel,
+  servers,
+  clients,
+  costAttribution,
+  onClientSaved,
+  onServerSaved,
+  onDefaultSaved,
+}: PricingManagerSlideOverProps) {
+  return (
+    <SlideOver isOpen={open} onClose={onClose} title="Pricing models" widthClass="w-[400px]">
+      <div className="flex flex-col gap-5 px-4 py-4">
+        <p className="text-[11px] text-text-muted leading-relaxed">{MODEL_PRECEDENCE_HINT}</p>
+
+        <TierSection
+          icon={<Users size={12} className="text-text-muted" />}
+          title="1 · Client models"
+          note="Pricing only. Does not create access restrictions or require a clients: block."
+        >
+          {clients.length === 0 ? (
+            <p className="text-[10px] text-text-muted/60 italic">
+              No clients observed yet. Clients appear after their first tool call.
+            </p>
+          ) : (
+            clients.map((c) => (
+              <TierRow key={c.name} name={c.name}>
+                <ClientModelCell
+                  client={c.name}
+                  declaredModel={c.declaredModel}
+                  costAttribution={costAttribution}
+                  onSaved={onClientSaved}
+                />
+              </TierRow>
+            ))
+          )}
+        </TierSection>
+
+        <TierSection
+          icon={<Server size={12} className="text-text-muted" />}
+          title="2 · Server models"
+          note="A server without its own model inherits the gateway default."
+        >
+          {servers.length === 0 ? (
+            <p className="text-[10px] text-text-muted/60 italic">No MCP servers in the stack.</p>
+          ) : (
+            servers.map((s) => (
+              <TierRow key={s.name} name={s.name}>
+                <ServerModelCell
+                  server={s.name}
+                  declaredModel={s.declaredModel}
+                  defaultModel={defaultModel}
+                  onSaved={onServerSaved}
+                />
+              </TierRow>
+            ))
+          )}
+        </TierSection>
+
+        <TierSection
+          icon={<Globe size={12} className="text-text-muted" />}
+          title="3 · Gateway default"
+          note="Stack-wide floor: prices every server without its own model."
+        >
+          <DefaultModelRow defaultModel={defaultModel} onSaved={onDefaultSaved} />
+        </TierSection>
+
+        <div className="border-t border-border/30 pt-3 space-y-1.5">
+          <p className="text-[9px] text-text-muted/60 leading-relaxed">{SNAPSHOT_NOTE}</p>
+          <p className="text-[9px] text-text-muted/60 leading-relaxed">
+            Unknown IDs record tokens but price as $0. A declared client model is a session
+            default and cannot observe mid-session model switches.
+          </p>
+        </div>
+      </div>
+    </SlideOver>
+  );
+}
+
+function TierSection({
+  icon,
+  title,
+  note,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  note: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <div className="flex items-center gap-1.5 mb-1">
+        {icon}
+        <h3 className="text-[11px] font-medium text-text-secondary">{title}</h3>
+      </div>
+      <p className="text-[9px] text-text-muted/60 mb-2 leading-relaxed">{note}</p>
+      <div className="space-y-1.5">{children}</div>
+    </section>
+  );
+}
+
+function TierRow({ name, children }: { name: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3 min-h-[26px]">
+      <span className="text-[11px] font-mono text-text-primary truncate" title={name}>
+        {name}
+      </span>
+      <div className="flex-shrink-0">{children}</div>
+    </div>
+  );
+}
+
+// DefaultModelRow is the gateway-tier twin of the client/server cells: pill
+// with "· default" provenance, inline ModelPicker editing, empty save clears
+// gateway.default_model (and the gateway: block when the clear empties it).
+function DefaultModelRow({
+  defaultModel,
+  onSaved,
+}: {
+  defaultModel: string;
+  onSaved: (model: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const save = useCallback(
+    async (model: string) => {
+      if (model === defaultModel) {
+        setEditing(false);
+        return;
+      }
+      setSaving(true);
+      setSaveError(null);
+      try {
+        const resp = await updateDefaultModel(model);
+        onSaved(model);
+        setEditing(false);
+        showToast('success', model === '' ? 'Gateway default model cleared' : 'Gateway default model saved');
+        if (resp.reloaded === false) {
+          showToast('warning', 'Stack updated. Run "gridctl reload" or restart with --watch to apply.');
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Save failed';
+        setSaveError(msg);
+        showToast('error', msg);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [defaultModel, onSaved],
+  );
+
+  if (editing) {
+    return (
+      <span className="inline-flex items-center gap-1">
+        <ModelPicker
+          value={defaultModel}
+          onCommit={(model) => void save(model)}
+          onCancel={() => setEditing(false)}
+          disabled={saving}
+          autoFocus
+          widthClass="w-56"
+          error={saveError}
+        />
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => setEditing(false)}
+          className="text-[10px] text-text-muted hover:text-text-secondary disabled:opacity-50"
+        >
+          cancel
+        </button>
+      </span>
+    );
+  }
+
+  if (defaultModel) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setSaveError(null);
+          setEditing(true);
+        }}
+        title={MODEL_PRECEDENCE_HINT}
+        className="inline-flex items-center gap-1 rounded-full bg-surface-highlight/60 border border-border/40 px-2 py-0.5 hover:border-primary/40 transition-colors"
+      >
+        <span className="text-[10px] font-mono text-text-primary">{defaultModel}</span>
+        <span className="text-[9px] text-text-muted/70">· default</span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setSaveError(null);
+        setEditing(true);
+      }}
+      title={MODEL_PRECEDENCE_HINT}
+      className="text-[10px] text-text-muted/60 hover:text-text-secondary transition-colors"
+    >
+      set default model
+    </button>
+  );
+}
+
+export default PricingManagerSlideOver;

--- a/web/src/components/pricing/ServerModelCell.tsx
+++ b/web/src/components/pricing/ServerModelCell.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useState } from 'react';
+import { updateServerModel } from '../../lib/api';
+import { showToast } from '../ui/Toast';
+import { ModelPicker } from './ModelPicker';
+import { MODEL_PRECEDENCE_HINT } from './constants';
+
+// ServerModelCell mirrors ClientModelCell for the server tier: a pill with
+// "· server" provenance when the server declares its own model:, a muted
+// "default: <id>" when it inherits gateway.default_model, and "set model"
+// when no attribution applies. Clicking edits inline through the shared
+// ModelPicker; an empty save clears the server's model: key so it falls
+// back to the default.
+export function ServerModelCell({
+  server,
+  declaredModel,
+  defaultModel,
+  onSaved,
+}: {
+  server: string;
+  declaredModel?: string;
+  defaultModel: string;
+  onSaved: (server: string, model: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const save = useCallback(
+    async (model: string) => {
+      if (model === (declaredModel ?? '')) {
+        setEditing(false);
+        return;
+      }
+      setSaving(true);
+      setSaveError(null);
+      try {
+        const resp = await updateServerModel(server, model);
+        onSaved(server, model);
+        setEditing(false);
+        showToast('success', model === '' ? `Pricing model cleared for ${server}` : `Pricing model saved for ${server}`);
+        if (resp.reloaded === false) {
+          showToast('warning', 'Stack updated. Run "gridctl reload" or restart with --watch to apply.');
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Save failed';
+        setSaveError(msg);
+        showToast('error', msg);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [server, declaredModel, onSaved],
+  );
+
+  if (editing) {
+    return (
+      <span className="inline-flex items-center gap-1">
+        <ModelPicker
+          value={declaredModel ?? ''}
+          onCommit={(model) => void save(model)}
+          onCancel={() => setEditing(false)}
+          disabled={saving}
+          autoFocus
+          widthClass="w-52"
+          error={saveError}
+        />
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => setEditing(false)}
+          className="text-[10px] text-text-muted hover:text-text-secondary disabled:opacity-50"
+        >
+          cancel
+        </button>
+      </span>
+    );
+  }
+
+  const openEditor = () => {
+    setSaveError(null);
+    setEditing(true);
+  };
+
+  if (declaredModel) {
+    return (
+      <button
+        type="button"
+        onClick={openEditor}
+        title={MODEL_PRECEDENCE_HINT}
+        className="inline-flex items-center gap-1 rounded-full bg-surface-highlight/60 border border-border/40 px-2 py-0.5 hover:border-primary/40 transition-colors"
+      >
+        <span className="text-[10px] font-mono text-text-primary">{declaredModel}</span>
+        <span className="text-[9px] text-text-muted/70">· server</span>
+      </button>
+    );
+  }
+
+  if (defaultModel) {
+    return (
+      <button
+        type="button"
+        onClick={openEditor}
+        title={MODEL_PRECEDENCE_HINT}
+        className="text-[10px] text-text-muted/60 hover:text-text-secondary transition-colors font-mono"
+      >
+        default: {defaultModel}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={openEditor}
+      title={MODEL_PRECEDENCE_HINT}
+      className="text-[10px] text-text-muted/60 hover:text-text-secondary transition-colors"
+    >
+      set model
+    </button>
+  );
+}
+
+export default ServerModelCell;

--- a/web/src/components/pricing/ServerModelCell.tsx
+++ b/web/src/components/pricing/ServerModelCell.tsx
@@ -101,7 +101,7 @@ export function ServerModelCell({
         type="button"
         onClick={openEditor}
         title={MODEL_PRECEDENCE_HINT}
-        className="text-[10px] text-text-muted/60 hover:text-text-secondary transition-colors font-mono"
+        className="text-[10px] text-text-muted/70 hover:text-secondary transition-colors font-mono"
       >
         default: {defaultModel}
       </button>
@@ -113,7 +113,7 @@ export function ServerModelCell({
       type="button"
       onClick={openEditor}
       title={MODEL_PRECEDENCE_HINT}
-      className="text-[10px] text-text-muted/60 hover:text-text-secondary transition-colors"
+      className="text-[10px] text-secondary hover:text-secondary-light transition-colors"
     >
       set model
     </button>

--- a/web/src/components/pricing/constants.ts
+++ b/web/src/components/pricing/constants.ts
@@ -1,0 +1,19 @@
+// Shared copy for the pricing-attribution surfaces. Every surface that
+// renders a model pill or picker repeats the same precedence story so the
+// mental model never shifts between the metrics tables, the sidebar
+// inspector, and the pricing manager.
+
+export const MODEL_PRECEDENCE_HINT =
+  'Pricing precedence: client model (client_models) > server model > gateway default_model. ' +
+  'A declared client model is a session-level default — it cannot track mid-session model switches.';
+
+// Rendered under the Cost KPI when no attribution is configured anywhere.
+// Points at the in-UI edit path first; stack.yaml stays the fallback for
+// operators who prefer the file.
+export const ATTRIBUTION_HINT =
+  'Set a pricing model in the Top Clients table below, or in stack.yaml, to enable estimates';
+
+// Footer copy for pickers and the pricing manager.
+export const SNAPSHOT_NOTE =
+  'Models come from the embedded LiteLLM snapshot (refreshed via make update-pricing at gateway rebuild).';
+export const UNKNOWN_MODEL_NOTE = 'Unknown model · records tokens but prices as $0';

--- a/web/src/components/wizard/steps/MCPServerForm.tsx
+++ b/web/src/components/wizard/steps/MCPServerForm.tsx
@@ -15,6 +15,7 @@ import {
   KeyRound,
   ShieldCheck,
 } from 'lucide-react';
+import { ModelPicker } from '../../pricing/ModelPicker';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '../../../lib/cn';
 import type { AutoscaleFormData, MCPServerFormData, ServerType } from '../../../lib/yaml-builder';
@@ -443,6 +444,7 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
   const advancedCount =
     (data.tools?.length ?? 0) +
     (data.outputFormat ? 1 : 0) +
+    (data.model ? 1 : 0) +
     (data.buildArgs ? Object.keys(data.buildArgs).length : 0) +
     (data.network ? 1 : 0) +
     (data.pinSchemas !== undefined ? 1 : 0) +
@@ -1369,6 +1371,20 @@ export function MCPServerForm({ data, onChange, errors }: MCPServerFormProps) {
               </option>
             ))}
           </select>
+        </div>
+
+        <div>
+          <label className={labelClass}>Pricing Model (cost estimates)</label>
+          <ModelPicker
+            value={data.model ?? ''}
+            onCommit={(model) => onChange({ model: model || undefined })}
+            commitOnBlur
+            widthClass="w-full"
+            placeholder="Inherit gateway default"
+          />
+          <p className="text-[10px] text-text-muted mt-1">
+            Prices this server's tool calls. Overrides the gateway default; pricing only, no behavior change
+          </p>
         </div>
 
         {visibility.buildArgs && (

--- a/web/src/components/wizard/steps/StackForm.tsx
+++ b/web/src/components/wizard/steps/StackForm.tsx
@@ -13,6 +13,7 @@ import {
   Trash2,
   AlertCircle,
   Zap,
+  DollarSign,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '../../../lib/cn';
@@ -23,6 +24,7 @@ import type {
 } from '../../../lib/yaml-builder';
 import { VariablesPopover } from '../VariablesPopover';
 import { VaultSetSelector } from '../VaultSetSelector';
+import { ModelPicker } from '../../pricing/ModelPicker';
 import { MCPServerForm } from './MCPServerForm';
 
 // --- Shared form primitives ---
@@ -963,6 +965,33 @@ export function StackForm({ data, onChange, errors }: StackFormProps) {
             />
             <p className="text-[10px] text-text-muted mt-1">Bytes. Default: 64KB (65536)</p>
           </div>
+        </div>
+      </Section>
+
+      {/* Section 2c: Pricing — collapsed by default; cost attribution is
+          optional and pricing-only (no behavior change). */}
+      <Section
+        title="Pricing"
+        icon={DollarSign}
+        expanded={expandedSections.has('pricing')}
+        onToggle={() => toggleSection('pricing')}
+        badge={data.gateway?.defaultModel ? '1' : undefined}
+      >
+        <div>
+          <label className={labelClass}>Default Pricing Model</label>
+          <ModelPicker
+            value={data.gateway?.defaultModel ?? ''}
+            onCommit={(model) =>
+              onChange({ gateway: { ...data.gateway, defaultModel: model || undefined } })
+            }
+            commitOnBlur
+            widthClass="w-full"
+            placeholder="e.g. claude-opus-4-7"
+          />
+          <p className="text-[10px] text-text-muted mt-1">
+            Stack-wide floor for cost estimates: prices every server without its own model.
+            Per-client models (client_models) can be set after apply, from the Metrics tab
+          </p>
         </div>
       </Section>
 

--- a/web/src/components/workspaces/TopologyWorkspace.tsx
+++ b/web/src/components/workspaces/TopologyWorkspace.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, RefreshCw, WifiOff } from 'lucide-react';
 import { Sidebar } from '../layout/Sidebar';
 import { Canvas } from '../graph/Canvas';
 import { AccessLens } from '../topology/AccessLens';
+import { PricingManagerHost } from '../pricing/PricingManagerHost';
 import { ResizeHandle } from '../ui/ResizeHandle';
 import { useStackStore } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
@@ -113,6 +114,11 @@ export function TopologyWorkspace() {
               action bar, commit gate, and dirty-exit guard. Mounted in the
               canvas column so its absolute overlays anchor to the canvas. */}
           <AccessLens servers={accessServers} />
+
+          {/* Pricing models manager: the canonical three-tier cost-attribution
+              editor. Same canvas-column anchoring as the Access Lens
+              slide-over; opened from Metrics, the inspector, or the palette. */}
+          <PricingManagerHost />
         </div>
 
         {sidebarOpen && (

--- a/web/src/hooks/useGlobalCommands.tsx
+++ b/web/src/hooks/useGlobalCommands.tsx
@@ -3,6 +3,7 @@ import { useReactFlow } from '@xyflow/react';
 import { useNavigate } from 'react-router-dom';
 import {
   Activity,
+  DollarSign,
   Key,
   Library,
   Terminal,
@@ -49,6 +50,7 @@ export function useGlobalCommands({ onRefresh }: GlobalCommandsOptions = {}) {
   const toggleSpecMode = useUIStore((s) => s.toggleSpecMode);
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
   const setShowVault = useUIStore((s) => s.setShowVault);
+  const setPricingManagerOpen = useUIStore((s) => s.setPricingManagerOpen);
 
   const mcpServers = useStackStore((s) => s.mcpServers);
   const selectNode = useStackStore((s) => s.selectNode);
@@ -236,6 +238,18 @@ export function useGlobalCommands({ onRefresh }: GlobalCommandsOptions = {}) {
         keywords: ['wizard', 'create', 'new', 'server', 'add', 'resource'],
         onSelect: () => useWizardStore.getState().open(),
       },
+      {
+        id: 'action:pricing-models',
+        label: 'Edit pricing models',
+        section: 'global',
+        icon: <DollarSign size={14} />,
+        keywords: ['pricing', 'cost', 'model', 'models', 'attribution', 'usd', 'edit'],
+        onSelect: () => {
+          // The manager mounts in the Topology workspace's canvas column.
+          navigate('/topology');
+          setPricingManagerOpen(true);
+        },
+      },
     ];
     registerCommands('canvas-actions', commands);
     return () => unregisterCommands('canvas-actions');
@@ -250,6 +264,8 @@ export function useGlobalCommands({ onRefresh }: GlobalCommandsOptions = {}) {
     toggleDriftOverlay,
     toggleCompactCards,
     toggleSpecMode,
+    setPricingManagerOpen,
+    navigate,
     onRefresh,
   ]);
 

--- a/web/src/hooks/usePricingModels.ts
+++ b/web/src/hooks/usePricingModels.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { fetchPricingModels } from '../lib/api';
+
+// Window-scoped cache for the known-models list. The embedded pricing
+// snapshot only changes on a gateway rebuild, so one fetch serves every
+// picker in this window (main or detached). The in-flight promise is shared
+// so simultaneous first-renders coalesce into a single request.
+let cachedModels: string[] | null = null;
+let inFlight: Promise<string[]> | null = null;
+
+function loadPricingModels(): Promise<string[]> {
+  if (cachedModels !== null) return Promise.resolve(cachedModels);
+  if (inFlight) return inFlight;
+  inFlight = fetchPricingModels()
+    .then((resp) => {
+      cachedModels = resp.models;
+      return resp.models;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+  return inFlight;
+}
+
+// usePricingModels returns the canonical model IDs known to the active
+// pricing source, fetching them once per window. Returns an empty array
+// until loaded (or on fetch failure — pickers degrade to free text; pricing
+// is best-effort anyway).
+export function usePricingModels(): string[] {
+  const [models, setModels] = useState<string[]>(cachedModels ?? []);
+
+  useEffect(() => {
+    if (cachedModels !== null) return;
+    let cancelled = false;
+    loadPricingModels()
+      .then((list) => {
+        if (!cancelled) setModels(list);
+      })
+      .catch(() => {
+        // Degrade to free text.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return models;
+}
+
+// resetPricingModelsCacheForTests clears the module cache so unit tests can
+// exercise the fetch path in isolation.
+export function resetPricingModelsCacheForTests(): void {
+  cachedModels = null;
+  inFlight = null;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, SkillUsageResponse, RegistryStatus, AgentSkill, ItemState, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SourceSyncSummary, SkillSyncResult, SkillDiffResponse, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention, PricingModelsResponse, UpdateClientModelResponse } from '../types';
+import type { GatewayStatus, MCPServerStatus, ClientStatus, ToolsListResult, ToolUsageResponse, SkillUsageResponse, RegistryStatus, AgentSkill, ItemState, SkillFile, SkillValidationResult, TokenMetricsResponse, CostMetricsResponse, OptimizeReport, ValidationResult, PlanDiff, SpecHealth, StackSpec, SkillSourceStatus, SkillPreviewResponse, ImportResult, SourceUpdateCheck, UpdateSummary, SourceSyncSummary, SkillSyncResult, SkillDiffResponse, InventoryRecord, TelemetryMutationResponse, TelemetryPersistDefaults, TelemetryRetention, PricingModelsResponse, UpdateClientModelResponse, UpdateServerModelResponse, UpdateDefaultModelResponse } from '../types';
 
 // Base URL for API calls - empty for same origin
 const API_BASE = '';
@@ -564,6 +564,74 @@ export async function updateClientModel(
   }
 
   return data as UpdateClientModelResponse;
+}
+
+/**
+ * Set (or clear, with an empty string) an MCP server's pricing model
+ * (the server's model: field). Pricing attribution only.
+ * PUT /api/mcp-servers/{name}/model
+ */
+export async function updateServerModel(
+  name: string,
+  model: string,
+): Promise<UpdateServerModelResponse> {
+  const response = await fetch(
+    `${API_BASE}/api/mcp-servers/${encodeURIComponent(name)}/model`,
+    {
+      method: 'PUT',
+      headers: buildHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ model }),
+    },
+  );
+
+  if (response.status === 401) throw new AuthError('Authentication required');
+
+  const data = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const err = data?.error;
+    const msg =
+      err && typeof err === 'object' && typeof err.message === 'string'
+        ? err.message
+        : typeof err === 'string'
+          ? err
+          : `Update server model failed: ${response.status} ${response.statusText}`;
+    throw new Error(msg);
+  }
+
+  return data as UpdateServerModelResponse;
+}
+
+/**
+ * Set (or clear, with an empty string) the gateway-level default pricing
+ * model (gateway.default_model). Pricing attribution only.
+ * PUT /api/gateway/default-model
+ */
+export async function updateDefaultModel(
+  model: string,
+): Promise<UpdateDefaultModelResponse> {
+  const response = await fetch(`${API_BASE}/api/gateway/default-model`, {
+    method: 'PUT',
+    headers: buildHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ model }),
+  });
+
+  if (response.status === 401) throw new AuthError('Authentication required');
+
+  const data = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const err = data?.error;
+    const msg =
+      err && typeof err === 'object' && typeof err.message === 'string'
+        ? err.message
+        : typeof err === 'string'
+          ? err
+          : `Update default model failed: ${response.status} ${response.statusText}`;
+    throw new Error(msg);
+  }
+
+  return data as UpdateDefaultModelResponse;
 }
 
 export async function fetchGatewayLogs(lines = 100, level?: string): Promise<LogEntry[]> {

--- a/web/src/lib/yaml-builder.ts
+++ b/web/src/lib/yaml-builder.ts
@@ -72,6 +72,9 @@ export interface MCPServerFormData {
   buildArgs?: Record<string, string>;
   tools?: string[];
   outputFormat?: string;
+  // Pricing model for cost estimates (model: in YAML). Overrides
+  // gateway.default_model for this server; optional and pricing-only.
+  model?: string;
   network?: string;
   pinSchemas?: boolean;
   // Replicas (mutually exclusive with autoscale)
@@ -112,6 +115,9 @@ export interface StackFormData {
     codeMode?: string;
     codeModeTimeout?: number;
     outputFormat?: string;
+    // Stack-wide pricing floor (default_model: in YAML). Prices every
+    // server without its own model; optional and pricing-only.
+    defaultModel?: string;
     maxToolResultBytes?: number;
     tracing?: {
       enabled?: boolean;
@@ -281,6 +287,7 @@ function buildMCPServer(data: MCPServerFormData, indentLevel = 2): string {
     lines.push(serializeArray(data.tools, indentLevel + 4));
   }
   if (data.outputFormat) lines.push(`${inner}output_format: ${data.outputFormat}`);
+  if (data.model) lines.push(`${inner}model: ${yamlValue(data.model)}`);
   if (data.network) lines.push(`${inner}network: ${data.network}`);
   if (data.pinSchemas !== undefined) lines.push(`${inner}pin_schemas: ${data.pinSchemas}`);
 
@@ -376,6 +383,7 @@ function buildStack(data: StackFormData): string {
     if (data.gateway.codeMode) lines.push(`  code_mode: ${data.gateway.codeMode}`);
     if (data.gateway.codeModeTimeout) lines.push(`  code_mode_timeout: ${data.gateway.codeModeTimeout}`);
     if (data.gateway.outputFormat) lines.push(`  output_format: ${data.gateway.outputFormat}`);
+    if (data.gateway.defaultModel) lines.push(`  default_model: ${yamlValue(data.gateway.defaultModel)}`);
     if (data.gateway.maxToolResultBytes) lines.push(`  maxToolResultBytes: ${data.gateway.maxToolResultBytes}`);
 
     const gw = data.gateway;

--- a/web/src/pages/DetachedMetricsPage.tsx
+++ b/web/src/pages/DetachedMetricsPage.tsx
@@ -15,6 +15,10 @@ import { fetchStatus, fetchTokenMetrics, fetchCostMetrics, clearTokenMetrics } f
 import { formatCompactNumber, formatUSD } from '../lib/format';
 import { POLLING } from '../lib/constants';
 import { AreaChart } from '../components/chart/AreaChart';
+import { ClientModelCell } from '../components/pricing/ClientModelCell';
+import { ServerModelCell } from '../components/pricing/ServerModelCell';
+import { PricingManagerSlideOver } from '../components/pricing/PricingManagerSlideOver';
+import { ATTRIBUTION_HINT } from '../components/pricing/constants';
 import type { GatewayStatus, TokenMetricsResponse, CostMetricsResponse, TokenUsage, CostUsage } from '../types';
 import {
   Pause,
@@ -85,6 +89,11 @@ function DetachedMetricsPageContent() {
   const [tokenUsage, setTokenUsage] = useState<TokenUsage | null>(null);
   const [costUsage, setCostUsage] = useState<CostUsage | null>(null);
   const [costAttribution, setCostAttribution] = useState(false);
+  const [clientModels, setClientModels] = useState<Record<string, string>>({});
+  const [serverDeclared, setServerDeclared] = useState<Record<string, string>>({});
+  const [serverNames, setServerNames] = useState<string[]>([]);
+  const [defaultModel, setDefaultModel] = useState('');
+  const [pricingManagerOpen, setPricingManagerOpen] = useState(false);
   const [timeRange, setTimeRange] = useState<TimeRange>('live');
   const [isPaused, setIsPaused] = useState(false);
   const [metricsData, setMetricsData] = useState<TokenMetricsResponse | null>(null);
@@ -110,6 +119,14 @@ function DetachedMetricsPageContent() {
         setTokenUsage(status.token_usage ?? null);
         setCostUsage(status.cost ?? null);
         setCostAttribution(status.cost_attribution ?? false);
+        setClientModels(status.client_models ?? {});
+        setDefaultModel(status.default_model ?? '');
+        const declared: Record<string, string> = {};
+        for (const s of status['mcp-servers'] ?? []) {
+          if (s.model) declared[s.name] = s.model;
+        }
+        setServerDeclared(declared);
+        setServerNames((status['mcp-servers'] ?? []).map((s) => s.name));
       } catch {
         // Ignore status errors
       }
@@ -187,6 +204,32 @@ function DetachedMetricsPageContent() {
       setClientSortDirection('desc');
     }
   };
+
+  // Optimistic local updates after a successful model save. The detached
+  // window owns local state (not the main window's store); the next status
+  // poll confirms from the backend, and the main window catches up on its
+  // own poll.
+  const handleClientModelSaved = useCallback((client: string, model: string) => {
+    setClientModels((prev) => {
+      const next = { ...prev };
+      if (model === '') delete next[client];
+      else next[client] = model;
+      return next;
+    });
+  }, []);
+
+  const handleServerModelSaved = useCallback((server: string, model: string) => {
+    setServerDeclared((prev) => {
+      const next = { ...prev };
+      if (model === '') delete next[server];
+      else next[server] = model;
+      return next;
+    });
+  }, []);
+
+  const handleDefaultModelSaved = useCallback((model: string) => {
+    setDefaultModel(model);
+  }, []);
 
   // Per-server data
   const perServerEntries = tokenUsage?.per_server
@@ -382,6 +425,14 @@ function DetachedMetricsPageContent() {
             )}
           </div>
 
+          <IconButton
+            icon={DollarSign}
+            onClick={() => setPricingManagerOpen(true)}
+            tooltip="Edit pricing models"
+            size="sm"
+            variant="ghost"
+          />
+
           <div className="w-px h-4 bg-border/50 mx-1" />
           <IconButton
             icon={isFullscreen ? Minimize2 : Maximize2}
@@ -518,6 +569,7 @@ function DetachedMetricsPageContent() {
                   <thead>
                     <tr className="border-b border-border/30">
                       <ClientSortableHeader label="Client" column="name" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} />
+                      <th className="px-3 py-1.5 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">Model</th>
                       <ClientSortableHeader label="Input" column="input" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
                       <ClientSortableHeader label="Output" column="output" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
                       <ClientSortableHeader label="Total" column="total" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
@@ -528,6 +580,14 @@ function DetachedMetricsPageContent() {
                     {sortedClients.map((client) => (
                       <tr key={client.name} className="border-b border-border/20 last:border-0 hover:bg-surface-highlight/30 transition-colors">
                         <td className="px-3 py-2 font-medium text-text-primary font-mono">{client.name}</td>
+                        <td className="px-3 py-2">
+                          <ClientModelCell
+                            client={client.name}
+                            declaredModel={clientModels[client.name]}
+                            costAttribution={costAttribution}
+                            onSaved={handleClientModelSaved}
+                          />
+                        </td>
                         <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(client.input)}</td>
                         <td className="px-3 py-2 text-right text-primary tabular-nums">{formatCompactNumber(client.output)}</td>
                         <td className="px-3 py-2 text-right text-text-primary font-semibold tabular-nums">{formatCompactNumber(client.total)}</td>
@@ -548,6 +608,7 @@ function DetachedMetricsPageContent() {
                   <thead>
                     <tr className="border-b border-border/30">
                       <SortableHeader label="Server" column="name" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
+                      <th className="px-3 py-1.5 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">Model</th>
                       <SortableHeader label="Input" column="input" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} align="right" />
                       <SortableHeader label="Output" column="output" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} align="right" />
                       <SortableHeader label="Total" column="total" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} align="right" />
@@ -557,6 +618,14 @@ function DetachedMetricsPageContent() {
                     {sortedServers.map((server) => (
                       <tr key={server.name} className="border-b border-border/20 hover:bg-surface-highlight/30 transition-colors">
                         <td className="px-3 py-2 font-medium text-text-primary font-mono">{server.name}</td>
+                        <td className="px-3 py-2">
+                          <ServerModelCell
+                            server={server.name}
+                            declaredModel={serverDeclared[server.name]}
+                            defaultModel={defaultModel}
+                            onSaved={handleServerModelSaved}
+                          />
+                        </td>
                         <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(server.input)}</td>
                         <td className="px-3 py-2 text-right text-primary tabular-nums">{formatCompactNumber(server.output)}</td>
                         <td className="px-3 py-2 text-right text-text-primary font-semibold tabular-nums">{formatCompactNumber(server.total)}</td>
@@ -591,6 +660,24 @@ function DetachedMetricsPageContent() {
       {showClearConfirm && (
         <div className="fixed inset-0 z-40" onClick={() => setShowClearConfirm(false)} />
       )}
+
+      {/* Pricing models manager — detached host: data from this window's
+          local status poll, optimistic updates into the same local state. */}
+      <PricingManagerSlideOver
+        open={pricingManagerOpen}
+        onClose={() => setPricingManagerOpen(false)}
+        defaultModel={defaultModel}
+        servers={serverNames.map((name) => ({ name, declaredModel: serverDeclared[name] }))}
+        clients={[...new Set([
+          ...Object.keys(clientModels),
+          ...Object.keys(tokenUsage?.per_client ?? {}),
+          ...Object.keys(costUsage?.per_client ?? {}),
+        ])].sort().map((name) => ({ name, declaredModel: clientModels[name] }))}
+        costAttribution={costAttribution}
+        onClientSaved={handleClientModelSaved}
+        onServerSaved={handleServerModelSaved}
+        onDefaultSaved={handleDefaultModelSaved}
+      />
     </div>
   );
 }
@@ -630,7 +717,7 @@ function CostKPICard({
       </span>
       {showHint && (
         <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
-          Set <code className="font-mono">model:</code> in stack.yaml to enable estimates
+          {ATTRIBUTION_HINT}
         </span>
       )}
     </div>

--- a/web/src/stores/useStackStore.ts
+++ b/web/src/stores/useStackStore.ts
@@ -62,6 +62,8 @@ interface StackState {
   costUsage: CostUsage | null;   // USD cost snapshot; null when no cost recorded
   costAttribution: boolean; // True when any client or server has a pricing model configured
   clientModels: Record<string, string>; // Declared client -> model pricing map (client_models)
+  serverModels: Record<string, string>; // EFFECTIVE server -> model map (model: with default folded in)
+  defaultModel: string;     // Gateway-level default_model; empty when not configured
   stackName: string;        // Active stack name; empty string in stackless mode
 
   // === React Flow State ===
@@ -89,6 +91,16 @@ interface StackState {
   // === Actions ===
   setGatewayStatus: (status: GatewayStatus) => void;
   setClients: (clients: ClientStatus[]) => void;
+  // Optimistic local edit of a single client's declared pricing model so the
+  // pill reflects a save before the next status poll confirms it. An empty
+  // model removes the entry (mirrors the backend's clear semantics).
+  setClientModelLocal: (client: string, model: string) => void;
+  // Optimistic local edit of a server's declared model. Recomputes the
+  // server's effective entry (declared, else gateway default).
+  setServerModelLocal: (server: string, model: string) => void;
+  // Optimistic local edit of gateway.default_model. Recomputes every
+  // server's effective entry from its declared model and the new default.
+  setDefaultModelLocal: (model: string) => void;
   setTools: (tools: Tool[]) => void;
   setToolCatalog: (toolCatalog: Tool[]) => void;
   setError: (error: string | null) => void;
@@ -121,6 +133,8 @@ export const useStackStore = create<StackState>()(
     costUsage: null,
     costAttribution: false,
     clientModels: {},
+    serverModels: {},
+    defaultModel: '',
     stackName: '',
     nodes: [],
     edges: [],
@@ -155,6 +169,8 @@ export const useStackStore = create<StackState>()(
         costUsage: status.cost ?? null,
         costAttribution: status.cost_attribution ?? false,
         clientModels: status.client_models ?? {},
+        serverModels: status.server_models ?? {},
+        defaultModel: status.default_model ?? '',
         stackName: status.stack_name || '',
         autoscaleHistory: folded.history,
         autoscaleDecisions: folded.decisions,
@@ -171,6 +187,39 @@ export const useStackStore = create<StackState>()(
       set({ clients });
       // No refreshNodesAndEdges here -- setGatewayStatus already triggers it,
       // and clients are read from store state during refresh.
+    },
+
+    setClientModelLocal: (client, model) => {
+      const next = { ...get().clientModels };
+      if (model === '') {
+        delete next[client];
+      } else {
+        next[client] = model;
+      }
+      set({ clientModels: next });
+    },
+
+    setServerModelLocal: (server, model) => {
+      const mcpServers = get().mcpServers.map((s) =>
+        s.name === server ? { ...s, model: model || undefined } : s,
+      );
+      const serverModels = { ...get().serverModels };
+      const effective = model || get().defaultModel;
+      if (effective) {
+        serverModels[server] = effective;
+      } else {
+        delete serverModels[server];
+      }
+      set({ mcpServers, serverModels });
+    },
+
+    setDefaultModelLocal: (model) => {
+      const serverModels: Record<string, string> = {};
+      for (const s of get().mcpServers) {
+        const effective = s.model || model;
+        if (effective) serverModels[s.name] = effective;
+      }
+      set({ defaultModel: model, serverModels });
     },
 
     setTools: (tools) => set({ tools }),

--- a/web/src/stores/useUIStore.ts
+++ b/web/src/stores/useUIStore.ts
@@ -170,6 +170,12 @@ interface UIState extends WorkspaceSlice, CompactModeSlice {
   accessEditorSeedSlug: string | null;
   openAccessEditor: (slug?: string | null) => void;
   closeAccessEditor: () => void;
+
+  // Pricing models manager: the canonical three-tier cost-attribution
+  // editor, opened from Metrics, the inspector, or the command palette.
+  // Transient (not persisted).
+  pricingManagerOpen: boolean;
+  setPricingManagerOpen: (open: boolean) => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -264,6 +270,9 @@ export const useUIStore = create<UIState>()(
       openAccessEditor: (slug) =>
         set({ accessEditorOpen: true, accessEditorSeedSlug: slug ?? null }),
       closeAccessEditor: () => set({ accessEditorOpen: false, accessEditorSeedSlug: null }),
+
+      pricingManagerOpen: false,
+      setPricingManagerOpen: (pricingManagerOpen) => set({ pricingManagerOpen }),
 
       // Detached window actions
       setLogsDetached: (logsDetached) => set({ logsDetached }),

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -75,6 +75,10 @@ export interface MCPServerStatus {
   // whitelist" (expose all tools the gateway loaded). Present and non-empty
   // means the operator has curated a subset.
   toolWhitelist?: string[];
+  // Pricing model DECLARED on this server in stack.yaml (model: field only;
+  // a gateway default_model is not folded in). Absent when the server
+  // inherits the default or has no attribution.
+  model?: string;
   replicas?: ReplicaStatus[]; // Per-replica runtime status
   autoscale?: AutoscaleStatus; // Live autoscale snapshot (absent when not configured)
 }
@@ -220,6 +224,8 @@ export interface GatewayStatus {
   cost?: CostUsage;        // Cost snapshot (omitted until any cost is recorded)
   cost_attribution?: boolean; // True when any client or server has a pricing model configured
   client_models?: Record<string, string>; // Declared client -> model pricing map (client_models)
+  server_models?: Record<string, string>; // EFFECTIVE server -> model map (model: with default_model folded in)
+  default_model?: string;  // Gateway-level default_model (omitted when not configured)
   stack_name?: string;     // Active stack name; omitted in stackless mode
 }
 
@@ -233,6 +239,21 @@ export interface PricingModelsResponse {
 export interface UpdateClientModelResponse {
   client: string;
   profileKey: string;
+  model: string;
+  reloaded: boolean;
+  reloadedAt?: string;
+}
+
+// Response from PUT /api/mcp-servers/{name}/model
+export interface UpdateServerModelResponse {
+  server: string;
+  model: string;
+  reloaded: boolean;
+  reloadedAt?: string;
+}
+
+// Response from PUT /api/gateway/default-model
+export interface UpdateDefaultModelResponse {
   model: string;
   reloaded: boolean;
   reloadedAt?: string;


### PR DESCRIPTION
## Description

Makes all three cost-attribution tiers (`client_models:`, per-server `model:`, `gateway.default_model`) viewable and editable in the web UI through a shared searchable model picker, and fixes the detached metrics window missing the client Model column shipped in #774.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- New `PUT /api/mcp-servers/{name}/model` and `PUT /api/gateway/default-model` endpoints, cloned from the client-model patcher: atomic comment-preserving yaml.Node writes, per-path lock, 409 on external modification, hot reload on success. Clearing removes keys so stacks round-trip to their pre-feature shape (a `gateway:` block created by the endpoint is dropped when emptied; pre-existing blocks are preserved).
- `/api/status` now exposes `server_models` (effective map), `default_model`, and each server's declared `model`, wired through the controller's existing attribution state.
- Shared `ModelPicker` combobox over `GET /api/pricing/models`: live substring filtering, provider grouping, full keyboard control, virtualized above 150 rows via `@tanstack/react-virtual` (the only new dependency), free text allowed with a soft "prices as \$0" note. Replaces the native `<datalist>`.
- Detached `/metrics` parity: Top Clients Model column with inline editing, per-server Model column, and the pricing manager; stale "Set `model:` in stack.yaml" hints replaced in both metrics surfaces.
- "Pricing models" slide-over manager listing all three tiers in precedence order; opens from the Metrics toolbar, the sidebar inspector's new Pricing section, or the command palette. Non-modal (AccessLens idiom) so the canvas and cost chart stay live.
- Creation wizard: `gateway.default_model` (Pricing section) and per-server `model:` (Advanced section), emitted by the YAML builder.
- Pricing stays best-effort and access-inert: unknown IDs save with a soft warning, and no pricing path touches the `clients:` block.

## Testing

- 16 new Go tests: patcher edge cases (insert, replace, clear-deletes-key, clear-drops-created-block, comment round-trips, 409 conflict), handler round-trips, status exposure, controller declared/default exposure. `make test` and `golangci-lint run` pass.
- 16 new Vitest tests: picker filtering, keyboard navigation, grouping, free-text pass-through, unknown-model note, cell save/conflict/no-op flows, pricing YAML serialization. All 1,006 frontend tests pass.
- Manual: `make build && ./gridctl apply -f <stack>`, then edit each tier from the Metrics tab, manager, and detached window; saves hot-reload without container restarts.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed
- [x] Changelog entry added under [Unreleased]

Closes #777