### PR TITLE
fix: quiet pins 503 poll, catch unknown routes, set tab title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,15 @@ All notable changes to gridctl will be documented in this file.
 
 ### Fixed
 
+- **Web UI console noise, blank unknown routes, and the default tab title.**
+  Three small dashboard fixes. `GET /api/pins` now returns `200` with an empty
+  object when schema pinning is not configured, instead of a `503` that the
+  polling UI logged as a console error every refresh cycle. Unmatched URLs (a
+  typo, a stale bookmark, or a removed route) now redirect to the landing
+  workspace rather than rendering a blank page. The browser tab title reads
+  "Gridctl" (and appends the active workspace, for example "Gridctl - Topology")
+  instead of the build-tool default "web".
+
 - **Pricing model picker truncated long model IDs.** The dropdown was pinned to
   the narrow editor cell's width, so IDs like
   `anthropic.claude-3-opus-20240229` were cut off with no readable fallback.

--- a/internal/api/pins.go
+++ b/internal/api/pins.go
@@ -6,9 +6,15 @@ import (
 
 // handleListPins returns all servers' pin records.
 // GET /api/pins
+//
+// When schema pinning is not configured the store is nil. That is a normal,
+// expected state rather than an error, so this returns 200 with an empty object
+// (the same shape as a configured-but-empty store). The UI polls this endpoint
+// on every refresh cycle; returning a 5xx here would log a console error on each
+// poll for stacks that simply do not enable pinning.
 func (s *Server) handleListPins(w http.ResponseWriter, r *http.Request) {
 	if s.pinStore == nil {
-		writeJSONError(w, "Pin store not available", http.StatusServiceUnavailable)
+		writeJSON(w, map[string]any{})
 		return
 	}
 	servers := s.pinStore.GetAll()

--- a/internal/api/pins_test.go
+++ b/internal/api/pins_test.go
@@ -28,8 +28,19 @@ func TestHandlePins_NoStore(t *testing.T) {
 	w := httptest.NewRecorder()
 	server.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusServiceUnavailable {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	// An unconfigured pin store is a normal state, not an error: the list
+	// endpoint returns 200 with an empty object so the polling UI does not log
+	// a console error on every refresh cycle.
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(result))
 	}
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#08080a" />
-    <title>web</title>
+    <title>Gridctl</title>
     <style>html,body,#root{background:#08080a;margin:0;padding:0;height:100%;width:100%}</style>
   </head>
   <body style="background:#08080a">

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6856,9 +6856,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -12719,9 +12719,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -1,7 +1,22 @@
 import { describe, it, expect } from 'vitest'
+import { documentTitleForWorkspace } from '../types/workspace'
 
 describe('smoke test', () => {
   it('vitest runs successfully', () => {
     expect(1 + 1).toBe(2)
+  })
+})
+
+describe('documentTitleForWorkspace', () => {
+  it('returns the base name for a non-workspace path', () => {
+    expect(documentTitleForWorkspace(null)).toBe('Gridctl')
+  })
+
+  it('appends the workspace label', () => {
+    expect(documentTitleForWorkspace('topology')).toBe('Gridctl - Topology')
+  })
+
+  it('uses the display label, not the id, for vault', () => {
+    expect(documentTitleForWorkspace('vault')).toBe('Gridctl - Variables')
   })
 })

--- a/web/src/__tests__/router-redirects.test.tsx
+++ b/web/src/__tests__/router-redirects.test.tsx
@@ -37,6 +37,21 @@ function renderRedirect(initial: string) {
   );
 }
 
+// Mirrors the catch-all in routes.tsx: unmatched URLs redirect to "/", where
+// RootRedirect resolves the landing workspace.
+function renderCatchAll(initial: string) {
+  return render(
+    <MemoryRouter initialEntries={[initial]}>
+      <Routes>
+        <Route path="/" element={<RootRedirect />} />
+        <Route path="/topology" element={<div>topology-page</div>} />
+        <Route path="/library" element={<div>library-page</div>} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
 function LocationProbe() {
   const location = useLocation();
   return (
@@ -134,5 +149,19 @@ describe('legacy workspace redirects', () => {
   it('redirects /runs/:runID → /library', () => {
     renderRedirect('/runs/abc123');
     expect(screen.getByText('library-page')).toBeInTheDocument();
+  });
+});
+
+describe('catch-all route', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useStackStore.setState({ gatewayInfo: null });
+    useRegistryStore.setState({ skills: [] });
+  });
+
+  it('redirects an unknown URL to the resolved landing workspace', () => {
+    renderCatchAll('/does-not-exist');
+    // No skills declared, so RootRedirect lands on /topology rather than a blank page.
+    expect(screen.getByText('topology-page')).toBeInTheDocument();
   });
 });

--- a/web/src/components/shell/AppShell.tsx
+++ b/web/src/components/shell/AppShell.tsx
@@ -15,7 +15,7 @@ import { usePolling } from '../../hooks/usePolling';
 import { useSSEShutdown } from '../../hooks/useSSEShutdown';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { useGlobalCommands } from '../../hooks/useGlobalCommands';
-import { isWorkspace, type Workspace } from '../../types/workspace';
+import { documentTitleForWorkspace, isWorkspace, type Workspace } from '../../types/workspace';
 import {
   LAST_WORKSPACE_GLOBAL_KEY,
   LAST_WORKSPACE_PER_STACK_PREFIX,
@@ -88,6 +88,13 @@ function AppShellInner() {
     setActiveWorkspace(ws);
     persistLastWorkspace(ws, stackId);
   }, [pathname, stackId, setActiveWorkspace]);
+
+  // Reflect the active workspace in the document title so browser tabs and
+  // history entries are identifiable. Falls back to the base name for
+  // non-workspace paths.
+  useEffect(() => {
+    document.title = documentTitleForWorkspace(workspaceFromPath(pathname));
+  }, [pathname]);
 
   const handleBottomPanelResize = useCallback((delta: number) => {
     setBottomPanelHeight((prev) => {

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -98,6 +98,11 @@ export function AppRoutes() {
           renders at /metrics-window (window type key stays `metrics`). */}
       <Route path="/metrics-window" element={<DetachedMetricsPage />} />
       <Route path="/traces" element={<DetachedTracesPage />} />
+
+      {/* Catch-all: any unmatched URL (typo, stale bookmark, removed route)
+          redirects to the root, where RootRedirect resolves the landing
+          workspace. Keeps unknown paths from rendering a blank page. */}
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );
 }

--- a/web/src/types/workspace.ts
+++ b/web/src/types/workspace.ts
@@ -35,3 +35,13 @@ export const WORKSPACE_LABELS: Record<Workspace, string> = Object.fromEntries(
 export function isWorkspace(value: unknown): value is Workspace {
   return typeof value === 'string' && (WORKSPACES as readonly string[]).includes(value);
 }
+
+// Base product name used for the document title.
+export const DOCUMENT_TITLE_BASE = 'Gridctl';
+
+// Builds the browser tab title for the active workspace, e.g. "Gridctl -
+// Variables". Falls back to the base name for non-workspace or transitional
+// paths so the tab never shows "Gridctl - undefined".
+export function documentTitleForWorkspace(ws: Workspace | null): string {
+  return ws ? `${DOCUMENT_TITLE_BASE} - ${WORKSPACE_LABELS[ws]}` : DOCUMENT_TITLE_BASE;
+}


### PR DESCRIPTION
## Description

Three small web UI fixes found during a dashboard walkthrough: the pins endpoint floods the browser console, unknown URLs render a blank page, and the browser tab title is the build-tool default.

## Type of Change

- [x] Bug fix

## Changes Made

- `GET /api/pins` returns `200` with an empty object when no pin store is configured, instead of a `503` the polling UI logged as a console error every refresh cycle. The mutating handlers and the per-server GET are unchanged.
- Added a catch-all `path="*"` route that redirects unmatched URLs to the landing workspace (via `RootRedirect`) instead of rendering a blank page.
- Set the document title to `Gridctl`, appending the active workspace (for example `Gridctl - Topology`) via a small effect in `AppShell`.

## Testing

- `go test ./internal/api/...` (updated `TestHandlePins_NoStore` to expect 200 + empty body).
- `cd web && npm test` (added catch-all route and title-helper tests; full suite 1053 passing).
- `go vet`, `gofmt`, `eslint`, and `tsc --noEmit` clean on changed files.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #805