### PR TITLE
docs: add Antigravity manual config snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ Supported clients: Claude Desktop, Claude Code, Cursor, Windsurf, VS Code, Gemin
 
 Restart Claude Desktop after editing. All tools from your stack are now available.
 
+#### Antigravity
+```json
+{
+  "mcpServers": {
+    "gridctl": {
+      "serverUrl": "http://localhost:8180/mcp"
+    }
+  }
+}
+```
+
+Antigravity borrows Windsurf's `serverUrl` field but speaks streamable HTTP, so point it at the `/mcp` endpoint (not `/sse`). The IDE and CLI share `~/.gemini/config/mcp_config.json` on Antigravity 2.0. Since Antigravity caps each MCP server at 100 tools, pair a large stack with `gateway.code_mode: on`.
+
 </details>
 
 ## 🎬 Features


### PR DESCRIPTION
## Description

Adds an Antigravity entry to the README "Manual configuration" block. PR #821 already added Antigravity to the supported-clients roster, CHANGELOG, and AGENTS.md, but the manual-config section (the one linking section that enumerates per-client setup) still only covered the generic case and Claude Desktop.

## Type of Change

- [x] Documentation

## Changes Made

- Add `#### Antigravity` snippet under "Manual configuration" with the `serverUrl` -> `/mcp` config that `gridctl link antigravity` writes
- Note the `serverUrl`-but-streamable-HTTP quirk, the shared `~/.gemini/config/mcp_config.json` path, and the 100-tool cap / `code_mode` pairing

## Testing

Doc-only change. JSON snippet verified against `pkg/provisioner/antigravity.go` (`serverUrl` field pointed at the streamable `/mcp` endpoint).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed