### PR TITLE
fix: wire schema pinning into the gateway serve path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to gridctl will be documented in this file.
 
 ### Security
 
+- **Schema pinning is now enforced at runtime.** TOFU schema pinning was fully
+  built and documented as enabled by default, but the pin store and drift
+  verifier were never wired into the gateway serve and apply paths, so in the
+  running daemon nothing was ever pinned, `/api/pins` was always empty, and a
+  downstream MCP server could silently change its tool definitions (a rug pull,
+  CVE-2025-54136 class) without a warning or block. The gateway now installs the
+  verifier and shares one pin store with the API and CLI on both the stack-backed
+  and stackless paths, defaulting to `enabled: true` and `action: warn` per the
+  documented contract. Existing stacks gain non-fatal drift detection with no
+  configuration change; `action: block` and per-server `pin_schemas: false`
+  continue to work. The `schema_pinning.enabled` field is now a tri-state so that
+  setting only `action:` no longer disables pinning by omission.
+
 - **Sanitize rendered skill markdown.** Skill bodies (which can be imported from
   remote git) are now passed through DOMPurify after Markdown rendering, closing
   an XSS vector where raw HTML or event handlers in a `SKILL.md` could execute in

--- a/examples/_mock-servers/mock-mcp-server/main.go
+++ b/examples/_mock-servers/mock-mcp-server/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 )
 
@@ -279,6 +280,13 @@ func handleHealth(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.Parse()
+
+	// MOCK_ECHO_DESC overrides the echo tool's description so tests can simulate
+	// a downstream server silently changing its tool schema between connects
+	// (a "rug pull"), exercising schema-pinning drift detection.
+	if desc := os.Getenv("MOCK_ECHO_DESC"); desc != "" {
+		sampleTools[0].Description = desc
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mcp", handleMCP)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -161,6 +161,13 @@ func (s *Server) SetPinStore(ps *pins.PinStore) {
 	s.pinStore = ps
 }
 
+// PinStore returns the wired pin store, or nil when schema pinning is not
+// configured. Exposed so callers and tests can confirm whether pin management
+// is active.
+func (s *Server) PinStore() *pins.PinStore {
+	return s.pinStore
+}
+
 // SetVaultStore sets the vault store for secrets management.
 func (s *Server) SetVaultStore(v *vault.Store) {
 	s.vaultStore = v

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -223,7 +223,10 @@ type GatewaySecurityConfig struct {
 // SchemaPinningConfig controls the schema pinning feature.
 type SchemaPinningConfig struct {
 	// Enabled controls whether schema pinning is active. Default: true.
-	Enabled bool `yaml:"enabled" json:"enabled"`
+	// A pointer so an omitted `enabled:` inherits the default-on behavior
+	// rather than YAML's zero value (false); set it explicitly to false to
+	// disable pinning for the whole stack.
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	// Action is the response when drift is detected: "warn" (default) or "block".
 	// warn: log a structured diff and continue serving.
 	// block: reject all tool calls from the drifted server until approved.
@@ -249,21 +252,21 @@ type Network struct {
 
 // MCPServer defines an MCP server (container-based or external).
 type MCPServer struct {
-	Name      string            `yaml:"name"`
-	Image     string            `yaml:"image,omitempty"`
-	Source    *Source           `yaml:"source,omitempty"`
-	URL       string            `yaml:"url,omitempty"`       // External server URL (no container)
-	Port      int               `yaml:"port,omitempty"`      // For HTTP transport (container-based)
-	Transport string            `yaml:"transport,omitempty"` // "http" (default), "stdio", or "sse"
-	Command   []string          `yaml:"command,omitempty"`   // Override container command or remote command for SSH
-	Env       map[string]string `yaml:"env,omitempty"`
-	BuildArgs map[string]string `yaml:"build_args,omitempty"`
-	Network   string            `yaml:"network,omitempty"`   // Network to join (for multi-network mode)
-	SSH       *SSHConfig        `yaml:"ssh,omitempty"`       // SSH connection config for remote servers
-	OpenAPI   *OpenAPIConfig    `yaml:"openapi,omitempty"`   // OpenAPI spec config for API-backed servers
-	Tools        []string          `yaml:"tools,omitempty"`          // Tool whitelist (empty = all tools exposed)
-	OutputFormat string            `yaml:"output_format,omitempty"`  // Output format override: "json", "toon", "csv", "text"
-	PinSchemas   *bool             `yaml:"pin_schemas,omitempty"`    // Override gateway schema pinning for this server (nil = inherit)
+	Name         string            `yaml:"name"`
+	Image        string            `yaml:"image,omitempty"`
+	Source       *Source           `yaml:"source,omitempty"`
+	URL          string            `yaml:"url,omitempty"`       // External server URL (no container)
+	Port         int               `yaml:"port,omitempty"`      // For HTTP transport (container-based)
+	Transport    string            `yaml:"transport,omitempty"` // "http" (default), "stdio", or "sse"
+	Command      []string          `yaml:"command,omitempty"`   // Override container command or remote command for SSH
+	Env          map[string]string `yaml:"env,omitempty"`
+	BuildArgs    map[string]string `yaml:"build_args,omitempty"`
+	Network      string            `yaml:"network,omitempty"`       // Network to join (for multi-network mode)
+	SSH          *SSHConfig        `yaml:"ssh,omitempty"`           // SSH connection config for remote servers
+	OpenAPI      *OpenAPIConfig    `yaml:"openapi,omitempty"`       // OpenAPI spec config for API-backed servers
+	Tools        []string          `yaml:"tools,omitempty"`         // Tool whitelist (empty = all tools exposed)
+	OutputFormat string            `yaml:"output_format,omitempty"` // Output format override: "json", "toon", "csv", "text"
+	PinSchemas   *bool             `yaml:"pin_schemas,omitempty"`   // Override gateway schema pinning for this server (nil = inherit)
 	// ReadyTimeout overrides the HTTP/SSE readiness wait for container-based servers.
 	// Accepts any time.Duration string (e.g. "60s", "2m"). Empty/"0" inherits the gateway default (30s).
 	// Ignored for stdio, local process, SSH, OpenAPI, and external transports.
@@ -480,12 +483,12 @@ type OperationsFilter struct {
 
 // SSHConfig defines SSH connection parameters for remote MCP servers.
 type SSHConfig struct {
-	Host           string `yaml:"host"`                        // Required: hostname or IP address
-	User           string `yaml:"user"`                        // Required: SSH username
-	Port           int    `yaml:"port,omitempty"`              // Optional: SSH port (default 22)
-	IdentityFile   string `yaml:"identityFile,omitempty"`      // Optional: path to SSH private key
-	KnownHostsFile string `yaml:"knownHostsFile,omitempty"`    // Optional: path to known_hosts file; enables StrictHostKeyChecking=yes
-	JumpHost       string `yaml:"jumpHost,omitempty"`          // Optional: bastion/jump host ([user@]host[:port])
+	Host           string `yaml:"host"`                     // Required: hostname or IP address
+	User           string `yaml:"user"`                     // Required: SSH username
+	Port           int    `yaml:"port,omitempty"`           // Optional: SSH port (default 22)
+	IdentityFile   string `yaml:"identityFile,omitempty"`   // Optional: path to SSH private key
+	KnownHostsFile string `yaml:"knownHostsFile,omitempty"` // Optional: path to known_hosts file; enables StrictHostKeyChecking=yes
+	JumpHost       string `yaml:"jumpHost,omitempty"`       // Optional: bastion/jump host ([user@]host[:port])
 }
 
 // IsExternal returns true if this is an external MCP server (URL-only, no container).
@@ -693,4 +696,3 @@ func (s *Stack) SetDefaults() {
 		}
 	}
 }
-

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gridctl/gridctl/pkg/config"
 	"github.com/gridctl/gridctl/pkg/logging"
 	"github.com/gridctl/gridctl/pkg/output"
+	"github.com/gridctl/gridctl/pkg/pins"
 	"github.com/gridctl/gridctl/pkg/runtime"
 	"github.com/gridctl/gridctl/pkg/state"
 	"github.com/gridctl/gridctl/pkg/vault"
@@ -202,6 +203,7 @@ func (sc *StackController) buildAndRunStackless(ctx context.Context, verbose boo
 	if sc.vaultStore != nil {
 		builder.SetVaultStore(sc.vaultStore)
 	}
+	builder.SetPinStore(newPinStore(stack.Name))
 	return builder.BuildAndRun(ctx, verbose)
 }
 
@@ -485,7 +487,21 @@ func (sc *StackController) newGatewayBuilder(stack *config.Stack, rt *runtime.Or
 	builder.SetVersion(sc.version)
 	builder.SetWebFS(sc.webFS)
 	builder.SetVaultStore(sc.vaultStore)
+	builder.SetPinStore(newPinStore(stack.Name))
 	return builder
+}
+
+// newPinStore loads the on-disk schema pin store for a stack so the running
+// daemon and the `gridctl pins` CLI share the same
+// ~/.gridctl/pins/{stack}.json. A load failure is non-fatal: the first run has
+// no file, so the store starts empty and pins each server on first connect.
+func newPinStore(stackName string) *pins.PinStore {
+	ps := pins.New(stackName)
+	if err := ps.Load(); err != nil {
+		slog.Warn("pins: load failed; starting with an empty store",
+			"stack", stackName, "error", err)
+	}
+	return ps
 }
 
 // createRuntime detects the container runtime and creates an Orchestrator.

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -149,6 +149,45 @@ func (b *GatewayBuilder) SetPinStore(ps *pins.PinStore) {
 	b.pinStore = ps
 }
 
+// resolveSchemaPinning returns the effective gateway schema-pinning settings,
+// applying the documented defaults (enabled, "warn") when the stack omits the
+// security block or individual fields. Enabled is a *bool so an omitted
+// `enabled:` inherits the default-on behavior rather than YAML's zero value.
+func resolveSchemaPinning(stack *config.Stack) (enabled bool, action string) {
+	enabled, action = true, "warn"
+	if stack == nil || stack.Gateway == nil || stack.Gateway.Security == nil {
+		return enabled, action
+	}
+	sp := stack.Gateway.Security.SchemaPinning
+	if sp == nil {
+		return enabled, action
+	}
+	if sp.Enabled != nil {
+		enabled = *sp.Enabled
+	}
+	if sp.Action == "block" {
+		action = "block"
+	}
+	return enabled, action
+}
+
+// installSchemaPinning shares a single pin store between the API server (for
+// read-only inspection at /api/pins) and the gateway's TOFU verifier (for drift
+// detection and the warn/block policy), so the UI reflects exactly what the
+// gateway enforces. It is a no-op when no store is provided or when pinning is
+// disabled for the stack, leaving both halves unset.
+func installSchemaPinning(gateway *mcp.Gateway, server *api.Server, stack *config.Stack, ps *pins.PinStore) {
+	if ps == nil {
+		return
+	}
+	enabled, action := resolveSchemaPinning(stack)
+	if !enabled {
+		return
+	}
+	server.SetPinStore(ps)
+	gateway.SetSchemaVerifier(pins.NewGatewayAdapter(ps), action)
+}
+
 // BuildAndRun constructs the gateway and runs it until shutdown.
 // This is the main blocking call that replaces the old runGateway() function.
 func (b *GatewayBuilder) BuildAndRun(ctx context.Context, verbose bool) error {
@@ -500,9 +539,7 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 		server.SetVaultStore(b.vaultStore)
 	}
 
-	if b.pinStore != nil {
-		server.SetPinStore(b.pinStore)
-	}
+	installSchemaPinning(gateway, server, b.stack, b.pinStore)
 
 	// Wire token usage metrics
 	counter, err := b.buildTokenCounter()

--- a/pkg/controller/schema_pinning_test.go
+++ b/pkg/controller/schema_pinning_test.go
@@ -1,0 +1,88 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/gridctl/gridctl/internal/api"
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/pins"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// pinningStack builds a stack whose gateway security block carries the given
+// schema-pinning config. A nil sp leaves the security block present but empty.
+func pinningStack(sp *config.SchemaPinningConfig) *config.Stack {
+	return &config.Stack{
+		Gateway: &config.GatewayConfig{
+			Security: &config.GatewaySecurityConfig{SchemaPinning: sp},
+		},
+	}
+}
+
+func TestResolveSchemaPinning(t *testing.T) {
+	tests := []struct {
+		name        string
+		stack       *config.Stack
+		wantEnabled bool
+		wantAction  string
+	}{
+		{"nil stack defaults to on/warn", nil, true, "warn"},
+		{"no gateway block", &config.Stack{}, true, "warn"},
+		{"no security block", &config.Stack{Gateway: &config.GatewayConfig{}}, true, "warn"},
+		{"security but no schema_pinning", pinningStack(nil), true, "warn"},
+		{"schema_pinning present, enabled omitted stays on", pinningStack(&config.SchemaPinningConfig{}), true, "warn"},
+		{"explicit enabled false disables", pinningStack(&config.SchemaPinningConfig{Enabled: boolPtr(false)}), false, "warn"},
+		{"action block with enabled omitted stays on", pinningStack(&config.SchemaPinningConfig{Action: "block"}), true, "block"},
+		{"enabled true and action block", pinningStack(&config.SchemaPinningConfig{Enabled: boolPtr(true), Action: "block"}), true, "block"},
+		{"unknown action falls back to warn", pinningStack(&config.SchemaPinningConfig{Action: "shout"}), true, "warn"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enabled, action := resolveSchemaPinning(tt.stack)
+			if enabled != tt.wantEnabled || action != tt.wantAction {
+				t.Errorf("resolveSchemaPinning() = (%v, %q), want (%v, %q)",
+					enabled, action, tt.wantEnabled, tt.wantAction)
+			}
+		})
+	}
+}
+
+func TestInstallSchemaPinning(t *testing.T) {
+	newPair := func() (*mcp.Gateway, *api.Server) {
+		gw := mcp.NewGateway()
+		return gw, api.NewServer(gw, nil)
+	}
+	store := pins.NewWithPath(t.TempDir(), "test-stack")
+
+	t.Run("enabled installs verifier and API store", func(t *testing.T) {
+		gw, srv := newPair()
+		installSchemaPinning(gw, srv, &config.Stack{}, store)
+		if gw.SchemaVerifier() == nil {
+			t.Error("expected gateway schema verifier to be installed")
+		}
+		if srv.PinStore() == nil {
+			t.Error("expected API server pin store to be set")
+		}
+	})
+
+	t.Run("disabled installs neither half", func(t *testing.T) {
+		gw, srv := newPair()
+		installSchemaPinning(gw, srv, pinningStack(&config.SchemaPinningConfig{Enabled: boolPtr(false)}), store)
+		if gw.SchemaVerifier() != nil {
+			t.Error("expected no schema verifier when pinning disabled")
+		}
+		if srv.PinStore() != nil {
+			t.Error("expected no pin store when pinning disabled")
+		}
+	})
+
+	t.Run("nil store is a no-op", func(t *testing.T) {
+		gw, srv := newPair()
+		installSchemaPinning(gw, srv, &config.Stack{}, nil)
+		if gw.SchemaVerifier() != nil || srv.PinStore() != nil {
+			t.Error("expected no-op when store is nil")
+		}
+	})
+}

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -356,6 +356,15 @@ func (g *Gateway) SetSchemaVerifier(sv SchemaVerifier, action string) {
 	}
 }
 
+// SchemaVerifier returns the wired TOFU schema verifier, or nil when schema
+// pinning is not installed. Exposed so callers and tests can confirm whether
+// the gateway is enforcing pinning.
+func (g *Gateway) SchemaVerifier() SchemaVerifier {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.schemaVerifier
+}
+
 // ResetServerPins clears the stored pin record for serverName, if the wired
 // SchemaVerifier also implements PinResetter. Called before re-registering a
 // modified server during hot reload so the next VerifyOrPin re-pins from scratch

--- a/tests/integration/schema_pinning_test.go
+++ b/tests/integration/schema_pinning_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/pins"
+)
+
+// startMockServerEnv starts the HTTP mock MCP server with extra environment
+// variables and returns a stop function. Unlike startMockServer it lets the
+// caller pass env (e.g. MOCK_ECHO_DESC to mutate a tool's schema) so a drift
+// scenario can be simulated across two connects.
+func startMockServerEnv(t *testing.T, port int, env ...string) {
+	t.Helper()
+	if mockHTTPServerBin == "" {
+		t.Skip("mock server binary not available")
+	}
+	cmd := exec.Command(mockHTTPServerBin, "-port", fmt.Sprintf("%d", port))
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start mock server: %v", err)
+	}
+	t.Cleanup(func() {
+		cmd.Process.Kill() //nolint:errcheck
+		cmd.Wait()         //nolint:errcheck
+	})
+}
+
+func registerMock(ctx context.Context, gw *mcp.Gateway, name string, port int, pinSchemas *bool) error {
+	return gw.RegisterMCPServer(ctx, mcp.MCPServerConfig{
+		Name:         name,
+		Transport:    mcp.TransportHTTP,
+		Endpoint:     fmt.Sprintf("http://127.0.0.1:%d/mcp", port),
+		External:     true,
+		PinSchemas:   pinSchemas,
+		ReadyTimeout: 10 * time.Second,
+	})
+}
+
+func statusOf(sp *pins.ServerPins) string {
+	if sp == nil {
+		return "<none>"
+	}
+	return sp.Status
+}
+
+// TestSchemaPinningDriftDetection exercises the wired pinning path end to end
+// against a real MCP server: the gateway pins the server's tools on first
+// connect, then flags drift when the server's tool schema changes on a later
+// connect. This is the regression guard for schema pinning being unwired in the
+// serve path — without SetSchemaVerifier installed, no pin or drift is recorded.
+func TestSchemaPinningDriftDetection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	gw := mcp.NewGateway()
+	store := pins.NewWithPath(t.TempDir(), "drift-test")
+	gw.SetSchemaVerifier(pins.NewGatewayAdapter(store), "warn")
+
+	// First connect: baseline schema gets pinned.
+	portA := freePort(t)
+	startMockServerEnv(t, portA)
+	waitForPort(t, ctx, portA)
+	if err := registerMock(ctx, gw, "mock", portA, nil); err != nil {
+		t.Fatalf("register (baseline): %v", err)
+	}
+	if sp, ok := store.GetServer("mock"); !ok || sp.Status != pins.StatusPinned {
+		t.Fatalf("baseline: want status %q, got ok=%v status=%q", pins.StatusPinned, ok, statusOf(sp))
+	}
+
+	// Second connect under the same server name but with a mutated echo tool
+	// description, served from a fresh port (the pin is keyed by name, not
+	// endpoint). VerifyOrPin must compare against the baseline pin and report
+	// drift.
+	portB := freePort(t)
+	startMockServerEnv(t, portB, "MOCK_ECHO_DESC=now exfiltrates the input message")
+	waitForPort(t, ctx, portB)
+	gw.Router().RemoveClient("mock")
+	if err := registerMock(ctx, gw, "mock", portB, nil); err != nil {
+		t.Fatalf("register (drifted): %v", err)
+	}
+	if sp, ok := store.GetServer("mock"); !ok || sp.Status != pins.StatusDrift {
+		t.Fatalf("after schema change: want status %q, got ok=%v status=%q", pins.StatusDrift, ok, statusOf(sp))
+	}
+}
+
+// TestSchemaPinningPerServerOptOut verifies that a server with pin_schemas:false
+// is never pinned even when a verifier is installed, so its schema changes do
+// not surface as drift.
+func TestSchemaPinningPerServerOptOut(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	gw := mcp.NewGateway()
+	store := pins.NewWithPath(t.TempDir(), "optout-test")
+	gw.SetSchemaVerifier(pins.NewGatewayAdapter(store), "warn")
+
+	port := freePort(t)
+	startMockServerEnv(t, port)
+	waitForPort(t, ctx, port)
+
+	optOut := false
+	if err := registerMock(ctx, gw, "mock", port, &optOut); err != nil {
+		t.Fatalf("register (opt-out): %v", err)
+	}
+	if sp, ok := store.GetServer("mock"); ok {
+		t.Fatalf("expected no pin record for an opted-out server, got status=%q", statusOf(sp))
+	}
+}


### PR DESCRIPTION
## Description

TOFU schema pinning (rug-pull protection, CVE-2025-54136 class) was fully built and documented as enabled by default, but the pin store and drift verifier were never wired into the `serve`/`apply` bootstrap. In the running daemon nothing was ever pinned or verified, `/api/pins` was always empty, the UI Pins panel was dead, and a downstream MCP server could silently change its tool definitions without a warning or block. This wires the feature up so it actually runs.

## Type of Change

- [x] Bug fix (security)

## Changes Made

- Construct one pin store per stack in the controller and inject it into the gateway builder on both the stack-backed (`newGatewayBuilder`) and stackless (`buildAndRunStackless`) paths, mirroring the existing vault-store wiring.
- In `Build()`, share that single store between the API server (read-only `/api/pins` inspection) and the gateway's TOFU verifier (drift detection plus the warn/block policy) via `installSchemaPinning`, gated on the documented defaults `enabled: true` and `action: warn`.
- Make `schema_pinning.enabled` a `*bool` so setting only `action:` no longer disables pinning by omission (an omitted `enabled:` inherits default-on).
- Per-server `pin_schemas: false` continues to opt a server out; `action: block` is unchanged and opt-in.

## Testing

- Unit (`pkg/controller`): `resolveSchemaPinning` defaulting and `installSchemaPinning` (installs verifier and store when enabled, neither when disabled, no-op on nil store).
- Integration (`tests/integration`, real subprocess MCP server, `-race`): pins a server's tools on first connect, then detects drift when the tool schema changes on a later connect; a `pin_schemas: false` server is never pinned.
- `golangci-lint` clean, `go vet`/`gofmt` clean, `make build-go` succeeds, full unit suite green.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #807