### PR TITLE
chore: automate LiteLLM pricing snapshot refresh

### DIFF
--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -1,0 +1,68 @@
+name: Update Pricing Snapshot
+
+# Keeps the embedded LiteLLM pricing snapshot
+# (pkg/pricing/data/model_prices.json) current without a maintainer remembering
+# to run `make update-pricing`. Weekly, this fetches the upstream table, runs it
+# through the validation gate (scripts/validate-pricing.sh), and — only when the
+# table actually changed — opens or updates a single reviewable PR. The binary
+# still embeds only the committed file; nothing here touches the build.
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC. Weekly is enough — upstream churn is gradual and a
+    # human reviews every refresh PR.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Fetches upstream, validates the candidate (JSON / non-empty / model
+      # floor / shrink guard), and replaces the committed file only on success.
+      # A malformed or truncated upstream response fails the job loudly rather
+      # than committing bad data; a network failure leaves the file untouched.
+      # jq, curl, and make are preinstalled on ubuntu-latest.
+      - name: Refresh pricing snapshot (validated)
+        run: make update-pricing
+
+      # peter-evans/create-pull-request is a no-op when the working tree is
+      # clean (table unchanged), and reuses the same branch/PR on re-runs so the
+      # refresh never opens duplicates.
+      #
+      # NOTE: the default GITHUB_TOKEN does not trigger downstream workflows
+      # (Gatekeeper, etc.) on the PR it opens. If CI must run on the auto-PR,
+      # swap in a PAT or GitHub App token here. Kept on GITHUB_TOKEN for v1.
+      # Also requires Settings -> Actions -> General -> "Allow GitHub Actions to
+      # create and approve pull requests" to be enabled, or this step fails.
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          branch: chore/update-pricing
+          delete-branch: true
+          sign-commits: true
+          commit-message: "chore: update LiteLLM pricing snapshot"
+          title: "chore: update LiteLLM pricing snapshot"
+          labels: chore
+          body: |
+            Automated refresh of the embedded LiteLLM pricing snapshot
+            (`pkg/pricing/data/model_prices.json`).
+
+            The upstream table was fetched and passed the validation gate
+            (`make update-pricing` → `scripts/validate-pricing.sh`: valid JSON,
+            non-empty, model-count floor, and shrink guard). The diff below is
+            the price-table delta.
+
+            Review and merge to ship the updated rates. This PR is opened by the
+            scheduled `Update Pricing Snapshot` workflow; re-runs update it in
+            place rather than opening duplicates.

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ web/coverage/
 tmp/
 temp/
 
+# Pricing refresh temp file (make update-pricing writes here before atomic mv)
+pkg/pricing/data/.model_prices.*
+
 # Mock server binaries and PID files
 examples/_mock-servers/local-stdio-server/mock-stdio-server
 examples/_mock-servers/mock-mcp-server/mock-mcp-server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Automated LiteLLM pricing snapshot refresh.** A scheduled
+  `Update Pricing Snapshot` workflow fetches the upstream LiteLLM table weekly,
+  runs it through a validation gate (`make validate-pricing` →
+  `scripts/validate-pricing.sh`: valid JSON, non-empty, a model-count floor, and
+  an 80% shrink guard), and opens or updates a single reviewable PR only when the
+  table changed. `make update-pricing` now runs the same gate before replacing
+  the committed snapshot, so a poisoned, empty, or truncated upstream response
+  fails loudly instead of landing silently. The build is unchanged: the binary
+  still embeds only the committed file, with no live fetch at build or release
+  time.
+
 - **Refreshed the embedded LiteLLM pricing snapshot.** Updated
   `pkg/pricing/data/model_prices.json` to the current upstream table so newly
   released models (e.g. `claude-opus-4-8`) appear in the cost-model picker and

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-web build-go dev clean help test test-coverage test-integration test-frontend mock-servers clean-mock-servers generate update-pricing
+.PHONY: all build build-web build-go dev clean help test test-coverage test-integration test-frontend mock-servers clean-mock-servers generate update-pricing validate-pricing
 
 # Version from git tags (fallback to dev)
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -125,14 +125,28 @@ PRICING_URL := https://raw.githubusercontent.com/BerriAI/litellm/main/model_pric
 PRICING_DEST := pkg/pricing/data/model_prices.json
 update-pricing:
 	@echo "Refreshing pricing data from $(PRICING_URL)..."
-	@tmp=$$(mktemp); \
+	@tmp=$$(mktemp $(dir $(PRICING_DEST)).model_prices.XXXXXX); \
 	if curl -sSL --fail --max-time 30 -o $$tmp $(PRICING_URL); then \
-		mv $$tmp $(PRICING_DEST); \
-		echo "Updated $(PRICING_DEST) ($$(wc -c < $(PRICING_DEST)) bytes)."; \
+		if scripts/validate-pricing.sh $$tmp $(PRICING_DEST); then \
+			mv $$tmp $(PRICING_DEST); \
+			echo "Updated $(PRICING_DEST) ($$(wc -c < $(PRICING_DEST)) bytes)."; \
+		else \
+			rm -f $$tmp; \
+			echo "ERROR: pricing validation failed; keeping existing $(PRICING_DEST)." >&2; \
+			exit 1; \
+		fi; \
 	else \
 		rm -f $$tmp; \
 		echo "WARN: pricing refresh failed; keeping existing $(PRICING_DEST)."; \
 	fi
+
+# Validate a pricing snapshot without fetching. Defaults to the committed file;
+# point it at any candidate with FILE=/path/to/table.json to test the gate (it is
+# always compared against the committed snapshot's entry count). Exits non-zero on
+# malformed, empty, or substantially-shrunken input. Shared by update-pricing and
+# the scheduled refresh workflow.
+validate-pricing:
+	@scripts/validate-pricing.sh "$${FILE:-$(PRICING_DEST)}" "$(PRICING_DEST)"
 
 # Generate mocks (requires mockgen: go install go.uber.org/mock/mockgen@latest)
 generate:
@@ -158,6 +172,7 @@ help:
 	@echo "  make test-integration - Run integration tests (requires Docker)"
 	@echo "  make generate   - Regenerate mock files (requires mockgen)"
 	@echo "  make update-pricing - Refresh embedded LiteLLM pricing data (weekly)"
+	@echo "  make validate-pricing [FILE=...] - Validate a pricing snapshot (gate for update-pricing)"
 	@echo "  make mock-servers [PORT=9001] - Build and run mock MCP servers for examples"
 	@echo "  make clean-mock-servers - Stop and remove mock MCP servers"
 	@echo "  make help       - Show this help message"

--- a/scripts/validate-pricing.sh
+++ b/scripts/validate-pricing.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Validate a candidate LiteLLM pricing snapshot before it replaces the committed
+# one. Guards `make update-pricing` (and the scheduled refresh workflow) against a
+# poisoned, empty, or truncated upstream response landing silently — the failure
+# mode behind LiteLLM's 2026-01-27 model-cost-map incident, where a malformed but
+# HTTP-200 `main` shipped invalid JSON.
+#
+# Usage:
+#   validate-pricing.sh <candidate.json> [<reference.json>]
+#
+#   <candidate.json>   File to validate (required).
+#   <reference.json>   Committed snapshot to compare entry counts against
+#                      (optional). When omitted or absent, the shrink check is
+#                      skipped (bootstrap case).
+#
+# Checks (any failure exits non-zero and touches nothing):
+#   a. Candidate parses as JSON.
+#   b. Top level is a non-empty object.
+#   c. Priced-model count >= MIN_MODELS.
+#   d. Priced-model count has not shrunk below SHRINK_PCT% of the reference.
+#
+# A "priced model" is counted the way pkg/pricing/litellm.go parses: a top-level
+# object entry (excluding the `sample_spec` sentinel) carrying at least one
+# nonzero numeric cost field. Non-model top-level keys are not assumed to be
+# priced.
+#
+# Tunables (env):
+#   MIN_MODELS   Minimum priced-model floor (default 1000).
+#   SHRINK_PCT   Minimum percent of the reference count to accept (default 80).
+#
+# Exit codes:
+#   0 = candidate is valid
+#   1 = candidate failed a check, or arguments/tools are missing
+set -euo pipefail
+
+MIN_MODELS="${MIN_MODELS:-1000}"
+SHRINK_PCT="${SHRINK_PCT:-80}"
+
+candidate="${1:-}"
+reference="${2:-}"
+
+if [[ -z "$candidate" ]]; then
+  echo "validate-pricing: usage: $0 <candidate.json> [<reference.json>]" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "validate-pricing: jq is required but not installed" >&2
+  exit 1
+fi
+
+if [[ ! -f "$candidate" ]]; then
+  echo "validate-pricing: candidate file not found: $candidate" >&2
+  exit 1
+fi
+
+# (a) Parses as JSON.
+if ! jq empty "$candidate" >/dev/null 2>&1; then
+  echo "validate-pricing: FAIL — $candidate is not valid JSON" >&2
+  exit 1
+fi
+
+# (b) Non-empty top-level object.
+if ! jq -e 'type == "object" and (length > 0)' "$candidate" >/dev/null 2>&1; then
+  echo "validate-pricing: FAIL — $candidate is not a non-empty JSON object" >&2
+  exit 1
+fi
+
+# Count priced models the way the Go parser does: object entries (minus the
+# sample_spec sentinel) with at least one nonzero numeric cost field.
+count_models() {
+  jq '[ to_entries[]
+        | select(.key != "sample_spec")
+        | select(.value | type == "object")
+        # Mirror the Go parser (pkg/pricing/litellm.go): it unmarshals each entry
+        # into float64 cost fields, so an entry where ANY cost field is a string
+        # (the sample_spec-mirroring shape behind the 2026-01-27 poisoning) fails
+        # to decode and is dropped whole. Reject such entries here too rather than
+        # counting a sibling numeric field.
+        | select(
+            [ .value.input_cost_per_token,
+              .value.output_cost_per_token,
+              .value.cache_read_input_token_cost,
+              .value.cache_creation_input_token_cost ]
+            | all(. == null or type == "number")
+          )
+        | select(
+            ( [ .value.input_cost_per_token,
+                .value.output_cost_per_token,
+                .value.cache_read_input_token_cost,
+                .value.cache_creation_input_token_cost ]
+              | map(select(type == "number" and . != 0))
+              | length ) > 0
+          )
+      ] | length' "$1"
+}
+
+candidate_count="$(count_models "$candidate")"
+
+# (c) Floor.
+if (( candidate_count < MIN_MODELS )); then
+  echo "validate-pricing: FAIL — $candidate has $candidate_count priced models, below floor of $MIN_MODELS" >&2
+  exit 1
+fi
+
+# (d) Shrink guard (only when a valid reference is available).
+if [[ -n "$reference" && -f "$reference" ]] && jq empty "$reference" >/dev/null 2>&1; then
+  reference_count="$(count_models "$reference")"
+  if (( reference_count > 0 )); then
+    # candidate_count >= SHRINK_PCT% of reference_count, in integer math.
+    if (( candidate_count * 100 < reference_count * SHRINK_PCT )); then
+      echo "validate-pricing: FAIL — $candidate has $candidate_count priced models, below ${SHRINK_PCT}% of the committed $reference_count" >&2
+      exit 1
+    fi
+  fi
+fi
+
+echo "validate-pricing: OK — $candidate has $candidate_count priced models (floor $MIN_MODELS)"


### PR DESCRIPTION
## Description

Keeps the embedded LiteLLM pricing snapshot current and reproducible by adding a validation gate to the refresh path and a weekly workflow that opens a reviewable auto-PR when the upstream table changes. The embedded `model_prices.json` and the build are intentionally unchanged, so this PR carries no data churn.

## Type of Change

- [x] Chore (tooling / CI, no user-facing behavior change)

## Changes Made

- `scripts/validate-pricing.sh`: shared gate asserting valid JSON, non-empty object, a model-count floor (`MIN_MODELS`, default 1000), and an 80% shrink guard vs the committed file. Counts priced models the way `pkg/pricing/litellm.go` parses (object entries minus `sample_spec`, all-or-nothing on numeric cost fields), so a string-poisoned entry is rejected rather than over-counted. Read-only.
- `Makefile`: `update-pricing` now validates the freshly-fetched temp file before the atomic `mv`, replacing only on pass and exiting non-zero on validation failure (curl failure stays non-fatal). New `validate-pricing` target (`FILE=` override) shares the gate. Temp file is created adjacent to the destination so `mv` is a same-filesystem rename on CI.
- `.github/workflows/update-pricing.yaml`: weekly cron + `workflow_dispatch`; runs the validated refresh and opens/updates a single `chore`-labeled PR via `peter-evans/create-pull-request@v8` only when the table changed. No-op when unchanged.
- `.gitignore`: ignores the `pkg/pricing/data/.model_prices.*` refresh temp.
- `CHANGELOG.md`: `[Unreleased]` entry.

No live fetch is added to any build or release step; the binary still embeds only the committed file.

## Testing

- `make validate-pricing` and a live upstream fetch both pass; empty, non-JSON, non-object, below-floor, and shrunken (1500 < 80% of 2196) inputs all exit non-zero without touching the committed file; 2000 passes.
- `make update-pricing`: validation-fail exits non-zero (snapshot untouched), curl-fail exits 0 (snapshot untouched), success path replaces atomically with no leftover temps.
- `go test ./pkg/pricing/...` passes; `shellcheck` clean; workflow YAML validated.

## Deployment notes

- The default `GITHUB_TOKEN` does not trigger downstream CI on the auto-PR (swap a PAT/App token if needed).
- Requires "Allow GitHub Actions to create and approve pull requests" enabled in repo settings.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #789.