### PR TITLE
fix: make gateway.tracing.enabled tri-state default-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -606,6 +606,12 @@ All notable changes to gridctl will be documented in this file.
   always used the default of 1000. The field is now wired through to the tracing
   provider; an unset or non-positive value continues to use the 1000 default.
 
+- **`gateway.tracing.enabled` is now a tri-state.** The field was a plain `bool`,
+  so a `tracing:` block that set other fields but omitted `enabled:` silently
+  disabled tracing (the omitted key resolved to `false`, overriding the documented
+  default of `true`). It is now a `*bool`: an omitted `enabled:` inherits the
+  default-on behavior, and `enabled: false` still disables explicitly.
+
 ## [0.1.0-beta.10] - 2026-05-18
 
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -154,7 +154,10 @@ type Secrets struct {
 // TracingConfig configures distributed tracing for the gateway.
 type TracingConfig struct {
 	// Enabled controls whether tracing is active. Default: true.
-	Enabled bool `yaml:"enabled" json:"enabled"`
+	// A pointer so an omitted `enabled:` inherits the default-on behavior
+	// rather than YAML's zero value (false); set it explicitly to false to
+	// disable tracing.
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	// Sampling is the head-based sampling rate [0.0, 1.0]. Default: 1.0.
 	Sampling float64 `yaml:"sampling,omitempty" json:"sampling,omitempty"`
 	// Retention is how long completed traces are kept in memory (e.g. "24h"). Default: "24h".

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -243,6 +243,45 @@ max_traces: 250
 	}
 }
 
+func TestTracingConfig_EnabledYAMLTriState(t *testing.T) {
+	tests := []struct {
+		name   string
+		yamlIn string
+		want   *bool
+	}{
+		{
+			name: "omitted enabled stays nil (inherits default)",
+			yamlIn: `sampling: 0.5
+`,
+			want: nil,
+		},
+		{
+			name: "explicit false",
+			yamlIn: `enabled: false
+`,
+			want: boolPtr(false),
+		},
+		{
+			name: "explicit true",
+			yamlIn: `enabled: true
+`,
+			want: boolPtr(true),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var tcfg TracingConfig
+			if err := yaml.Unmarshal([]byte(tc.yamlIn), &tcfg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !boolPtrEqual(tcfg.Enabled, tc.want) {
+				t.Errorf("Enabled = %v, want %v", tcfg.Enabled, tc.want)
+			}
+		})
+	}
+}
+
 func TestStack_NonContainerWorkloads(t *testing.T) {
 	stack := Stack{
 		Name: "test",

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -938,7 +938,9 @@ func buildTracingConfig(gw *config.GatewayConfig) *tracing.Config {
 		return cfg
 	}
 	t := gw.Tracing
-	cfg.Enabled = t.Enabled
+	if t.Enabled != nil {
+		cfg.Enabled = *t.Enabled
+	}
 	if t.Sampling > 0 {
 		cfg.Sampling = t.Sampling
 	}

--- a/pkg/controller/gateway_builder_test.go
+++ b/pkg/controller/gateway_builder_test.go
@@ -73,17 +73,17 @@ func TestBuildTracingConfig_MaxTraces(t *testing.T) {
 		},
 		{
 			name: "explicit value is honored",
-			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Enabled: true, MaxTraces: 50}},
+			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Enabled: boolPtr(true), MaxTraces: 50}},
 			want: 50,
 		},
 		{
 			name: "zero value preserves default",
-			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Enabled: true, MaxTraces: 0}},
+			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Enabled: boolPtr(true), MaxTraces: 0}},
 			want: defaultMaxTraces,
 		},
 		{
 			name: "negative value preserves default",
-			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Enabled: true, MaxTraces: -5}},
+			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Enabled: boolPtr(true), MaxTraces: -5}},
 			want: defaultMaxTraces,
 		},
 	}
@@ -93,6 +93,49 @@ func TestBuildTracingConfig_MaxTraces(t *testing.T) {
 			cfg := buildTracingConfig(tt.gw)
 			if cfg.MaxTraces != tt.want {
 				t.Errorf("MaxTraces = %d, want %d", cfg.MaxTraces, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildTracingConfig_Enabled(t *testing.T) {
+	tests := []struct {
+		name string
+		gw   *config.GatewayConfig
+		want bool
+	}{
+		{
+			name: "nil gateway defaults to enabled",
+			gw:   nil,
+			want: true,
+		},
+		{
+			name: "nil tracing block defaults to enabled",
+			gw:   &config.GatewayConfig{},
+			want: true,
+		},
+		{
+			name: "tracing block without enabled preserves default",
+			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Sampling: 0.5}},
+			want: true,
+		},
+		{
+			name: "explicit false disables",
+			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Enabled: boolPtr(false)}},
+			want: false,
+		},
+		{
+			name: "explicit true enables",
+			gw:   &config.GatewayConfig{Tracing: &config.TracingConfig{Enabled: boolPtr(true)}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := buildTracingConfig(tt.gw)
+			if cfg.Enabled != tt.want {
+				t.Errorf("Enabled = %v, want %v", cfg.Enabled, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

`gateway.tracing.enabled` defaults to `true`, but as a plain `bool` an omitted `enabled:` inside a present `tracing:` block resolved to `false`, silently disabling tracing. This makes the field a tri-state `*bool`, mirroring the existing `schema_pinning.enabled` pattern, so an omitted key inherits the default-on behavior.

## Type of Change

- [x] Bug fix

## Changes Made

- Change `config.TracingConfig.Enabled` from `bool` to `*bool` with `yaml`/`json` `enabled,omitempty`
- In `buildTracingConfig`, only override the default when set (`if t.Enabled != nil`), so a `tracing:` block without `enabled:` stays enabled
- Add a table-driven regression test for tri-state resolution and a YAML tri-state round-trip test
- Changelog entry under `[Unreleased]`

The runtime `tracing.Config.Enabled` stays a plain `bool`; this is backend-only (the web wizard already models `enabled` as optional). `omitempty` also stops `gridctl export` from emitting a spurious `enabled: false`.

## Testing

- `go test -race ./pkg/config/... ./pkg/controller/...` passes
- `golangci-lint run` clean for the touched packages

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #818