### PR TITLE
feat: effective model attribution with provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Effective model attribution with provenance.** Gridctl now records which
+  model priced each recorded dollar — per client and per server — and surfaces
+  an "effective model" with provenance (`declared` when one model priced all of
+  an entity's cost, `mixed` when several did, `none` when traffic was observed
+  but nothing priced it). This is exact recording at observation time, not
+  inference: the resolved model is known when cost is recorded. The model
+  histograms persist and replay alongside cost, so provenance survives a
+  restart. `/api/status` gains additive `effective_client_models` /
+  `effective_server_models` maps (and the client/server status objects gain an
+  `effectiveModel` field); the Metrics tab and detached window show a
+  `<dominant> · NN%` pill for mixed clients/servers (clickable into the pricing
+  manager) and a muted `unpriced` tag for none, with a one-line honesty note on
+  the Cost card when any blend is present; the sidebar inspector and pricing
+  manager surface the same read-only effective info. `gridctl optimize`'s
+  `expensive_model_on_cheap_task` finding names the dominant model and labels
+  its provenance. Provenance describes which declaration priced the traffic, not
+  what the client actually ran — the gateway cannot observe the client's model
+  choice, so the labels never claim detection. See `docs/cost-observability.md`.
+
 - **In-UI pricing model editing across all three attribution tiers.** Cost
   attribution no longer requires hand-editing stack.yaml: the per-server
   `model:` and `gateway.default_model` tiers join `client_models:` as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,13 @@ All notable changes to gridctl will be documented in this file.
 
 ### Fixed
 
+- **Pricing model picker truncated long model IDs.** The dropdown was pinned to
+  the narrow editor cell's width, so IDs like
+  `anthropic.claude-3-opus-20240229` were cut off with no readable fallback.
+  The popover now grows to fit the widest option (capped so it stays on screen),
+  and the footer previews the highlighted row's full ID verbatim during keyboard
+  navigation.
+
 - **Detached metrics window missing the client Model column.** The popout
   `/metrics` window now has full parity with the Metrics tab: the Top Clients
   Model column with inline editing, the per-server Model column, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,8 +298,11 @@ All notable changes to gridctl will be documented in this file.
   the narrow editor cell's width, so IDs like
   `anthropic.claude-3-opus-20240229` were cut off with no readable fallback.
   The popover now grows to fit the widest option (capped so it stays on screen),
-  and the footer previews the highlighted row's full ID verbatim during keyboard
-  navigation.
+  the footer previews the highlighted row's full ID verbatim during keyboard
+  navigation, and the popover can anchor to its right edge so it grows inward
+  instead of overflowing a narrow container. The pricing manager slide-over is
+  wider with larger labels, so model names are readable without the horizontal
+  scrollbar the cramped panel produced.
 
 - **Detached metrics window missing the client Model column.** The popout
   `/metrics` window now has full parity with the Metrics tab: the Top Clients

--- a/docs/cost-observability.md
+++ b/docs/cost-observability.md
@@ -45,6 +45,22 @@ Two limitations to keep expectations honest. A declared client model is a sessio
 
 Cost figures are estimates — tokenizer-approximated counts multiplied by published list rates. They are built for comparing servers and clients, spotting waste, and trending over time, not for reconciling invoices.
 
+## Effective models (provenance)
+
+The four declared tiers answer "which model *should* price this call". Once calls land, gridctl also records which model *did* price each recorded dollar, per client and per server, and surfaces it as an **effective model** with provenance. This is exact recording, not inference: the resolved model is known at the moment cost is recorded, so the effective model is the model gridctl actually applied — never a guess reverse-engineered from the cost.
+
+| Provenance | Meaning | Shown as |
+|---|---|---|
+| `declared` | One model priced all of this entity's recorded cost | The model, unchanged from before |
+| `mixed` | Two or more models priced the traffic (an undeclared client hitting servers with different `model:` values, or a declaration changed mid-session) | `<dominant> · NN%` with the full breakdown on hover |
+| `none` | Traffic was observed but no attribution resolved, so cost is $0 | A muted `unpriced` tag |
+
+Effective models appear in the Metrics tab's Top Clients and per-server tables (and the detached metrics window), the sidebar inspector's Pricing section, the Pricing models manager, and on `/api/status` as `effective_client_models` / `effective_server_models`. A `mixed` cell is clickable: it opens the Pricing models manager so declaring a single client model — which collapses the blend for future traffic — is one step away.
+
+**What provenance does and does not mean.** A provenance label describes which *declaration* priced the traffic, not which model the upstream client actually ran. The gateway sits below the LLM client and cannot observe the client's model choice (the same reason attribution is declared in the first place). So `mixed` means "your declarations priced this traffic at more than one rate", not "the client used several models", and the UI never says "detected" or "used". True declared-vs-actual drift detection is not possible without a model signal on the wire; the effective model is the honest, exact record of what gridctl applied. Statistical inference of the client's model from the observed cost/token ratio was evaluated and rejected: gridctl computes the cost itself from the resolved model, so such inference would only restate the declaration it started from.
+
+Effective-model history persists alongside cost, so the provenance you see after a gateway restart matches what it was before. `gridctl optimize`'s `expensive_model_on_cheap_task` finding names the dominant model that priced a server's traffic and labels its provenance in both the table detail and `--format json`.
+
 ## Refreshing pricing data
 
 The pricing snapshot is embedded at build time via `//go:embed pkg/pricing/data/model_prices.json`. Refresh it when providers adjust rates or add new models:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -267,6 +267,23 @@ func (s *Server) defaultModelValue() string {
 	return s.defaultModel()
 }
 
+// effectiveClientModels and effectiveServerModels derive the read-time
+// effective-model + provenance maps from the live accumulator snapshots.
+// Return nil when no accumulator is wired or no traffic has been observed.
+func (s *Server) effectiveClientModels() map[string]EffectiveModel {
+	if s.metricsAccumulator == nil {
+		return nil
+	}
+	return deriveEffectiveModels(s.metricsAccumulator.Snapshot().PerClient, s.metricsAccumulator.CostSnapshot().PerClientModels)
+}
+
+func (s *Server) effectiveServerModels() map[string]EffectiveModel {
+	if s.metricsAccumulator == nil {
+		return nil
+	}
+	return deriveEffectiveModels(s.metricsAccumulator.Snapshot().PerServer, s.metricsAccumulator.CostSnapshot().PerServerModels)
+}
+
 // SetStartWatcher sets a callback that activates live-reload file watching for
 // the given stack path. Called by POST /api/stack/initialize after cold-loading.
 func (s *Server) SetStartWatcher(fn func(stackPath string)) {
@@ -494,7 +511,15 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		// Omitted when not configured. Lets the UI render "inherits
 		// default: <id>" provenance for servers without their own model.
 		DefaultModel string `json:"default_model,omitempty"`
-		StackName    string `json:"stack_name,omitempty"`
+		// EffectiveClientModels and EffectiveServerModels report which model
+		// actually priced each client's / server's recorded cost, with
+		// provenance (declared | mixed | none). Derived read-only from the
+		// accumulator's model histograms; they describe which declaration
+		// gridctl applied, not what the upstream client ran. Omitted when no
+		// traffic has been observed.
+		EffectiveClientModels map[string]EffectiveModel `json:"effective_client_models,omitempty"`
+		EffectiveServerModels map[string]EffectiveModel `json:"effective_server_models,omitempty"`
+		StackName             string                    `json:"stack_name,omitempty"`
 	}{
 		Gateway: ServerInfo{
 			Name:      s.gateway.ServerInfo().Name,
@@ -521,9 +546,12 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	if s.metricsAccumulator != nil {
 		snap := s.metricsAccumulator.Snapshot()
 		status.TokenUsage = &snap
-		if cost := s.metricsAccumulator.CostSnapshot(); !costSnapshotIsZero(cost) {
+		cost := s.metricsAccumulator.CostSnapshot()
+		if !costSnapshotIsZero(cost) {
 			status.Cost = &cost
 		}
+		status.EffectiveClientModels = deriveEffectiveModels(snap.PerClient, cost.PerClientModels)
+		status.EffectiveServerModels = deriveEffectiveModels(snap.PerServer, cost.PerServerModels)
 	}
 	status.ClientModels = s.clientModelAttributionMap()
 	status.ServerModels = s.modelAttributionMap()
@@ -622,6 +650,10 @@ type MCPServerStatus struct {
 	// (model: field only — a gateway default_model is not folded in here).
 	// Empty when the server inherits the default or has no attribution.
 	Model string `json:"model,omitempty"`
+	// EffectiveModel reports which model actually priced this server's
+	// recorded cost, with provenance (declared | mixed | none). Read-only
+	// and derived from observed cost; nil when the server has no traffic.
+	EffectiveModel *EffectiveModel `json:"effectiveModel,omitempty"`
 
 	Replicas  []mcp.ReplicaStatus  `json:"replicas,omitempty"`
 	Autoscale *mcp.AutoscaleStatus `json:"autoscale,omitempty"`
@@ -630,6 +662,7 @@ type MCPServerStatus struct {
 func (s *Server) getMCPServerStatuses() []MCPServerStatus {
 	mcpStatuses := s.gateway.Status()
 	declaredModels := s.declaredServerModelsMap()
+	effective := s.effectiveServerModels()
 	statuses := make([]MCPServerStatus, len(mcpStatuses))
 	for i, ms := range mcpStatuses {
 		status := MCPServerStatus{
@@ -656,6 +689,9 @@ func (s *Server) getMCPServerStatuses() []MCPServerStatus {
 		if ms.LastCheck != nil {
 			ts := ms.LastCheck.Format(time.RFC3339)
 			status.LastCheck = &ts
+		}
+		if em, ok := effective[ms.Name]; ok {
+			status.EffectiveModel = &em
 		}
 		statuses[i] = status
 	}
@@ -1120,6 +1156,10 @@ type ClientStatus struct {
 	// client_models, when present. Pricing attribution only — it carries no
 	// access-control meaning and is independent of EffectiveScope.
 	Model string `json:"model,omitempty"`
+	// EffectiveModel reports which model actually priced this client's
+	// recorded cost, with provenance (declared | mixed | none). Read-only
+	// and derived from observed cost; nil when the client has no traffic.
+	EffectiveModel *EffectiveModel `json:"effectiveModel,omitempty"`
 	// EffectiveScope is the backend-computed per-client tool access scope when a
 	// `clients:` block is configured: the servers and prefixed tools this client
 	// can reach. nil when no access scoping is in effect, so the frontend can
@@ -1147,6 +1187,7 @@ func (s *Server) handleClients(w http.ResponseWriter, r *http.Request) {
 
 	scopingOn := s.gateway != nil && s.gateway.ClientAccessConfigured()
 	clientModels := s.clientModelAttributionMap()
+	effective := s.effectiveClientModels()
 
 	infos := s.provisioners.AllClientInfo(serverName)
 	statuses := make([]ClientStatus, 0, len(infos))
@@ -1159,6 +1200,9 @@ func (s *Server) handleClients(w http.ResponseWriter, r *http.Request) {
 			Transport:  info.Transport,
 			ConfigPath: info.ConfigPath,
 			Model:      clientModels[info.Slug],
+		}
+		if em, ok := effective[info.Slug]; ok {
+			status.EffectiveModel = &em
 		}
 		// Surface the backend-computed effective scope keyed on the client's
 		// stable identifier (its slug, which is what `gridctl link` assigns and

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1307,6 +1307,57 @@ func TestHandleStatus_IncludesTokenUsage(t *testing.T) {
 	}
 }
 
+func TestHandleStatus_IncludesEffectiveModels(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	// A client whose calls priced under two different models -> mixed; a
+	// server priced under a single model -> declared.
+	srv.metricsAccumulator.RecordReplicaWithClient("github", -1, "cursor", 100, 50)
+	srv.metricsAccumulator.RecordCostWithModel("github", -1, "cursor", "claude-opus-4-7", 100, 50, metrics.CostBreakdown{Input: 0.80, Output: 0.10})
+	srv.metricsAccumulator.RecordReplicaWithClient("lookup", -1, "cursor", 100, 50)
+	srv.metricsAccumulator.RecordCostWithModel("lookup", -1, "cursor", "claude-haiku-4-5", 100, 50, metrics.CostBreakdown{Input: 0.05, Output: 0.05})
+
+	handler := srv.Handler()
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var result struct {
+		EffectiveClientModels map[string]EffectiveModel `json:"effective_client_models"`
+		EffectiveServerModels map[string]EffectiveModel `json:"effective_server_models"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	cursor, ok := result.EffectiveClientModels["cursor"]
+	if !ok {
+		t.Fatalf("expected effective_client_models[cursor]; got %+v", result.EffectiveClientModels)
+	}
+	if cursor.Provenance != "mixed" {
+		t.Errorf("cursor provenance = %q, want mixed", cursor.Provenance)
+	}
+	if cursor.Model != "claude-opus-4-7" {
+		t.Errorf("cursor dominant model = %q, want claude-opus-4-7", cursor.Model)
+	}
+	if len(cursor.Models) != 2 {
+		t.Errorf("cursor breakdown len = %d, want 2", len(cursor.Models))
+	}
+
+	github, ok := result.EffectiveServerModels["github"]
+	if !ok {
+		t.Fatalf("expected effective_server_models[github]; got %+v", result.EffectiveServerModels)
+	}
+	if github.Provenance != "declared" {
+		t.Errorf("github provenance = %q, want declared", github.Provenance)
+	}
+	if github.Model != "claude-opus-4-7" {
+		t.Errorf("github model = %q, want claude-opus-4-7", github.Model)
+	}
+}
+
 func TestHandleStatus_NoTokenUsageWithoutAccumulator(t *testing.T) {
 	srv := newTestServer(t)
 	handler := srv.Handler()

--- a/internal/api/effective_model.go
+++ b/internal/api/effective_model.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"sort"
+
+	"github.com/gridctl/gridctl/pkg/metrics"
+)
+
+// Model provenance values carried on every EffectiveModel. The set is an
+// open string enum so future signals can extend it without reshaping the
+// API. `reported` is reserved for a future protocol-level model signal (an
+// upstream client declaring its model on the wire) and is unused today.
+const (
+	provenanceDeclared = "declared" // one model priced all of this entity's recorded cost
+	provenanceMixed    = "mixed"    // two or more models priced this entity's traffic
+	provenanceNone     = "none"     // traffic observed but no cost recorded (no attribution)
+	// provenanceReported is intentionally unused in v1. Declared here so the
+	// contract is documented in one place for when a wire signal lands.
+	provenanceReported = "reported" //nolint:unused // reserved for a future protocol-level model signal
+)
+
+// ModelShare is one model's slice of an entity's recorded cost: the model
+// ID, its USD cost, and its share (0–1) of the entity's total recorded cost.
+type ModelShare struct {
+	Model   string  `json:"model"`
+	CostUSD float64 `json:"cost_usd"`
+	Share   float64 `json:"share"`
+}
+
+// EffectiveModel is the read-time interpretation of which model(s) priced an
+// entity's (client or server) traffic, with provenance. It describes which
+// declaration gridctl applied when pricing the traffic — NOT which model the
+// upstream client actually used; the gateway cannot observe that. Model and
+// Share describe the dominant entry; Models lists every model that priced the
+// entity, descending by cost.
+type EffectiveModel struct {
+	Model      string       `json:"model,omitempty"`
+	Provenance string       `json:"provenance"`
+	Share      float64      `json:"share,omitempty"`
+	Models     []ModelShare `json:"models,omitempty"`
+}
+
+// deriveEffectiveModels computes the effective model + provenance for every
+// entity that has either recorded cost (a model histogram) or observed
+// traffic (tokens). It is a pure function of the two snapshots so it is
+// trivially testable.
+//
+//   - One histogram model        → declared (that model, share 1.0).
+//   - Two or more histogram models → mixed (dominant by cost; full breakdown).
+//   - Tokens but no histogram     → none (traffic priced as $0, no attribution).
+//   - Neither                     → omitted.
+//
+// tokenTotals supplies the `none` case (it needs token volume, which the
+// cost histogram does not carry). Both maps may be nil.
+func deriveEffectiveModels(tokenTotals map[string]metrics.TokenCounts, histograms map[string]map[string]metrics.ModelCost) map[string]EffectiveModel {
+	if len(tokenTotals) == 0 && len(histograms) == 0 {
+		return nil
+	}
+	out := make(map[string]EffectiveModel)
+
+	for entity, models := range histograms {
+		if em, ok := effectiveFromHistogram(models); ok {
+			out[entity] = em
+		}
+	}
+
+	// Entities with traffic but no histogram are `none` (priced as $0).
+	for entity, tokens := range tokenTotals {
+		if _, done := out[entity]; done {
+			continue
+		}
+		if tokens.TotalTokens > 0 {
+			out[entity] = EffectiveModel{Provenance: provenanceNone}
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// effectiveFromHistogram reduces one entity's model histogram to an
+// EffectiveModel. Returns ok=false when the histogram is empty (the caller
+// then considers the `none` case from token data).
+func effectiveFromHistogram(models map[string]metrics.ModelCost) (EffectiveModel, bool) {
+	if len(models) == 0 {
+		return EffectiveModel{}, false
+	}
+
+	shares := make([]ModelShare, 0, len(models))
+	var total float64
+	for model, mc := range models {
+		shares = append(shares, ModelShare{Model: model, CostUSD: mc.CostUSD})
+		total += mc.CostUSD
+	}
+	// Descending by cost, then model ID ascending for a deterministic order
+	// (and stable dominant selection on exact-cost ties).
+	sort.Slice(shares, func(i, j int) bool {
+		if shares[i].CostUSD != shares[j].CostUSD {
+			return shares[i].CostUSD > shares[j].CostUSD
+		}
+		return shares[i].Model < shares[j].Model
+	})
+	if total > 0 {
+		for i := range shares {
+			shares[i].Share = shares[i].CostUSD / total
+		}
+	}
+
+	dominant := shares[0]
+	provenance := provenanceDeclared
+	if len(shares) > 1 {
+		provenance = provenanceMixed
+	}
+	return EffectiveModel{
+		Model:      dominant.Model,
+		Provenance: provenance,
+		Share:      dominant.Share,
+		Models:     shares,
+	}, true
+}

--- a/internal/api/effective_model_test.go
+++ b/internal/api/effective_model_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/metrics"
+)
+
+func approxEq(a, b float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < 1e-9
+}
+
+func TestDeriveEffectiveModels_Declared(t *testing.T) {
+	histograms := map[string]map[string]metrics.ModelCost{
+		"claude-code": {"claude-opus-4-7": {CostUSD: 1.50, InputTokens: 100, OutputTokens: 50}},
+	}
+	tokens := map[string]metrics.TokenCounts{
+		"claude-code": {InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+	}
+
+	got := deriveEffectiveModels(tokens, histograms)
+	em, ok := got["claude-code"]
+	if !ok {
+		t.Fatalf("expected entry for claude-code; got %+v", got)
+	}
+	if em.Provenance != provenanceDeclared {
+		t.Errorf("provenance = %q, want declared", em.Provenance)
+	}
+	if em.Model != "claude-opus-4-7" {
+		t.Errorf("model = %q, want claude-opus-4-7", em.Model)
+	}
+	if !approxEq(em.Share, 1.0) {
+		t.Errorf("share = %v, want 1.0", em.Share)
+	}
+	if len(em.Models) != 1 {
+		t.Errorf("models len = %d, want 1", len(em.Models))
+	}
+}
+
+func TestDeriveEffectiveModels_Mixed(t *testing.T) {
+	histograms := map[string]map[string]metrics.ModelCost{
+		"cursor": {
+			"claude-opus-4-7":  {CostUSD: 0.90},
+			"claude-haiku-4-5": {CostUSD: 0.10},
+		},
+	}
+	tokens := map[string]metrics.TokenCounts{
+		"cursor": {TotalTokens: 400},
+	}
+
+	got := deriveEffectiveModels(tokens, histograms)
+	em := got["cursor"]
+	if em.Provenance != provenanceMixed {
+		t.Fatalf("provenance = %q, want mixed", em.Provenance)
+	}
+	if em.Model != "claude-opus-4-7" {
+		t.Errorf("dominant model = %q, want claude-opus-4-7", em.Model)
+	}
+	if !approxEq(em.Share, 0.9) {
+		t.Errorf("dominant share = %v, want 0.9", em.Share)
+	}
+	if len(em.Models) != 2 {
+		t.Fatalf("models len = %d, want 2", len(em.Models))
+	}
+	// Descending by cost: opus first.
+	if em.Models[0].Model != "claude-opus-4-7" || em.Models[1].Model != "claude-haiku-4-5" {
+		t.Errorf("models not sorted by cost desc: %+v", em.Models)
+	}
+	// Shares sum to 1.0.
+	if !approxEq(em.Models[0].Share+em.Models[1].Share, 1.0) {
+		t.Errorf("shares do not sum to 1.0: %+v", em.Models)
+	}
+}
+
+func TestDeriveEffectiveModels_None(t *testing.T) {
+	// Tokens observed but no cost histogram → none.
+	tokens := map[string]metrics.TokenCounts{
+		"gemini-cli": {InputTokens: 200, OutputTokens: 100, TotalTokens: 300},
+	}
+	got := deriveEffectiveModels(tokens, nil)
+	em, ok := got["gemini-cli"]
+	if !ok {
+		t.Fatalf("expected none entry; got %+v", got)
+	}
+	if em.Provenance != provenanceNone {
+		t.Errorf("provenance = %q, want none", em.Provenance)
+	}
+	if em.Model != "" || len(em.Models) != 0 {
+		t.Errorf("none entry should carry no model; got %+v", em)
+	}
+}
+
+func TestDeriveEffectiveModels_NoTrafficOmitted(t *testing.T) {
+	tokens := map[string]metrics.TokenCounts{
+		"idle": {TotalTokens: 0},
+	}
+	got := deriveEffectiveModels(tokens, nil)
+	if _, ok := got["idle"]; ok {
+		t.Errorf("entity with zero traffic should be omitted; got %+v", got)
+	}
+}
+
+func TestDeriveEffectiveModels_DeclaredWinsOverNone(t *testing.T) {
+	// An entity present in both tokens and histogram derives from the
+	// histogram (declared), not the token-only none path.
+	histograms := map[string]map[string]metrics.ModelCost{
+		"claude-code": {"claude-opus-4-7": {CostUSD: 1.0}},
+	}
+	tokens := map[string]metrics.TokenCounts{
+		"claude-code": {TotalTokens: 150},
+	}
+	got := deriveEffectiveModels(tokens, histograms)
+	if got["claude-code"].Provenance != provenanceDeclared {
+		t.Errorf("provenance = %q, want declared", got["claude-code"].Provenance)
+	}
+}
+
+func TestDeriveEffectiveModels_EmptyInputsNil(t *testing.T) {
+	if got := deriveEffectiveModels(nil, nil); got != nil {
+		t.Errorf("empty inputs should derive nil; got %+v", got)
+	}
+}

--- a/internal/api/optimize.go
+++ b/internal/api/optimize.go
@@ -110,9 +110,71 @@ func (s *Server) optimizeStats() optimize.Stats {
 			SavingsPercent:  snap.FormatSavings.SavingsPercent,
 		}
 		stats.ServerCallCount = computeServerCallCount(acc.ToolUsageSnapshot())
+		stats.ModelHistograms = serverModelHistograms(acc.CostSnapshot().PerServerModels)
 	}
+	// Declared per-server attribution provides rates; the histogram (when
+	// present) names the model that actually priced traffic. Merge so the
+	// dominant histogram model rides with its looked-up rate, which
+	// resolveDominantRate prefers over the declared value.
 	stats.ModelStats = lookupModelStats(s.modelAttributionMap())
+	stats.ModelStats = mergeHistogramModelStats(stats.ModelStats, stats.ModelHistograms)
 	return stats
+}
+
+// serverModelHistograms flattens the accumulator's per-server model cost
+// histogram (model -> ModelCost) into the model -> USD shape pkg/optimize
+// consumes. Returns nil when no histogram data exists so the optimize path
+// keeps its pre-histogram behavior.
+func serverModelHistograms(perServer map[string]map[string]metrics.ModelCost) map[string]map[string]float64 {
+	if len(perServer) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]float64, len(perServer))
+	for server, models := range perServer {
+		inner := make(map[string]float64, len(models))
+		for model, mc := range models {
+			inner[model] = mc.CostUSD
+		}
+		out[server] = inner
+	}
+	return out
+}
+
+// mergeHistogramModelStats ensures each server's dominant histogram model
+// carries its pricing rate in ModelStats, so resolveDominantRate can name the
+// exact model that priced traffic with a real (not cost÷tokens) rate. A
+// declared ModelStat for the same server is overridden only when the
+// dominant histogram model differs and prices successfully.
+func mergeHistogramModelStats(declared map[string]optimize.ModelStat, histograms map[string]map[string]float64) map[string]optimize.ModelStat {
+	if len(histograms) == 0 {
+		return declared
+	}
+	out := declared
+	if out == nil {
+		out = make(map[string]optimize.ModelStat)
+	}
+	for server, models := range histograms {
+		dominant := optimize.DominantModel(models)
+		if dominant == "" {
+			continue
+		}
+		if existing, ok := out[server]; ok && existing.Model == dominant {
+			continue // declared rate already names the dominant model
+		}
+		rates, ok := pricing.Lookup(dominant)
+		if !ok {
+			continue
+		}
+		out[server] = optimize.ModelStat{
+			Model:             dominant,
+			InputUSDPerToken:  rates.InputPerToken,
+			OutputUSDPerToken: rates.OutputPerToken,
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // computeSchemaTokens estimates per-server schema-overhead tokens by

--- a/pkg/metrics/accumulator.go
+++ b/pkg/metrics/accumulator.go
@@ -104,6 +104,24 @@ func (c CostMicroUSDCounts) TotalMicroUSD() int64 {
 	return c.InputMicroUSD + c.OutputMicroUSD + c.CacheReadMicroUSD + c.CacheWriteMicroUSD
 }
 
+// ModelCost is the per-model slice of an entity's cost histogram: the USD
+// cost and token volume recorded under one resolved model ID. Token fields
+// count only the calls that were priced (cost recorded), not the entity's
+// full token traffic — unpriced calls have no model to attribute to.
+type ModelCost struct {
+	CostUSD      float64 `json:"cost_usd"`
+	InputTokens  int64   `json:"input_tokens,omitempty"`
+	OutputTokens int64   `json:"output_tokens,omitempty"`
+}
+
+// ModelMicroCounts is the int64 micro-USD persistence shape for one model
+// histogram bucket, mirroring CostMicroUSDCounts' role for plain cost.
+type ModelMicroCounts struct {
+	CostMicroUSD int64 `json:"cost_micro_usd,omitempty"`
+	InputTokens  int64 `json:"input_tokens,omitempty"`
+	OutputTokens int64 `json:"output_tokens,omitempty"`
+}
+
 // CostUsage is the top-level cost snapshot. The shape mirrors TokenUsage so
 // API consumers can render cost charts beside token charts.
 type CostUsage struct {
@@ -113,6 +131,13 @@ type CostUsage struct {
 	// PerClient groups USD cost by the originating MCP client. omitempty so
 	// pre-attribution consumers keep their existing JSON shape.
 	PerClient map[string]CostCounts `json:"per_client,omitempty"`
+	// PerServerModels and PerClientModels break each entity's recorded cost
+	// down by the model that priced it (entity -> model ID -> totals). The
+	// model is always known at RecordCostWithModel time — these are exact
+	// recordings of which declared rate applied, not statistical estimates.
+	// omitempty preserves the pre-histogram JSON shape.
+	PerServerModels map[string]map[string]ModelCost `json:"per_server_models,omitempty"`
+	PerClientModels map[string]map[string]ModelCost `json:"per_client_models,omitempty"`
 }
 
 // CostDataPoint is the time-series shape for cost-over-time queries.
@@ -232,6 +257,16 @@ type clientCounters struct {
 	cacheWriteCostMicroUSD atomic.Int64
 }
 
+// modelCounters holds atomic counters for one (entity, model) histogram
+// bucket: micro-USD cost plus the token volume priced under that model.
+// Cardinality is bounded by the number of distinct models that actually
+// price traffic (a handful in practice), so the nested maps stay small.
+type modelCounters struct {
+	costMicroUSD atomic.Int64
+	inputTokens  atomic.Int64
+	outputTokens atomic.Int64
+}
+
 // ToolStat is the snapshot shape for per-(server, tool) call tracking.
 // Used by pkg/optimize to detect tools that have not seen any calls
 // inside a freshness window. Calls is the cumulative count since the
@@ -306,6 +341,16 @@ type Accumulator struct {
 	clientBufMu sync.RWMutex
 	clientBufs  map[string]*serverBuffer
 
+	// Per-server and per-client model histograms: entity -> model ID ->
+	// counters for cost recorded under that model. Written by
+	// RecordCostWithModel alongside the plain cost counters so every
+	// recorded dollar carries its pricing model. Cardinality is bounded by
+	// (entities × models in use); no eviction by design.
+	serverModelMu sync.RWMutex
+	serverModels  map[string]map[string]*modelCounters
+	clientModelMu sync.RWMutex
+	clientModels  map[string]map[string]*modelCounters
+
 	// Per-(server, tool) call counters. Powers the unused_tool optimize
 	// heuristic: a tool registered on a server but absent from this map
 	// (or with a stale LastCalledAt) has not been called recently.
@@ -347,16 +392,18 @@ func NewAccumulator(maxDataPoints int) *Accumulator {
 		maxDataPoints = 10000
 	}
 	return &Accumulator{
-		startedAt:   time.Now(),
-		servers:     make(map[string]*serverCounters),
-		replicas:    make(map[string]map[int]*replicaCounters),
-		buckets:     make([]bucket, maxDataPoints),
-		maxSize:     maxDataPoints,
-		serverBufs:  make(map[string]*serverBuffer),
-		clients:     make(map[string]*clientCounters),
-		clientBufs:  make(map[string]*serverBuffer),
-		toolUsage:   make(map[string]map[string]*toolUsage),
-		promptUsage: make(map[string]*promptUsage),
+		startedAt:    time.Now(),
+		servers:      make(map[string]*serverCounters),
+		replicas:     make(map[string]map[int]*replicaCounters),
+		buckets:      make([]bucket, maxDataPoints),
+		maxSize:      maxDataPoints,
+		serverBufs:   make(map[string]*serverBuffer),
+		clients:      make(map[string]*clientCounters),
+		clientBufs:   make(map[string]*serverBuffer),
+		serverModels: make(map[string]map[string]*modelCounters),
+		clientModels: make(map[string]map[string]*modelCounters),
+		toolUsage:    make(map[string]map[string]*toolUsage),
+		promptUsage:  make(map[string]*promptUsage),
 	}
 }
 
@@ -752,6 +799,69 @@ func (a *Accumulator) RecordCostWithClient(serverName string, replicaID int, cli
 	}
 }
 
+// RecordCostWithModel is RecordCostWithClient plus model attribution: the
+// resolved model ID that priced this call is recorded into the per-server
+// (and, when clientID is non-empty, per-client) model histograms alongside
+// the plain cost counters. inputTokens/outputTokens are the call's token
+// counts — the same values the observer records via RecordReplicaWithClient —
+// so each histogram bucket carries the token volume priced under its model.
+//
+// An empty model updates the plain cost counters only (matching the
+// pre-histogram behavior); in practice the observer never records cost
+// without a resolved model, so every recorded dollar lands in a histogram.
+func (a *Accumulator) RecordCostWithModel(serverName string, replicaID int, clientID, model string, inputTokens, outputTokens int, cost CostBreakdown) {
+	if cost.IsZero() || !cost.IsValid() {
+		return
+	}
+	a.RecordCostWithClient(serverName, replicaID, clientID, cost)
+	if model == "" {
+		return
+	}
+
+	totalMicro := usdToMicro(cost.Input) + usdToMicro(cost.Output) +
+		usdToMicro(cost.CacheRead) + usdToMicro(cost.CacheWrite)
+
+	mc := getOrCreateModelCounters(&a.serverModelMu, a.serverModels, serverName, model)
+	mc.costMicroUSD.Add(totalMicro)
+	mc.inputTokens.Add(int64(inputTokens))
+	mc.outputTokens.Add(int64(outputTokens))
+
+	if clientID != "" {
+		cc := getOrCreateModelCounters(&a.clientModelMu, a.clientModels, clientID, model)
+		cc.costMicroUSD.Add(totalMicro)
+		cc.inputTokens.Add(int64(inputTokens))
+		cc.outputTokens.Add(int64(outputTokens))
+	}
+}
+
+// getOrCreateModelCounters returns the (entity, model) histogram bucket from
+// the given map, creating the nested maps on first use. The same
+// double-checked-locking pattern as the per-server/per-client counters.
+func getOrCreateModelCounters(mu *sync.RWMutex, histograms map[string]map[string]*modelCounters, entity, model string) *modelCounters {
+	mu.RLock()
+	if m, ok := histograms[entity]; ok {
+		if mc, ok := m[model]; ok {
+			mu.RUnlock()
+			return mc
+		}
+	}
+	mu.RUnlock()
+
+	mu.Lock()
+	defer mu.Unlock()
+	m, ok := histograms[entity]
+	if !ok {
+		m = make(map[string]*modelCounters)
+		histograms[entity] = m
+	}
+	mc, ok := m[model]
+	if !ok {
+		mc = &modelCounters{}
+		m[model] = mc
+	}
+	return mc
+}
+
 // getOrCreateServerCounters returns the per-server counter bucket, creating
 // it on first use. Safe for concurrent access. Used by RecordCost; the
 // token RecordReplica path inlines the same double-checked-locking pattern.
@@ -1075,6 +1185,63 @@ func (a *Accumulator) CostMicroSnapshot() map[string]CostMicroUSDCounts {
 	return out
 }
 
+// ServerModelMicroSnapshot returns the per-server model histograms in the
+// int64 micro-USD shape the persistence layer round-trips. Keyed
+// server -> model -> counts, mirroring CostMicroSnapshot's role for plain
+// per-server cost. Only per-server histograms persist; per-client cost (and
+// thus per-client model histograms) have no on-disk equivalent, matching the
+// existing cost-persistence scope.
+func (a *Accumulator) ServerModelMicroSnapshot() map[string]map[string]ModelMicroCounts {
+	a.serverModelMu.RLock()
+	defer a.serverModelMu.RUnlock()
+	if len(a.serverModels) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]ModelMicroCounts, len(a.serverModels))
+	for server, models := range a.serverModels {
+		inner := make(map[string]ModelMicroCounts, len(models))
+		for model, mc := range models {
+			inner[model] = ModelMicroCounts{
+				CostMicroUSD: mc.costMicroUSD.Load(),
+				InputTokens:  mc.inputTokens.Load(),
+				OutputTokens: mc.outputTokens.Load(),
+			}
+		}
+		out[server] = inner
+	}
+	return out
+}
+
+// RestoreServerModels overwrites the per-server model histograms from a
+// persisted snapshot, the model analogue of RestoreCost. Used on daemon
+// startup so a restored server's effective-model provenance matches what it
+// was before restart (otherwise replayed cost would render with empty
+// provenance). Servers absent from the map keep their current histogram.
+func (a *Accumulator) RestoreServerModels(perServer map[string]map[string]ModelMicroCounts) {
+	if len(perServer) == 0 {
+		return
+	}
+	a.serverModelMu.Lock()
+	defer a.serverModelMu.Unlock()
+	for server, models := range perServer {
+		inner, ok := a.serverModels[server]
+		if !ok {
+			inner = make(map[string]*modelCounters, len(models))
+			a.serverModels[server] = inner
+		}
+		for model, counts := range models {
+			mc, ok := inner[model]
+			if !ok {
+				mc = &modelCounters{}
+				inner[model] = mc
+			}
+			mc.costMicroUSD.Store(counts.CostMicroUSD)
+			mc.inputTokens.Store(counts.InputTokens)
+			mc.outputTokens.Store(counts.OutputTokens)
+		}
+	}
+}
+
 // CostSnapshot returns the current cost usage summary in USD. The shape
 // mirrors Snapshot()'s TokenUsage so API responses can carry both side by
 // side. Cache fields are non-zero only when RecordCost recorded cache
@@ -1139,10 +1306,36 @@ func (a *Accumulator) CostSnapshot() CostUsage {
 			CacheWriteUSD: sessionCacheWrite,
 			TotalUSD:      sessionInput + sessionOutput + sessionCacheRead + sessionCacheWrite,
 		},
-		PerServer:  perServer,
-		PerReplica: perReplica,
-		PerClient:  perClient,
+		PerServer:       perServer,
+		PerReplica:      perReplica,
+		PerClient:       perClient,
+		PerServerModels: readModelHistograms(&a.serverModelMu, a.serverModels),
+		PerClientModels: readModelHistograms(&a.clientModelMu, a.clientModels),
 	}
+}
+
+// readModelHistograms snapshots a model histogram map into the public
+// ModelCost shape (USD floats). Returns nil when empty so CostSnapshot's
+// omitempty keeps the pre-histogram JSON shape.
+func readModelHistograms(mu *sync.RWMutex, histograms map[string]map[string]*modelCounters) map[string]map[string]ModelCost {
+	mu.RLock()
+	defer mu.RUnlock()
+	if len(histograms) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]ModelCost, len(histograms))
+	for entity, models := range histograms {
+		inner := make(map[string]ModelCost, len(models))
+		for model, mc := range models {
+			inner[model] = ModelCost{
+				CostUSD:      microToUSD(mc.costMicroUSD.Load()),
+				InputTokens:  mc.inputTokens.Load(),
+				OutputTokens: mc.outputTokens.Load(),
+			}
+		}
+		out[entity] = inner
+	}
+	return out
 }
 
 // readCostCounts assembles a CostCounts from raw micro-USD atomic loads.
@@ -1531,6 +1724,14 @@ func (a *Accumulator) Clear() {
 	a.clients = make(map[string]*clientCounters)
 	a.clientMu.Unlock()
 
+	a.serverModelMu.Lock()
+	a.serverModels = make(map[string]map[string]*modelCounters)
+	a.serverModelMu.Unlock()
+
+	a.clientModelMu.Lock()
+	a.clientModels = make(map[string]map[string]*modelCounters)
+	a.clientModelMu.Unlock()
+
 	a.bufMu.Lock()
 	a.buckets = make([]bucket, a.maxSize)
 	a.position = 0
@@ -1600,6 +1801,17 @@ func (a *Accumulator) ClearCost() {
 		cc.cacheWriteCostMicroUSD.Store(0)
 	}
 	a.clientMu.RUnlock()
+
+	// Model histograms are pure cost data — drop them entirely (rather than
+	// zeroing) so a cleared entity reports provenance `none`, not a `mixed`
+	// histogram full of zero-cost models.
+	a.serverModelMu.Lock()
+	a.serverModels = make(map[string]map[string]*modelCounters)
+	a.serverModelMu.Unlock()
+
+	a.clientModelMu.Lock()
+	a.clientModels = make(map[string]map[string]*modelCounters)
+	a.clientModelMu.Unlock()
 
 	a.bufMu.Lock()
 	for i := range a.buckets {

--- a/pkg/metrics/accumulator_test.go
+++ b/pkg/metrics/accumulator_test.go
@@ -461,6 +461,174 @@ func TestAccumulator_RecordCost_ZeroIsNoop(t *testing.T) {
 	}
 }
 
+// --- Model histogram tests ---
+
+func TestAccumulator_RecordCostWithModel_SingleModel(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordCostWithModel("github", -1, "claude-code", "claude-opus-4-7", 100, 50, CostBreakdown{Input: 0.10, Output: 0.20})
+	acc.RecordCostWithModel("github", -1, "claude-code", "claude-opus-4-7", 40, 10, CostBreakdown{Input: 0.05, Output: 0.05})
+
+	snap := acc.CostSnapshot()
+
+	srv := snap.PerServerModels["github"]
+	if len(srv) != 1 {
+		t.Fatalf("expected 1 server model bucket, got %d (%+v)", len(srv), srv)
+	}
+	m := srv["claude-opus-4-7"]
+	if !approxCostEq(m.CostUSD, 0.40) {
+		t.Errorf("server model cost = %v, want 0.40", m.CostUSD)
+	}
+	if m.InputTokens != 140 || m.OutputTokens != 60 {
+		t.Errorf("server model tokens = (%d,%d), want (140,60)", m.InputTokens, m.OutputTokens)
+	}
+
+	cli := snap.PerClientModels["claude-code"]
+	if len(cli) != 1 {
+		t.Fatalf("expected 1 client model bucket, got %d (%+v)", len(cli), cli)
+	}
+	if !approxCostEq(cli["claude-opus-4-7"].CostUSD, 0.40) {
+		t.Errorf("client model cost = %v, want 0.40", cli["claude-opus-4-7"].CostUSD)
+	}
+}
+
+func TestAccumulator_RecordCostWithModel_MultipleModels(t *testing.T) {
+	acc := NewAccumulator(100)
+	// One undeclared client whose calls hit two servers priced at different models.
+	acc.RecordCostWithModel("github", -1, "cursor", "claude-opus-4-7", 100, 50, CostBreakdown{Input: 0.80, Output: 0.10})
+	acc.RecordCostWithModel("lookup", -1, "cursor", "claude-haiku-4-5", 100, 50, CostBreakdown{Input: 0.05, Output: 0.05})
+
+	snap := acc.CostSnapshot()
+	cli := snap.PerClientModels["cursor"]
+	if len(cli) != 2 {
+		t.Fatalf("expected 2 client model buckets, got %d (%+v)", len(cli), cli)
+	}
+	if !approxCostEq(cli["claude-opus-4-7"].CostUSD, 0.90) {
+		t.Errorf("opus cost = %v, want 0.90", cli["claude-opus-4-7"].CostUSD)
+	}
+	if !approxCostEq(cli["claude-haiku-4-5"].CostUSD, 0.10) {
+		t.Errorf("haiku cost = %v, want 0.10", cli["claude-haiku-4-5"].CostUSD)
+	}
+}
+
+func TestAccumulator_RecordCostWithModel_EmptyModelSkipsHistogram(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordCostWithModel("github", -1, "claude-code", "", 100, 50, CostBreakdown{Input: 0.10, Output: 0.20})
+
+	snap := acc.CostSnapshot()
+	if snap.PerServerModels != nil {
+		t.Errorf("empty model must not create a histogram; got %+v", snap.PerServerModels)
+	}
+	// Plain cost is still recorded.
+	if !approxCostEq(snap.PerServer["github"].TotalUSD, 0.30) {
+		t.Errorf("plain cost should still record; got %v", snap.PerServer["github"].TotalUSD)
+	}
+}
+
+func TestAccumulator_RecordCostWithModel_ZeroCostNoop(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordCostWithModel("github", -1, "claude-code", "claude-opus-4-7", 0, 0, CostBreakdown{})
+	snap := acc.CostSnapshot()
+	if snap.PerServerModels != nil || snap.PerClientModels != nil {
+		t.Errorf("zero-cost record must not create histograms; got server=%+v client=%+v",
+			snap.PerServerModels, snap.PerClientModels)
+	}
+}
+
+func TestAccumulator_RecordCostWithModel_AnonymousSkipsClientHistogram(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordCostWithModel("github", -1, "", "claude-opus-4-7", 100, 50, CostBreakdown{Input: 0.10, Output: 0.20})
+	snap := acc.CostSnapshot()
+	if _, ok := snap.PerServerModels["github"]; !ok {
+		t.Error("anonymous call should still record per-server model histogram")
+	}
+	if snap.PerClientModels != nil {
+		t.Errorf("anonymous call must not create per-client histogram; got %+v", snap.PerClientModels)
+	}
+}
+
+func TestAccumulator_RecordCostWithModel_Concurrent(t *testing.T) {
+	acc := NewAccumulator(1000)
+	var wg sync.WaitGroup
+	const goroutines = 50
+	const calls = 50
+	models := []string{"claude-opus-4-7", "claude-haiku-4-5"}
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for j := 0; j < calls; j++ {
+				acc.RecordCostWithModel("server", -1, "client", models[(g+j)%2], 1, 1, CostBreakdown{Input: 0.001, Output: 0.001})
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	snap := acc.CostSnapshot()
+	var total float64
+	for _, m := range snap.PerServerModels["server"] {
+		total += m.CostUSD
+	}
+	want := 0.002 * float64(goroutines*calls)
+	if !approxCostEq(total, want) {
+		t.Errorf("histogram total under concurrent writes = %v, want %v", total, want)
+	}
+}
+
+func TestAccumulator_RestoreServerModels_RoundTrip(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordCostWithModel("github", -1, "claude-code", "claude-opus-4-7", 100, 50, CostBreakdown{Input: 0.30, Output: 0.10})
+	acc.RecordCostWithModel("lookup", -1, "claude-code", "claude-haiku-4-5", 80, 20, CostBreakdown{Input: 0.05, Output: 0.05})
+
+	persisted := acc.ServerModelMicroSnapshot()
+	if len(persisted) != 2 {
+		t.Fatalf("expected 2 servers in micro snapshot, got %d", len(persisted))
+	}
+
+	// Restore into a fresh accumulator (the restart case).
+	restored := NewAccumulator(100)
+	restored.RestoreServerModels(persisted)
+
+	snap := restored.CostSnapshot()
+	g := snap.PerServerModels["github"]["claude-opus-4-7"]
+	if !approxCostEq(g.CostUSD, 0.40) || g.InputTokens != 100 || g.OutputTokens != 50 {
+		t.Errorf("github bucket after restore = %+v, want cost 0.40 tokens (100,50)", g)
+	}
+	l := snap.PerServerModels["lookup"]["claude-haiku-4-5"]
+	if !approxCostEq(l.CostUSD, 0.10) {
+		t.Errorf("lookup bucket cost after restore = %v, want 0.10", l.CostUSD)
+	}
+}
+
+func TestAccumulator_RestoreServerModels_EmptyIsNoop(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RestoreServerModels(nil)
+	if acc.ServerModelMicroSnapshot() != nil {
+		t.Error("restoring an empty map should leave histograms empty")
+	}
+}
+
+func TestAccumulator_ClearCost_DropsModelHistograms(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordCostWithModel("github", -1, "claude-code", "claude-opus-4-7", 100, 50, CostBreakdown{Input: 0.30, Output: 0.10})
+	acc.ClearCost()
+	snap := acc.CostSnapshot()
+	if snap.PerServerModels != nil || snap.PerClientModels != nil {
+		t.Errorf("ClearCost must drop model histograms; got server=%+v client=%+v",
+			snap.PerServerModels, snap.PerClientModels)
+	}
+}
+
+func TestAccumulator_Clear_DropsModelHistograms(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordCostWithModel("github", -1, "claude-code", "claude-opus-4-7", 100, 50, CostBreakdown{Input: 0.30, Output: 0.10})
+	acc.Clear()
+	snap := acc.CostSnapshot()
+	if snap.PerServerModels != nil || snap.PerClientModels != nil {
+		t.Errorf("Clear must drop model histograms; got server=%+v client=%+v",
+			snap.PerServerModels, snap.PerClientModels)
+	}
+}
+
 func TestAccumulator_QueryCost(t *testing.T) {
 	acc := NewAccumulator(100)
 	acc.RecordCost("server-a", -1, CostBreakdown{Input: 0.10, Output: 0.20})

--- a/pkg/metrics/observer.go
+++ b/pkg/metrics/observer.go
@@ -117,7 +117,7 @@ func (o *Observer) observe(serverName string, replicaID int, clientID, toolName 
 	if !ok {
 		return summary
 	}
-	o.accumulator.RecordCostWithClient(serverName, replicaID, clientID, CostBreakdown{
+	o.accumulator.RecordCostWithModel(serverName, replicaID, clientID, model, inputTokens, outputTokens, CostBreakdown{
 		Input:      cost.Input,
 		Output:     cost.Output,
 		CacheRead:  cost.CacheRead,

--- a/pkg/optimize/optimize.go
+++ b/pkg/optimize/optimize.go
@@ -81,6 +81,17 @@ type Finding struct {
 	// resolves the finding. Multi-line strings are allowed.
 	Remediation string `json:"remediation"`
 
+	// Model names the model the finding refers to, when one is known. Set
+	// by expensive_model_on_cheap_task from the dominant model that priced
+	// the server's traffic. Empty when only an effective rate was available.
+	Model string `json:"model,omitempty"`
+
+	// Provenance describes how Model was determined: "declared" when it is
+	// the model that priced the server's recorded cost; empty when the
+	// finding fired on a rate inferred from observed cost÷tokens with no
+	// model identity. Mirrors the effective-model provenance vocabulary.
+	Provenance string `json:"provenance,omitempty"`
+
 	// DetectedAt is the wall-clock time the report was generated, not
 	// the time the underlying condition began.
 	DetectedAt time.Time `json:"detected_at"`
@@ -204,6 +215,13 @@ type Stats struct {
 	// causes expensive_model_on_cheap_task to fall back to inferring
 	// the rate from observed cost÷tokens.
 	ModelStats map[string]ModelStat
+
+	// ModelHistograms carries the per-server breakdown of recorded cost by
+	// the model that priced it (server -> model ID -> USD). When present it
+	// names the dominant model exactly (the model that priced the most
+	// cost), which resolveDominantRate prefers over the declared ModelStat
+	// or the cost÷tokens fallback. nil leaves the existing behavior intact.
+	ModelHistograms map[string]map[string]float64
 }
 
 // PinStat carries the schema-overhead inputs for a single server. The
@@ -685,9 +703,13 @@ func detectExpensiveModelOnCheapTask(stats Stats, now time.Time) []Finding {
 		if avgTokensPerCall > expensiveModelMaxAvgTokensPerCall {
 			continue
 		}
-		rate, modelName := resolveDominantRate(stats.ModelStats[srv.Name], usage)
+		rate, modelName := resolveDominantRate(stats.ModelStats[srv.Name], stats.ModelHistograms[srv.Name], usage)
 		if rate < expensiveModelInputRateThreshold {
 			continue
+		}
+		provenance := ""
+		if modelName != "" {
+			provenance = "declared"
 		}
 		out = append(out, Finding{
 			ID:               "expensive-model-cheap-task-" + srv.Name,
@@ -698,6 +720,8 @@ func detectExpensiveModelOnCheapTask(stats Stats, now time.Time) []Finding {
 			Server:           srv.Name,
 			ImpactUSDPerWeek: 0, // informational; client-side model swap is the action
 			Remediation:      remediationExpensiveModel(srv, modelName),
+			Model:            modelName,
+			Provenance:       provenance,
 			DetectedAt:       now,
 		})
 	}
@@ -730,18 +754,17 @@ func remediationFormatShortfall(srv ServerInfo) string {
 
 func summaryExpensiveModel(srv ServerInfo, usage ServerUsage, nCalls int64, modelName string, rate float64) string {
 	avg := float64(usage.TotalTokens) / float64(nCalls)
-	model := modelName
-	if model == "" {
-		model = "an Opus-tier model"
+	if modelName == "" {
+		return "Server '" + srv.Name + "' is priced at an Opus-tier rate (" + formatRatePerMillion(rate) + " per million input tokens) but the average call is only " + formatRatio(avg) + " tokens — a simple-lookup pattern. The model selection lives client-side; consider routing this server to a cheaper model when possible."
 	}
-	return "Server '" + srv.Name + "' is being called with " + model + " (" + formatRatePerMillion(rate) + " per million input tokens) but the average call is only " + formatRatio(avg) + " tokens — a simple-lookup pattern. The model selection lives client-side; consider routing this server to a cheaper model when possible."
+	return "Server '" + srv.Name + "' traffic is priced as " + modelName + " (" + formatRatePerMillion(rate) + " per million input tokens) but the average call is only " + formatRatio(avg) + " tokens — a simple-lookup pattern. The model selection lives client-side; consider routing this server to a cheaper model when possible."
 }
 
 func remediationExpensiveModel(srv ServerInfo, modelName string) string {
 	if modelName == "" {
 		return "# Model selection is client-side; pick a smaller model (e.g. Haiku, gpt-4o-mini) for prompts that primarily call '" + srv.Name + "'."
 	}
-	return "# Currently observed model: " + modelName + "\n# Model selection is client-side; pick a smaller model (e.g. Haiku, gpt-4o-mini) for prompts that primarily call '" + srv.Name + "'."
+	return "# Priced as (declared): " + modelName + "\n# Model selection is client-side; pick a smaller model (e.g. Haiku, gpt-4o-mini) for prompts that primarily call '" + srv.Name + "'."
 }
 
 func usesFormatConversion(format string) bool {
@@ -753,7 +776,31 @@ func usesFormatConversion(format string) bool {
 	}
 }
 
-func resolveDominantRate(ms ModelStat, usage ServerUsage) (float64, string) {
+// resolveDominantRate returns the effective input-token rate and the model
+// name for a server's expensive-model check. Resolution order:
+//
+//  1. The histogram's dominant model (the model that priced the most cost) is
+//     the exact, observed attribution. When it has a known rate (ms carries
+//     that model's rate), use it.
+//  2. The declared ModelStat rate, when present.
+//  3. The cost÷tokens fallback — an effective rate with no model identity.
+//
+// histogram maps model ID -> recorded USD for this server; nil leaves the
+// pre-histogram behavior. ms is expected to carry the dominant model's rate
+// when the call site resolved one (the API layer looks it up against the
+// pricing source).
+func resolveDominantRate(ms ModelStat, histogram map[string]float64, usage ServerUsage) (float64, string) {
+	dominant := DominantModel(histogram)
+	if dominant != "" {
+		// The histogram names the model exactly. Prefer its rate when the
+		// call site supplied one for this same model.
+		if ms.InputUSDPerToken > 0 && ms.Model == dominant {
+			return ms.InputUSDPerToken, dominant
+		}
+		if usage.TotalTokens > 0 && usage.TotalCostUSD > 0 {
+			return usage.TotalCostUSD / float64(usage.TotalTokens), dominant
+		}
+	}
 	if ms.InputUSDPerToken > 0 {
 		return ms.InputUSDPerToken, ms.Model
 	}
@@ -761,6 +808,22 @@ func resolveDominantRate(ms ModelStat, usage ServerUsage) (float64, string) {
 		return usage.TotalCostUSD / float64(usage.TotalTokens), ms.Model
 	}
 	return 0, ms.Model
+}
+
+// DominantModel returns the model ID with the highest recorded cost in a
+// histogram (model ID -> USD), breaking ties by model ID for determinism.
+// Empty when the histogram is nil or empty. Exported so the API layer
+// resolves "the dominant model" with the exact same tie-break rule this
+// package uses, keeping the two in agreement.
+func DominantModel(histogram map[string]float64) string {
+	var best string
+	var bestCost float64
+	for model, cost := range histogram {
+		if cost > bestCost || (cost == bestCost && (best == "" || model < best)) {
+			best, bestCost = model, cost
+		}
+	}
+	return best
 }
 
 func filterByImpact(in []Finding, min float64) []Finding {

--- a/pkg/optimize/optimize_test.go
+++ b/pkg/optimize/optimize_test.go
@@ -523,8 +523,57 @@ func TestAnalyze_ExpensiveModel_FiresOnHighRateLowAvgTokens(t *testing.T) {
 	if !strings.Contains(hit.Summary, "claude-opus-4-7") {
 		t.Errorf("summary should name the model; got %q", hit.Summary)
 	}
+	if hit.Model != "claude-opus-4-7" {
+		t.Errorf("finding Model = %q, want claude-opus-4-7", hit.Model)
+	}
+	if hit.Provenance != "declared" {
+		t.Errorf("finding Provenance = %q, want declared", hit.Provenance)
+	}
 	if hit.ImpactUSDPerWeek != 0 {
 		t.Errorf("impact must be zero (informational only); got %v", hit.ImpactUSDPerWeek)
+	}
+}
+
+// TestAnalyze_ExpensiveModel_NamesDominantHistogramModel verifies the finding
+// names the model that priced the most cost (from the histogram) even when no
+// declared ModelStat exists, and labels its provenance declared.
+func TestAnalyze_ExpensiveModel_NamesDominantHistogramModel(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "lookup", Tools: []string{"get_user"}, Initialized: true},
+	}
+	// Effective rate = 0.0005 / 10 = 5e-5 = $50/M, above threshold.
+	stats.Usage = map[string]ServerUsage{
+		"lookup": {OutputTokens: 5, TotalTokens: 10, TotalCostUSD: 0.0005},
+	}
+	stats.ServerCallCount = map[string]int64{"lookup": 50}
+	stats.ToolUsage = map[string]map[string]ToolStat{
+		"lookup": {"get_user": {Calls: 50, LastCalledAt: fixedNow.Add(-1 * time.Hour)}},
+	}
+	// No declared ModelStat; the histogram names the dominant model exactly.
+	stats.ModelHistograms = map[string]map[string]float64{
+		"lookup": {"claude-opus-4-7": 0.0004, "claude-haiku-4-5": 0.0001},
+	}
+
+	rep := Analyze(stats, Options{})
+	var hit *Finding
+	for i := range rep.Findings {
+		if rep.Findings[i].Heuristic == "expensive_model_on_cheap_task" {
+			hit = &rep.Findings[i]
+			break
+		}
+	}
+	if hit == nil {
+		t.Fatal("expected expensive_model_on_cheap_task finding")
+	}
+	if hit.Model != "claude-opus-4-7" {
+		t.Errorf("finding should name dominant histogram model; got Model=%q", hit.Model)
+	}
+	if hit.Provenance != "declared" {
+		t.Errorf("provenance = %q, want declared", hit.Provenance)
+	}
+	if !strings.Contains(hit.Summary, "claude-opus-4-7") {
+		t.Errorf("summary should name the dominant model; got %q", hit.Summary)
 	}
 }
 

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -50,6 +50,14 @@ type MetricsSnapshotLine struct {
 	// the reserved PromptUsageNamespace by the dedicated prompt-usage writer.
 	// omitempty keeps every per-server line byte-identical.
 	PromptUsage map[string]metrics.ToolStat `json:"prompt_usage,omitempty"`
+	// ModelCost carries the server's *cumulative* per-model cost histogram
+	// (modelID -> cost + token volume priced under it) at flush time — the
+	// effective-model-provenance analogue of CostTotal. Persisted as a
+	// cumulative snapshot (like ToolUsage), not a diff: SeedFromFile takes
+	// the most recent non-nil ModelCost per server (cleared on a token
+	// Reset) so provenance survives a restart alongside the cost it explains.
+	// omitempty keeps pre-histogram and token-only lines byte-identical.
+	ModelCost map[string]metrics.ModelMicroCounts `json:"model_cost,omitempty"`
 }
 
 // PromptUsageNamespace is the reserved flusher key under which global
@@ -69,11 +77,12 @@ type MetricsFlusher struct {
 	interval time.Duration
 	logger   *slog.Logger
 
-	mu        sync.Mutex
-	writers   map[string]*lumberjack.Logger          // serverName -> writer
-	prev      map[string]metrics.TokenCounts         // serverName -> last token snapshot
-	prevCost  map[string]metrics.CostMicroUSDCounts  // serverName -> last cost snapshot (parallel to prev)
-	prevTools map[string]map[string]metrics.ToolStat // serverName -> last per-tool snapshot (parallel to prev)
+	mu         sync.Mutex
+	writers    map[string]*lumberjack.Logger                  // serverName -> writer
+	prev       map[string]metrics.TokenCounts                 // serverName -> last token snapshot
+	prevCost   map[string]metrics.CostMicroUSDCounts          // serverName -> last cost snapshot (parallel to prev)
+	prevTools  map[string]map[string]metrics.ToolStat         // serverName -> last per-tool snapshot (parallel to prev)
+	prevModels map[string]map[string]metrics.ModelMicroCounts // serverName -> last per-model cost snapshot (parallel to prev)
 
 	// Global prompt (skill) usage. The skills registry is not a per-server
 	// entry, so it gets a single dedicated writer rather than living in the
@@ -101,6 +110,7 @@ func NewMetricsFlusher(acc *metrics.Accumulator, interval time.Duration) *Metric
 		prev:        make(map[string]metrics.TokenCounts),
 		prevCost:    make(map[string]metrics.CostMicroUSDCounts),
 		prevTools:   make(map[string]map[string]metrics.ToolStat),
+		prevModels:  make(map[string]map[string]metrics.ModelMicroCounts),
 		prevPrompts: make(map[string]metrics.ToolStat),
 		stop:        make(chan struct{}),
 		done:        make(chan struct{}),
@@ -169,6 +179,7 @@ func (f *MetricsFlusher) RemoveServer(name string) {
 	delete(f.prev, name)
 	delete(f.prevCost, name)
 	delete(f.prevTools, name)
+	delete(f.prevModels, name)
 }
 
 // SetPromptUsageWriter installs (or replaces) the writer for the global
@@ -307,6 +318,7 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 	snap := f.acc.Snapshot()
 	costSnap := f.acc.CostMicroSnapshot()
 	toolSnap := f.acc.ToolUsageSnapshot()
+	modelSnap := f.acc.ServerModelMicroSnapshot()
 	promptSnap := f.acc.PromptUsageSnapshot()
 
 	type planned struct {
@@ -326,6 +338,7 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 		// the zero CostMicroUSDCounts so the diff math stays uniform.
 		currentCost := costSnap[name]
 		currentTools := toolSnap[name]
+		currentModels := modelSnap[name]
 		prev, hadPrev := f.prev[name]
 		prevCost, hadPrevCost := f.prevCost[name]
 		// Per-tool usage has no diff/reset machinery — it persists as a
@@ -334,6 +347,12 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 		// attribute tokens), mirroring how cost forces a line independently
 		// of the token diff.
 		toolChanged := toolUsageChanged(f.prevTools[name], currentTools)
+		// Per-model cost is also a cumulative snapshot. A model histogram
+		// only advances when cost advances, so a changed histogram already
+		// coincides with a non-zero cost diff — but track it explicitly for
+		// symmetry with toolChanged and to stay robust if that coupling
+		// ever changes.
+		modelChanged := modelCostChanged(f.prevModels[name], currentModels)
 		line := MetricsSnapshotLine{
 			Time:   now.UTC(),
 			Server: name,
@@ -389,7 +408,7 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 		// emits because it carries the post-reset boundary signal even
 		// when the post-reset state is zero.
 		tokenDiffZero := tokenDiff.InputTokens == 0 && tokenDiff.OutputTokens == 0 && tokenDiff.TotalTokens == 0
-		if !line.Reset && !line.CostReset && tokenDiffZero && costDiff.IsZero() && !toolChanged {
+		if !line.Reset && !line.CostReset && tokenDiffZero && costDiff.IsZero() && !toolChanged && !modelChanged {
 			continue
 		}
 
@@ -408,6 +427,12 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 		if len(currentTools) > 0 {
 			line.ToolUsage = currentTools
 		}
+		// Carry the freshest cumulative model histogram on every emitted
+		// line so the most recent line per server holds the latest
+		// provenance snapshot for SeedFromFile to restore.
+		if len(currentModels) > 0 {
+			line.ModelCost = currentModels
+		}
 
 		plan = append(plan, planned{writer: writer, line: line})
 		// Update prev / prevCost under the lock — even if the write fails
@@ -418,6 +443,7 @@ func (f *MetricsFlusher) flushOnce(now time.Time) {
 		f.prev[name] = current
 		f.prevCost[name] = currentCost
 		f.prevTools[name] = currentTools
+		f.prevModels[name] = currentModels
 	}
 
 	// Prompt (skill) usage is global cumulative state under a dedicated
@@ -509,6 +535,22 @@ func toolUsageChanged(prev, current map[string]metrics.ToolStat) bool {
 	return false
 }
 
+// modelCostChanged reports whether a server's cumulative per-model cost
+// histogram differs between two snapshots. A new model key or any changed
+// cost component returns true. Comparing cost alone suffices: token volume
+// in a bucket only advances together with cost.
+func modelCostChanged(prev, current map[string]metrics.ModelMicroCounts) bool {
+	if len(prev) != len(current) {
+		return true
+	}
+	for model, cur := range current {
+		if p, ok := prev[model]; !ok || p.CostMicroUSD != cur.CostMicroUSD {
+			return true
+		}
+	}
+	return false
+}
+
 // SeedFromFile reads up to the last n NDJSON entries from path and seeds
 // these surfaces atomically: cumulative per-server token totals (via
 // Restore), cumulative per-server cost totals (via RestoreCost), cumulative
@@ -584,6 +626,7 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 	latest := make(map[string]metrics.TokenCounts)
 	latestCost := make(map[string]metrics.CostMicroUSDCounts)
 	latestTools := make(map[string]map[string]metrics.ToolStat)
+	latestModels := make(map[string]map[string]metrics.ModelMicroCounts)
 	series := make([]seriesPoint, 0, len(lines))
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -608,9 +651,16 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 		// Any ToolUsage on this same line (post-reset activity) then wins.
 		if rec.Reset {
 			delete(latestTools, rec.Server)
+			delete(latestModels, rec.Server)
 		}
 		if rec.ToolUsage != nil {
 			latestTools[rec.Server] = rec.ToolUsage
+		}
+		// Model histograms ride the same cumulative-snapshot contract as
+		// tool usage: most recent non-nil wins, cleared on a token Reset so
+		// stale provenance never outlives the cost it explained.
+		if rec.ModelCost != nil {
+			latestModels[rec.Server] = rec.ModelCost
 		}
 		// Reset and CostReset are independent: a token-reset line skips
 		// token replay (Diff is the full carryover, replaying would spike
@@ -655,6 +705,7 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 	f.acc.Restore(latest)
 	f.acc.RestoreCost(latestCost)
 	f.acc.RestoreToolUsage(latestTools)
+	f.acc.RestoreServerModels(latestModels)
 	f.mu.Lock()
 	for name, counts := range latest {
 		f.prev[name] = counts
@@ -664,6 +715,9 @@ func (f *MetricsFlusher) SeedFromFile(path string, n int) error {
 	}
 	for name, tools := range latestTools {
 		f.prevTools[name] = tools
+	}
+	for name, models := range latestModels {
+		f.prevModels[name] = models
 	}
 	f.mu.Unlock()
 	return nil

--- a/pkg/telemetry/metrics_test.go
+++ b/pkg/telemetry/metrics_test.go
@@ -678,6 +678,85 @@ func TestMetricsFlusher_ToolUsagePersistence(t *testing.T) {
 	})
 }
 
+// TestMetricsFlusher_ModelCostPersistence covers effective-model provenance
+// surviving a gateway restart: a flush writes the cumulative per-model cost
+// histogram, a fresh accumulator restores it via SeedFromFile so a replayed
+// cost arrives with its provenance intact, and a token reset drops the
+// carried-over histogram so a wiped accumulator does not resurrect stale
+// model attribution.
+func TestMetricsFlusher_ModelCostPersistence(t *testing.T) {
+	t.Run("flush persists model histogram and seed restores it", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		acc := metrics.NewAccumulator(100)
+		acc.RecordCostWithModel("github", -1, "claude-code", "claude-opus-4-7", 100, 50, metrics.CostBreakdown{Input: 0.30, Output: 0.10})
+
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.AddServer("github", path, LogOpts{}); err != nil {
+			t.Fatalf("AddServer: %v", err)
+		}
+		f.flushOnce(time.Now())
+
+		var persisted map[string]metrics.ModelMicroCounts
+		for _, l := range readMetricsLines(t, path) {
+			var rec MetricsSnapshotLine
+			if err := json.Unmarshal([]byte(l), &rec); err == nil && rec.ModelCost != nil {
+				persisted = rec.ModelCost
+			}
+		}
+		if persisted == nil {
+			t.Fatal("no flushed line carried model_cost")
+		}
+		if got := persisted["claude-opus-4-7"].CostMicroUSD; got != 400_000 {
+			t.Errorf("persisted opus cost = %d micro-USD, want 400000", got)
+		}
+
+		// Restart: fresh accumulator seeded from the same file.
+		acc2 := metrics.NewAccumulator(100)
+		f2 := NewMetricsFlusher(acc2, time.Hour)
+		if err := f2.SeedFromFile(path, 100); err != nil {
+			t.Fatalf("SeedFromFile: %v", err)
+		}
+		snap := acc2.CostSnapshot()
+		m := snap.PerServerModels["github"]["claude-opus-4-7"]
+		if m.CostUSD < 0.399 || m.CostUSD > 0.401 {
+			t.Errorf("restored opus cost = %v, want ~0.40", m.CostUSD)
+		}
+		if m.InputTokens != 100 || m.OutputTokens != 50 {
+			t.Errorf("restored opus tokens = (%d,%d), want (100,50)", m.InputTokens, m.OutputTokens)
+		}
+	})
+
+	t.Run("token reset drops carried-over model histogram on seed", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:      time.Now().Add(-time.Hour).UTC(),
+			Server:    "github",
+			Total:     metrics.TokenCounts{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+			ModelCost: map[string]metrics.ModelMicroCounts{"claude-opus-4-7": {CostMicroUSD: 400_000, InputTokens: 100, OutputTokens: 50}},
+		})
+		writeRawLine(t, path, `{"reset":true,"ts":"2026-05-06T00:00:00Z","server":"github"}`)
+		writeMetricsLine(t, path, MetricsSnapshotLine{
+			Time:   time.Now().UTC(),
+			Server: "github",
+			Reset:  true,
+			Total:  metrics.TokenCounts{},
+		})
+
+		acc := metrics.NewAccumulator(100)
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.SeedFromFile(path, 100); err != nil {
+			t.Fatalf("SeedFromFile: %v", err)
+		}
+		if snap := acc.CostSnapshot(); snap.PerServerModels != nil {
+			t.Errorf("post-reset seed should restore no model histogram; got %v", snap.PerServerModels)
+		}
+	})
+}
+
 // writeMetricsLine appends one MetricsSnapshotLine as NDJSON to path.
 func writeMetricsLine(t *testing.T, path string, line MetricsSnapshotLine) {
 	t.Helper()

--- a/web/src/__tests__/ClientModelCell.test.tsx
+++ b/web/src/__tests__/ClientModelCell.test.tsx
@@ -39,6 +39,60 @@ describe('ClientModelCell', () => {
     expect(screen.getByText('per-server')).toBeInTheDocument();
   });
 
+  it('renders a mixed-provenance tag with dominant model and share', () => {
+    const onOpenManager = vi.fn();
+    render(
+      <ClientModelCell
+        client="cursor"
+        costAttribution
+        effective={{
+          provenance: 'mixed',
+          model: 'claude-opus-4-7',
+          share: 0.82,
+          models: [
+            { model: 'claude-opus-4-7', cost_usd: 0.82, share: 0.82 },
+            { model: 'claude-haiku-4-5', cost_usd: 0.18, share: 0.18 },
+          ],
+        }}
+        onSaved={vi.fn()}
+        onOpenManager={onOpenManager}
+      />,
+    );
+    expect(screen.getByText('claude-opus-4-7')).toBeInTheDocument();
+    expect(screen.getByText('· 82% · mixed')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('claude-opus-4-7'));
+    expect(onOpenManager).toHaveBeenCalled();
+  });
+
+  it('renders an unpriced tag for none provenance', () => {
+    render(
+      <ClientModelCell
+        client="gemini-cli"
+        costAttribution
+        effective={{ provenance: 'none' }}
+        onSaved={vi.fn()}
+        onOpenManager={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('unpriced')).toBeInTheDocument();
+    // Never a blank cell, and the declared "per-server" fallback is replaced.
+    expect(screen.queryByText('per-server')).not.toBeInTheDocument();
+  });
+
+  it('declared model takes precedence over effective provenance', () => {
+    render(
+      <ClientModelCell
+        client="claude-code"
+        declaredModel="claude-opus-4-7"
+        costAttribution
+        effective={{ provenance: 'mixed', model: 'claude-haiku-4-5', share: 0.6 }}
+        onSaved={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('· client')).toBeInTheDocument();
+    expect(screen.queryByText(/mixed/)).not.toBeInTheDocument();
+  });
+
   it('saves a committed model and reports it to the host', async () => {
     const onSaved = vi.fn();
     const update = vi.spyOn(apiModule, 'updateClientModel').mockResolvedValue({

--- a/web/src/__tests__/EffectiveModelTag.test.tsx
+++ b/web/src/__tests__/EffectiveModelTag.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EffectiveModelTag } from '../components/pricing/EffectiveModelTag';
+import { topShares, mixedTooltip, sharePct } from '../components/pricing/effectiveModel';
+import type { ModelShare } from '../types';
+
+describe('effectiveModel helpers', () => {
+  it('sharePct rounds to whole percent', () => {
+    expect(sharePct(0.823)).toBe('82%');
+    expect(sharePct(1)).toBe('100%');
+  });
+
+  it('topShares groups the tail into "other"', () => {
+    const models: ModelShare[] = [
+      { model: 'a', cost_usd: 5, share: 0.5 },
+      { model: 'b', cost_usd: 3, share: 0.3 },
+      { model: 'c', cost_usd: 1, share: 0.1 },
+      { model: 'd', cost_usd: 0.6, share: 0.06 },
+      { model: 'e', cost_usd: 0.4, share: 0.04 },
+    ];
+    const grouped = topShares(models, 3);
+    expect(grouped).toHaveLength(4);
+    expect(grouped[3].model).toBe('other');
+    expect(grouped[3].share).toBeCloseTo(0.1, 5);
+  });
+
+  it('mixedTooltip names models and carries the honesty note', () => {
+    const tip = mixedTooltip({
+      provenance: 'mixed',
+      model: 'claude-opus-4-7',
+      share: 0.8,
+      models: [
+        { model: 'claude-opus-4-7', cost_usd: 0.8, share: 0.8 },
+        { model: 'claude-haiku-4-5', cost_usd: 0.2, share: 0.2 },
+      ],
+    });
+    expect(tip).toContain('claude-opus-4-7 80%');
+    expect(tip).toContain('not observed client behavior');
+  });
+});
+
+describe('EffectiveModelTag', () => {
+  it('renders mixed with dominant model and share and fires onClick', () => {
+    const onClick = vi.fn();
+    render(
+      <EffectiveModelTag
+        effective={{ provenance: 'mixed', model: 'claude-opus-4-7', share: 0.82, models: [] }}
+        onClick={onClick}
+      />,
+    );
+    expect(screen.getByText('claude-opus-4-7')).toBeInTheDocument();
+    expect(screen.getByText('· 82% · mixed')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('renders none as an unpriced tag', () => {
+    render(<EffectiveModelTag effective={{ provenance: 'none' }} />);
+    expect(screen.getByText('unpriced')).toBeInTheDocument();
+  });
+
+  it('exposes an accessible label that does not rely on color', () => {
+    render(
+      <EffectiveModelTag
+        effective={{ provenance: 'mixed', model: 'claude-opus-4-7', share: 0.82, models: [] }}
+        onClick={vi.fn()}
+      />,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label') ?? '').toMatch(/Mixed pricing/);
+  });
+});

--- a/web/src/__tests__/ModelPicker.test.tsx
+++ b/web/src/__tests__/ModelPicker.test.tsx
@@ -63,6 +63,19 @@ describe('ModelPicker', () => {
     expect(onCommit).toHaveBeenCalledWith('claude-opus-4-7');
   });
 
+  it('previews the highlighted option ID in the footer', async () => {
+    render(<ModelPicker value="" onCommit={vi.fn()} autoFocus />);
+    await waitFor(() => expect(screen.getAllByRole('option').length).toBe(MODELS.length));
+
+    fireEvent.keyDown(getInput(), { key: 'ArrowDown' });
+    // The footer mirrors the first highlighted item verbatim; the option row
+    // shows the same ID, so scope the assertion to the footer node.
+    await waitFor(() => {
+      const previews = screen.getAllByText('claude-haiku-4-5');
+      expect(previews.some((el) => el.classList.contains('break-all'))).toBe(true);
+    });
+  });
+
   it('passes free text through on Enter when nothing is highlighted', async () => {
     const onCommit = vi.fn();
     render(<ModelPicker value="" onCommit={onCommit} autoFocus />);

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -37,6 +37,8 @@ import { useUIStore } from '../../stores/useUIStore';
 import { useAccessLensStore } from '../../stores/useAccessLensStore';
 import { useWindowManager } from '../../hooks/useWindowManager';
 import { formatRelativeTime } from '../../lib/time';
+import { EffectiveModelTag } from '../pricing/EffectiveModelTag';
+import { MODEL_PRECEDENCE_HINT } from '../pricing/constants';
 import type { MCPServerNodeData, ResourceNodeData, ClientNodeData } from '../../types';
 
 export function Sidebar() {
@@ -50,6 +52,8 @@ export function Sidebar() {
   const clients = useStackStore((s) => s.clients);
   const mcpServers = useStackStore((s) => s.mcpServers);
   const clientModels = useStackStore((s) => s.clientModels);
+  const effectiveClientModels = useStackStore((s) => s.effectiveClientModels);
+  const effectiveServerModels = useStackStore((s) => s.effectiveServerModels);
   const defaultModel = useStackStore((s) => s.defaultModel);
   const costAttribution = useStackStore((s) => s.costAttribution);
   const setPricingManagerOpen = useUIStore((s) => s.setPricingManagerOpen);
@@ -410,6 +414,13 @@ export function Sidebar() {
           const declared = isClient
             ? clientModels[clientData?.slug ?? '']
             : mcpServers.find((s) => s.name === data.name)?.model;
+          const effective = isClient
+            ? effectiveClientModels[clientData?.slug ?? '']
+            : effectiveServerModels[data.name];
+          // Show the read-only Effective line only when it adds information
+          // beyond the declared line: a mixed blend or unpriced traffic.
+          const showEffective =
+            effective && (effective.provenance === 'mixed' || effective.provenance === 'none');
           return (
             <InspectorSection title="Pricing" icon={DollarSign}>
               <div className="space-y-3">
@@ -434,6 +445,14 @@ export function Sidebar() {
                     </span>
                   )}
                 </div>
+                {showEffective && effective && (
+                  <div className="flex justify-between items-center gap-3">
+                    <span className="text-sm text-text-muted" title={MODEL_PRECEDENCE_HINT}>
+                      Effective
+                    </span>
+                    <EffectiveModelTag effective={effective} onClick={() => setPricingManagerOpen(true)} />
+                  </div>
+                )}
                 <button
                   type="button"
                   onClick={() => setPricingManagerOpen(true)}

--- a/web/src/components/metrics/MetricsTab.tsx
+++ b/web/src/components/metrics/MetricsTab.tsx
@@ -26,7 +26,7 @@ import { AreaChart } from '../chart/AreaChart';
 import { PersistedFromMarker } from '../telemetry/PersistedFromMarker';
 import { ClientModelCell } from '../pricing/ClientModelCell';
 import { ServerModelCell } from '../pricing/ServerModelCell';
-import { ATTRIBUTION_HINT } from '../pricing/constants';
+import { ATTRIBUTION_HINT, MIXED_PROVENANCE_NOTE } from '../pricing/constants';
 import type { TokenMetricsResponse, CostMetricsResponse } from '../../types';
 
 type TimeRange = 'live' | '1h' | '6h' | '24h' | '7d';
@@ -49,6 +49,8 @@ export function MetricsTab() {
   const costUsage = useStackStore((s) => s.costUsage);
   const costAttribution = useStackStore((s) => s.costAttribution);
   const clientModels = useStackStore((s) => s.clientModels);
+  const effectiveClientModels = useStackStore((s) => s.effectiveClientModels);
+  const effectiveServerModels = useStackStore((s) => s.effectiveServerModels);
   const mcpServers = useStackStore((s) => s.mcpServers);
   const defaultModel = useStackStore((s) => s.defaultModel);
   const setClientModelLocal = useStackStore((s) => s.setClientModelLocal);
@@ -212,6 +214,15 @@ export function MetricsTab() {
   // absent or $0.00 forever. Surface the config hint instead of leaving the
   // user to wonder whether traffic is free.
   const showAttributionHint = !costAttribution && !(sessionCostUSD && sessionCostUSD > 0);
+
+  // The honesty subline appears whenever any client or server resolved to a
+  // blend of pricing models — a reminder that cost is priced by declarations,
+  // not observed client behavior.
+  const hasMixedProvenance = useMemo(() => {
+    const anyMixed = (m: Record<string, { provenance: string }>) =>
+      Object.values(m).some((e) => e.provenance === 'mixed');
+    return anyMixed(effectiveClientModels) || anyMixed(effectiveServerModels);
+  }, [effectiveClientModels, effectiveServerModels]);
 
   const hasData =
     sessionTotal > 0 ||
@@ -432,7 +443,7 @@ export function MetricsTab() {
               <KPICard label="Input Tokens" value={sessionInput} colorClass="text-secondary" />
               <KPICard label="Output Tokens" value={sessionOutput} colorClass="text-primary" />
               <KPICard label="Total Tokens" value={sessionTotal} colorClass="text-text-primary" />
-              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} showHint={showAttributionHint} />
+              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} showHint={showAttributionHint} showMixedNote={hasMixedProvenance} />
               {savingsPercent > 0 && (
                 <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
                   <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Format Savings</span>
@@ -539,8 +550,10 @@ export function MetricsTab() {
                           <ClientModelCell
                             client={client.name}
                             declaredModel={clientModels[client.name]}
+                            effective={effectiveClientModels[client.name]}
                             costAttribution={costAttribution}
                             onSaved={setClientModelLocal}
+                            onOpenManager={() => setPricingManagerOpen(true)}
                           />
                         </td>
                         <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(client.input)}</td>
@@ -605,7 +618,9 @@ export function MetricsTab() {
                             server={server.name}
                             declaredModel={declaredServerModels[server.name]}
                             defaultModel={defaultModel}
+                            effective={effectiveServerModels[server.name]}
                             onSaved={setServerModelLocal}
+                            onOpenManager={() => setPricingManagerOpen(true)}
                           />
                         </td>
                         <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(server.input)}</td>
@@ -650,10 +665,12 @@ function CostKPICard({
   usd,
   hasCost,
   showHint,
+  showMixedNote,
 }: {
   usd: number | undefined;
   hasCost: boolean;
   showHint?: boolean;
+  showMixedNote?: boolean;
 }) {
   return (
     <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
@@ -672,6 +689,11 @@ function CostKPICard({
       {showHint && (
         <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
           {ATTRIBUTION_HINT}
+        </span>
+      )}
+      {!showHint && showMixedNote && (
+        <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
+          {MIXED_PROVENANCE_NOTE}
         </span>
       )}
     </div>

--- a/web/src/components/pricing/ClientModelCell.tsx
+++ b/web/src/components/pricing/ClientModelCell.tsx
@@ -4,14 +4,17 @@ import { updateClientModel } from '../../lib/api';
 import { showToast } from '../ui/Toast';
 import { ModelPicker } from './ModelPicker';
 import { MODEL_PRECEDENCE_HINT } from './constants';
+import { EffectiveModelTag } from './EffectiveModelTag';
+import type { EffectiveModel } from '../../types';
 
 // ClientModelCell shows which model a client's calls are priced as and lets
 // the operator set it inline. A pill with "· client" provenance renders only
 // for clients explicitly declared in client_models; non-declaring clients
-// aggregate heterogeneous per-server/default rates, so they get a muted
-// "per-server" (when any attribution is configured) rather than an invented
-// single model. Clicking opens the shared ModelPicker combobox; free text is
-// allowed (unknown IDs price as zero, best-effort).
+// aggregate heterogeneous per-server/default rates. For those, `effective`
+// surfaces the read-only provenance (mixed: dominant model + share; none:
+// "unpriced") instead of a bare "per-server". Clicking the declared pill
+// opens the inline ModelPicker; clicking a mixed/none tag opens the pricing
+// manager so a declaration is one step away.
 //
 // State stays with the host: `declaredModel` is the saved value and
 // `onSaved` reports a successful write so the main window can update its
@@ -19,13 +22,17 @@ import { MODEL_PRECEDENCE_HINT } from './constants';
 export function ClientModelCell({
   client,
   declaredModel,
+  effective,
   costAttribution,
   onSaved,
+  onOpenManager,
 }: {
   client: string;
   declaredModel?: string;
+  effective?: EffectiveModel;
   costAttribution: boolean;
   onSaved: (client: string, model: string) => void;
+  onOpenManager?: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -97,6 +104,13 @@ export function ClientModelCell({
         <span className="text-[9px] text-text-muted/70">· client</span>
       </button>
     );
+  }
+
+  // No declaration. When observed cost yields a mixed/none provenance, surface
+  // it read-only (a click opens the manager to declare). Otherwise fall back
+  // to the original per-server / set-model affordance.
+  if (effective && (effective.provenance === 'mixed' || effective.provenance === 'none')) {
+    return <EffectiveModelTag effective={effective} onClick={onOpenManager} />;
   }
 
   return (

--- a/web/src/components/pricing/ClientModelCell.tsx
+++ b/web/src/components/pricing/ClientModelCell.tsx
@@ -26,6 +26,7 @@ export function ClientModelCell({
   costAttribution,
   onSaved,
   onOpenManager,
+  pickerAlign,
 }: {
   client: string;
   declaredModel?: string;
@@ -33,6 +34,7 @@ export function ClientModelCell({
   costAttribution: boolean;
   onSaved: (client: string, model: string) => void;
   onOpenManager?: () => void;
+  pickerAlign?: 'left' | 'right';
 }) {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -75,6 +77,7 @@ export function ClientModelCell({
           disabled={saving}
           autoFocus
           widthClass="w-52"
+          align={pickerAlign}
           error={saveError}
         />
         <button

--- a/web/src/components/pricing/EffectiveModelTag.tsx
+++ b/web/src/components/pricing/EffectiveModelTag.tsx
@@ -1,0 +1,63 @@
+import { cn } from '../../lib/cn';
+import type { EffectiveModel } from '../../types';
+import { mixedTooltip, unpricedTooltip, effectiveAriaLabel, sharePct } from './effectiveModel';
+
+// EffectiveModelTag renders the read-only `mixed` and `none` provenance
+// states shared by the client and server cells. Declared models keep their
+// existing pill in the host cell; this component only covers the two
+// non-declared states so the common case is visually unchanged.
+//
+//   mixed → "<dominant> · NN%" muted pill, hover shows the histogram + the
+//           "declared, not observed" honesty note; click opens the manager.
+//   none  → muted "unpriced", hover explains cost is $0.
+//
+// Provenance is conveyed by visible text (not color alone) and an aria-label
+// carrying the full sentence, per the accessibility contract.
+export function EffectiveModelTag({
+  effective,
+  onClick,
+}: {
+  effective: EffectiveModel;
+  onClick?: () => void;
+}) {
+  if (effective.provenance === 'mixed') {
+    const dominant = effective.model ?? '—';
+    const pct = sharePct(effective.share ?? 0);
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={!onClick}
+        title={mixedTooltip(effective)}
+        aria-label={effectiveAriaLabel(effective)}
+        className={cn(
+          'inline-flex items-center gap-1 rounded-full border border-dashed border-border/50 px-2 py-0.5',
+          'bg-surface-highlight/40 transition-colors',
+          onClick && 'hover:border-primary/40 cursor-pointer',
+        )}
+      >
+        <span className="text-[10px] font-mono text-text-secondary">{dominant}</span>
+        <span className="text-[9px] text-text-muted/70">· {pct} · mixed</span>
+      </button>
+    );
+  }
+
+  // none
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!onClick}
+      title={unpricedTooltip()}
+      aria-label={effectiveAriaLabel(effective)}
+      className={cn(
+        'text-[10px] text-text-muted/70 transition-colors',
+        onClick && 'hover:text-secondary cursor-pointer',
+      )}
+    >
+      unpriced
+    </button>
+  );
+}
+
+export default EffectiveModelTag;

--- a/web/src/components/pricing/ModelPicker.tsx
+++ b/web/src/components/pricing/ModelPicker.tsx
@@ -65,6 +65,12 @@ export interface ModelPickerProps {
   autoFocus?: boolean;
   /** Width class for the input; defaults to the metrics-cell width. */
   widthClass?: string;
+  /**
+   * Edge the option popover anchors to. 'left' (default) grows rightward;
+   * 'right' grows leftward, which keeps the popover inside a narrow container
+   * when the input sits against its right edge (e.g. the pricing slide-over).
+   */
+  align?: 'left' | 'right';
   /** Non-null renders the error state (red border + title). */
   error?: string | null;
   /**
@@ -90,6 +96,7 @@ export function ModelPicker({
   disabled = false,
   autoFocus = false,
   widthClass = 'w-52',
+  align = 'left',
   error = null,
   commitOnBlur = false,
 }: ModelPickerProps) {
@@ -279,7 +286,11 @@ export function ModelPicker({
 
       {open && rows.length > 0 && (
         <div
-          className="absolute left-0 top-full mt-1 z-50 min-w-full w-max max-w-[min(420px,90vw)] rounded-md border border-border/50 bg-surface-elevated shadow-xl overflow-hidden"
+          className={cn(
+            'absolute top-full mt-1 z-50 min-w-full w-max max-w-[min(420px,90vw)]',
+            'rounded-md border border-border/50 bg-surface-elevated shadow-xl overflow-hidden',
+            align === 'right' ? 'right-0' : 'left-0',
+          )}
         >
           <div
             ref={scrollRef}

--- a/web/src/components/pricing/ModelPicker.tsx
+++ b/web/src/components/pricing/ModelPicker.tsx
@@ -104,6 +104,11 @@ export function ModelPicker({
   const knownSet = useMemo(() => new Set(models), [models]);
   const isUnknown = draft.trim() !== '' && models.length > 0 && !knownSet.has(draft.trim());
 
+  // Full ID of the highlighted row, shown verbatim in the footer so an ID
+  // wider than the popover stays readable during keyboard navigation.
+  const activeRow = open && active >= 0 ? rows[active] : undefined;
+  const activeId = activeRow?.kind === 'item' ? activeRow.id : '';
+
   const virtualize = rows.length > VIRTUALIZE_AT;
   const virtualizer = useVirtualizer({
     count: virtualize ? rows.length : 0,
@@ -274,7 +279,7 @@ export function ModelPicker({
 
       {open && rows.length > 0 && (
         <div
-          className="absolute left-0 right-0 top-full mt-1 z-50 rounded-md border border-border/50 bg-surface-elevated shadow-xl overflow-hidden"
+          className="absolute left-0 top-full mt-1 z-50 min-w-full w-max max-w-[min(420px,90vw)] rounded-md border border-border/50 bg-surface-elevated shadow-xl overflow-hidden"
         >
           <div
             ref={scrollRef}
@@ -302,7 +307,13 @@ export function ModelPicker({
             )}
           </div>
           <div className="px-2 py-1 border-t border-border/30 text-[9px] text-text-muted/60 select-none">
-            {models.length > 0 ? `${models.length} models · LiteLLM snapshot` : 'Loading models…'}
+            {activeId ? (
+              <span className="font-mono text-text-secondary break-all">{activeId}</span>
+            ) : models.length > 0 ? (
+              `${models.length} models · LiteLLM snapshot`
+            ) : (
+              'Loading models…'
+            )}
           </div>
         </div>
       )}

--- a/web/src/components/pricing/PricingManagerHost.tsx
+++ b/web/src/components/pricing/PricingManagerHost.tsx
@@ -15,6 +15,8 @@ export function PricingManagerHost() {
   const mcpServers = useStackStore((s) => s.mcpServers);
   const defaultModel = useStackStore((s) => s.defaultModel);
   const clientModels = useStackStore((s) => s.clientModels);
+  const effectiveClientModels = useStackStore((s) => s.effectiveClientModels);
+  const effectiveServerModels = useStackStore((s) => s.effectiveServerModels);
   const costUsage = useStackStore((s) => s.costUsage);
   const tokenUsage = useStackStore((s) => s.tokenUsage);
   const costAttribution = useStackStore((s) => s.costAttribution);
@@ -48,6 +50,8 @@ export function PricingManagerHost() {
       servers={servers}
       clients={clients}
       costAttribution={costAttribution}
+      effectiveClientModels={effectiveClientModels}
+      effectiveServerModels={effectiveServerModels}
       onClientSaved={setClientModelLocal}
       onServerSaved={setServerModelLocal}
       onDefaultSaved={setDefaultModelLocal}

--- a/web/src/components/pricing/PricingManagerSlideOver.tsx
+++ b/web/src/components/pricing/PricingManagerSlideOver.tsx
@@ -54,17 +54,17 @@ export function PricingManagerSlideOver({
   onDefaultSaved,
 }: PricingManagerSlideOverProps) {
   return (
-    <SlideOver isOpen={open} onClose={onClose} title="Pricing models" widthClass="w-[400px]">
-      <div className="flex flex-col gap-5 px-4 py-4">
-        <p className="text-[11px] text-text-muted leading-relaxed">{MODEL_PRECEDENCE_HINT}</p>
+    <SlideOver isOpen={open} onClose={onClose} title="Pricing models" widthClass="w-[520px]">
+      <div className="flex flex-col gap-6 px-5 py-5">
+        <p className="text-xs text-text-muted leading-relaxed">{MODEL_PRECEDENCE_HINT}</p>
 
         <TierSection
-          icon={<Users size={12} className="text-text-muted" />}
+          icon={<Users size={14} className="text-text-muted" />}
           title="1 · Client models"
           note="Pricing only. Does not create access restrictions or require a clients: block."
         >
           {clients.length === 0 ? (
-            <p className="text-[10px] text-text-muted/60 italic">
+            <p className="text-[11px] text-text-muted/60 italic">
               No clients observed yet. Clients appear after their first tool call.
             </p>
           ) : (
@@ -79,6 +79,7 @@ export function PricingManagerSlideOver({
                   declaredModel={c.declaredModel}
                   costAttribution={costAttribution}
                   onSaved={onClientSaved}
+                  pickerAlign="right"
                 />
               </TierRow>
             ))
@@ -86,12 +87,12 @@ export function PricingManagerSlideOver({
         </TierSection>
 
         <TierSection
-          icon={<Server size={12} className="text-text-muted" />}
+          icon={<Server size={14} className="text-text-muted" />}
           title="2 · Server models"
           note="A server without its own model inherits the gateway default."
         >
           {servers.length === 0 ? (
-            <p className="text-[10px] text-text-muted/60 italic">No MCP servers in the stack.</p>
+            <p className="text-[11px] text-text-muted/60 italic">No MCP servers in the stack.</p>
           ) : (
             servers.map((s) => (
               <TierRow key={s.name} name={s.name} effective={s.declaredModel ? effectiveServerModels?.[s.name] : undefined}>
@@ -100,6 +101,7 @@ export function PricingManagerSlideOver({
                   declaredModel={s.declaredModel}
                   defaultModel={defaultModel}
                   onSaved={onServerSaved}
+                  pickerAlign="right"
                 />
               </TierRow>
             ))
@@ -107,16 +109,16 @@ export function PricingManagerSlideOver({
         </TierSection>
 
         <TierSection
-          icon={<Globe size={12} className="text-text-muted" />}
+          icon={<Globe size={14} className="text-text-muted" />}
           title="3 · Gateway default"
           note="Stack-wide floor: prices every server without its own model."
         >
           <DefaultModelRow defaultModel={defaultModel} onSaved={onDefaultSaved} />
         </TierSection>
 
-        <div className="border-t border-border/30 pt-3 space-y-1.5">
-          <p className="text-[10px] text-text-muted leading-relaxed">{SNAPSHOT_NOTE}</p>
-          <p className="text-[10px] text-text-muted leading-relaxed">
+        <div className="border-t border-border/30 pt-4 space-y-2">
+          <p className="text-[11px] text-text-muted leading-relaxed">{SNAPSHOT_NOTE}</p>
+          <p className="text-[11px] text-text-muted leading-relaxed">
             Unknown IDs record tokens but price as $0. A declared client model is a session
             default and cannot observe mid-session model switches.
           </p>
@@ -139,12 +141,12 @@ function TierSection({
 }) {
   return (
     <section>
-      <div className="flex items-center gap-1.5 mb-1">
+      <div className="flex items-center gap-2 mb-1.5">
         {icon}
-        <h3 className="text-xs font-medium text-text-secondary">{title}</h3>
+        <h3 className="text-sm font-medium text-text-secondary">{title}</h3>
       </div>
-      <p className="text-[11px] text-text-muted mb-2 leading-relaxed">{note}</p>
-      <div className="space-y-1.5">{children}</div>
+      <p className="text-xs text-text-muted mb-2.5 leading-relaxed">{note}</p>
+      <div className="space-y-2">{children}</div>
     </section>
   );
 }
@@ -162,16 +164,16 @@ function TierRow({
   // the drift signal worth surfacing read-only beside the editable cell.
   const showDrift = effective?.provenance === 'mixed';
   return (
-    <div className="flex flex-col gap-0.5 min-h-[26px] justify-center">
+    <div className="flex flex-col gap-0.5 min-h-[30px] justify-center">
       <div className="flex items-center justify-between gap-3">
-        <span className="text-xs font-mono text-text-primary truncate" title={name}>
+        <span className="text-sm font-mono text-text-primary truncate" title={name}>
           {name}
         </span>
         <div className="flex-shrink-0">{children}</div>
       </div>
       {showDrift && effective && (
         <div className="flex items-center justify-between gap-3">
-          <span className="text-[9px] text-text-muted/60 uppercase tracking-wider">Effective</span>
+          <span className="text-[10px] text-text-muted/60 uppercase tracking-wider">Effective</span>
           <div className="flex-shrink-0">
             <EffectiveModelTag effective={effective} />
           </div>

--- a/web/src/components/pricing/PricingManagerSlideOver.tsx
+++ b/web/src/components/pricing/PricingManagerSlideOver.tsx
@@ -6,7 +6,9 @@ import { updateDefaultModel } from '../../lib/api';
 import { ModelPicker } from './ModelPicker';
 import { ClientModelCell } from './ClientModelCell';
 import { ServerModelCell } from './ServerModelCell';
+import { EffectiveModelTag } from './EffectiveModelTag';
 import { MODEL_PRECEDENCE_HINT, SNAPSHOT_NOTE } from './constants';
+import type { EffectiveModel } from '../../types';
 
 export interface PricingManagerSlideOverProps {
   open: boolean;
@@ -18,6 +20,9 @@ export interface PricingManagerSlideOverProps {
   /** Declared clients plus clients observed in cost/token data. */
   clients: Array<{ name: string; declaredModel?: string }>;
   costAttribution: boolean;
+  /** Read-only effective model + provenance per client / server (optional). */
+  effectiveClientModels?: Record<string, EffectiveModel>;
+  effectiveServerModels?: Record<string, EffectiveModel>;
   onClientSaved: (client: string, model: string) => void;
   onServerSaved: (server: string, model: string) => void;
   onDefaultSaved: (model: string) => void;
@@ -42,6 +47,8 @@ export function PricingManagerSlideOver({
   servers,
   clients,
   costAttribution,
+  effectiveClientModels,
+  effectiveServerModels,
   onClientSaved,
   onServerSaved,
   onDefaultSaved,
@@ -62,7 +69,11 @@ export function PricingManagerSlideOver({
             </p>
           ) : (
             clients.map((c) => (
-              <TierRow key={c.name} name={c.name}>
+              <TierRow key={c.name} name={c.name} effective={c.declaredModel ? effectiveClientModels?.[c.name] : undefined}>
+                {/* The manager's job is editing, so the cell keeps its
+                    editable affordance for undeclared rows; mixed/none
+                    provenance surfaces in the read-only Effective sub-line
+                    (drift) rather than replacing the editor. */}
                 <ClientModelCell
                   client={c.name}
                   declaredModel={c.declaredModel}
@@ -83,7 +94,7 @@ export function PricingManagerSlideOver({
             <p className="text-[10px] text-text-muted/60 italic">No MCP servers in the stack.</p>
           ) : (
             servers.map((s) => (
-              <TierRow key={s.name} name={s.name}>
+              <TierRow key={s.name} name={s.name} effective={s.declaredModel ? effectiveServerModels?.[s.name] : undefined}>
                 <ServerModelCell
                   server={s.name}
                   declaredModel={s.declaredModel}
@@ -138,13 +149,34 @@ function TierSection({
   );
 }
 
-function TierRow({ name, children }: { name: string; children: React.ReactNode }) {
+function TierRow({
+  name,
+  effective,
+  children,
+}: {
+  name: string;
+  effective?: EffectiveModel;
+  children: React.ReactNode;
+}) {
+  // A declared row whose traffic actually priced under a blend of models is
+  // the drift signal worth surfacing read-only beside the editable cell.
+  const showDrift = effective?.provenance === 'mixed';
   return (
-    <div className="flex items-center justify-between gap-3 min-h-[26px]">
-      <span className="text-xs font-mono text-text-primary truncate" title={name}>
-        {name}
-      </span>
-      <div className="flex-shrink-0">{children}</div>
+    <div className="flex flex-col gap-0.5 min-h-[26px] justify-center">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs font-mono text-text-primary truncate" title={name}>
+          {name}
+        </span>
+        <div className="flex-shrink-0">{children}</div>
+      </div>
+      {showDrift && effective && (
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-[9px] text-text-muted/60 uppercase tracking-wider">Effective</span>
+          <div className="flex-shrink-0">
+            <EffectiveModelTag effective={effective} />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/pricing/ServerModelCell.tsx
+++ b/web/src/components/pricing/ServerModelCell.tsx
@@ -3,23 +3,31 @@ import { updateServerModel } from '../../lib/api';
 import { showToast } from '../ui/Toast';
 import { ModelPicker } from './ModelPicker';
 import { MODEL_PRECEDENCE_HINT } from './constants';
+import { EffectiveModelTag } from './EffectiveModelTag';
+import type { EffectiveModel } from '../../types';
 
 // ServerModelCell mirrors ClientModelCell for the server tier: a pill with
 // "· server" provenance when the server declares its own model:, a muted
 // "default: <id>" when it inherits gateway.default_model, and "set model"
-// when no attribution applies. Clicking edits inline through the shared
-// ModelPicker; an empty save clears the server's model: key so it falls
-// back to the default.
+// when no attribution applies. When the server has no single declaration but
+// observed cost yields a mixed provenance (a server priced under more than
+// one model over time), `effective` surfaces it read-only. Clicking the
+// declared/default affordances edits inline; clicking a mixed/none tag opens
+// the pricing manager.
 export function ServerModelCell({
   server,
   declaredModel,
   defaultModel,
+  effective,
   onSaved,
+  onOpenManager,
 }: {
   server: string;
   declaredModel?: string;
   defaultModel: string;
+  effective?: EffectiveModel;
   onSaved: (server: string, model: string) => void;
+  onOpenManager?: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -95,6 +103,12 @@ export function ServerModelCell({
     );
   }
 
+  // A heterogeneous pricing history (mixed) reflects reality better than a
+  // single "default:" label, so it takes precedence over the default below.
+  if (effective?.provenance === 'mixed') {
+    return <EffectiveModelTag effective={effective} onClick={onOpenManager} />;
+  }
+
   if (defaultModel) {
     return (
       <button
@@ -106,6 +120,10 @@ export function ServerModelCell({
         default: {defaultModel}
       </button>
     );
+  }
+
+  if (effective?.provenance === 'none') {
+    return <EffectiveModelTag effective={effective} onClick={onOpenManager} />;
   }
 
   return (

--- a/web/src/components/pricing/ServerModelCell.tsx
+++ b/web/src/components/pricing/ServerModelCell.tsx
@@ -21,6 +21,7 @@ export function ServerModelCell({
   effective,
   onSaved,
   onOpenManager,
+  pickerAlign,
 }: {
   server: string;
   declaredModel?: string;
@@ -28,6 +29,7 @@ export function ServerModelCell({
   effective?: EffectiveModel;
   onSaved: (server: string, model: string) => void;
   onOpenManager?: () => void;
+  pickerAlign?: 'left' | 'right';
 }) {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -70,6 +72,7 @@ export function ServerModelCell({
           disabled={saving}
           autoFocus
           widthClass="w-52"
+          align={pickerAlign}
           error={saveError}
         />
         <button

--- a/web/src/components/pricing/constants.ts
+++ b/web/src/components/pricing/constants.ts
@@ -17,3 +17,15 @@ export const ATTRIBUTION_HINT =
 export const SNAPSHOT_NOTE =
   'Models come from the embedded LiteLLM snapshot (refreshed via make update-pricing at gateway rebuild).';
 export const UNKNOWN_MODEL_NOTE = 'Unknown model · records tokens but prices as $0';
+
+// Shown on the Cost KPI when any client/server has `mixed` provenance. The
+// honesty contract: provenance describes which declaration priced the
+// traffic, never what the upstream client actually ran.
+export const MIXED_PROVENANCE_NOTE =
+  'Cost is priced by your declared models, not observed client behavior. ' +
+  'A blend of rates means a client hit servers priced at different models, or a declaration changed.';
+
+// Tooltip on a `none` effective-model cell: traffic ran but nothing priced it.
+export const UNPRICED_NOTE =
+  'Traffic observed but no pricing model applied, so cost is $0. ' +
+  'Declare a client or server model to price it.';

--- a/web/src/components/pricing/effectiveModel.ts
+++ b/web/src/components/pricing/effectiveModel.ts
@@ -1,0 +1,52 @@
+// Shared helpers for rendering effective-model provenance in the pricing
+// cells, the sidebar inspector, and the pricing manager. Keeping the
+// formatting in one place guarantees the metrics table and its detached
+// twin read identically, and that every surface uses the same honesty copy.
+import type { EffectiveModel, ModelShare } from '../../types';
+import { MIXED_PROVENANCE_NOTE, UNPRICED_NOTE } from './constants';
+
+// Percent label for a 0–1 share, e.g. 0.823 -> "82%".
+export function sharePct(share: number): string {
+  return `${Math.round(share * 100)}%`;
+}
+
+// Top-N models by cost, grouping the remainder into a single "other" row so a
+// dense cell never lists a long tail. Shares are preserved from the backend
+// (already descending); the grouped "other" sums the rest.
+export function topShares(models: ModelShare[], n = 3): ModelShare[] {
+  if (models.length <= n) return models;
+  const head = models.slice(0, n);
+  const tail = models.slice(n);
+  const otherCost = tail.reduce((s, m) => s + m.cost_usd, 0);
+  const otherShare = tail.reduce((s, m) => s + m.share, 0);
+  return [...head, { model: 'other', cost_usd: otherCost, share: otherShare }];
+}
+
+// Native-title tooltip text for a mixed-provenance cell: the per-model
+// breakdown followed by the honesty note. Plain text (no markup) so it works
+// in a `title` attribute everywhere the pills render.
+export function mixedTooltip(em: EffectiveModel): string {
+  const lines = topShares(em.models ?? [])
+    .map((m) => `${m.model} ${sharePct(m.share)}`)
+    .join('  ·  ');
+  return `Priced as: ${lines}\n${MIXED_PROVENANCE_NOTE}`;
+}
+
+// Tooltip text for a none-provenance cell.
+export function unpricedTooltip(): string {
+  return UNPRICED_NOTE;
+}
+
+// Accessible label for a non-default provenance state, carrying the full
+// sentence so it reaches screen readers without relying on color or the
+// truncated visible label.
+export function effectiveAriaLabel(em: EffectiveModel): string {
+  if (em.provenance === 'mixed') {
+    const dominant = em.model ?? 'unknown';
+    return `Mixed pricing: priced as ${dominant} at ${sharePct(em.share ?? 0)} of cost, plus other declared models. Click to edit pricing models.`;
+  }
+  if (em.provenance === 'none') {
+    return 'Unpriced: traffic observed but no pricing model applied. Click to edit pricing models.';
+  }
+  return '';
+}

--- a/web/src/pages/DetachedMetricsPage.tsx
+++ b/web/src/pages/DetachedMetricsPage.tsx
@@ -18,8 +18,8 @@ import { AreaChart } from '../components/chart/AreaChart';
 import { ClientModelCell } from '../components/pricing/ClientModelCell';
 import { ServerModelCell } from '../components/pricing/ServerModelCell';
 import { PricingManagerSlideOver } from '../components/pricing/PricingManagerSlideOver';
-import { ATTRIBUTION_HINT } from '../components/pricing/constants';
-import type { GatewayStatus, TokenMetricsResponse, CostMetricsResponse, TokenUsage, CostUsage } from '../types';
+import { ATTRIBUTION_HINT, MIXED_PROVENANCE_NOTE } from '../components/pricing/constants';
+import type { GatewayStatus, TokenMetricsResponse, CostMetricsResponse, TokenUsage, CostUsage, EffectiveModel } from '../types';
 import {
   Pause,
   Play,
@@ -91,6 +91,8 @@ function DetachedMetricsPageContent() {
   const [costAttribution, setCostAttribution] = useState(false);
   const [clientModels, setClientModels] = useState<Record<string, string>>({});
   const [serverDeclared, setServerDeclared] = useState<Record<string, string>>({});
+  const [effectiveClientModels, setEffectiveClientModels] = useState<Record<string, EffectiveModel>>({});
+  const [effectiveServerModels, setEffectiveServerModels] = useState<Record<string, EffectiveModel>>({});
   const [serverNames, setServerNames] = useState<string[]>([]);
   const [defaultModel, setDefaultModel] = useState('');
   const [pricingManagerOpen, setPricingManagerOpen] = useState(false);
@@ -120,6 +122,8 @@ function DetachedMetricsPageContent() {
         setCostUsage(status.cost ?? null);
         setCostAttribution(status.cost_attribution ?? false);
         setClientModels(status.client_models ?? {});
+        setEffectiveClientModels(status.effective_client_models ?? {});
+        setEffectiveServerModels(status.effective_server_models ?? {});
         setDefaultModel(status.default_model ?? '');
         const declared: Record<string, string> = {};
         for (const s of status['mcp-servers'] ?? []) {
@@ -257,6 +261,9 @@ function DetachedMetricsPageContent() {
   // Mirrors MetricsTab: without model attribution the gateway cannot price
   // calls, so explain the config requirement instead of a bare dash/$0.00.
   const showAttributionHint = !costAttribution && !(sessionCostUSD && sessionCostUSD > 0);
+  const hasMixedProvenance =
+    Object.values(effectiveClientModels).some((e) => e.provenance === 'mixed') ||
+    Object.values(effectiveServerModels).some((e) => e.provenance === 'mixed');
   const hasData =
     sessionTotal > 0 ||
     (metricsData?.data_points?.length ?? 0) > 0 ||
@@ -490,7 +497,7 @@ function DetachedMetricsPageContent() {
               <KPICard label="Input Tokens" value={sessionInput} colorClass="text-secondary" />
               <KPICard label="Output Tokens" value={sessionOutput} colorClass="text-primary" />
               <KPICard label="Total Tokens" value={sessionTotal} colorClass="text-text-primary" />
-              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} showHint={showAttributionHint} />
+              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} showHint={showAttributionHint} showMixedNote={hasMixedProvenance} />
               {savingsPercent > 0 && (
                 <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
                   <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Format Savings</span>
@@ -584,8 +591,10 @@ function DetachedMetricsPageContent() {
                           <ClientModelCell
                             client={client.name}
                             declaredModel={clientModels[client.name]}
+                            effective={effectiveClientModels[client.name]}
                             costAttribution={costAttribution}
                             onSaved={handleClientModelSaved}
+                            onOpenManager={() => setPricingManagerOpen(true)}
                           />
                         </td>
                         <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(client.input)}</td>
@@ -623,7 +632,9 @@ function DetachedMetricsPageContent() {
                             server={server.name}
                             declaredModel={serverDeclared[server.name]}
                             defaultModel={defaultModel}
+                            effective={effectiveServerModels[server.name]}
                             onSaved={handleServerModelSaved}
+                            onOpenManager={() => setPricingManagerOpen(true)}
                           />
                         </td>
                         <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(server.input)}</td>
@@ -674,6 +685,8 @@ function DetachedMetricsPageContent() {
           ...Object.keys(costUsage?.per_client ?? {}),
         ])].sort().map((name) => ({ name, declaredModel: clientModels[name] }))}
         costAttribution={costAttribution}
+        effectiveClientModels={effectiveClientModels}
+        effectiveServerModels={effectiveServerModels}
         onClientSaved={handleClientModelSaved}
         onServerSaved={handleServerModelSaved}
         onDefaultSaved={handleDefaultModelSaved}
@@ -696,10 +709,12 @@ function CostKPICard({
   usd,
   hasCost,
   showHint,
+  showMixedNote,
 }: {
   usd: number | undefined;
   hasCost: boolean;
   showHint?: boolean;
+  showMixedNote?: boolean;
 }) {
   return (
     <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
@@ -718,6 +733,11 @@ function CostKPICard({
       {showHint && (
         <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
           {ATTRIBUTION_HINT}
+        </span>
+      )}
+      {!showHint && showMixedNote && (
+        <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
+          {MIXED_PROVENANCE_NOTE}
         </span>
       )}
     </div>

--- a/web/src/stores/useStackStore.ts
+++ b/web/src/stores/useStackStore.ts
@@ -11,6 +11,7 @@ import type {
   Tool,
   TokenUsage,
   CostUsage,
+  EffectiveModel,
   ConnectionStatus,
   AutoscaleDecisionKind,
 } from '../types';
@@ -64,6 +65,10 @@ interface StackState {
   clientModels: Record<string, string>; // Declared client -> model pricing map (client_models)
   serverModels: Record<string, string>; // EFFECTIVE server -> model map (model: with default folded in)
   defaultModel: string;     // Gateway-level default_model; empty when not configured
+  // Effective model + provenance per client / server, derived read-only from
+  // observed cost. Empty until traffic is observed.
+  effectiveClientModels: Record<string, EffectiveModel>;
+  effectiveServerModels: Record<string, EffectiveModel>;
   stackName: string;        // Active stack name; empty string in stackless mode
 
   // === React Flow State ===
@@ -134,6 +139,8 @@ export const useStackStore = create<StackState>()(
     costAttribution: false,
     clientModels: {},
     serverModels: {},
+    effectiveClientModels: {},
+    effectiveServerModels: {},
     defaultModel: '',
     stackName: '',
     nodes: [],
@@ -170,6 +177,8 @@ export const useStackStore = create<StackState>()(
         costAttribution: status.cost_attribution ?? false,
         clientModels: status.client_models ?? {},
         serverModels: status.server_models ?? {},
+        effectiveClientModels: status.effective_client_models ?? {},
+        effectiveServerModels: status.effective_server_models ?? {},
         defaultModel: status.default_model ?? '',
         stackName: status.stack_name || '',
         autoscaleHistory: folded.history,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -79,6 +79,9 @@ export interface MCPServerStatus {
   // a gateway default_model is not folded in). Absent when the server
   // inherits the default or has no attribution.
   model?: string;
+  // Which model actually priced this server's recorded cost, with provenance.
+  // Read-only; absent when the server has no observed traffic.
+  effectiveModel?: EffectiveModel;
   replicas?: ReplicaStatus[]; // Per-replica runtime status
   autoscale?: AutoscaleStatus; // Live autoscale snapshot (absent when not configured)
 }
@@ -110,6 +113,9 @@ export interface ClientStatus {
   transport: string;  // "native SSE", "native HTTP", or "mcp-remote bridge"
   configPath?: string; // Config file path (only if detected)
   model?: string;     // Declared pricing model from client_models (pricing only, not access)
+  // Which model actually priced this client's recorded cost, with provenance.
+  // Read-only; absent when the client has no observed traffic.
+  effectiveModel?: EffectiveModel;
   effectiveScope?: ClientScopeResult; // Per-client access scope (when scoping is configured)
 }
 
@@ -213,6 +219,29 @@ export interface OptimizeReport {
   generated_at: string;
 }
 
+// Model provenance for an effective-model attribution. Mirrors the
+// pkg/optimize / internal/api vocabulary. `declared` = one model priced all
+// recorded cost; `mixed` = multiple models priced the traffic; `none` =
+// traffic observed but nothing priced (cost $0). The set is open so a future
+// `reported` (a wire-level model signal) can extend it.
+export type ModelProvenance = 'declared' | 'mixed' | 'none';
+
+// One model's slice of an entity's recorded cost.
+export interface ModelShare {
+  model: string;
+  cost_usd: number;
+  share: number; // 0–1 of the entity's total recorded cost
+}
+
+// Which model(s) priced an entity's traffic, with provenance. Describes which
+// declaration gridctl applied when pricing — NOT what the upstream client ran.
+export interface EffectiveModel {
+  model?: string;             // dominant model (omitted for `none`)
+  provenance: ModelProvenance;
+  share?: number;             // dominant model's cost share (omitted for `none`)
+  models?: ModelShare[];      // full breakdown, descending by cost
+}
+
 // Gateway status response from GET /api/status
 export interface GatewayStatus {
   gateway: ServerInfo;
@@ -226,6 +255,10 @@ export interface GatewayStatus {
   client_models?: Record<string, string>; // Declared client -> model pricing map (client_models)
   server_models?: Record<string, string>; // EFFECTIVE server -> model map (model: with default_model folded in)
   default_model?: string;  // Gateway-level default_model (omitted when not configured)
+  // Effective model + provenance per client / server, derived read-only from
+  // observed cost. Omitted until traffic is observed.
+  effective_client_models?: Record<string, EffectiveModel>;
+  effective_server_models?: Record<string, EffectiveModel>;
   stack_name?: string;     // Active stack name; omitted in stackless mode
 }
 


### PR DESCRIPTION
## Description

Records which model priced each recorded dollar (per client and per server) and surfaces an "effective model" with provenance (`declared` | `mixed` | `none`) across the status API, metrics UI, optimize findings, and CLI. This is exact recording at observation time, not inference: the resolved model is already known when cost is recorded.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- `pkg/metrics`: per-client/per-server model cost histograms written in `RecordCostWithModel` (one map increment alongside the existing cost counters); exposed on `CostSnapshot`.
- `pkg/telemetry`: histograms persist and replay alongside cost, so provenance survives a restart (cleared on a token reset like tool usage).
- `internal/api`: pure `deriveEffectiveModels` produces `effective_client_models` / `effective_server_models` on `/api/status` (additive, omitempty) plus an `effectiveModel` field on the client and server status objects.
- `pkg/optimize`: `expensive_model_on_cheap_task` names the dominant model that priced a server's traffic and labels its provenance, in both the table detail and `--format json`.
- Web UI: `mixed` renders `<dominant> · NN%` (clickable into the pricing manager) and `none` renders a muted `unpriced` tag — never a blank cell; a one-line honesty note on the Cost card when any blend is present; sidebar inspector and pricing manager show the same read-only effective info; MetricsTab and DetachedMetricsPage kept at parity.

Provenance describes which declaration priced the traffic, not what the client actually ran — the gateway cannot observe the client's model choice, so the labels never claim detection. Drift detection is impossible without a model signal on the wire; statistical inference from cost/token ratios was evaluated and rejected (gridctl computes the cost from the resolved model, so inference would only restate the declaration).

## Testing

- `make test` (Go, incl. new histogram/persistence/derivation tests under `-race`).
- `cd web && npm test` (1015 pass, incl. new cell/tag provenance tests).
- `make build` embeds the UI cleanly; `golangci-lint run` clean on touched packages.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #786.