### PR TITLE
fix: honor gateway.tracing.max_traces from stack.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -598,6 +598,14 @@ All notable changes to gridctl will be documented in this file.
   `vault-*`). Version references in `docs/installation.md` and
   `docs/project-status.md` bumped to `v0.1.0-beta.10`.
 
+### Fixed
+
+- **`gateway.tracing.max_traces` is now honored from `stack.yaml`.** The field
+  was documented but silently ignored: the stack schema had no `MaxTraces` field,
+  so the value was dropped during YAML decode and the in-memory trace ring buffer
+  always used the default of 1000. The field is now wired through to the tracing
+  provider; an unset or non-positive value continues to use the 1000 default.
+
 ## [0.1.0-beta.10] - 2026-05-18
 
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -163,6 +163,8 @@ type TracingConfig struct {
 	Export string `yaml:"export,omitempty" json:"export,omitempty"`
 	// Endpoint is the OTLP endpoint URL (e.g. "http://localhost:4318").
 	Endpoint string `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`
+	// MaxTraces is the in-memory ring buffer capacity (number of traces). Default: 1000.
+	MaxTraces int `yaml:"max_traces,omitempty" json:"max_traces,omitempty"`
 }
 
 // GatewayConfig holds optional gateway-level configuration.

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -197,6 +197,52 @@ replica_policy: least-connections
 	}
 }
 
+func TestTracingConfig_MaxTracesYAMLRoundTrip(t *testing.T) {
+	tests := []struct {
+		name          string
+		yamlIn        string
+		wantMaxTraces int
+	}{
+		{
+			name: "no max_traces field",
+			yamlIn: `enabled: true
+`,
+			wantMaxTraces: 0,
+		},
+		{
+			name: "explicit max_traces",
+			yamlIn: `enabled: true
+max_traces: 250
+`,
+			wantMaxTraces: 250,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var tcfg TracingConfig
+			if err := yaml.Unmarshal([]byte(tc.yamlIn), &tcfg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if tcfg.MaxTraces != tc.wantMaxTraces {
+				t.Errorf("MaxTraces = %d, want %d", tcfg.MaxTraces, tc.wantMaxTraces)
+			}
+
+			out, err := yaml.Marshal(&tcfg)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var got TracingConfig
+			if err := yaml.Unmarshal(out, &got); err != nil {
+				t.Fatalf("re-unmarshal: %v", err)
+			}
+			if got.MaxTraces != tcfg.MaxTraces {
+				t.Errorf("round-trip mismatch: got %d, want %d", got.MaxTraces, tcfg.MaxTraces)
+			}
+		})
+	}
+}
+
 func TestStack_NonContainerWorkloads(t *testing.T) {
 	stack := Stack{
 		Name: "test",

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -947,6 +947,9 @@ func buildTracingConfig(gw *config.GatewayConfig) *tracing.Config {
 	}
 	cfg.Export = t.Export
 	cfg.Endpoint = t.Endpoint
+	if t.MaxTraces > 0 {
+		cfg.MaxTraces = t.MaxTraces
+	}
 	return cfg
 }
 

--- a/pkg/controller/gateway_builder_test.go
+++ b/pkg/controller/gateway_builder_test.go
@@ -52,6 +52,52 @@ func TestGatewayBuilder_BuildLogging_Existing(t *testing.T) {
 }
 
 
+func TestBuildTracingConfig_MaxTraces(t *testing.T) {
+	// The documented default ring buffer capacity (docs/config-schema.md).
+	const defaultMaxTraces = 1000
+
+	tests := []struct {
+		name string
+		gw   *config.GatewayConfig
+		want int
+	}{
+		{
+			name: "nil gateway uses default",
+			gw:   nil,
+			want: defaultMaxTraces,
+		},
+		{
+			name: "nil tracing block uses default",
+			gw:   &config.GatewayConfig{},
+			want: defaultMaxTraces,
+		},
+		{
+			name: "explicit value is honored",
+			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Enabled: true, MaxTraces: 50}},
+			want: 50,
+		},
+		{
+			name: "zero value preserves default",
+			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Enabled: true, MaxTraces: 0}},
+			want: defaultMaxTraces,
+		},
+		{
+			name: "negative value preserves default",
+			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Enabled: true, MaxTraces: -5}},
+			want: defaultMaxTraces,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := buildTracingConfig(tt.gw)
+			if cfg.MaxTraces != tt.want {
+				t.Errorf("MaxTraces = %d, want %d", cfg.MaxTraces, tt.want)
+			}
+		})
+	}
+}
+
 func TestGatewayBuilder_SetVersion(t *testing.T) {
 	builder := NewGatewayBuilder(Config{}, &config.Stack{}, "", nil, &runtime.UpResult{})
 	builder.SetVersion("v0.1.0")


### PR DESCRIPTION
## Description

`gateway.tracing.max_traces` was documented but silently ignored — the stack schema had no matching field, so the value was dropped during YAML decode and the in-memory trace ring buffer always used the default of 1000. This wires the field through to the tracing provider.

## Type of Change

- [x] Bug fix

## Changes Made

- Add `MaxTraces int` (`yaml`/`json` `max_traces,omitempty`) to `config.TracingConfig`
- Copy it in `buildTracingConfig` with a default-preserving guard (`if t.MaxTraces > 0`), so unset/zero/negative values keep the 1000 default
- Add a table-driven regression test for `buildTracingConfig` (previously untested) and a `TracingConfig` YAML round-trip test
- Changelog entry under `[Unreleased]`

## Testing

- `go test -race ./pkg/config/... ./pkg/controller/...` passes
- `golangci-lint run` clean for the touched packages

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #816