### PR TITLE
feat: promote Metrics to a first-class workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
+- **Metrics promoted to a first-class workspace.** Cost and token observability
+  is now a top-level workspace (`/metrics`, switcher pill, Cmd/Ctrl+5) alongside
+  Topology, Library, Variables, and Tools, replacing the buried bottom-panel tab
+  as the primary surface. The dashboard is a three-rail layout: a scope
+  navigator (overview / clients / servers / models), a center with the session
+  KPI row, token and estimated-cost trend charts, the active breakdown, and a
+  ranked cost-by-model mix, plus a right-rail inspector that details the selected
+  client or server (per-entity sparklines, cost provenance, and the inline
+  pricing-model editor). Scope and selection are URL-synced so reload and deep
+  links survive. The bottom Metrics tab is retained as a glance-only summary (KPI
+  row, one sparkline, and a "View all in Metrics" link), and the detached popout
+  moves to `/metrics-window`. The status bar token counter now links to the
+  workspace and gains an estimated-cost chip. The bottom tab, workspace, and
+  detached window all render one shared dashboard body, removing the prior
+  duplication between them. No stack.yaml or API changes.
+
 - **Automated LiteLLM pricing snapshot refresh.** A scheduled
   `Update Pricing Snapshot` workflow fetches the upstream LiteLLM table weekly,
   runs it through a validation gate (`make validate-pricing` →

--- a/web/src/__tests__/MetricsWorkspace.test.tsx
+++ b/web/src/__tests__/MetricsWorkspace.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { MetricsWorkspace } from '../components/workspaces/MetricsWorkspace';
+import { useStackStore } from '../stores/useStackStore';
+import { useUIStore, COMPACT_MODE_DEFAULTS } from '../stores/useUIStore';
+import type { CostUsage, MCPServerStatus, TokenUsage } from '../types';
+
+vi.mock('../components/ui/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../hooks/useWindowManager', () => ({
+  useWindowManager: () => ({
+    openDetachedWindow: vi.fn(),
+    closeDetachedWindow: vi.fn(),
+    broadcastStateUpdate: vi.fn(),
+    broadcastSelectionChange: vi.fn(),
+  }),
+}));
+vi.mock('../lib/api', async (importActual) => {
+  const actual = await importActual<typeof import('../lib/api')>();
+  return {
+    ...actual,
+    fetchTokenMetrics: vi.fn().mockResolvedValue({ range: '30m', interval: '1m', data_points: [], per_server: {} }),
+    fetchCostMetrics: vi.fn().mockResolvedValue({ range: '30m', interval: '1m', data_points: [], per_server: {}, per_client: {} }),
+    clearTokenMetrics: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+function server(name: string): MCPServerStatus {
+  return { name, transport: 'stdio', initialized: true, tools: [], healthy: true } as unknown as MCPServerStatus;
+}
+
+const tokenUsage: TokenUsage = {
+  session: { input_tokens: 100, output_tokens: 40, total_tokens: 140 },
+  per_server: {
+    github: { input_tokens: 60, output_tokens: 20, total_tokens: 80 },
+    atlassian: { input_tokens: 40, output_tokens: 20, total_tokens: 60 },
+  },
+  per_client: { claude: { input_tokens: 100, output_tokens: 40, total_tokens: 140 } },
+  format_savings: { original_tokens: 0, formatted_tokens: 0, saved_tokens: 0, savings_percent: 0 },
+};
+
+const costUsage: CostUsage = {
+  session: { input_usd: 0.2, output_usd: 0.1, total_usd: 0.3 },
+  per_server: { github: { input_usd: 0.15, output_usd: 0.05, total_usd: 0.2 } },
+  per_client: { claude: { input_usd: 0.2, output_usd: 0.1, total_usd: 0.3 } },
+};
+
+function seed(over: Partial<ReturnType<typeof useStackStore.getState>> = {}) {
+  useStackStore.setState({
+    isLoading: false,
+    mcpServers: [server('github'), server('atlassian')],
+    tokenUsage,
+    costUsage,
+    costAttribution: true,
+    clientModels: {},
+    effectiveClientModels: {},
+    effectiveServerModels: {},
+    defaultModel: '',
+    ...over,
+  });
+}
+
+beforeEach(() => {
+  useUIStore.setState({ compactMode: { ...COMPACT_MODE_DEFAULTS } });
+  seed();
+});
+
+function renderAt(path = '/metrics') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <MetricsWorkspace />
+    </MemoryRouter>,
+  );
+}
+
+describe('MetricsWorkspace', () => {
+  it('renders the scope navigator and the session KPI row', () => {
+    renderAt();
+    // Anchor names so "Models" doesn't also match the "Edit pricing models" control.
+    expect(screen.getByRole('button', { name: /^overview/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^clients/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^servers/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^models/i })).toBeInTheDocument();
+    // KPI row carries the session total.
+    expect(screen.getByText('Total Tokens')).toBeInTheDocument();
+    expect(screen.getByText('140')).toBeInTheDocument();
+  });
+
+  it('defaults to the overview scope with the model-mix panel', () => {
+    renderAt();
+    expect(screen.getByText('Cost by Model')).toBeInTheDocument();
+  });
+
+  it('switches to the servers breakdown and selects a row into the inspector', async () => {
+    renderAt();
+    fireEvent.click(screen.getByRole('button', { name: /^servers/i }));
+
+    // The breakdown table now lists each server.
+    expect(await screen.findByText('github')).toBeInTheDocument();
+    expect(screen.getByText('atlassian')).toBeInTheDocument();
+
+    // Selecting a row opens the inspector (its "Pricing model" section is
+    // unique to a selected entity).
+    fireEvent.click(screen.getByText('github'));
+    expect(await screen.findByText('Pricing model')).toBeInTheDocument();
+  });
+
+  it('shows the model-mix panel under the models scope', () => {
+    renderAt('/metrics?scope=models');
+    expect(screen.getByText('Cost by Model')).toBeInTheDocument();
+  });
+
+  it('shows the onboarding empty state when there is no traffic', async () => {
+    seed({ tokenUsage: null, costUsage: null, costAttribution: false });
+    renderAt();
+    // The first-load skeleton clears once the (empty) series resolves.
+    expect(await screen.findByText('Your metrics home')).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/metricsData.test.ts
+++ b/web/src/__tests__/metricsData.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import {
+  derivePerServerRows,
+  derivePerClientRows,
+  sortBreakdownRows,
+  aggregateModelMix,
+  deriveSessionKpis,
+  hasMetricsData,
+  buildTokenChartData,
+  buildCostChartData,
+  type SessionKpis,
+} from '../components/metrics/metricsData';
+import type {
+  TokenUsage,
+  CostUsage,
+  EffectiveModel,
+  TokenMetricsResponse,
+  CostMetricsResponse,
+} from '../types';
+
+function tokenUsage(over: Partial<TokenUsage> = {}): TokenUsage {
+  return {
+    session: { input_tokens: 100, output_tokens: 40, total_tokens: 140 },
+    per_server: {
+      github: { input_tokens: 60, output_tokens: 20, total_tokens: 80 },
+      atlassian: { input_tokens: 40, output_tokens: 20, total_tokens: 60 },
+    },
+    format_savings: { original_tokens: 0, formatted_tokens: 0, saved_tokens: 0, savings_percent: 0 },
+    ...over,
+  };
+}
+
+function costUsage(over: Partial<CostUsage> = {}): CostUsage {
+  return {
+    session: { input_usd: 0.2, output_usd: 0.1, total_usd: 0.3 },
+    per_server: {
+      github: { input_usd: 0.15, output_usd: 0.05, total_usd: 0.2 },
+    },
+    ...over,
+  };
+}
+
+describe('derivePerServerRows', () => {
+  it('joins per-server tokens with per-server cost; unknown cost is undefined', () => {
+    const rows = derivePerServerRows(tokenUsage(), costUsage());
+    const github = rows.find((r) => r.name === 'github')!;
+    const atlas = rows.find((r) => r.name === 'atlassian')!;
+    expect(github.total).toBe(80);
+    expect(github.cost).toBe(0.2);
+    // atlassian has tokens but no cost entry → undefined (renders as em-dash)
+    expect(atlas.cost).toBeUndefined();
+  });
+
+  it('returns [] when there is no token usage', () => {
+    expect(derivePerServerRows(null)).toEqual([]);
+  });
+});
+
+describe('derivePerClientRows', () => {
+  it('unions clients across token and cost snapshots', () => {
+    const tu = tokenUsage({ per_client: { claude: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } } });
+    const cu = costUsage({ per_client: { cursor: { input_usd: 0.01, output_usd: 0, total_usd: 0.01 } } });
+    const rows = derivePerClientRows(tu, cu);
+    const names = rows.map((r) => r.name).sort();
+    expect(names).toEqual(['claude', 'cursor']);
+    // claude has tokens but no cost → undefined; cursor has cost but zero tokens
+    expect(rows.find((r) => r.name === 'claude')!.cost).toBeUndefined();
+    expect(rows.find((r) => r.name === 'cursor')!.cost).toBe(0.01);
+    expect(rows.find((r) => r.name === 'cursor')!.total).toBe(0);
+  });
+});
+
+describe('sortBreakdownRows', () => {
+  const rows = [
+    { name: 'b', input: 0, output: 0, total: 30, cost: 0.3 },
+    { name: 'a', input: 0, output: 0, total: 10, cost: undefined },
+    { name: 'c', input: 0, output: 0, total: 20, cost: 0.1 },
+  ];
+
+  it('sorts by total descending', () => {
+    expect(sortBreakdownRows(rows, 'total', 'desc').map((r) => r.name)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts unknown cost to the bottom on descending', () => {
+    expect(sortBreakdownRows(rows, 'cost', 'desc').map((r) => r.name)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts unknown cost to the top on ascending', () => {
+    expect(sortBreakdownRows(rows, 'cost', 'asc').map((r) => r.name)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('sorts by name', () => {
+    expect(sortBreakdownRows(rows, 'name', 'asc').map((r) => r.name)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not mutate the input array', () => {
+    const copy = [...rows];
+    sortBreakdownRows(rows, 'total', 'asc');
+    expect(rows).toEqual(copy);
+  });
+});
+
+describe('aggregateModelMix', () => {
+  it('sums cost per model across servers, descending, with recomputed shares', () => {
+    const servers: Record<string, EffectiveModel> = {
+      github: {
+        provenance: 'mixed',
+        models: [
+          { model: 'gpt-4o', cost_usd: 0.6, share: 0.75 },
+          { model: 'gpt-4o-mini', cost_usd: 0.2, share: 0.25 },
+        ],
+      },
+      atlassian: {
+        provenance: 'declared',
+        model: 'gpt-4o',
+        models: [{ model: 'gpt-4o', cost_usd: 0.2, share: 1 }],
+      },
+    };
+    const mix = aggregateModelMix(servers, {});
+    expect(mix.map((m) => m.model)).toEqual(['gpt-4o', 'gpt-4o-mini']);
+    expect(mix[0].cost_usd).toBeCloseTo(0.8);
+    expect(mix[0].share).toBeCloseTo(0.8); // 0.8 / 1.0 total
+    expect(mix.reduce((s, m) => s + m.share, 0)).toBeCloseTo(1);
+  });
+
+  it('falls back to client breakdowns when no server priced', () => {
+    const clients: Record<string, EffectiveModel> = {
+      claude: { provenance: 'declared', model: 'claude-opus', models: [{ model: 'claude-opus', cost_usd: 0.5, share: 1 }] },
+    };
+    const mix = aggregateModelMix({}, clients);
+    expect(mix).toHaveLength(1);
+    expect(mix[0].model).toBe('claude-opus');
+  });
+
+  it('returns [] when nothing is priced', () => {
+    expect(aggregateModelMix({}, {})).toEqual([]);
+  });
+});
+
+describe('deriveSessionKpis', () => {
+  it('marks hasCost and suppresses the attribution hint when cost exists', () => {
+    const k = deriveSessionKpis(tokenUsage(), costUsage(), true, {}, {});
+    expect(k.hasCost).toBe(true);
+    expect(k.costUSD).toBe(0.3);
+    expect(k.showAttributionHint).toBe(false);
+  });
+
+  it('shows the attribution hint when no attribution and no cost', () => {
+    const k = deriveSessionKpis(tokenUsage(), null, false, {}, {});
+    expect(k.hasCost).toBe(false);
+    expect(k.showAttributionHint).toBe(true);
+  });
+
+  it('flags mixed provenance from either client or server effective models', () => {
+    const k = deriveSessionKpis(tokenUsage(), costUsage(), true, {}, { github: { provenance: 'mixed' } });
+    expect(k.hasMixedProvenance).toBe(true);
+  });
+});
+
+describe('hasMetricsData', () => {
+  const emptyKpis: SessionKpis = {
+    input: 0, output: 0, total: 0, costUSD: undefined, hasCost: false,
+    savingsPercent: 0, savedTokens: 0, showAttributionHint: true, hasMixedProvenance: false,
+  };
+
+  it('is false with no totals and no series', () => {
+    expect(hasMetricsData(emptyKpis, null, null)).toBe(false);
+  });
+
+  it('is true when the session has tokens', () => {
+    expect(hasMetricsData({ ...emptyKpis, total: 5 }, null, null)).toBe(true);
+  });
+
+  it('is true when a token series has points', () => {
+    const series = { range: '1h', interval: '1m', data_points: [{ timestamp: 't', input_tokens: 1, output_tokens: 1, total_tokens: 2 }], per_server: {} } as TokenMetricsResponse;
+    expect(hasMetricsData(emptyKpis, series, null)).toBe(true);
+  });
+});
+
+describe('chart data builders', () => {
+  it('buildTokenChartData maps points to input/output series', () => {
+    const series = {
+      range: '1h', interval: '1m',
+      data_points: [{ timestamp: '2026-01-01T00:00:00Z', input_tokens: 3, output_tokens: 2, total_tokens: 5 }],
+      per_server: {},
+    } as TokenMetricsResponse;
+    const out = buildTokenChartData(series);
+    expect(out).toHaveLength(1);
+    expect(out[0]['Input Tokens']).toBe(3);
+    expect(out[0]['Output Tokens']).toBe(2);
+  });
+
+  it('buildCostChartData maps points to a USD series', () => {
+    const series = {
+      range: '1h', interval: '1m',
+      data_points: [{ timestamp: '2026-01-01T00:00:00Z', usd: 0.42 }],
+      per_server: {},
+    } as CostMetricsResponse;
+    const out = buildCostChartData(series);
+    expect(out[0]['Cost (USD)']).toBe(0.42);
+  });
+
+  it('returns [] for null inputs', () => {
+    expect(buildTokenChartData(null)).toEqual([]);
+    expect(buildCostChartData(null)).toEqual([]);
+  });
+});

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -1,21 +1,26 @@
-import { Wifi, WifiOff, Clock, Server, Box, Radio, Code, Gauge, ArrowDown } from 'lucide-react';
+import { Wifi, WifiOff, Clock, Server, Box, Radio, Code, Gauge, ArrowDown, DollarSign } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { cn } from '../../lib/cn';
 import { useStackStore } from '../../stores/useStackStore';
 import { formatRelativeTime } from '../../lib/time';
-import { formatCompactNumber } from '../../lib/format';
+import { formatCompactNumber, formatUSD } from '../../lib/format';
 import { SpecHealthBadge } from '../spec/SpecHealthBadge';
 import { PinDriftBadge } from '../pins/PinDriftBadge';
 
 export function StatusBar() {
+  const navigate = useNavigate();
   const mcpServers = useStackStore((s) => s.mcpServers);
   const resources = useStackStore((s) => s.resources);
   const sessions = useStackStore((s) => s.sessions);
   const codeMode = useStackStore((s) => s.codeMode);
   const tokenUsage = useStackStore((s) => s.tokenUsage);
+  const costUsage = useStackStore((s) => s.costUsage);
   const tokenizerName = useStackStore((s) => s.gatewayInfo?.tokenizer);
   const connectionStatus = useStackStore((s) => s.connectionStatus);
   const lastUpdated = useStackStore((s) => s.lastUpdated);
   const error = useStackStore((s) => s.error);
+
+  const sessionCostUSD = costUsage?.session.total_usd;
 
   const runningServers = (mcpServers ?? []).filter((s) => s.initialized).length;
   const unhealthyServers = (mcpServers ?? []).filter((s) => s.healthy === false).length;
@@ -95,15 +100,36 @@ export function StatusBar() {
           </div>
         )}
 
-        {/* Token counter */}
+        {/* Token counter — opens the Metrics workspace */}
         {tokenUsage && tokenUsage.session.total_tokens > 0 && (
-          <div className="flex items-center gap-2 text-text-muted">
+          <button
+            type="button"
+            onClick={() => navigate('/metrics')}
+            aria-label="Open Metrics workspace"
+            className="flex items-center gap-2 text-text-muted rounded px-1 -mx-1 hover:bg-surface-highlight/50 hover:text-text-secondary transition-colors"
+          >
             <Gauge size={11} className="text-primary" />
             <span>
               <span className="text-primary font-semibold">{formatCompactNumber(tokenUsage.session.total_tokens)}</span>
               <span className="ml-1">tokens</span>
             </span>
-          </div>
+          </button>
+        )}
+
+        {/* Session cost — emerald + "$" so it reads as money without relying on
+            color alone. Opens the Metrics workspace. */}
+        {sessionCostUSD !== undefined && (
+          <button
+            type="button"
+            onClick={() => navigate('/metrics')}
+            aria-label={`Estimated session cost ${formatUSD(sessionCostUSD)}. Open Metrics workspace`}
+            title="Estimated cost · open Metrics"
+            className="flex items-center gap-1.5 text-text-muted rounded px-1 -mx-1 hover:bg-surface-highlight/50 transition-colors"
+          >
+            <DollarSign size={11} className="text-emerald-400" />
+            <span className="text-emerald-400 font-semibold tabular-nums">{formatUSD(sessionCostUSD)}</span>
+            <span className="text-text-muted/60">est.</span>
+          </button>
         )}
 
         {/* Tokenizer mode indicator */}

--- a/web/src/components/metrics/MetricsControls.tsx
+++ b/web/src/components/metrics/MetricsControls.tsx
@@ -1,0 +1,130 @@
+import { useState, type ReactNode } from 'react';
+import { Pause, Play, RefreshCw, Trash2, DollarSign } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { IconButton } from '../ui/IconButton';
+import { METRICS_TIME_RANGES, type MetricsTimeRange } from '../../hooks/useMetricsSeries';
+
+// MetricsControls is the shared control cluster for every metrics surface:
+// the time-range segmented control, a live/pause toggle, refresh, clear (with
+// an inline confirm), the pricing-manager opener, and a host-supplied `right`
+// slot (popout in-shell, fullscreen detached). Pulling it out of the three
+// hosts keeps their toolbars identical and the clear-confirm logic in one place.
+export function MetricsControls({
+  timeRange,
+  onTimeRange,
+  isPaused,
+  onTogglePause,
+  onRefresh,
+  onClear,
+  onOpenPricing,
+  right,
+  className,
+}: {
+  timeRange: MetricsTimeRange;
+  onTimeRange: (range: MetricsTimeRange) => void;
+  isPaused: boolean;
+  onTogglePause: () => void;
+  onRefresh: () => void;
+  onClear: () => void;
+  onOpenPricing: () => void;
+  right?: ReactNode;
+  className?: string;
+}) {
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+
+  return (
+    <div className={cn('flex items-center justify-between gap-2', className)}>
+      <div className="flex items-center gap-2">
+        <div className="flex items-center bg-background/60 rounded-md border border-border/40 overflow-hidden">
+          {METRICS_TIME_RANGES.map((range) => (
+            <button
+              key={range.value}
+              onClick={() => onTimeRange(range.value)}
+              aria-pressed={timeRange === range.value}
+              className={cn(
+                'px-2.5 py-1 text-[10px] font-medium transition-colors',
+                timeRange === range.value
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-text-muted hover:text-text-secondary hover:bg-surface-highlight/40',
+              )}
+            >
+              {range.label}
+            </button>
+          ))}
+        </div>
+
+        {timeRange === 'live' && !isPaused && (
+          <span className="flex items-center gap-1 text-[9px] text-status-running font-medium">
+            <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse motion-reduce:animate-none" />
+            Live
+          </span>
+        )}
+        {timeRange === 'live' && isPaused && (
+          <span className="text-[10px] px-2 py-0.5 bg-status-pending/15 text-status-pending rounded-full font-medium border border-status-pending/20">
+            Paused
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1">
+        {timeRange === 'live' && (
+          <IconButton
+            icon={isPaused ? Play : Pause}
+            onClick={onTogglePause}
+            tooltip={isPaused ? 'Resume live updates' : 'Pause live updates'}
+            size="sm"
+            variant="ghost"
+            className={isPaused ? 'text-status-running hover:text-status-running' : ''}
+          />
+        )}
+        <IconButton icon={RefreshCw} onClick={onRefresh} tooltip="Refresh" size="sm" variant="ghost" />
+
+        <div className="relative">
+          <IconButton
+            icon={Trash2}
+            onClick={() => setShowClearConfirm(true)}
+            tooltip="Clear Metrics"
+            size="sm"
+            variant="ghost"
+            className="hover:text-status-error"
+          />
+          {showClearConfirm && (
+            <>
+              <div className="fixed inset-0 z-40" onClick={() => setShowClearConfirm(false)} />
+              <div className="absolute right-0 top-full mt-1 z-50 p-3 rounded-lg bg-surface-elevated border border-border/50 shadow-xl min-w-[220px]">
+                <p className="text-xs text-text-primary font-medium mb-2">Clear all token metrics?</p>
+                <p className="text-[10px] text-text-muted mb-3">This cannot be undone.</p>
+                <div className="flex items-center gap-2 justify-end">
+                  <button
+                    onClick={() => setShowClearConfirm(false)}
+                    className="px-2.5 py-1 text-[10px] font-medium rounded-md bg-surface-highlight text-text-secondary hover:text-text-primary transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowClearConfirm(false);
+                      onClear();
+                    }}
+                    className="px-2.5 py-1 text-[10px] font-medium rounded-md bg-status-error/15 text-status-error hover:bg-status-error/25 transition-colors"
+                  >
+                    Clear
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        <IconButton icon={DollarSign} onClick={onOpenPricing} tooltip="Edit pricing models" size="sm" variant="ghost" />
+
+        {right && (
+          <>
+            <div className="w-px h-4 bg-border/50 mx-0.5" />
+            {right}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/metrics/MetricsInspector.tsx
+++ b/web/src/components/metrics/MetricsInspector.tsx
@@ -1,0 +1,224 @@
+import { X, DollarSign } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { formatCompactNumber, formatUSD } from '../../lib/format';
+import { AreaChart } from '../chart/AreaChart';
+import { ClientModelCell } from '../pricing/ClientModelCell';
+import { ServerModelCell } from '../pricing/ServerModelCell';
+import {
+  ATTRIBUTION_HINT,
+  MIXED_PROVENANCE_NOTE,
+  UNPRICED_NOTE,
+  MODEL_PRECEDENCE_HINT,
+} from '../pricing/constants';
+import type { BreakdownRow } from './metricsData';
+import type { CostDataPoint, EffectiveModel, TokenDataPoint } from '../../types';
+
+export type MetricsInspectorScope = 'clients' | 'servers';
+
+interface MetricsInspectorProps {
+  scope: MetricsInspectorScope;
+  // The selected entity's KPI row, or null to show the overview/legend.
+  row: BreakdownRow | null;
+  effective?: EffectiveModel;
+  declaredModel?: string;
+  defaultModel: string;
+  costAttribution: boolean;
+  onClientSaved: (client: string, model: string) => void;
+  onServerSaved: (server: string, model: string) => void;
+  onOpenManager: () => void;
+  onClose: () => void;
+  // Per-entity series for the inspector sparklines, when available.
+  tokenPoints?: TokenDataPoint[];
+  costPoints?: CostDataPoint[];
+}
+
+// MetricsInspector is the workspace right rail: a per-entity detail view for
+// the selected client or server. It hosts the inline model editor (relocated
+// here so the breakdown tables stay scannable), the entity's KPI numbers,
+// per-entity sparklines, and the cost-provenance note. With nothing selected
+// it falls back to a cost-provenance legend explaining the attribution model.
+export function MetricsInspector({
+  scope,
+  row,
+  effective,
+  declaredModel,
+  defaultModel,
+  costAttribution,
+  onClientSaved,
+  onServerSaved,
+  onOpenManager,
+  onClose,
+  tokenPoints,
+  costPoints,
+}: MetricsInspectorProps) {
+  if (!row) return <InspectorOverview onOpenManager={onOpenManager} />;
+
+  const tokenSeries = (tokenPoints ?? []).map((dp) => ({
+    time: new Date(dp.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+    'Input Tokens': dp.input_tokens,
+    'Output Tokens': dp.output_tokens,
+  }));
+  const costSeries = (costPoints ?? []).map((dp) => ({
+    time: new Date(dp.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+    'Cost (USD)': dp.usd,
+  }));
+  const costSeriesHasData = costSeries.some((d) => d['Cost (USD)'] > 0);
+
+  return (
+    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle">
+      <div className="flex-shrink-0 flex items-center gap-2 px-4 py-3 border-b border-border-subtle">
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-[0.3em] text-text-muted/60">
+            {scope === 'clients' ? 'client' : 'server'}
+          </div>
+          <div className="font-mono text-sm text-text-primary truncate" title={row.name}>
+            {row.name}
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close inspector"
+          className="ml-auto p-1 rounded hover:bg-surface-highlight transition-colors"
+        >
+          <X size={14} className="text-text-muted" />
+        </button>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark p-4 space-y-4">
+        {/* Pricing model editor */}
+        <section className="space-y-1.5">
+          <h3 className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">Pricing model</h3>
+          <div title={MODEL_PRECEDENCE_HINT}>
+            {scope === 'clients' ? (
+              <ClientModelCell
+                client={row.name}
+                declaredModel={declaredModel}
+                effective={effective}
+                costAttribution={costAttribution}
+                onSaved={onClientSaved}
+                onOpenManager={onOpenManager}
+                pickerAlign="left"
+              />
+            ) : (
+              <ServerModelCell
+                server={row.name}
+                declaredModel={declaredModel}
+                defaultModel={defaultModel}
+                effective={effective}
+                onSaved={onServerSaved}
+                onOpenManager={onOpenManager}
+                pickerAlign="left"
+              />
+            )}
+          </div>
+          {effective?.provenance === 'mixed' && (
+            <p className="text-[10px] leading-snug text-text-muted/70">{MIXED_PROVENANCE_NOTE}</p>
+          )}
+          {effective?.provenance === 'none' && (
+            <p className="text-[10px] leading-snug text-text-muted/70">{UNPRICED_NOTE}</p>
+          )}
+        </section>
+
+        {/* KPI numbers */}
+        <section className="grid grid-cols-2 gap-2">
+          <InspectorStat label="Input" value={formatCompactNumber(row.input)} className="text-secondary" />
+          <InspectorStat label="Output" value={formatCompactNumber(row.output)} className="text-primary" />
+          <InspectorStat label="Total" value={formatCompactNumber(row.total)} className="text-text-primary" />
+          <InspectorStat
+            label="Cost · est."
+            value={row.cost === undefined ? '—' : formatUSD(row.cost)}
+            className={row.cost === undefined ? 'text-text-muted' : 'text-emerald-400'}
+          />
+        </section>
+
+        {/* Token sparkline */}
+        {tokenSeries.length > 0 && (
+          <section className="space-y-1">
+            <h3 className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">Tokens over time</h3>
+            <div role="img" aria-label={`Token usage over time for ${row.name}`}>
+              <AreaChart
+                data={tokenSeries}
+                index="time"
+                categories={['Input Tokens', 'Output Tokens']}
+                colors={['teal', 'amber']}
+                type="stacked"
+                fill="gradient"
+                showLegend={false}
+                showGridLines={false}
+                showYAxis={false}
+                valueFormatter={(v: number) => formatCompactNumber(v)}
+                className="h-24"
+              />
+            </div>
+          </section>
+        )}
+
+        {/* Cost sparkline */}
+        {costSeriesHasData && (
+          <section className="space-y-1">
+            <h3 className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70 inline-flex items-center gap-1">
+              <DollarSign size={10} className="text-emerald-400" /> Cost over time
+            </h3>
+            <div role="img" aria-label={`Estimated cost over time for ${row.name}`}>
+              <AreaChart
+                data={costSeries}
+                index="time"
+                categories={['Cost (USD)']}
+                colors={['emerald']}
+                type="default"
+                fill="gradient"
+                showLegend={false}
+                showGridLines={false}
+                showYAxis={false}
+                valueFormatter={(v: number) => formatUSD(v)}
+                className="h-20"
+              />
+            </div>
+          </section>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function InspectorStat({ label, value, className }: { label: string; value: string; className?: string }) {
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-2.5">
+      <span className="text-[9px] text-text-muted uppercase tracking-wider block mb-0.5">{label}</span>
+      <span className={cn('text-sm font-bold tabular-nums', className)}>{value}</span>
+    </div>
+  );
+}
+
+// Shown when nothing is selected — a cost-provenance legend rather than an
+// empty rail, carrying the same honesty copy the cards use.
+function InspectorOverview({ onOpenManager }: { onOpenManager: () => void }) {
+  return (
+    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle">
+      <div className="flex-shrink-0 px-4 py-3 border-b border-border-subtle">
+        <div className="text-[10px] uppercase tracking-[0.3em] text-text-muted/60">about cost</div>
+      </div>
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark p-4 space-y-3 text-[11px] leading-relaxed text-text-muted">
+        <p>
+          Select a client or server to inspect its tokens, estimated cost, and pricing model.
+        </p>
+        <p className="text-text-secondary">{ATTRIBUTION_HINT}.</p>
+        <div className="space-y-1.5 pt-1">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">provenance</p>
+          <p><span className="font-mono text-text-secondary">declared</span> — one model priced all recorded cost.</p>
+          <p><span className="font-mono text-text-secondary">mixed</span> — {MIXED_PROVENANCE_NOTE}</p>
+          <p><span className="font-mono text-text-secondary">none</span> — {UNPRICED_NOTE}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onOpenManager}
+          className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-2.5 py-1 text-[10px] font-medium text-primary hover:bg-primary/20 transition-colors"
+        >
+          <DollarSign size={11} /> Edit pricing models
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+export default MetricsInspector;

--- a/web/src/components/metrics/MetricsTab.tsx
+++ b/web/src/components/metrics/MetricsTab.tsx
@@ -1,426 +1,97 @@
-import { useEffect, useRef, useState, useCallback, useMemo, type ComponentType } from 'react';
-import {
-  Pause,
-  Play,
-  Trash2,
-  BarChart3,
-  ArrowUpDown,
-  ArrowUp,
-  ArrowDown,
-  AlertCircle,
-  RefreshCw,
-  DollarSign,
-  Users,
-} from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
-import { cn } from '../../lib/cn';
-import { IconButton } from '../ui/IconButton';
-import { PopoutButton } from '../ui/PopoutButton';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { BarChart3, AlertCircle, ArrowRight } from 'lucide-react';
 import { useUIStore } from '../../stores/useUIStore';
 import { useStackStore } from '../../stores/useStackStore';
-import { fetchTokenMetrics, clearTokenMetrics, fetchCostMetrics } from '../../lib/api';
 import { useWindowManager } from '../../hooks/useWindowManager';
-import { formatCompactNumber, formatUSD } from '../../lib/format';
-import { POLLING } from '../../lib/constants';
-import { AreaChart } from '../chart/AreaChart';
+import { useMetricsSeries, type MetricsTimeRange } from '../../hooks/useMetricsSeries';
+import { PopoutButton } from '../ui/PopoutButton';
 import { PersistedFromMarker } from '../telemetry/PersistedFromMarker';
-import { ClientModelCell } from '../pricing/ClientModelCell';
-import { ServerModelCell } from '../pricing/ServerModelCell';
-import { ATTRIBUTION_HINT, MIXED_PROVENANCE_NOTE } from '../pricing/constants';
-import type { TokenMetricsResponse, CostMetricsResponse } from '../../types';
+import { MetricsControls } from './MetricsControls';
+import { MetricsKpiRow, TokenChart } from './metricsShared';
+import { buildTokenChartData, deriveSessionKpis, hasMetricsData } from './metricsData';
 
-type TimeRange = 'live' | '1h' | '6h' | '24h' | '7d';
-type SortColumn = 'name' | 'input' | 'output' | 'total';
-type SortDirection = 'asc' | 'desc';
-type ClientSortColumn = 'name' | 'input' | 'output' | 'total' | 'cost';
-
-const TIME_RANGES: { value: TimeRange; label: string }[] = [
-  { value: 'live', label: 'Live' },
-  { value: '1h', label: '1h' },
-  { value: '6h', label: '6h' },
-  { value: '24h', label: '24h' },
-  { value: '7d', label: '7d' },
-];
-
+// MetricsTab is the bottom-panel glance surface: the session KPI row and a
+// single token sparkline, sized to coexist with the canvas. The full
+// breakdown (cost chart, per-client / per-server / model tables, attribution
+// editing) lives in the Metrics workspace — "View all" routes there. All three
+// surfaces (this tab, the workspace, the detached window) render the same
+// shared atoms from metricsShared so cost stays defined in one place.
 export function MetricsTab() {
+  const navigate = useNavigate();
   const bottomPanelOpen = useUIStore((s) => s.bottomPanelOpen);
   const bottomPanelTab = useUIStore((s) => s.bottomPanelTab);
+  const metricsDetached = useUIStore((s) => s.metricsDetached);
+  const setPricingManagerOpen = useUIStore((s) => s.setPricingManagerOpen);
+
   const tokenUsage = useStackStore((s) => s.tokenUsage);
   const costUsage = useStackStore((s) => s.costUsage);
   const costAttribution = useStackStore((s) => s.costAttribution);
-  const clientModels = useStackStore((s) => s.clientModels);
   const effectiveClientModels = useStackStore((s) => s.effectiveClientModels);
   const effectiveServerModels = useStackStore((s) => s.effectiveServerModels);
-  const mcpServers = useStackStore((s) => s.mcpServers);
-  const defaultModel = useStackStore((s) => s.defaultModel);
-  const setClientModelLocal = useStackStore((s) => s.setClientModelLocal);
-  const setServerModelLocal = useStackStore((s) => s.setServerModelLocal);
-  const metricsDetached = useUIStore((s) => s.metricsDetached);
-  const setPricingManagerOpen = useUIStore((s) => s.setPricingManagerOpen);
+
   const { openDetachedWindow } = useWindowManager();
-  const [timeRange, setTimeRange] = useState<TimeRange>('live');
+  const [timeRange, setTimeRange] = useState<MetricsTimeRange>('live');
   const [isPaused, setIsPaused] = useState(false);
-  const [metricsData, setMetricsData] = useState<TokenMetricsResponse | null>(null);
-  const [costData, setCostData] = useState<CostMetricsResponse | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [showClearConfirm, setShowClearConfirm] = useState(false);
-  const [sortColumn, setSortColumn] = useState<SortColumn>('total');
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
-  const [clientSortColumn, setClientSortColumn] = useState<ClientSortColumn>('cost');
-  const [clientSortDirection, setClientSortDirection] = useState<SortDirection>('desc');
 
-  const intervalRef = useRef<number | null>(null);
   const isVisible = bottomPanelOpen && bottomPanelTab === 'metrics';
+  const { metricsData, costData, isLoading, error, reload, clear } = useMetricsSeries({
+    timeRange,
+    enabled: isVisible,
+    paused: isPaused,
+  });
 
-  // Map time range to API range param
-  const apiRange = timeRange === 'live' ? '30m' : timeRange;
-
-  const loadMetrics = useCallback(async () => {
-    try {
-      // Piggyback the cost fetch on the existing token-metrics polling
-      // cycle (per the design system: do not add a second poll). When
-      // either request fails we surface the first error but still keep
-      // any successful payload to avoid losing the chart on a transient
-      // failure of just one endpoint.
-      const [tokenResult, costResult] = await Promise.allSettled([
-        fetchTokenMetrics(apiRange),
-        fetchCostMetrics(apiRange),
-      ]);
-      if (tokenResult.status === 'fulfilled') {
-        setMetricsData(tokenResult.value);
-      }
-      if (costResult.status === 'fulfilled') {
-        setCostData(costResult.value);
-      }
-      const firstFailure =
-        (tokenResult.status === 'rejected' && tokenResult.reason) ||
-        (costResult.status === 'rejected' && costResult.reason);
-      if (firstFailure) {
-        setError(firstFailure instanceof Error ? firstFailure.message : 'Failed to fetch metrics');
-      } else {
-        setError(null);
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch metrics');
-    } finally {
-      setIsLoading(false);
-    }
-  }, [apiRange]);
-
-  // Fetch on mount and when range changes
-  useEffect(() => {
-    if (!isVisible) return;
-    setIsLoading(true);
-    loadMetrics();
-  }, [isVisible, apiRange, loadMetrics]);
-
-  // Auto-refresh in live mode
-  useEffect(() => {
-    if (!isVisible || isPaused || timeRange !== 'live') {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-      return;
-    }
-
-    intervalRef.current = window.setInterval(loadMetrics, POLLING.METRICS);
-
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    };
-  }, [isVisible, isPaused, timeRange, loadMetrics]);
-
-  const handleClearMetrics = async () => {
-    try {
-      await clearTokenMetrics();
-      setMetricsData(null);
-      setCostData(null);
-      setShowClearConfirm(false);
-      setIsLoading(true);
-      loadMetrics();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to clear metrics');
-    }
-  };
-
-  const handleSort = (column: SortColumn) => {
-    if (sortColumn === column) {
-      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
-    } else {
-      setSortColumn(column);
-      setSortDirection('desc');
-    }
-  };
-
-  const handleClientSort = (column: ClientSortColumn) => {
-    if (clientSortColumn === column) {
-      setClientSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
-    } else {
-      setClientSortColumn(column);
-      setClientSortDirection('desc');
-    }
-  };
-
-  // Per-server data from the real-time status (for KPI + table)
-  const perServerEntries = useMemo(() => {
-    if (!tokenUsage?.per_server) return [];
-    return Object.entries(tokenUsage.per_server).map(([name, counts]) => ({
-      name,
-      input: counts.input_tokens,
-      output: counts.output_tokens,
-      total: counts.total_tokens,
-    }));
-  }, [tokenUsage]);
-
-  // Declared per-server models (model: field only, no default folded in) for
-  // the Model column's provenance pills.
-  const declaredServerModels = useMemo(() => {
-    const out: Record<string, string> = {};
-    for (const s of mcpServers) {
-      if (s.model) out[s.name] = s.model;
-    }
-    return out;
-  }, [mcpServers]);
-
-  // Sort per-server entries
-  const sortedServers = useMemo(() => {
-    const sorted = [...perServerEntries];
-    sorted.sort((a, b) => {
-      const dir = sortDirection === 'asc' ? 1 : -1;
-      if (sortColumn === 'name') return dir * a.name.localeCompare(b.name);
-      return dir * (a[sortColumn] - b[sortColumn]);
-    });
-    return sorted;
-  }, [perServerEntries, sortColumn, sortDirection]);
-
-  // Session totals from real-time status
-  const sessionInput = tokenUsage?.session.input_tokens ?? 0;
-  const sessionOutput = tokenUsage?.session.output_tokens ?? 0;
-  const sessionTotal = tokenUsage?.session.total_tokens ?? 0;
-  const savingsPercent = tokenUsage?.format_savings.savings_percent ?? 0;
-  const savedTokens = tokenUsage?.format_savings.saved_tokens ?? 0;
-
-  // Cost shown only when the backend has actually emitted a cost field on
-  // /api/status. costUsage is null until the first priced call lands —
-  // displaying "—" then matches the UX spec ("never a fabricated number").
-  const sessionCostUSD = costUsage?.session.total_usd;
-  const hasCost = sessionCostUSD !== undefined;
-  // Without model attribution the gateway cannot price calls, so cost stays
-  // absent or $0.00 forever. Surface the config hint instead of leaving the
-  // user to wonder whether traffic is free.
-  const showAttributionHint = !costAttribution && !(sessionCostUSD && sessionCostUSD > 0);
-
-  // The honesty subline appears whenever any client or server resolved to a
-  // blend of pricing models — a reminder that cost is priced by declarations,
-  // not observed client behavior.
-  const hasMixedProvenance = useMemo(() => {
-    const anyMixed = (m: Record<string, { provenance: string }>) =>
-      Object.values(m).some((e) => e.provenance === 'mixed');
-    return anyMixed(effectiveClientModels) || anyMixed(effectiveServerModels);
-  }, [effectiveClientModels, effectiveServerModels]);
-
-  const hasData =
-    sessionTotal > 0 ||
-    (metricsData?.data_points?.length ?? 0) > 0 ||
-    (costData?.data_points?.length ?? 0) > 0;
-
-  // Transform API data points to Recharts format
-  const chartData = useMemo(() => {
-    if (!metricsData?.data_points) return [];
-    return metricsData.data_points.map((dp) => ({
-      time: new Date(dp.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-      "Input Tokens": dp.input_tokens,
-      "Output Tokens": dp.output_tokens,
-    }));
-  }, [metricsData]);
-
-  const costChartData = useMemo(() => {
-    if (!costData?.data_points) return [];
-    return costData.data_points.map((dp) => ({
-      time: new Date(dp.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-      "Cost (USD)": dp.usd,
-    }));
-  }, [costData]);
-
-  const costSeriesHasData = costChartData.some((d) => d['Cost (USD)'] > 0);
-
-  // Per-client breakdown — joins the real-time token + cost snapshots so a
-  // client without any priced calls still shows up with cost = 0 (and
-  // pricing-unknown clients render as "—" in the cost column).
-  const perClientRows = useMemo(() => {
-    const tokenClients = tokenUsage?.per_client ?? {};
-    const costClients = costUsage?.per_client ?? {};
-    const names = new Set<string>([...Object.keys(tokenClients), ...Object.keys(costClients)]);
-    return Array.from(names).map((name) => {
-      const tokens = tokenClients[name];
-      const cost = costClients[name];
-      return {
-        name,
-        input: tokens?.input_tokens ?? 0,
-        output: tokens?.output_tokens ?? 0,
-        total: tokens?.total_tokens ?? 0,
-        cost: cost?.total_usd,
-      };
-    });
-  }, [tokenUsage, costUsage]);
-
-  const sortedClients = useMemo(() => {
-    const sorted = [...perClientRows];
-    sorted.sort((a, b) => {
-      const dir = clientSortDirection === 'asc' ? 1 : -1;
-      if (clientSortColumn === 'name') return dir * a.name.localeCompare(b.name);
-      if (clientSortColumn === 'cost') {
-        // Treat unknown cost as -Infinity so it sinks to the bottom on
-        // descending sort and bubbles to the top on ascending sort.
-        const aCost = a.cost ?? -Infinity;
-        const bCost = b.cost ?? -Infinity;
-        return dir * (aCost - bCost);
-      }
-      return dir * (a[clientSortColumn] - b[clientSortColumn]);
-    });
-    return sorted;
-  }, [perClientRows, clientSortColumn, clientSortDirection]);
+  const kpis = deriveSessionKpis(
+    tokenUsage,
+    costUsage,
+    costAttribution,
+    effectiveClientModels,
+    effectiveServerModels,
+  );
+  const chartData = buildTokenChartData(metricsData);
+  const hasData = hasMetricsData(kpis, metricsData, costData);
 
   return (
     <div className="flex flex-col h-full">
-      {/* Control bar */}
-      <div className="flex items-center justify-between px-4 h-9 flex-shrink-0 border-b border-border/30 bg-surface-elevated/20">
-        <div className="flex items-center gap-2">
-          {/* Time range selector */}
-          <div className="flex items-center bg-background/60 rounded-md border border-border/40 overflow-hidden">
-            {TIME_RANGES.map((range) => (
-              <button
-                key={range.value}
-                onClick={() => {
-                  setTimeRange(range.value);
-                  if (range.value === 'live') setIsPaused(false);
-                }}
-                className={cn(
-                  'px-2.5 py-1 text-[10px] font-medium transition-colors',
-                  timeRange === range.value
-                    ? 'bg-primary/15 text-primary'
-                    : 'text-text-muted hover:text-text-secondary hover:bg-surface-highlight/40'
-                )}
-              >
-                {range.label}
-              </button>
-            ))}
-          </div>
-
-          {/* Live indicator */}
-          {timeRange === 'live' && !isPaused && (
-            <span className="flex items-center gap-1 text-[9px] text-status-running font-medium">
-              <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
-              Live
-            </span>
-          )}
-        </div>
-
-        <div className="flex items-center gap-1">
-          {timeRange === 'live' && (
-            <IconButton
-              icon={isPaused ? Play : Pause}
-              onClick={() => setIsPaused(!isPaused)}
-              tooltip={isPaused ? 'Resume live updates' : 'Pause live updates'}
-              size="sm"
-              variant="ghost"
-              className={isPaused ? 'text-status-running hover:text-status-running' : ''}
-            />
-          )}
-          <IconButton
-            icon={RefreshCw}
-            onClick={() => { setIsLoading(true); loadMetrics(); }}
-            tooltip="Refresh"
-            size="sm"
-            variant="ghost"
-          />
-
-          {/* Clear metrics */}
-          <div className="relative">
-            <IconButton
-              icon={Trash2}
-              onClick={() => setShowClearConfirm(true)}
-              tooltip="Clear Metrics"
-              size="sm"
-              variant="ghost"
-              className="hover:text-status-error"
-            />
-            {showClearConfirm && (
-              <div className="absolute right-0 top-full mt-1 z-50 p-3 rounded-lg bg-surface-elevated border border-border/50 shadow-xl min-w-[220px]">
-                <p className="text-xs text-text-primary font-medium mb-2">Clear all token metrics?</p>
-                <p className="text-[10px] text-text-muted mb-3">This cannot be undone.</p>
-                <div className="flex items-center gap-2 justify-end">
-                  <button
-                    onClick={() => setShowClearConfirm(false)}
-                    className="px-2.5 py-1 text-[10px] font-medium rounded-md bg-surface-highlight text-text-secondary hover:text-text-primary transition-colors"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    onClick={handleClearMetrics}
-                    className="px-2.5 py-1 text-[10px] font-medium rounded-md bg-status-error/15 text-status-error hover:bg-status-error/25 transition-colors"
-                  >
-                    Clear
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-
-          <IconButton
-            icon={DollarSign}
-            onClick={() => setPricingManagerOpen(true)}
-            tooltip="Edit pricing models"
-            size="sm"
-            variant="ghost"
-          />
-
-          <div className="w-px h-4 bg-border/50 mx-0.5" />
-          <PopoutButton
-            onClick={() => openDetachedWindow('metrics')}
-            disabled={metricsDetached}
-          />
-        </div>
+      <div className="flex items-center px-4 h-9 flex-shrink-0 border-b border-border/30 bg-surface-elevated/20">
+        <MetricsControls
+          className="w-full"
+          timeRange={timeRange}
+          onTimeRange={(r) => {
+            setTimeRange(r);
+            if (r === 'live') setIsPaused(false);
+          }}
+          isPaused={isPaused}
+          onTogglePause={() => setIsPaused((p) => !p)}
+          onRefresh={reload}
+          onClear={() => void clear()}
+          onOpenPricing={() => setPricingManagerOpen(true)}
+          right={<PopoutButton onClick={() => openDetachedWindow('metrics')} disabled={metricsDetached} />}
+        />
       </div>
 
-      {/* Content */}
       <div className="flex-1 overflow-auto scrollbar-dark min-h-0 p-4">
-        {/* Loading skeleton */}
         {isLoading && !metricsData && (
           <div className="space-y-4 animate-pulse">
-            {/* KPI skeleton */}
-            <div className="grid grid-cols-3 gap-3">
-              {[1, 2, 3].map((i) => (
+            <div className="grid grid-cols-4 gap-3">
+              {[1, 2, 3, 4].map((i) => (
                 <div key={i} className="h-16 rounded-lg bg-surface-elevated/60 border border-border/30" />
               ))}
             </div>
-            {/* Chart skeleton */}
-            <div className="h-40 rounded-lg bg-surface-elevated/60 border border-border/30" />
-            {/* Table skeleton */}
-            <div className="h-24 rounded-lg bg-surface-elevated/60 border border-border/30" />
+            <div className="h-36 rounded-lg bg-surface-elevated/60 border border-border/30" />
           </div>
         )}
 
-        {/* Error state */}
         {error && !isLoading && (
           <div className="flex flex-col items-center justify-center h-full gap-3">
             <AlertCircle size={24} className="text-status-error" />
             <span className="text-xs text-status-error">{error}</span>
-            <button
-              onClick={() => { setError(null); setIsLoading(true); loadMetrics(); }}
-              className="text-xs text-primary hover:underline"
-            >
+            <button onClick={reload} className="text-xs text-primary hover:underline">
               Retry
             </button>
           </div>
         )}
 
-        {/* Empty state */}
         {!isLoading && !error && !hasData && (
           <div className="flex flex-col items-center justify-center h-full text-text-muted gap-2">
             <BarChart3 size={24} className="text-text-muted/30" />
@@ -429,379 +100,22 @@ export function MetricsTab() {
           </div>
         )}
 
-        {/* Data view — shown even while loading if we have stale data to prevent flash */}
         {!error && hasData && (
           <div className="space-y-4">
-            {/* Aggregate persisted-from boundary — only renders when at
-                least one server has metrics persistence enabled and files
-                exist on disk. Sits above the KPI cards so it reads as a
-                provenance hint for the data below. */}
             <PersistedFromMarker serverName={null} signal="metrics" />
-
-            {/* KPI Cards */}
-            <div className={cn('grid gap-3', savingsPercent > 0 ? 'grid-cols-5' : 'grid-cols-4')}>
-              <KPICard label="Input Tokens" value={sessionInput} colorClass="text-secondary" />
-              <KPICard label="Output Tokens" value={sessionOutput} colorClass="text-primary" />
-              <KPICard label="Total Tokens" value={sessionTotal} colorClass="text-text-primary" />
-              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} showHint={showAttributionHint} showMixedNote={hasMixedProvenance} />
-              {savingsPercent > 0 && (
-                <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-                  <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Format Savings</span>
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-lg font-bold text-status-running tabular-nums">{Math.round(savingsPercent)}%</span>
-                    <span className="text-[10px] text-text-muted">{formatCompactNumber(savedTokens)} saved</span>
-                  </div>
-                  {/* Savings bar */}
-                  <div className="mt-2 h-1.5 rounded-full bg-surface-highlight overflow-hidden flex">
-                    <div
-                      className="h-full bg-primary rounded-full"
-                      style={{ width: `${100 - savingsPercent}%` }}
-                    />
-                    <div
-                      className="h-full bg-primary/20"
-                      style={{ width: `${savingsPercent}%` }}
-                    />
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Area Chart */}
-            <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-              <div className="flex items-center justify-between mb-1">
-                <span className="text-[11px] font-medium text-text-secondary">Token Usage Over Time</span>
-                {metricsData && (
-                  <span className="text-[9px] text-text-muted font-mono">
-                    {metricsData.data_points?.length ?? 0} points &middot; {metricsData.interval} interval
-                  </span>
-                )}
-              </div>
-              <AreaChart
-                data={chartData}
-                index="time"
-                categories={["Input Tokens", "Output Tokens"]}
-                colors={["teal", "amber"]}
-                type="stacked"
-                fill="gradient"
-                showLegend={true}
-                showGridLines={true}
-                showYAxis={true}
-                yAxisWidth={48}
-                valueFormatter={(v: number) => formatCompactNumber(v)}
-                className="h-36"
-              />
-            </div>
-
-            {/* Cost Over Time — only render once the gateway has emitted any
-                cost data. Pre-PR-1 stacks (no priced calls yet) get the
-                token chart unchanged with no empty cost panel below it. */}
-            {(hasCost || costSeriesHasData) && (
-              <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-[11px] font-medium text-text-secondary inline-flex items-center gap-1.5">
-                    <DollarSign size={11} className="text-emerald-400" />
-                    Cost Over Time
-                  </span>
-                  {costData && (
-                    <span className="text-[9px] text-text-muted font-mono">
-                      {costData.data_points?.length ?? 0} points &middot; {costData.interval} interval
-                    </span>
-                  )}
-                </div>
-                <AreaChart
-                  data={costChartData}
-                  index="time"
-                  categories={["Cost (USD)"]}
-                  colors={["emerald"]}
-                  type="default"
-                  fill="gradient"
-                  showLegend={false}
-                  showGridLines={true}
-                  showYAxis={true}
-                  yAxisWidth={56}
-                  valueFormatter={(v: number) => formatUSD(v)}
-                  className="h-32"
-                />
-              </div>
-            )}
-
-            {/* Top Clients — joins per_client tokens + cost from /api/status.
-                Hidden when the backend hasn't surfaced any per-client
-                attribution yet (pre-PR-2 stacks, or sessions where every
-                tool call ran without a known clientInfo). */}
-            {sortedClients.length > 0 && (
-              <PanelHeader icon={Users} label="Top Clients">
-                <table className="w-full text-xs">
-                  <thead>
-                    <tr className="border-b border-border/30">
-                      <ClientSortableHeader label="Client" column="name" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} />
-                      <th className="px-3 py-1.5 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">Model</th>
-                      <ClientSortableHeader label="Input" column="input" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
-                      <ClientSortableHeader label="Output" column="output" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
-                      <ClientSortableHeader label="Total" column="total" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
-                      <ClientSortableHeader label="Cost" column="cost" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedClients.map((client) => (
-                      <tr key={client.name} className="border-b border-border/20 last:border-0 hover:bg-surface-highlight/30 transition-colors">
-                        <td className="px-3 py-2 font-medium text-text-primary font-mono">{client.name}</td>
-                        <td className="px-3 py-2">
-                          <ClientModelCell
-                            client={client.name}
-                            declaredModel={clientModels[client.name]}
-                            effective={effectiveClientModels[client.name]}
-                            costAttribution={costAttribution}
-                            onSaved={setClientModelLocal}
-                            onOpenManager={() => setPricingManagerOpen(true)}
-                          />
-                        </td>
-                        <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(client.input)}</td>
-                        <td className="px-3 py-2 text-right text-primary tabular-nums">{formatCompactNumber(client.output)}</td>
-                        <td className="px-3 py-2 text-right text-text-primary font-semibold tabular-nums">{formatCompactNumber(client.total)}</td>
-                        <td className={cn('px-3 py-2 text-right tabular-nums', client.cost === undefined ? 'text-text-muted' : 'text-emerald-400')}>
-                          {client.cost === undefined ? '—' : formatUSD(client.cost)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </PanelHeader>
-            )}
-
-            {/* Per-Server Breakdown Table */}
-            {sortedServers.length > 0 && (
-              <div className="rounded-lg bg-surface-elevated/60 border border-border/30 overflow-hidden">
-                <table className="w-full text-xs">
-                  <thead>
-                    <tr className="border-b border-border/30">
-                      <SortableHeader
-                        label="Server"
-                        column="name"
-                        sortColumn={sortColumn}
-                        sortDirection={sortDirection}
-                        onSort={handleSort}
-                      />
-                      <th className="px-3 py-1.5 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">Model</th>
-                      <SortableHeader
-                        label="Input"
-                        column="input"
-                        sortColumn={sortColumn}
-                        sortDirection={sortDirection}
-                        onSort={handleSort}
-                        align="right"
-                      />
-                      <SortableHeader
-                        label="Output"
-                        column="output"
-                        sortColumn={sortColumn}
-                        sortDirection={sortDirection}
-                        onSort={handleSort}
-                        align="right"
-                      />
-                      <SortableHeader
-                        label="Total"
-                        column="total"
-                        sortColumn={sortColumn}
-                        sortDirection={sortDirection}
-                        onSort={handleSort}
-                        align="right"
-                      />
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedServers.map((server) => (
-                      <tr key={server.name} className="border-b border-border/20 hover:bg-surface-highlight/30 transition-colors">
-                        <td className="px-3 py-2 font-medium text-text-primary font-mono">{server.name}</td>
-                        <td className="px-3 py-2">
-                          <ServerModelCell
-                            server={server.name}
-                            declaredModel={declaredServerModels[server.name]}
-                            defaultModel={defaultModel}
-                            effective={effectiveServerModels[server.name]}
-                            onSaved={setServerModelLocal}
-                            onOpenManager={() => setPricingManagerOpen(true)}
-                          />
-                        </td>
-                        <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(server.input)}</td>
-                        <td className="px-3 py-2 text-right text-primary tabular-nums">{formatCompactNumber(server.output)}</td>
-                        <td className="px-3 py-2 text-right text-text-primary font-semibold tabular-nums">{formatCompactNumber(server.total)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
+            <MetricsKpiRow kpis={kpis} />
+            <TokenChart data={chartData} metricsData={metricsData} />
+            <button
+              type="button"
+              onClick={() => navigate('/metrics')}
+              className="w-full flex items-center justify-center gap-1.5 rounded-lg border border-border/40 bg-background/40 py-2 text-[11px] font-medium text-text-secondary hover:text-text-primary hover:border-primary/40 transition-colors"
+            >
+              View all in Metrics
+              <ArrowRight size={12} />
+            </button>
           </div>
         )}
       </div>
-
-      {/* Click-away handler for clear confirm */}
-      {showClearConfirm && (
-        <div className="fixed inset-0 z-40" onClick={() => setShowClearConfirm(false)} />
-      )}
     </div>
-  );
-}
-
-// KPI Card component
-function KPICard({ label, value, colorClass }: { label: string; value: number; colorClass: string }) {
-  return (
-    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-      <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">{label}</span>
-      <span className={cn('text-lg font-bold tabular-nums', colorClass)}>{formatCompactNumber(value)}</span>
-    </div>
-  );
-}
-
-// CostKPICard — session USD spend. Renders an em-dash when the gateway
-// hasn't priced any calls yet (per the UX spec: never show a fabricated
-// number). The icon stays muted-by-default; the value carries the accent
-// so the card reads as "cost-flavored" without competing with the amber
-// Output KPI to its left. When no server has model attribution configured
-// (showHint), a one-line pointer explains how to enable estimates — without
-// it, cost can never populate and the dash/$0.00 reads as "free."
-function CostKPICard({
-  usd,
-  hasCost,
-  showHint,
-  showMixedNote,
-}: {
-  usd: number | undefined;
-  hasCost: boolean;
-  showHint?: boolean;
-  showMixedNote?: boolean;
-}) {
-  return (
-    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-      <span className="text-[10px] text-text-muted uppercase tracking-wider flex items-center gap-1 mb-1">
-        <DollarSign size={10} className="text-text-muted/70" />
-        Cost
-      </span>
-      <span
-        className={cn(
-          'text-lg font-bold tabular-nums',
-          hasCost ? 'text-emerald-400' : 'text-text-muted',
-        )}
-      >
-        {hasCost ? formatUSD(usd ?? 0) : '—'}
-      </span>
-      {showHint && (
-        <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
-          {ATTRIBUTION_HINT}
-        </span>
-      )}
-      {!showHint && showMixedNote && (
-        <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
-          {MIXED_PROVENANCE_NOTE}
-        </span>
-      )}
-    </div>
-  );
-}
-
-// PanelHeader wraps a labeled section with a thin header strip plus the
-// shared elevated-surface frame. Keeps the Top Clients panel visually
-// distinct from the per-server table without introducing a second
-// surface variant.
-function PanelHeader({
-  icon: Icon,
-  label,
-  children,
-}: {
-  icon: LucideIcon | ComponentType<{ size?: number; className?: string }>;
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 overflow-hidden">
-      <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border/30 bg-surface-highlight/30">
-        <Icon size={11} className="text-text-muted" />
-        <span className="text-[11px] font-medium text-text-secondary">{label}</span>
-      </div>
-      {children}
-    </div>
-  );
-}
-
-// Sortable table header
-function SortableHeader({
-  label,
-  column,
-  sortColumn,
-  sortDirection,
-  onSort,
-  align = 'left',
-}: {
-  label: string;
-  column: SortColumn;
-  sortColumn: SortColumn;
-  sortDirection: SortDirection;
-  onSort: (column: SortColumn) => void;
-  align?: 'left' | 'right';
-}) {
-  const isActive = sortColumn === column;
-  const SortIcon = isActive
-    ? sortDirection === 'asc' ? ArrowUp : ArrowDown
-    : ArrowUpDown;
-
-  return (
-    <th
-      className={cn(
-        'px-3 py-2 font-medium text-text-muted cursor-pointer hover:text-text-secondary transition-colors select-none',
-        align === 'right' && 'text-right'
-      )}
-      tabIndex={0}
-      role="columnheader"
-      aria-sort={isActive ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
-      onClick={() => onSort(column)}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSort(column); } }}
-    >
-      <span className="inline-flex items-center gap-1">
-        {label}
-        <SortIcon size={10} className={isActive ? 'text-primary' : 'text-text-muted/40'} />
-      </span>
-    </th>
-  );
-}
-
-// ClientSortableHeader — sibling of SortableHeader for the wider
-// ClientSortColumn type. A separate component keeps each table's sort
-// state strongly typed without forcing a generic header.
-function ClientSortableHeader({
-  label,
-  column,
-  sortColumn,
-  sortDirection,
-  onSort,
-  align = 'left',
-}: {
-  label: string;
-  column: ClientSortColumn;
-  sortColumn: ClientSortColumn;
-  sortDirection: SortDirection;
-  onSort: (column: ClientSortColumn) => void;
-  align?: 'left' | 'right';
-}) {
-  const isActive = sortColumn === column;
-  const SortIcon = isActive ? (sortDirection === 'asc' ? ArrowUp : ArrowDown) : ArrowUpDown;
-
-  return (
-    <th
-      className={cn(
-        'px-3 py-2 font-medium text-text-muted cursor-pointer hover:text-text-secondary transition-colors select-none',
-        align === 'right' && 'text-right'
-      )}
-      tabIndex={0}
-      role="columnheader"
-      aria-sort={isActive ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
-      onClick={() => onSort(column)}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSort(column); } }}
-    >
-      <span className="inline-flex items-center gap-1">
-        {label}
-        <SortIcon size={10} className={isActive ? 'text-primary' : 'text-text-muted/40'} />
-      </span>
-    </th>
   );
 }

--- a/web/src/components/metrics/metricsData.ts
+++ b/web/src/components/metrics/metricsData.ts
@@ -1,0 +1,172 @@
+// Pure data helpers and types for the metrics surfaces. Kept JSX-free and
+// separate from metricsShared.tsx so Fast Refresh stays happy (a file may not
+// export both components and plain functions). The bottom glance tab, the
+// Metrics workspace, and the detached window all derive their numbers here so
+// cost/token math is defined exactly once.
+import type {
+  CostUsage,
+  EffectiveModel,
+  ModelShare,
+  TokenMetricsResponse,
+  CostMetricsResponse,
+  TokenUsage,
+} from '../../types';
+
+export type SortDirection = 'asc' | 'desc';
+// One sort vocabulary for both the client and server breakdown tables. Servers
+// simply omit the `cost` column in the classic surfaces, so the wider type is
+// harmless there.
+export type BreakdownSortColumn = 'name' | 'input' | 'output' | 'total' | 'cost';
+
+// A single row in a breakdown table. `cost` is optional: undefined means
+// pricing-unknown (rendered as an em-dash, never $0).
+export interface BreakdownRow {
+  name: string;
+  input: number;
+  output: number;
+  total: number;
+  cost?: number;
+}
+
+export function derivePerServerRows(
+  tokenUsage: TokenUsage | null,
+  costUsage?: CostUsage | null,
+): BreakdownRow[] {
+  if (!tokenUsage?.per_server) return [];
+  return Object.entries(tokenUsage.per_server).map(([name, counts]) => ({
+    name,
+    input: counts.input_tokens,
+    output: counts.output_tokens,
+    total: counts.total_tokens,
+    cost: costUsage?.per_server?.[name]?.total_usd,
+  }));
+}
+
+export function derivePerClientRows(
+  tokenUsage: TokenUsage | null,
+  costUsage: CostUsage | null,
+): BreakdownRow[] {
+  const tokenClients = tokenUsage?.per_client ?? {};
+  const costClients = costUsage?.per_client ?? {};
+  const names = new Set<string>([...Object.keys(tokenClients), ...Object.keys(costClients)]);
+  return Array.from(names).map((name) => ({
+    name,
+    input: tokenClients[name]?.input_tokens ?? 0,
+    output: tokenClients[name]?.output_tokens ?? 0,
+    total: tokenClients[name]?.total_tokens ?? 0,
+    cost: costClients[name]?.total_usd,
+  }));
+}
+
+export function sortBreakdownRows(
+  rows: BreakdownRow[],
+  column: BreakdownSortColumn,
+  direction: SortDirection,
+): BreakdownRow[] {
+  const dir = direction === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    if (column === 'name') return dir * a.name.localeCompare(b.name);
+    if (column === 'cost') {
+      // Unknown cost sinks on descending, floats on ascending.
+      const aCost = a.cost ?? -Infinity;
+      const bCost = b.cost ?? -Infinity;
+      return dir * (aCost - bCost);
+    }
+    return dir * (a[column] - b[column]);
+  });
+}
+
+export function buildTokenChartData(metricsData: TokenMetricsResponse | null) {
+  if (!metricsData?.data_points) return [];
+  return metricsData.data_points.map((dp) => ({
+    time: new Date(dp.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+    'Input Tokens': dp.input_tokens,
+    'Output Tokens': dp.output_tokens,
+  }));
+}
+
+export function buildCostChartData(costData: CostMetricsResponse | null) {
+  if (!costData?.data_points) return [];
+  return costData.data_points.map((dp) => ({
+    time: new Date(dp.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+    'Cost (USD)': dp.usd,
+  }));
+}
+
+// Aggregate a model→cost mix from the per-entity effective-model breakdowns.
+// Each EffectiveModel.models[] partitions that entity's recorded cost, so
+// summing across servers yields the global mix without double-counting (the
+// client breakdowns partition the SAME total — we use servers as the single
+// source, falling back to clients when no server traffic priced yet).
+export function aggregateModelMix(
+  effectiveServerModels: Record<string, EffectiveModel>,
+  effectiveClientModels: Record<string, EffectiveModel>,
+): ModelShare[] {
+  const sum = (source: Record<string, EffectiveModel>): Map<string, number> => {
+    const byModel = new Map<string, number>();
+    for (const em of Object.values(source)) {
+      for (const m of em.models ?? []) {
+        byModel.set(m.model, (byModel.get(m.model) ?? 0) + m.cost_usd);
+      }
+    }
+    return byModel;
+  };
+  let byModel = sum(effectiveServerModels);
+  if (byModel.size === 0) byModel = sum(effectiveClientModels);
+  const total = Array.from(byModel.values()).reduce((s, v) => s + v, 0);
+  if (total <= 0) return [];
+  return Array.from(byModel.entries())
+    .map(([model, cost_usd]) => ({ model, cost_usd, share: cost_usd / total }))
+    .sort((a, b) => b.cost_usd - a.cost_usd);
+}
+
+// Session-level KPI bundle, derived once and shared by every surface's KPI row.
+export interface SessionKpis {
+  input: number;
+  output: number;
+  total: number;
+  costUSD: number | undefined;
+  hasCost: boolean;
+  savingsPercent: number;
+  savedTokens: number;
+  showAttributionHint: boolean;
+  hasMixedProvenance: boolean;
+}
+
+export function deriveSessionKpis(
+  tokenUsage: TokenUsage | null,
+  costUsage: CostUsage | null,
+  costAttribution: boolean,
+  effectiveClientModels: Record<string, EffectiveModel>,
+  effectiveServerModels: Record<string, EffectiveModel>,
+): SessionKpis {
+  const costUSD = costUsage?.session.total_usd;
+  const hasCost = costUSD !== undefined;
+  const anyMixed = (m: Record<string, EffectiveModel>) =>
+    Object.values(m).some((e) => e.provenance === 'mixed');
+  return {
+    input: tokenUsage?.session.input_tokens ?? 0,
+    output: tokenUsage?.session.output_tokens ?? 0,
+    total: tokenUsage?.session.total_tokens ?? 0,
+    costUSD,
+    hasCost,
+    savingsPercent: tokenUsage?.format_savings.savings_percent ?? 0,
+    savedTokens: tokenUsage?.format_savings.saved_tokens ?? 0,
+    // Without attribution the gateway cannot price calls, so explain the
+    // config requirement instead of leaving a bare dash/$0.00.
+    showAttributionHint: !costAttribution && !(costUSD && costUSD > 0),
+    hasMixedProvenance: anyMixed(effectiveClientModels) || anyMixed(effectiveServerModels),
+  };
+}
+
+export function hasMetricsData(
+  kpis: SessionKpis,
+  metricsData: TokenMetricsResponse | null,
+  costData: CostMetricsResponse | null,
+): boolean {
+  return (
+    kpis.total > 0 ||
+    (metricsData?.data_points?.length ?? 0) > 0 ||
+    (costData?.data_points?.length ?? 0) > 0
+  );
+}

--- a/web/src/components/metrics/metricsShared.tsx
+++ b/web/src/components/metrics/metricsShared.tsx
@@ -1,0 +1,389 @@
+import { type ComponentType, type ReactNode } from 'react';
+import { ArrowDown, ArrowUp, ArrowUpDown, DollarSign } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { formatCompactNumber, formatUSD } from '../../lib/format';
+import { AreaChart } from '../chart/AreaChart';
+import { ATTRIBUTION_HINT, MIXED_PROVENANCE_NOTE } from '../pricing/constants';
+import { sharePct } from '../pricing/effectiveModel';
+import type { ModelShare, TokenMetricsResponse, CostMetricsResponse } from '../../types';
+import type {
+  BreakdownRow,
+  BreakdownSortColumn,
+  SessionKpis,
+  SortDirection,
+} from './metricsData';
+
+// Presentational atoms shared by every metrics surface (bottom glance tab,
+// Metrics workspace, detached window). Pure data helpers and types live in
+// metricsData.ts — this file is components only so Fast Refresh stays happy.
+
+// ---------------------------------------------------------------------------
+// KPI cards
+// ---------------------------------------------------------------------------
+
+export function KPICard({ label, value, colorClass }: { label: string; value: number; colorClass: string }) {
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
+      <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">{label}</span>
+      <span className={cn('text-lg font-bold tabular-nums', colorClass)}>{formatCompactNumber(value)}</span>
+    </div>
+  );
+}
+
+// CostKPICard — session USD spend. Renders an em-dash when nothing has been
+// priced yet (never a fabricated number). Cost is conveyed by the "$" icon and
+// the "Cost" label, not color alone. The honesty subline points at the config
+// requirement (showHint) or the mixed-provenance caveat.
+export function CostKPICard({
+  usd,
+  hasCost,
+  showHint,
+  showMixedNote,
+}: {
+  usd: number | undefined;
+  hasCost: boolean;
+  showHint?: boolean;
+  showMixedNote?: boolean;
+}) {
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
+      <span className="text-[10px] text-text-muted uppercase tracking-wider flex items-center gap-1 mb-1">
+        <DollarSign size={10} className="text-text-muted/70" />
+        Cost <span className="text-text-muted/50 normal-case tracking-normal">· est.</span>
+      </span>
+      <span className={cn('text-lg font-bold tabular-nums', hasCost ? 'text-emerald-400' : 'text-text-muted')}>
+        {hasCost ? formatUSD(usd ?? 0) : '—'}
+      </span>
+      {showHint && (
+        <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">{ATTRIBUTION_HINT}</span>
+      )}
+      {!showHint && showMixedNote && (
+        <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">{MIXED_PROVENANCE_NOTE}</span>
+      )}
+    </div>
+  );
+}
+
+export function FormatSavingsCard({ savingsPercent, savedTokens }: { savingsPercent: number; savedTokens: number }) {
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
+      <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Format Savings</span>
+      <div className="flex items-baseline gap-2">
+        <span className="text-lg font-bold text-status-running tabular-nums">{Math.round(savingsPercent)}%</span>
+        <span className="text-[10px] text-text-muted">{formatCompactNumber(savedTokens)} saved</span>
+      </div>
+      <div className="mt-2 h-1.5 rounded-full bg-surface-highlight overflow-hidden flex">
+        <div className="h-full bg-primary rounded-full" style={{ width: `${100 - savingsPercent}%` }} />
+        <div className="h-full bg-primary/20" style={{ width: `${savingsPercent}%` }} />
+      </div>
+    </div>
+  );
+}
+
+// The full session KPI grid, identical across surfaces.
+export function MetricsKpiRow({ kpis }: { kpis: SessionKpis }) {
+  return (
+    <div className={cn('grid gap-3', kpis.savingsPercent > 0 ? 'grid-cols-5' : 'grid-cols-4')}>
+      <KPICard label="Input Tokens" value={kpis.input} colorClass="text-secondary" />
+      <KPICard label="Output Tokens" value={kpis.output} colorClass="text-primary" />
+      <KPICard label="Total Tokens" value={kpis.total} colorClass="text-text-primary" />
+      <CostKPICard
+        usd={kpis.costUSD}
+        hasCost={kpis.hasCost}
+        showHint={kpis.showAttributionHint}
+        showMixedNote={kpis.hasMixedProvenance}
+      />
+      {kpis.savingsPercent > 0 && (
+        <FormatSavingsCard savingsPercent={kpis.savingsPercent} savedTokens={kpis.savedTokens} />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Charts (with screen-reader text alternatives)
+// ---------------------------------------------------------------------------
+
+type TokenPoint = { time: string; 'Input Tokens': number; 'Output Tokens': number };
+type CostPoint = { time: string; 'Cost (USD)': number };
+
+// Exposes a role="img" + aria-label summary, since the underlying Recharts SVG
+// has no accessible description. The breakdown tables remain the full data
+// fallback for assistive tech.
+function ChartFrame({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div role="img" aria-label={label}>
+      {children}
+    </div>
+  );
+}
+
+export function TokenChart({
+  data,
+  metricsData,
+  heightClass = 'h-36',
+}: {
+  data: TokenPoint[];
+  metricsData: TokenMetricsResponse | null;
+  heightClass?: string;
+}) {
+  const peak = data.reduce((m, d) => Math.max(m, d['Input Tokens'] + d['Output Tokens']), 0);
+  const summary = `Token usage over time: ${data.length} points, peak ${formatCompactNumber(peak)} tokens per interval.`;
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[11px] font-medium text-text-secondary">Token Usage Over Time</span>
+        {metricsData && (
+          <span className="text-[9px] text-text-muted font-mono">
+            {metricsData.data_points?.length ?? 0} points &middot; {metricsData.interval} interval
+          </span>
+        )}
+      </div>
+      <ChartFrame label={summary}>
+        <AreaChart
+          data={data}
+          index="time"
+          categories={['Input Tokens', 'Output Tokens']}
+          colors={['teal', 'amber']}
+          type="stacked"
+          fill="gradient"
+          showLegend
+          showGridLines
+          showYAxis
+          yAxisWidth={48}
+          valueFormatter={(v: number) => formatCompactNumber(v)}
+          className={heightClass}
+        />
+      </ChartFrame>
+    </div>
+  );
+}
+
+export function CostChart({
+  data,
+  costData,
+  heightClass = 'h-32',
+}: {
+  data: CostPoint[];
+  costData: CostMetricsResponse | null;
+  heightClass?: string;
+}) {
+  const peak = data.reduce((m, d) => Math.max(m, d['Cost (USD)']), 0);
+  const summary = `Estimated cost over time: ${data.length} points, peak ${formatUSD(peak)} per interval.`;
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[11px] font-medium text-text-secondary inline-flex items-center gap-1.5">
+          <DollarSign size={11} className="text-emerald-400" />
+          Cost Over Time
+        </span>
+        {costData && (
+          <span className="text-[9px] text-text-muted font-mono">
+            {costData.data_points?.length ?? 0} points &middot; {costData.interval} interval
+          </span>
+        )}
+      </div>
+      <ChartFrame label={summary}>
+        <AreaChart
+          data={data}
+          index="time"
+          categories={['Cost (USD)']}
+          colors={['emerald']}
+          type="default"
+          fill="gradient"
+          // Legend on so cost is labeled by text, not color alone.
+          showLegend
+          showGridLines
+          showYAxis
+          yAxisWidth={56}
+          valueFormatter={(v: number) => formatUSD(v)}
+          className={heightClass}
+        />
+      </ChartFrame>
+    </div>
+  );
+}
+
+// Ranked horizontal bars for the model-mix (preferred over pie/donut for many
+// categories). Each row is a model with its cost share, read as text + length.
+export function ModelMixBars({ mix }: { mix: ModelShare[] }) {
+  if (mix.length === 0) {
+    return (
+      <p className="px-3 py-3 text-[11px] text-text-muted/70 leading-relaxed">
+        No priced traffic yet. Declare a client, server, or default pricing model to populate the
+        model mix.
+      </p>
+    );
+  }
+  const max = mix[0]?.share ?? 1;
+  return (
+    <ul className="px-3 py-2 space-y-1.5" aria-label="Cost by model">
+      {mix.map((m) => (
+        <li key={m.model} className="flex items-center gap-2">
+          <span className="w-40 flex-shrink-0 truncate font-mono text-[10px] text-text-secondary" title={m.model}>
+            {m.model}
+          </span>
+          <span className="relative flex-1 h-3 rounded-sm bg-surface-highlight/40 overflow-hidden">
+            <span
+              className="absolute inset-y-0 left-0 rounded-sm bg-emerald-500/40"
+              style={{ width: `${max > 0 ? (m.share / max) * 100 : 0}%` }}
+            />
+          </span>
+          <span className="w-12 flex-shrink-0 text-right tabular-nums text-[10px] text-text-muted">
+            {sharePct(m.share)}
+          </span>
+          <span className="w-16 flex-shrink-0 text-right tabular-nums text-[10px] text-emerald-400/90">
+            {formatUSD(m.cost_usd)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Table primitives
+// ---------------------------------------------------------------------------
+
+export function PanelHeader({
+  icon: Icon,
+  label,
+  children,
+  right,
+}: {
+  icon: LucideIcon | ComponentType<{ size?: number; className?: string }>;
+  label: string;
+  children: ReactNode;
+  right?: ReactNode;
+}) {
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 overflow-hidden">
+      <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border/30 bg-surface-highlight/30">
+        <Icon size={11} className="text-text-muted" />
+        <span className="text-[11px] font-medium text-text-secondary">{label}</span>
+        {right && <span className="ml-auto">{right}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function SortableHeader({
+  label,
+  column,
+  sortColumn,
+  sortDirection,
+  onSort,
+  align = 'left',
+}: {
+  label: string;
+  column: BreakdownSortColumn;
+  sortColumn: BreakdownSortColumn;
+  sortDirection: SortDirection;
+  onSort: (column: BreakdownSortColumn) => void;
+  align?: 'left' | 'right';
+}) {
+  const isActive = sortColumn === column;
+  const SortIcon = isActive ? (sortDirection === 'asc' ? ArrowUp : ArrowDown) : ArrowUpDown;
+  return (
+    <th
+      className={cn(
+        'px-3 py-2 font-medium text-text-muted cursor-pointer hover:text-text-secondary transition-colors select-none',
+        align === 'right' && 'text-right',
+      )}
+      tabIndex={0}
+      role="columnheader"
+      aria-sort={isActive ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+      onClick={() => onSort(column)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSort(column);
+        }
+      }}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        <SortIcon size={10} className={isActive ? 'text-primary' : 'text-text-muted/40'} />
+      </span>
+    </th>
+  );
+}
+
+// BreakdownTable renders the shared client/server breakdown. Each host injects
+// a Model cell via `renderModel`, shows a Cost column when `showCost`, and may
+// make rows selectable (`onSelectRow` + `selectedName`) to drive a detail
+// inspector. The Model cell stops propagation so editing never selects the row.
+export function BreakdownTable({
+  rows,
+  nameLabel,
+  sortColumn,
+  sortDirection,
+  onSort,
+  renderModel,
+  showCost = false,
+  selectedName,
+  onSelectRow,
+}: {
+  rows: BreakdownRow[];
+  nameLabel: string;
+  sortColumn: BreakdownSortColumn;
+  sortDirection: SortDirection;
+  onSort: (column: BreakdownSortColumn) => void;
+  renderModel?: (row: BreakdownRow) => ReactNode;
+  showCost?: boolean;
+  selectedName?: string | null;
+  onSelectRow?: (name: string) => void;
+}) {
+  return (
+    <table className="w-full text-xs">
+      <thead>
+        <tr className="border-b border-border/30">
+          <SortableHeader label={nameLabel} column="name" sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+          {renderModel && (
+            <th className="px-3 py-1.5 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">Model</th>
+          )}
+          <SortableHeader label="Input" column="input" sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} align="right" />
+          <SortableHeader label="Output" column="output" sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} align="right" />
+          <SortableHeader label="Total" column="total" sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} align="right" />
+          {showCost && (
+            <SortableHeader label="Cost" column="cost" sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} align="right" />
+          )}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => {
+          const selected = selectedName === row.name;
+          return (
+            <tr
+              key={row.name}
+              aria-selected={onSelectRow ? selected : undefined}
+              onClick={onSelectRow ? () => onSelectRow(row.name) : undefined}
+              className={cn(
+                'border-b border-border/20 last:border-0 transition-colors',
+                onSelectRow && 'cursor-pointer',
+                selected ? 'bg-primary/[0.07]' : 'hover:bg-surface-highlight/30',
+              )}
+            >
+              <td className="px-3 py-2 font-medium text-text-primary font-mono">{row.name}</td>
+              {renderModel && (
+                <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
+                  {renderModel(row)}
+                </td>
+              )}
+              <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(row.input)}</td>
+              <td className="px-3 py-2 text-right text-primary tabular-nums">{formatCompactNumber(row.output)}</td>
+              <td className="px-3 py-2 text-right text-text-primary font-semibold tabular-nums">{formatCompactNumber(row.total)}</td>
+              {showCost && (
+                <td className={cn('px-3 py-2 text-right tabular-nums', row.cost === undefined ? 'text-text-muted' : 'text-emerald-400')}>
+                  {row.cost === undefined ? '—' : formatUSD(row.cost)}
+                </td>
+              )}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/web/src/components/workspaces/MetricsWorkspace.tsx
+++ b/web/src/components/workspaces/MetricsWorkspace.tsx
@@ -1,0 +1,503 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { BarChart3, Boxes, Layers, Server, Users } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useUIStore } from '../../stores/useUIStore';
+import { useStackStore } from '../../stores/useStackStore';
+import { useWindowManager } from '../../hooks/useWindowManager';
+import { useListNav } from '../../hooks/useListNav';
+import { useMetricsSeries, type MetricsTimeRange } from '../../hooks/useMetricsSeries';
+import { WorkspaceShell } from '../layout/WorkspaceShell';
+import { PopoutButton } from '../ui/PopoutButton';
+import { PersistedFromMarker } from '../telemetry/PersistedFromMarker';
+import { ClientModelCell } from '../pricing/ClientModelCell';
+import { ServerModelCell } from '../pricing/ServerModelCell';
+import { MetricsControls } from '../metrics/MetricsControls';
+import { MetricsInspector } from '../metrics/MetricsInspector';
+import {
+  MetricsKpiRow,
+  TokenChart,
+  CostChart,
+  PanelHeader,
+  BreakdownTable,
+  ModelMixBars,
+} from '../metrics/metricsShared';
+import {
+  aggregateModelMix,
+  buildTokenChartData,
+  buildCostChartData,
+  derivePerServerRows,
+  derivePerClientRows,
+  deriveSessionKpis,
+  hasMetricsData,
+  sortBreakdownRows,
+  type BreakdownRow,
+  type BreakdownSortColumn,
+  type SortDirection,
+} from '../metrics/metricsData';
+
+type Scope = 'overview' | 'clients' | 'servers' | 'models';
+const SCOPES: Scope[] = ['overview', 'clients', 'servers', 'models'];
+
+function isScope(v: string | null): v is Scope {
+  return v != null && (SCOPES as string[]).includes(v);
+}
+
+// MetricsWorkspace is the first-class cost/token observability surface, sibling
+// to Topology, Library, Variables, and Tools. The left rail is a scope
+// navigator (overview / clients / servers / models); the center carries the
+// session KPI row, the trend charts, and the active scope's breakdown; the
+// right rail inspects the selected client or server (and hosts its inline
+// pricing-model editor). Scope and selection are URL-synced so reload and
+// deep-links survive. The full dashboard body is shared with the bottom
+// glance tab and the detached window via metricsShared.
+export function MetricsWorkspace() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const compact = useUIStore((s) => s.compactMode.metrics);
+  const setPricingManagerOpen = useUIStore((s) => s.setPricingManagerOpen);
+  const metricsDetached = useUIStore((s) => s.metricsDetached);
+
+  const tokenUsage = useStackStore((s) => s.tokenUsage);
+  const costUsage = useStackStore((s) => s.costUsage);
+  const costAttribution = useStackStore((s) => s.costAttribution);
+  const clientModels = useStackStore((s) => s.clientModels);
+  const effectiveClientModels = useStackStore((s) => s.effectiveClientModels);
+  const effectiveServerModels = useStackStore((s) => s.effectiveServerModels);
+  const mcpServers = useStackStore((s) => s.mcpServers);
+  const defaultModel = useStackStore((s) => s.defaultModel);
+  const setClientModelLocal = useStackStore((s) => s.setClientModelLocal);
+  const setServerModelLocal = useStackStore((s) => s.setServerModelLocal);
+
+  const { openDetachedWindow } = useWindowManager();
+
+  const [timeRange, setTimeRange] = useState<MetricsTimeRange>('live');
+  const [isPaused, setIsPaused] = useState(false);
+  const [serverSort, setServerSort] = useState<{ col: BreakdownSortColumn; dir: SortDirection }>({ col: 'total', dir: 'desc' });
+  const [clientSort, setClientSort] = useState<{ col: BreakdownSortColumn; dir: SortDirection }>({ col: 'cost', dir: 'desc' });
+  // Polite announcement for range/refresh, read by screen readers.
+  const [liveMsg, setLiveMsg] = useState('');
+
+  const { metricsData, costData, isLoading, error, reload, clear } = useMetricsSeries({
+    timeRange,
+    paused: isPaused,
+    perClient: true,
+  });
+
+  // ---- URL state ----------------------------------------------------------
+  const scope: Scope = isScope(searchParams.get('scope')) ? (searchParams.get('scope') as Scope) : 'overview';
+  const selected = searchParams.get('selected');
+
+  const setScope = useCallback(
+    (next: Scope) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          if (next === 'overview') params.delete('scope');
+          else params.set('scope', next);
+          // Selection is scope-local — drop it when the axis changes.
+          params.delete('selected');
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const setSelected = useCallback(
+    (name: string | null) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          if (name) params.set('selected', name);
+          else params.delete('selected');
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  // ---- Derived data -------------------------------------------------------
+  const kpis = deriveSessionKpis(tokenUsage, costUsage, costAttribution, effectiveClientModels, effectiveServerModels);
+  const chartData = useMemo(() => buildTokenChartData(metricsData), [metricsData]);
+  const costChartData = useMemo(() => buildCostChartData(costData), [costData]);
+  const costSeriesHasData = costChartData.some((d) => d['Cost (USD)'] > 0);
+  const hasData = hasMetricsData(kpis, metricsData, costData);
+
+  const declaredServerModels = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const s of mcpServers) if (s.model) out[s.name] = s.model;
+    return out;
+  }, [mcpServers]);
+
+  const serverRows = useMemo(
+    () => sortBreakdownRows(derivePerServerRows(tokenUsage, costUsage), serverSort.col, serverSort.dir),
+    [tokenUsage, costUsage, serverSort],
+  );
+  const clientRows = useMemo(
+    () => sortBreakdownRows(derivePerClientRows(tokenUsage, costUsage), clientSort.col, clientSort.dir),
+    [tokenUsage, costUsage, clientSort],
+  );
+  const modelMix = useMemo(
+    () => aggregateModelMix(effectiveServerModels, effectiveClientModels),
+    [effectiveServerModels, effectiveClientModels],
+  );
+
+  // Rows for the active selectable scope (clients/servers), used by the
+  // inspector lookup and keyboard navigation.
+  const activeRows: BreakdownRow[] = useMemo(
+    () => (scope === 'servers' ? serverRows : scope === 'clients' ? clientRows : []),
+    [scope, serverRows, clientRows],
+  );
+  const selectedRow = useMemo(
+    () => activeRows.find((r) => r.name === selected) ?? null,
+    [activeRows, selected],
+  );
+
+  // Keyboard nav over the active breakdown (clients/servers only).
+  const selectedIndex = useMemo(
+    () => activeRows.findIndex((r) => r.name === selected),
+    [activeRows, selected],
+  );
+  useListNav({
+    itemCount: activeRows.length,
+    selectedIndex,
+    setSelectedIndex: (i) => {
+      const next = activeRows[i];
+      if (next) setSelected(next.name);
+    },
+    enabled: scope === 'clients' || scope === 'servers',
+  });
+
+  const sortServers = (col: BreakdownSortColumn) =>
+    setServerSort((s) => (s.col === col ? { col, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { col, dir: 'desc' }));
+  const sortClients = (col: BreakdownSortColumn) =>
+    setClientSort((s) => (s.col === col ? { col, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { col, dir: 'desc' }));
+
+  // ---- Inspector wiring ---------------------------------------------------
+  const inspectorScope = scope === 'servers' ? 'servers' : 'clients';
+  const inspectorTokenPoints =
+    selectedRow && scope === 'servers' ? metricsData?.per_server?.[selectedRow.name] : undefined;
+  const inspectorCostPoints =
+    selectedRow && scope === 'servers'
+      ? costData?.per_server?.[selectedRow.name]
+      : selectedRow && scope === 'clients'
+        ? costData?.per_client?.[selectedRow.name]
+        : undefined;
+  const inspectorDeclared =
+    scope === 'servers' ? declaredServerModels[selectedRow?.name ?? ''] : clientModels[selectedRow?.name ?? ''];
+  const inspectorEffective =
+    scope === 'servers'
+      ? effectiveServerModels[selectedRow?.name ?? '']
+      : effectiveClientModels[selectedRow?.name ?? ''];
+
+  const inspector = (
+    <MetricsInspector
+      scope={inspectorScope}
+      row={scope === 'clients' || scope === 'servers' ? selectedRow : null}
+      effective={inspectorEffective}
+      declaredModel={inspectorDeclared}
+      defaultModel={defaultModel}
+      costAttribution={costAttribution}
+      onClientSaved={setClientModelLocal}
+      onServerSaved={setServerModelLocal}
+      onOpenManager={() => setPricingManagerOpen(true)}
+      onClose={() => setSelected(null)}
+      tokenPoints={inspectorTokenPoints}
+      costPoints={inspectorCostPoints}
+    />
+  );
+
+  const leftRail = (
+    <ScopeRail
+      compact={compact}
+      scope={scope}
+      onSelectScope={setScope}
+      clientCount={clientRows.length}
+      serverCount={serverRows.length}
+      modelCount={modelMix.length}
+    />
+  );
+
+  const onTimeRange = (r: MetricsTimeRange) => {
+    setTimeRange(r);
+    if (r === 'live') setIsPaused(false);
+    setLiveMsg(`Showing ${r === 'live' ? 'live' : r} metrics`);
+  };
+
+  return (
+    <div className="absolute inset-0 flex flex-col bg-background text-text-primary overflow-hidden">
+      <span className="sr-only" role="status" aria-live="polite">{liveMsg}</span>
+      <WorkspaceShell
+        workspace="metrics"
+        defaultLeftPct={20}
+        defaultRightPct={30}
+        left={leftRail}
+        right={inspector}
+        minLeftPx={200}
+        minRightPx={300}
+      >
+        <main className="flex flex-col h-full overflow-hidden">
+          <header
+            className={cn(
+              'flex-shrink-0 bg-surface/30 backdrop-blur-sm border-b border-border-subtle flex items-center justify-between gap-3 px-6',
+              compact ? 'py-2' : 'py-3',
+            )}
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="font-sans text-text-muted/60 text-[10px] uppercase tracking-[0.4em]">metrics</div>
+              <div className="font-mono text-[10px] text-text-muted truncate">
+                {kpis.total > 0 ? `${kpis.total.toLocaleString()} tokens` : 'no traffic yet'}
+              </div>
+            </div>
+            <MetricsControls
+              timeRange={timeRange}
+              onTimeRange={onTimeRange}
+              isPaused={isPaused}
+              onTogglePause={() => setIsPaused((p) => !p)}
+              onRefresh={() => {
+                reload();
+                setLiveMsg('Metrics refreshed');
+              }}
+              onClear={() => void clear()}
+              onOpenPricing={() => setPricingManagerOpen(true)}
+              right={<PopoutButton onClick={() => openDetachedWindow('metrics')} disabled={metricsDetached} />}
+            />
+          </header>
+
+          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark px-6 py-4">
+            {/* Mutually exclusive states: error → first-load skeleton (only when
+                nothing is showable yet) → empty → data. Store totals make
+                hasData true even before the series lands, so the data view wins
+                over the skeleton once any traffic exists. */}
+            {error && !isLoading && (
+              <ErrorState message={error} onRetry={reload} />
+            )}
+
+            {!error && !hasData && isLoading && !metricsData && <LoadingState />}
+
+            {!error && !hasData && !(isLoading && !metricsData) && (
+              <MetricsEmptyState onOpenPricing={() => setPricingManagerOpen(true)} />
+            )}
+
+            {!error && hasData && (
+              <div className="space-y-4 max-w-5xl">
+                <PersistedFromMarker serverName={null} signal="metrics" />
+                <MetricsKpiRow kpis={kpis} />
+                <div className="grid gap-4 xl:grid-cols-2">
+                  <TokenChart data={chartData} metricsData={metricsData} />
+                  {(kpis.hasCost || costSeriesHasData) && <CostChart data={costChartData} costData={costData} />}
+                </div>
+
+                {scope === 'overview' && (
+                  <PanelHeader icon={Layers} label="Cost by Model">
+                    <ModelMixBars mix={modelMix} />
+                  </PanelHeader>
+                )}
+
+                {scope === 'models' && (
+                  <PanelHeader icon={Layers} label="Cost by Model">
+                    <ModelMixBars mix={modelMix} />
+                  </PanelHeader>
+                )}
+
+                {scope === 'clients' && (
+                  <PanelHeader icon={Users} label="Top Clients">
+                    {clientRows.length > 0 ? (
+                      <BreakdownTable
+                        rows={clientRows}
+                        nameLabel="Client"
+                        sortColumn={clientSort.col}
+                        sortDirection={clientSort.dir}
+                        onSort={sortClients}
+                        showCost
+                        selectedName={selected}
+                        onSelectRow={setSelected}
+                        renderModel={(row) => (
+                          <ClientModelCell
+                            client={row.name}
+                            declaredModel={clientModels[row.name]}
+                            effective={effectiveClientModels[row.name]}
+                            costAttribution={costAttribution}
+                            onSaved={setClientModelLocal}
+                            onOpenManager={() => setPricingManagerOpen(true)}
+                          />
+                        )}
+                      />
+                    ) : (
+                      <EmptyScopeNote text="No per-client attribution yet. Calls carry a client identity once an MCP client connects." />
+                    )}
+                  </PanelHeader>
+                )}
+
+                {scope === 'servers' && (
+                  <PanelHeader icon={Server} label="Per-Server">
+                    {serverRows.length > 0 ? (
+                      <BreakdownTable
+                        rows={serverRows}
+                        nameLabel="Server"
+                        sortColumn={serverSort.col}
+                        sortDirection={serverSort.dir}
+                        onSort={sortServers}
+                        showCost
+                        selectedName={selected}
+                        onSelectRow={setSelected}
+                        renderModel={(row) => (
+                          <ServerModelCell
+                            server={row.name}
+                            declaredModel={declaredServerModels[row.name]}
+                            defaultModel={defaultModel}
+                            effective={effectiveServerModels[row.name]}
+                            onSaved={setServerModelLocal}
+                            onOpenManager={() => setPricingManagerOpen(true)}
+                          />
+                        )}
+                      />
+                    ) : (
+                      <EmptyScopeNote text="No per-server traffic recorded yet." />
+                    )}
+                  </PanelHeader>
+                )}
+              </div>
+            )}
+          </div>
+        </main>
+      </WorkspaceShell>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Left rail — scope navigator
+// ---------------------------------------------------------------------------
+
+interface ScopeRailProps {
+  compact: boolean;
+  scope: Scope;
+  onSelectScope: (s: Scope) => void;
+  clientCount: number;
+  serverCount: number;
+  modelCount: number;
+}
+
+function ScopeRail({ compact, scope, onSelectScope, clientCount, serverCount, modelCount }: ScopeRailProps) {
+  return (
+    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-r border-border-subtle">
+      <div className={cn('flex-shrink-0 px-3 border-b border-border-subtle/60', compact ? 'py-2' : 'py-3')}>
+        <div className="text-[10px] font-medium text-text-muted/60 uppercase tracking-[0.3em]">breakdown</div>
+      </div>
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark px-2 py-2 space-y-0.5">
+        <ScopePill label="Overview" icon={BarChart3} active={scope === 'overview'} onClick={() => onSelectScope('overview')} />
+        <ScopePill label="Clients" icon={Users} count={clientCount} active={scope === 'clients'} onClick={() => onSelectScope('clients')} />
+        <ScopePill label="Servers" icon={Server} count={serverCount} active={scope === 'servers'} onClick={() => onSelectScope('servers')} />
+        <ScopePill label="Models" icon={Boxes} count={modelCount} active={scope === 'models'} onClick={() => onSelectScope('models')} />
+      </div>
+    </aside>
+  );
+}
+
+function ScopePill({
+  label,
+  icon: Icon,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  icon: LucideIcon;
+  count?: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-current={active}
+      className={cn(
+        'group w-full flex items-center gap-2 px-3 py-1.5 rounded-md text-left transition-colors',
+        active ? 'bg-primary/10 text-primary' : 'text-text-secondary hover:bg-surface-highlight/50 hover:text-text-primary',
+      )}
+    >
+      <Icon size={13} className={active ? 'text-primary' : 'text-text-muted'} aria-hidden="true" />
+      <span className={cn('flex-1 min-w-0 text-xs font-medium truncate', active && 'text-primary')}>{label}</span>
+      {count !== undefined && (
+        <span
+          className={cn(
+            'flex-shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded tabular-nums',
+            active ? 'bg-primary/15 text-primary' : 'bg-surface-elevated text-text-muted',
+          )}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// States
+// ---------------------------------------------------------------------------
+
+function EmptyScopeNote({ text }: { text: string }) {
+  return <p className="px-3 py-3 text-[11px] text-text-muted/70 leading-relaxed">{text}</p>;
+}
+
+function LoadingState() {
+  return (
+    <div className="space-y-4 max-w-5xl animate-pulse">
+      <div className="grid grid-cols-4 gap-3">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="h-16 rounded-lg bg-surface-elevated/60 border border-border/30" />
+        ))}
+      </div>
+      <div className="grid gap-4 xl:grid-cols-2">
+        <div className="h-44 rounded-lg bg-surface-elevated/60 border border-border/30" />
+        <div className="h-44 rounded-lg bg-surface-elevated/60 border border-border/30" />
+      </div>
+    </div>
+  );
+}
+
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-3">
+      <span className="text-xs text-status-error">{message}</span>
+      <button onClick={onRetry} className="text-xs text-primary hover:underline">
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function MetricsEmptyState({ onOpenPricing }: { onOpenPricing: () => void }) {
+  return (
+    <div className="h-full flex items-center justify-center px-6 py-12">
+      <div className="max-w-md w-full text-center space-y-5 animate-fade-in-scale">
+        <div className="relative mx-auto w-16 h-16">
+          <div className="absolute inset-0 rounded-2xl bg-primary/10 border border-primary/20 flex items-center justify-center">
+            <BarChart3 size={26} className="text-primary/70" />
+          </div>
+          <div className="absolute -inset-2 rounded-3xl bg-primary/5 blur-2xl -z-10" />
+        </div>
+        <div className="space-y-1.5">
+          <h2 className="text-base font-semibold text-text-primary">Your metrics home</h2>
+          <p className="text-xs text-text-muted leading-relaxed">
+            Token usage appears here after the first tool call. Estimated cost needs a pricing model:
+            declare one per client or server, or set a gateway default.
+          </p>
+        </div>
+        <button
+          onClick={onOpenPricing}
+          className="inline-flex items-center gap-1.5 px-4 py-2 text-xs font-semibold rounded-lg bg-gradient-to-r from-primary to-primary-dark text-background shadow-[0_1px_12px_rgba(245,158,11,0.3)] hover:shadow-[0_2px_18px_rgba(245,158,11,0.4)] hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200"
+        >
+          Edit pricing models
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default MetricsWorkspace;

--- a/web/src/hooks/useGlobalCommands.tsx
+++ b/web/src/hooks/useGlobalCommands.tsx
@@ -111,8 +111,8 @@ export function useGlobalCommands({ onRefresh }: GlobalCommandsOptions = {}) {
         label: 'Open Metrics',
         section: 'global',
         icon: <BarChart2 size={14} />,
-        keywords: ['metrics', 'stats', 'tokens', 'usage', 'charts', 'open'],
-        onSelect: () => setBottomPanelTab('metrics'),
+        keywords: ['metrics', 'stats', 'tokens', 'usage', 'cost', 'charts', 'dashboard', 'open'],
+        onSelect: () => navigate('/metrics'),
       },
       {
         id: 'navigate:spec',

--- a/web/src/hooks/useMetricsSeries.ts
+++ b/web/src/hooks/useMetricsSeries.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchTokenMetrics, fetchCostMetrics, clearTokenMetrics } from '../lib/api';
+import { POLLING } from '../lib/constants';
+import type { TokenMetricsResponse, CostMetricsResponse } from '../types';
+
+export type MetricsTimeRange = 'live' | '1h' | '6h' | '24h' | '7d';
+
+export const METRICS_TIME_RANGES: { value: MetricsTimeRange; label: string }[] = [
+  { value: 'live', label: 'Live' },
+  { value: '1h', label: '1h' },
+  { value: '6h', label: '6h' },
+  { value: '24h', label: '24h' },
+  { value: '7d', label: '7d' },
+];
+
+// Map a UI range to the backend `range` param. "live" reads the last 30m and
+// pairs with the auto-refresh below.
+export function apiRangeFor(range: MetricsTimeRange): string {
+  return range === 'live' ? '30m' : range;
+}
+
+interface UseMetricsSeriesArgs {
+  timeRange: MetricsTimeRange;
+  // Gates fetching entirely (e.g. the bottom tab only loads while visible).
+  enabled?: boolean;
+  // Suspends the live auto-refresh without unmounting.
+  paused?: boolean;
+  // Request per-client cost buckets too (drives the workspace inspector's
+  // per-client cost sparkline). Off by default — the glance surfaces don't
+  // need it.
+  perClient?: boolean;
+}
+
+interface UseMetricsSeriesResult {
+  metricsData: TokenMetricsResponse | null;
+  costData: CostMetricsResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  reload: () => void;
+  clear: () => Promise<void>;
+}
+
+// useMetricsSeries owns the token + cost time-series polling shared by the
+// bottom Metrics tab, the Metrics workspace, and the detached window. It does
+// NOT own the real-time status snapshot (tokenUsage / costUsage / models) —
+// those come from the app store in-shell, or a local status poll in the
+// detached window. Both series are fetched on one cycle (Promise.allSettled)
+// so a transient failure of one endpoint never drops the other's data.
+export function useMetricsSeries({
+  timeRange,
+  enabled = true,
+  paused = false,
+  perClient = false,
+}: UseMetricsSeriesArgs): UseMetricsSeriesResult {
+  const [metricsData, setMetricsData] = useState<TokenMetricsResponse | null>(null);
+  const [costData, setCostData] = useState<CostMetricsResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const intervalRef = useRef<number | null>(null);
+
+  const apiRange = apiRangeFor(timeRange);
+
+  // No synchronous setState here: the first statement awaits, so callers
+  // (including the mount/range effect) never trigger a cascading render. The
+  // skeleton is gated on `!metricsData`, so once data lands it never reappears
+  // on a background refresh anyway; explicit reloads flip the flag themselves.
+  const loadMetrics = useCallback(async () => {
+    try {
+      const [tokenResult, costResult] = await Promise.allSettled([
+        fetchTokenMetrics(apiRange),
+        fetchCostMetrics(apiRange, perClient),
+      ]);
+      if (tokenResult.status === 'fulfilled') setMetricsData(tokenResult.value);
+      if (costResult.status === 'fulfilled') setCostData(costResult.value);
+      const firstFailure =
+        (tokenResult.status === 'rejected' && tokenResult.reason) ||
+        (costResult.status === 'rejected' && costResult.reason);
+      if (firstFailure) {
+        setError(firstFailure instanceof Error ? firstFailure.message : 'Failed to fetch metrics');
+      } else {
+        setError(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch metrics');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [apiRange, perClient]);
+
+  // Fetch on mount/enable and whenever the range changes. loadMetrics flips the
+  // loading flag itself, so the effect body stays free of synchronous setState.
+  useEffect(() => {
+    if (!enabled) return;
+    void loadMetrics();
+  }, [enabled, loadMetrics]);
+
+  // Auto-refresh while live and not paused.
+  useEffect(() => {
+    if (!enabled || paused || timeRange !== 'live') {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      return;
+    }
+    intervalRef.current = window.setInterval(() => void loadMetrics(), POLLING.METRICS);
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [enabled, paused, timeRange, loadMetrics]);
+
+  const reload = useCallback(() => {
+    void loadMetrics();
+  }, [loadMetrics]);
+
+  const clear = useCallback(async () => {
+    await clearTokenMetrics();
+    setMetricsData(null);
+    setCostData(null);
+    setIsLoading(true);
+    void loadMetrics();
+  }, [loadMetrics]);
+
+  return { metricsData, costData, isLoading, error, reload, clear };
+}

--- a/web/src/hooks/useWindowManager.ts
+++ b/web/src/hooks/useWindowManager.ts
@@ -11,11 +11,13 @@ const WINDOW_TITLES: Record<string, string> = {
   traces: 'Gridctl - Traces',
 };
 
-// The `registry` window type points at /library-window after the workspace
-// promotion; other types render at /<type>. Keeping the type key as
-// `registry` avoids churning every call-site and stored detached state.
+// Window types whose detached route differs from the default /<type>. Both
+// `registry` and `metrics` had their /<type> path claimed by an in-shell
+// workspace; the popout moves aside while the type key stays put, so no
+// call-site, broadcast channel, or stored detached state has to change.
 const WINDOW_PATHS: Record<string, string> = {
   registry: '/library-window',
+  metrics: '/metrics-window',
 };
 
 type DetachableWindow = 'logs' | 'sidebar' | 'editor' | 'registry' | 'metrics' | 'traces';

--- a/web/src/pages/DetachedMetricsPage.tsx
+++ b/web/src/pages/DetachedMetricsPage.tsx
@@ -1,34 +1,28 @@
-import { useEffect, useState, useCallback, Component, type ComponentType, type ReactNode } from 'react';
-import {
-  BarChart3,
-  AlertCircle,
-  Maximize2,
-  Minimize2,
-  DollarSign,
-  Users,
-} from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
-import { cn } from '../lib/cn';
+import { useEffect, useState, useCallback, Component, type ReactNode } from 'react';
+import { BarChart3, AlertCircle, Maximize2, Minimize2, Users, Server } from 'lucide-react';
 import { IconButton } from '../components/ui/IconButton';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
-import { fetchStatus, fetchTokenMetrics, fetchCostMetrics, clearTokenMetrics } from '../lib/api';
+import { fetchStatus } from '../lib/api';
 import { formatCompactNumber, formatUSD } from '../lib/format';
 import { POLLING } from '../lib/constants';
-import { AreaChart } from '../components/chart/AreaChart';
 import { ClientModelCell } from '../components/pricing/ClientModelCell';
 import { ServerModelCell } from '../components/pricing/ServerModelCell';
 import { PricingManagerSlideOver } from '../components/pricing/PricingManagerSlideOver';
-import { ATTRIBUTION_HINT, MIXED_PROVENANCE_NOTE } from '../components/pricing/constants';
-import type { GatewayStatus, TokenMetricsResponse, CostMetricsResponse, TokenUsage, CostUsage, EffectiveModel } from '../types';
+import { useMetricsSeries, type MetricsTimeRange } from '../hooks/useMetricsSeries';
+import { MetricsControls } from '../components/metrics/MetricsControls';
+import { MetricsKpiRow, TokenChart, CostChart, PanelHeader, BreakdownTable } from '../components/metrics/metricsShared';
 import {
-  Pause,
-  Play,
-  Trash2,
-  RefreshCw,
-  ArrowUpDown,
-  ArrowUp,
-  ArrowDown,
-} from 'lucide-react';
+  buildTokenChartData,
+  buildCostChartData,
+  derivePerServerRows,
+  derivePerClientRows,
+  deriveSessionKpis,
+  hasMetricsData,
+  sortBreakdownRows,
+  type BreakdownSortColumn,
+  type SortDirection,
+} from '../components/metrics/metricsData';
+import type { GatewayStatus, TokenUsage, CostUsage, EffectiveModel } from '../types';
 
 // Error boundary for detached window
 interface ErrorBoundaryState {
@@ -72,20 +66,10 @@ class DetachedErrorBoundary extends Component<{ children: ReactNode }, ErrorBoun
   }
 }
 
-type TimeRange = 'live' | '1h' | '6h' | '24h' | '7d';
-type SortColumn = 'name' | 'input' | 'output' | 'total';
-type SortDirection = 'asc' | 'desc';
-type ClientSortColumn = 'name' | 'input' | 'output' | 'total' | 'cost';
-
-const TIME_RANGES: { value: TimeRange; label: string }[] = [
-  { value: 'live', label: 'Live' },
-  { value: '1h', label: '1h' },
-  { value: '6h', label: '6h' },
-  { value: '24h', label: '24h' },
-  { value: '7d', label: '7d' },
-];
-
 function DetachedMetricsPageContent() {
+  // Real-time status snapshot — the detached window lives outside the app
+  // shell, so it owns its own status poll (the in-shell surfaces read the app
+  // store instead). The time-series come from the shared useMetricsSeries hook.
   const [tokenUsage, setTokenUsage] = useState<TokenUsage | null>(null);
   const [costUsage, setCostUsage] = useState<CostUsage | null>(null);
   const [costAttribution, setCostAttribution] = useState(false);
@@ -96,22 +80,20 @@ function DetachedMetricsPageContent() {
   const [serverNames, setServerNames] = useState<string[]>([]);
   const [defaultModel, setDefaultModel] = useState('');
   const [pricingManagerOpen, setPricingManagerOpen] = useState(false);
-  const [timeRange, setTimeRange] = useState<TimeRange>('live');
+  const [timeRange, setTimeRange] = useState<MetricsTimeRange>('live');
   const [isPaused, setIsPaused] = useState(false);
-  const [metricsData, setMetricsData] = useState<TokenMetricsResponse | null>(null);
-  const [costData, setCostData] = useState<CostMetricsResponse | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [showClearConfirm, setShowClearConfirm] = useState(false);
-  const [sortColumn, setSortColumn] = useState<SortColumn>('total');
+  const [sortColumn, setSortColumn] = useState<BreakdownSortColumn>('total');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
-  const [clientSortColumn, setClientSortColumn] = useState<ClientSortColumn>('cost');
+  const [clientSortColumn, setClientSortColumn] = useState<BreakdownSortColumn>('cost');
   const [clientSortDirection, setClientSortDirection] = useState<SortDirection>('desc');
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   useDetachedWindowSync('metrics');
 
-  const apiRange = timeRange === 'live' ? '30m' : timeRange;
+  const { metricsData, costData, isLoading, error, reload, clear } = useMetricsSeries({
+    timeRange,
+    paused: isPaused,
+  });
 
   // Poll status for real-time token + cost usage
   useEffect(() => {
@@ -141,69 +123,17 @@ function DetachedMetricsPageContent() {
     return () => clearInterval(interval);
   }, []);
 
-  const loadMetrics = useCallback(async () => {
-    try {
-      const [tokenResult, costResult] = await Promise.allSettled([
-        fetchTokenMetrics(apiRange),
-        fetchCostMetrics(apiRange),
-      ]);
-      if (tokenResult.status === 'fulfilled') setMetricsData(tokenResult.value);
-      if (costResult.status === 'fulfilled') setCostData(costResult.value);
-      const firstFailure =
-        (tokenResult.status === 'rejected' && tokenResult.reason) ||
-        (costResult.status === 'rejected' && costResult.reason);
-      if (firstFailure) {
-        setError(firstFailure instanceof Error ? firstFailure.message : 'Failed to fetch metrics');
-      } else {
-        setError(null);
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch metrics');
-    } finally {
-      setIsLoading(false);
-    }
-  }, [apiRange]);
-
-  // Fetch on mount and range change
-  useEffect(() => {
-    setIsLoading(true);
-    loadMetrics();
-  }, [apiRange, loadMetrics]);
-
-  // Auto-refresh in live mode
-  useEffect(() => {
-    if (isPaused || timeRange !== 'live') return;
-
-    const interval = window.setInterval(loadMetrics, POLLING.METRICS);
-    return () => clearInterval(interval);
-  }, [isPaused, timeRange, loadMetrics]);
-
-  const handleClearMetrics = async () => {
-    try {
-      await clearTokenMetrics();
-      setMetricsData(null);
-      setCostData(null);
-      setShowClearConfirm(false);
-      setIsLoading(true);
-      loadMetrics();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to clear metrics');
-    }
-  };
-
-  const handleSort = (column: SortColumn) => {
-    if (sortColumn === column) {
-      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
-    } else {
+  const handleSort = (column: BreakdownSortColumn) => {
+    if (sortColumn === column) setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else {
       setSortColumn(column);
       setSortDirection('desc');
     }
   };
 
-  const handleClientSort = (column: ClientSortColumn) => {
-    if (clientSortColumn === column) {
-      setClientSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
-    } else {
+  const handleClientSort = (column: BreakdownSortColumn) => {
+    if (clientSortColumn === column) setClientSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else {
       setClientSortColumn(column);
       setClientSortDirection('desc');
     }
@@ -211,8 +141,7 @@ function DetachedMetricsPageContent() {
 
   // Optimistic local updates after a successful model save. The detached
   // window owns local state (not the main window's store); the next status
-  // poll confirms from the backend, and the main window catches up on its
-  // own poll.
+  // poll confirms from the backend, and the main window catches up on its own.
   const handleClientModelSaved = useCallback((client: string, model: string) => {
     setClientModels((prev) => {
       const next = { ...prev };
@@ -235,81 +164,23 @@ function DetachedMetricsPageContent() {
     setDefaultModel(model);
   }, []);
 
-  // Per-server data
-  const perServerEntries = tokenUsage?.per_server
-    ? Object.entries(tokenUsage.per_server).map(([name, counts]) => ({
-        name,
-        input: counts.input_tokens,
-        output: counts.output_tokens,
-        total: counts.total_tokens,
-      }))
-    : [];
-
-  const sortedServers = [...perServerEntries].sort((a, b) => {
-    const dir = sortDirection === 'asc' ? 1 : -1;
-    if (sortColumn === 'name') return dir * a.name.localeCompare(b.name);
-    return dir * (a[sortColumn] - b[sortColumn]);
-  });
-
-  const sessionInput = tokenUsage?.session.input_tokens ?? 0;
-  const sessionOutput = tokenUsage?.session.output_tokens ?? 0;
-  const sessionTotal = tokenUsage?.session.total_tokens ?? 0;
-  const savingsPercent = tokenUsage?.format_savings.savings_percent ?? 0;
-  const savedTokens = tokenUsage?.format_savings.saved_tokens ?? 0;
-  const sessionCostUSD = costUsage?.session.total_usd;
-  const hasCost = sessionCostUSD !== undefined;
-  // Mirrors MetricsTab: without model attribution the gateway cannot price
-  // calls, so explain the config requirement instead of a bare dash/$0.00.
-  const showAttributionHint = !costAttribution && !(sessionCostUSD && sessionCostUSD > 0);
-  const hasMixedProvenance =
-    Object.values(effectiveClientModels).some((e) => e.provenance === 'mixed') ||
-    Object.values(effectiveServerModels).some((e) => e.provenance === 'mixed');
-  const hasData =
-    sessionTotal > 0 ||
-    (metricsData?.data_points?.length ?? 0) > 0 ||
-    (costData?.data_points?.length ?? 0) > 0;
-
-  const chartData = metricsData?.data_points
-    ? metricsData.data_points.map((dp) => ({
-        time: new Date(dp.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-        "Input Tokens": dp.input_tokens,
-        "Output Tokens": dp.output_tokens,
-      }))
-    : [];
-
-  const costChartData = costData?.data_points
-    ? costData.data_points.map((dp) => ({
-        time: new Date(dp.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-        "Cost (USD)": dp.usd,
-      }))
-    : [];
-
+  const kpis = deriveSessionKpis(
+    tokenUsage,
+    costUsage,
+    costAttribution,
+    effectiveClientModels,
+    effectiveServerModels,
+  );
+  const sortedServers = sortBreakdownRows(derivePerServerRows(tokenUsage), sortColumn, sortDirection);
+  const sortedClients = sortBreakdownRows(
+    derivePerClientRows(tokenUsage, costUsage),
+    clientSortColumn,
+    clientSortDirection,
+  );
+  const chartData = buildTokenChartData(metricsData);
+  const costChartData = buildCostChartData(costData);
   const costSeriesHasData = costChartData.some((d) => d['Cost (USD)'] > 0);
-
-  const tokenClients = tokenUsage?.per_client ?? {};
-  const costClients = costUsage?.per_client ?? {};
-  const clientNames = new Set<string>([...Object.keys(tokenClients), ...Object.keys(costClients)]);
-  const perClientRows = Array.from(clientNames).map((name) => {
-    const tokens = tokenClients[name];
-    const cost = costClients[name];
-    return {
-      name,
-      input: tokens?.input_tokens ?? 0,
-      output: tokens?.output_tokens ?? 0,
-      total: tokens?.total_tokens ?? 0,
-      cost: cost?.total_usd,
-    };
-  });
-  const sortedClients = [...perClientRows].sort((a, b) => {
-    const dir = clientSortDirection === 'asc' ? 1 : -1;
-    if (clientSortColumn === 'name') return dir * a.name.localeCompare(b.name);
-    if (clientSortColumn === 'cost') {
-      const aCost = a.cost ?? -Infinity;
-      const bCost = b.cost ?? -Infinity;
-      return dir * (aCost - bCost);
-    }
-    return dir * (a[clientSortColumn] - b[clientSortColumn]);
-  });
+  const hasData = hasMetricsData(kpis, metricsData, costData);
 
   const toggleFullscreen = async () => {
     if (!document.fullscreenElement) {
@@ -346,118 +217,37 @@ function DetachedMetricsPageContent() {
             <BarChart3 size={14} className="text-primary" />
           </div>
           <span className="text-sm font-semibold text-text-primary">Token Metrics</span>
-
-          {/* Time range selector */}
-          <div className="flex items-center bg-background/60 rounded-md border border-border/40 overflow-hidden ml-2">
-            {TIME_RANGES.map((range) => (
-              <button
-                key={range.value}
-                onClick={() => {
-                  setTimeRange(range.value);
-                  if (range.value === 'live') setIsPaused(false);
-                }}
-                className={cn(
-                  'px-2.5 py-1 text-[10px] font-medium transition-colors',
-                  timeRange === range.value
-                    ? 'bg-primary/15 text-primary'
-                    : 'text-text-muted hover:text-text-secondary hover:bg-surface-highlight/40'
-                )}
-              >
-                {range.label}
-              </button>
-            ))}
-          </div>
-
-          {timeRange === 'live' && !isPaused && (
-            <span className="flex items-center gap-1 text-[9px] text-status-running font-medium">
-              <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
-              Live
-            </span>
-          )}
-          {isPaused && (
-            <span className="text-[10px] px-2 py-0.5 bg-status-pending/15 text-status-pending rounded-full font-medium border border-status-pending/20">
-              Paused
-            </span>
-          )}
         </div>
 
-        <div className="flex items-center gap-1">
-          {timeRange === 'live' && (
+        <MetricsControls
+          timeRange={timeRange}
+          onTimeRange={(r) => {
+            setTimeRange(r);
+            if (r === 'live') setIsPaused(false);
+          }}
+          isPaused={isPaused}
+          onTogglePause={() => setIsPaused((p) => !p)}
+          onRefresh={reload}
+          onClear={() => void clear()}
+          onOpenPricing={() => setPricingManagerOpen(true)}
+          right={
             <IconButton
-              icon={isPaused ? Play : Pause}
-              onClick={() => setIsPaused(!isPaused)}
-              tooltip={isPaused ? 'Resume' : 'Pause'}
+              icon={isFullscreen ? Minimize2 : Maximize2}
+              onClick={toggleFullscreen}
+              tooltip={isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
               size="sm"
               variant="ghost"
-              className={isPaused ? 'text-status-running hover:text-status-running' : ''}
             />
-          )}
-          <IconButton
-            icon={RefreshCw}
-            onClick={() => { setIsLoading(true); loadMetrics(); }}
-            tooltip="Refresh"
-            size="sm"
-            variant="ghost"
-          />
-
-          {/* Clear metrics */}
-          <div className="relative">
-            <IconButton
-              icon={Trash2}
-              onClick={() => setShowClearConfirm(true)}
-              tooltip="Clear Metrics"
-              size="sm"
-              variant="ghost"
-              className="hover:text-status-error"
-            />
-            {showClearConfirm && (
-              <div className="absolute right-0 top-full mt-1 z-50 p-3 rounded-lg bg-surface-elevated border border-border/50 shadow-xl min-w-[220px]">
-                <p className="text-xs text-text-primary font-medium mb-2">Clear all token metrics?</p>
-                <p className="text-[10px] text-text-muted mb-3">This cannot be undone.</p>
-                <div className="flex items-center gap-2 justify-end">
-                  <button
-                    onClick={() => setShowClearConfirm(false)}
-                    className="px-2.5 py-1 text-[10px] font-medium rounded-md bg-surface-highlight text-text-secondary hover:text-text-primary transition-colors"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    onClick={handleClearMetrics}
-                    className="px-2.5 py-1 text-[10px] font-medium rounded-md bg-status-error/15 text-status-error hover:bg-status-error/25 transition-colors"
-                  >
-                    Clear
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-
-          <IconButton
-            icon={DollarSign}
-            onClick={() => setPricingManagerOpen(true)}
-            tooltip="Edit pricing models"
-            size="sm"
-            variant="ghost"
-          />
-
-          <div className="w-px h-4 bg-border/50 mx-1" />
-          <IconButton
-            icon={isFullscreen ? Minimize2 : Maximize2}
-            onClick={toggleFullscreen}
-            tooltip={isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
-            size="sm"
-            variant="ghost"
-          />
-        </div>
+          }
+        />
       </header>
 
       {/* Content */}
       <main className="flex-1 overflow-auto bg-background scrollbar-dark min-h-0 p-4">
-        {/* Loading skeleton */}
         {isLoading && !metricsData && (
           <div className="space-y-4 animate-pulse">
-            <div className="grid grid-cols-3 gap-3">
-              {[1, 2, 3].map((i) => (
+            <div className="grid grid-cols-4 gap-3">
+              {[1, 2, 3, 4].map((i) => (
                 <div key={i} className="h-16 rounded-lg bg-surface-elevated/60 border border-border/30" />
               ))}
             </div>
@@ -466,21 +256,16 @@ function DetachedMetricsPageContent() {
           </div>
         )}
 
-        {/* Error state */}
         {error && !isLoading && (
           <div className="flex flex-col items-center justify-center h-full gap-3">
             <AlertCircle size={24} className="text-status-error" />
             <span className="text-xs text-status-error">{error}</span>
-            <button
-              onClick={() => { setError(null); setIsLoading(true); loadMetrics(); }}
-              className="text-xs text-primary hover:underline"
-            >
+            <button onClick={reload} className="text-xs text-primary hover:underline">
               Retry
             </button>
           </div>
         )}
 
-        {/* Empty state */}
         {!isLoading && !error && !hasData && (
           <div className="flex flex-col items-center justify-center h-full text-text-muted gap-2">
             <BarChart3 size={32} className="text-text-muted/30" />
@@ -489,162 +274,57 @@ function DetachedMetricsPageContent() {
           </div>
         )}
 
-        {/* Data view */}
         {!error && hasData && (
           <div className="space-y-4">
-            {/* KPI Cards */}
-            <div className={cn('grid gap-3', savingsPercent > 0 ? 'grid-cols-5' : 'grid-cols-4')}>
-              <KPICard label="Input Tokens" value={sessionInput} colorClass="text-secondary" />
-              <KPICard label="Output Tokens" value={sessionOutput} colorClass="text-primary" />
-              <KPICard label="Total Tokens" value={sessionTotal} colorClass="text-text-primary" />
-              <CostKPICard usd={sessionCostUSD} hasCost={hasCost} showHint={showAttributionHint} showMixedNote={hasMixedProvenance} />
-              {savingsPercent > 0 && (
-                <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-                  <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Format Savings</span>
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-lg font-bold text-status-running tabular-nums">{Math.round(savingsPercent)}%</span>
-                    <span className="text-[10px] text-text-muted">{formatCompactNumber(savedTokens)} saved</span>
-                  </div>
-                  <div className="mt-2 h-1.5 rounded-full bg-surface-highlight overflow-hidden flex">
-                    <div className="h-full bg-primary rounded-full" style={{ width: `${100 - savingsPercent}%` }} />
-                    <div className="h-full bg-primary/20" style={{ width: `${savingsPercent}%` }} />
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Area Chart */}
-            <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-              <div className="flex items-center justify-between mb-1">
-                <span className="text-[11px] font-medium text-text-secondary">Token Usage Over Time</span>
-                {metricsData && (
-                  <span className="text-[9px] text-text-muted font-mono">
-                    {metricsData.data_points?.length ?? 0} points &middot; {metricsData.interval} interval
-                  </span>
-                )}
-              </div>
-              <AreaChart
-                data={chartData}
-                index="time"
-                categories={["Input Tokens", "Output Tokens"]}
-                colors={["teal", "amber"]}
-                type="stacked"
-                fill="gradient"
-                showLegend={true}
-                showGridLines={true}
-                showYAxis={true}
-                yAxisWidth={48}
-                valueFormatter={(v: number) => formatCompactNumber(v)}
-                className="h-48"
-              />
-            </div>
-
-            {(hasCost || costSeriesHasData) && (
-              <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-[11px] font-medium text-text-secondary inline-flex items-center gap-1.5">
-                    <DollarSign size={11} className="text-emerald-400" />
-                    Cost Over Time
-                  </span>
-                  {costData && (
-                    <span className="text-[9px] text-text-muted font-mono">
-                      {costData.data_points?.length ?? 0} points &middot; {costData.interval} interval
-                    </span>
-                  )}
-                </div>
-                <AreaChart
-                  data={costChartData}
-                  index="time"
-                  categories={["Cost (USD)"]}
-                  colors={["emerald"]}
-                  type="default"
-                  fill="gradient"
-                  showLegend={false}
-                  showGridLines={true}
-                  showYAxis={true}
-                  yAxisWidth={56}
-                  valueFormatter={(v: number) => formatUSD(v)}
-                  className="h-40"
-                />
-              </div>
+            <MetricsKpiRow kpis={kpis} />
+            <TokenChart data={chartData} metricsData={metricsData} heightClass="h-48" />
+            {(kpis.hasCost || costSeriesHasData) && (
+              <CostChart data={costChartData} costData={costData} heightClass="h-40" />
             )}
 
-            {/* Top Clients */}
             {sortedClients.length > 0 && (
               <PanelHeader icon={Users} label="Top Clients">
-                <table className="w-full text-xs">
-                  <thead>
-                    <tr className="border-b border-border/30">
-                      <ClientSortableHeader label="Client" column="name" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} />
-                      <th className="px-3 py-1.5 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">Model</th>
-                      <ClientSortableHeader label="Input" column="input" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
-                      <ClientSortableHeader label="Output" column="output" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
-                      <ClientSortableHeader label="Total" column="total" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
-                      <ClientSortableHeader label="Cost" column="cost" sortColumn={clientSortColumn} sortDirection={clientSortDirection} onSort={handleClientSort} align="right" />
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedClients.map((client) => (
-                      <tr key={client.name} className="border-b border-border/20 last:border-0 hover:bg-surface-highlight/30 transition-colors">
-                        <td className="px-3 py-2 font-medium text-text-primary font-mono">{client.name}</td>
-                        <td className="px-3 py-2">
-                          <ClientModelCell
-                            client={client.name}
-                            declaredModel={clientModels[client.name]}
-                            effective={effectiveClientModels[client.name]}
-                            costAttribution={costAttribution}
-                            onSaved={handleClientModelSaved}
-                            onOpenManager={() => setPricingManagerOpen(true)}
-                          />
-                        </td>
-                        <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(client.input)}</td>
-                        <td className="px-3 py-2 text-right text-primary tabular-nums">{formatCompactNumber(client.output)}</td>
-                        <td className="px-3 py-2 text-right text-text-primary font-semibold tabular-nums">{formatCompactNumber(client.total)}</td>
-                        <td className={cn('px-3 py-2 text-right tabular-nums', client.cost === undefined ? 'text-text-muted' : 'text-emerald-400')}>
-                          {client.cost === undefined ? '—' : formatUSD(client.cost)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                <BreakdownTable
+                  rows={sortedClients}
+                  nameLabel="Client"
+                  sortColumn={clientSortColumn}
+                  sortDirection={clientSortDirection}
+                  onSort={handleClientSort}
+                  showCost
+                  renderModel={(row) => (
+                    <ClientModelCell
+                      client={row.name}
+                      declaredModel={clientModels[row.name]}
+                      effective={effectiveClientModels[row.name]}
+                      costAttribution={costAttribution}
+                      onSaved={handleClientModelSaved}
+                      onOpenManager={() => setPricingManagerOpen(true)}
+                    />
+                  )}
+                />
               </PanelHeader>
             )}
 
-            {/* Per-Server Breakdown Table */}
             {sortedServers.length > 0 && (
-              <div className="rounded-lg bg-surface-elevated/60 border border-border/30 overflow-hidden">
-                <table className="w-full text-xs">
-                  <thead>
-                    <tr className="border-b border-border/30">
-                      <SortableHeader label="Server" column="name" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                      <th className="px-3 py-1.5 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">Model</th>
-                      <SortableHeader label="Input" column="input" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} align="right" />
-                      <SortableHeader label="Output" column="output" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} align="right" />
-                      <SortableHeader label="Total" column="total" sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} align="right" />
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedServers.map((server) => (
-                      <tr key={server.name} className="border-b border-border/20 hover:bg-surface-highlight/30 transition-colors">
-                        <td className="px-3 py-2 font-medium text-text-primary font-mono">{server.name}</td>
-                        <td className="px-3 py-2">
-                          <ServerModelCell
-                            server={server.name}
-                            declaredModel={serverDeclared[server.name]}
-                            defaultModel={defaultModel}
-                            effective={effectiveServerModels[server.name]}
-                            onSaved={handleServerModelSaved}
-                            onOpenManager={() => setPricingManagerOpen(true)}
-                          />
-                        </td>
-                        <td className="px-3 py-2 text-right text-secondary tabular-nums">{formatCompactNumber(server.input)}</td>
-                        <td className="px-3 py-2 text-right text-primary tabular-nums">{formatCompactNumber(server.output)}</td>
-                        <td className="px-3 py-2 text-right text-text-primary font-semibold tabular-nums">{formatCompactNumber(server.total)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              <PanelHeader icon={Server} label="Per-Server">
+                <BreakdownTable
+                  rows={sortedServers}
+                  nameLabel="Server"
+                  sortColumn={sortColumn}
+                  sortDirection={sortDirection}
+                  onSort={handleSort}
+                  renderModel={(row) => (
+                    <ServerModelCell
+                      server={row.name}
+                      declaredModel={serverDeclared[row.name]}
+                      defaultModel={defaultModel}
+                      effective={effectiveServerModels[row.name]}
+                      onSaved={handleServerModelSaved}
+                      onOpenManager={() => setPricingManagerOpen(true)}
+                    />
+                  )}
+                />
+              </PanelHeader>
             )}
           </div>
         )}
@@ -653,27 +333,23 @@ function DetachedMetricsPageContent() {
       {/* Footer */}
       <footer className="h-6 flex-shrink-0 bg-surface/90 backdrop-blur-xl border-t border-border/50 flex items-center justify-between px-4 text-[10px] text-text-muted">
         <span className="flex items-center gap-2">
-          {sessionTotal > 0 ? `${formatCompactNumber(sessionTotal)} total tokens` : 'No data'}
-          {hasCost && (
+          {kpis.total > 0 ? `${formatCompactNumber(kpis.total)} total tokens` : 'No data'}
+          {kpis.hasCost && (
             <>
               <span className="text-text-muted/50">·</span>
-              <span className="text-emerald-400/80">{formatUSD(sessionCostUSD ?? 0)}</span>
+              <span className="text-emerald-400/80">{formatUSD(kpis.costUSD ?? 0)}</span>
             </>
           )}
           {isPaused ? ' (paused)' : ''}
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-1.5 h-1.5 rounded-full bg-text-muted animate-pulse" />
+          <span className="w-1.5 h-1.5 rounded-full bg-text-muted animate-pulse motion-reduce:animate-none" />
           Detached Window
         </span>
       </footer>
 
-      {showClearConfirm && (
-        <div className="fixed inset-0 z-40" onClick={() => setShowClearConfirm(false)} />
-      )}
-
-      {/* Pricing models manager — detached host: data from this window's
-          local status poll, optimistic updates into the same local state. */}
+      {/* Pricing models manager — detached host: data from this window's local
+          status poll, optimistic updates into the same local state. */}
       <PricingManagerSlideOver
         open={pricingManagerOpen}
         onClose={() => setPricingManagerOpen(false)}
@@ -692,138 +368,6 @@ function DetachedMetricsPageContent() {
         onDefaultSaved={handleDefaultModelSaved}
       />
     </div>
-  );
-}
-
-// KPI Card
-function KPICard({ label, value, colorClass }: { label: string; value: number; colorClass: string }) {
-  return (
-    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-      <span className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">{label}</span>
-      <span className={cn('text-lg font-bold tabular-nums', colorClass)}>{formatCompactNumber(value)}</span>
-    </div>
-  );
-}
-
-function CostKPICard({
-  usd,
-  hasCost,
-  showHint,
-  showMixedNote,
-}: {
-  usd: number | undefined;
-  hasCost: boolean;
-  showHint?: boolean;
-  showMixedNote?: boolean;
-}) {
-  return (
-    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-3">
-      <span className="text-[10px] text-text-muted uppercase tracking-wider flex items-center gap-1 mb-1">
-        <DollarSign size={10} className="text-text-muted/70" />
-        Cost
-      </span>
-      <span
-        className={cn(
-          'text-lg font-bold tabular-nums',
-          hasCost ? 'text-emerald-400' : 'text-text-muted',
-        )}
-      >
-        {hasCost ? formatUSD(usd ?? 0) : '—'}
-      </span>
-      {showHint && (
-        <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
-          {ATTRIBUTION_HINT}
-        </span>
-      )}
-      {!showHint && showMixedNote && (
-        <span className="block mt-1 text-[9px] leading-snug text-text-muted/60">
-          {MIXED_PROVENANCE_NOTE}
-        </span>
-      )}
-    </div>
-  );
-}
-
-function PanelHeader({
-  icon: Icon,
-  label,
-  children,
-}: {
-  icon: LucideIcon | ComponentType<{ size?: number; className?: string }>;
-  label: string;
-  children: ReactNode;
-}) {
-  return (
-    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 overflow-hidden">
-      <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border/30 bg-surface-highlight/30">
-        <Icon size={11} className="text-text-muted" />
-        <span className="text-[11px] font-medium text-text-secondary">{label}</span>
-      </div>
-      {children}
-    </div>
-  );
-}
-
-function ClientSortableHeader({
-  label, column, sortColumn, sortDirection, onSort, align = 'left',
-}: {
-  label: string;
-  column: ClientSortColumn;
-  sortColumn: ClientSortColumn;
-  sortDirection: SortDirection;
-  onSort: (column: ClientSortColumn) => void;
-  align?: 'left' | 'right';
-}) {
-  const isActive = sortColumn === column;
-  const SortIcon = isActive ? (sortDirection === 'asc' ? ArrowUp : ArrowDown) : ArrowUpDown;
-
-  return (
-    <th
-      className={cn(
-        'px-3 py-2 font-medium text-text-muted cursor-pointer hover:text-text-secondary transition-colors select-none',
-        align === 'right' && 'text-right'
-      )}
-      tabIndex={0}
-      role="columnheader"
-      aria-sort={isActive ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
-      onClick={() => onSort(column)}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSort(column); } }}
-    >
-      <span className="inline-flex items-center gap-1">
-        {label}
-        <SortIcon size={10} className={isActive ? 'text-primary' : 'text-text-muted/40'} />
-      </span>
-    </th>
-  );
-}
-
-// Sortable header
-function SortableHeader({
-  label, column, sortColumn, sortDirection, onSort, align = 'left',
-}: {
-  label: string; column: SortColumn; sortColumn: SortColumn; sortDirection: SortDirection;
-  onSort: (column: SortColumn) => void; align?: 'left' | 'right';
-}) {
-  const isActive = sortColumn === column;
-  const SortIcon = isActive ? (sortDirection === 'asc' ? ArrowUp : ArrowDown) : ArrowUpDown;
-
-  return (
-    <th
-      className={cn(
-        'px-3 py-2 font-medium text-text-muted cursor-pointer hover:text-text-secondary transition-colors select-none',
-        align === 'right' && 'text-right'
-      )}
-      tabIndex={0}
-      role="columnheader"
-      aria-sort={isActive ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
-      onClick={() => onSort(column)}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSort(column); } }}
-    >
-      <span className="inline-flex items-center gap-1">
-        {label}
-        <SortIcon size={10} className={isActive ? 'text-primary' : 'text-text-muted/40'} />
-      </span>
-    </th>
   );
 }
 

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -15,6 +15,7 @@ const TopologyWorkspace = lazy(() => import('./components/workspaces/TopologyWor
 const LibraryWorkspace = lazy(() => import('./components/workspaces/LibraryWorkspace'));
 const VaultWorkspace = lazy(() => import('./components/workspaces/VaultWorkspace'));
 const ToolsWorkspace = lazy(() => import('./components/workspaces/ToolsWorkspace'));
+const MetricsWorkspace = lazy(() => import('./components/workspaces/MetricsWorkspace'));
 
 export function AppRoutes() {
   return (
@@ -65,6 +66,14 @@ export function AppRoutes() {
             </Suspense>
           }
         />
+        <Route
+          path="/metrics"
+          element={
+            <Suspense fallback={<WorkspaceLoadingShell />}>
+              <MetricsWorkspace />
+            </Suspense>
+          }
+        />
       </Route>
 
       {/* Root redirect — chooses a workspace based on stack + storage. */}
@@ -85,7 +94,9 @@ export function AppRoutes() {
       {/* /registry → /library-window: silent redirect for bookmarks and
           existing detached window handles. */}
       <Route path="/registry" element={<Navigate to="/library-window" replace />} />
-      <Route path="/metrics" element={<DetachedMetricsPage />} />
+      {/* /metrics is now the in-shell Metrics workspace; the detached popout
+          renders at /metrics-window (window type key stays `metrics`). */}
+      <Route path="/metrics-window" element={<DetachedMetricsPage />} />
       <Route path="/traces" element={<DetachedTracesPage />} />
     </Routes>
   );

--- a/web/src/stores/useUIStore.ts
+++ b/web/src/stores/useUIStore.ts
@@ -33,6 +33,7 @@ export const COMPACT_MODE_DEFAULTS: CompactModeMap = {
   library: false,
   vault: false,
   tools: false,
+  metrics: false,
 };
 
 export interface CompactModeSlice {

--- a/web/src/types/workspace.ts
+++ b/web/src/types/workspace.ts
@@ -1,9 +1,9 @@
 import type { LucideIcon } from 'lucide-react';
-import { Library, Lock, Network, Wrench } from 'lucide-react';
+import { BarChart3, Library, Lock, Network, Wrench } from 'lucide-react';
 
 // Top-level workspaces in the unified shell. Routed at /topology, /library,
-// /vault, and /tools inside AppShell.
-export type Workspace = 'topology' | 'library' | 'vault' | 'tools';
+// /vault, /tools, and /metrics inside AppShell.
+export type Workspace = 'topology' | 'library' | 'vault' | 'tools' | 'metrics';
 
 export interface WorkspaceConfig {
   id: Workspace;
@@ -20,7 +20,8 @@ export const WORKSPACE_CONFIG: readonly WorkspaceConfig[] = [
   { id: 'topology', label: 'Topology',  icon: Network,  shortcutKey: '1' },
   { id: 'library',  label: 'Library',   icon: Library,  shortcutKey: '2' },
   { id: 'vault',    label: 'Variables', icon: Lock,     shortcutKey: '3' },
-  { id: 'tools',    label: 'Tools',     icon: Wrench,   shortcutKey: '4' },
+  { id: 'tools',    label: 'Tools',     icon: Wrench,    shortcutKey: '4' },
+  { id: 'metrics',  label: 'Metrics',   icon: BarChart3, shortcutKey: '5' },
 ] as const;
 
 // Derived for back-compat with existing call-sites in useUIStore, AppShell,


### PR DESCRIPTION
## Description

Promotes Metrics from a bottom-panel tab to a fifth top-level workspace with a three-rail drill-down, and collapses the duplicated dashboard render path shared between the tab and its detached popout. Pure frontend; no backend or `stack.yaml` changes.

Closes #791

## Type of Change

- [x] New feature (`feat`)

## Changes Made

- New `/metrics` workspace (switcher pill, `Cmd/Ctrl+5`): left scope navigator (Overview/Clients/Servers/Models), center KPI row + token/cost charts + breakdown table, right per-entity inspector with inline pricing-model editor. Scope and selection are URL-synced (`?scope=`, `?selected=`).
- Extracted shared core so the tab, workspace, and detached window render from one place: pure helpers (`metricsData.ts`), presentation atoms (`metricsShared.tsx`), control cluster (`MetricsControls.tsx`), and a polling hook (`useMetricsSeries.ts`).
- Bottom tab slimmed to a glance view; detached popout relocated to `/metrics-window` (window-type key unchanged).
- StatusBar token counter links to the workspace and a new estimated-cost chip added; command palette routes to it.
- Cost is labeled "est."; charts use non-color cost encoding, `role="img"` summaries, and `motion-reduce` on the live pulse.

## Testing

- `npx tsc -b` clean; `npm test` (Vitest) 1041 passing, including new unit tests for the pure helpers and render/interaction tests for the workspace.
- `make build` succeeds; the workspace ships as its own lazy chunk.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed