### PR TITLE
feat: frost light-theme node and panel glass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ All notable changes to gridctl will be documented in this file.
 
 ### Added
 
-- Add a theme picker to the web UI with a Light / Dark / System triad: the dark "Obsidian Observatory" stays the default, a new hand-keyed light theme ("Observatory Day") is added, and System follows the OS `prefers-color-scheme` live. Choose it from the StatusBar (Appearance) or the command palette ("Appearance: …"); the choice persists, applies before first paint (no flash), and syncs across detached windows
+- Add a theme picker to the web UI with a Light / Dark / System triad: the dark "Obsidian Observatory" stays the default, a new hand-keyed light theme ("Observatory Day") is added, and System follows the OS `prefers-color-scheme` live. Choose it from the header (Appearance) or the command palette ("Appearance: …"); the choice persists, applies before first paint (no flash), and syncs across detached windows
+
+### Changed
+
+- Translate the topology node and tool-detail glass surfaces to frosted (translucent) glass in the light theme, so the canvas shows through softly and the glass language stays consistent with the dark theme
 
 ### Removed
 
+- Remove the one-time `${vault:KEY}` deprecation warning logged on stack load; the alias still resolves to `${var:KEY}`, the warning was just noise on every stand-up
 - Remove the dead Wiring Mode canvas overlay, the Secret Heatmap overlay (and its `/api/stack/secrets-map` endpoint), and the Drift overlay from the topology toolbar
 - Remove the dead latency-heat overlay code (`showLatencyHeat` store state and the unused `useLatencyHeat` hook), which was never wired to any UI or node
 

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -1,10 +1,8 @@
 package config
 
 import (
-	"log/slog"
 	"os"
 	"regexp"
-	"sync"
 )
 
 // Resolver looks up a variable by name. Returns value and whether it exists.
@@ -48,7 +46,7 @@ func VaultResolver(vault VaultLookup) Resolver {
 //   - ${VAR:-default}     — use default if undefined or empty
 //   - ${VAR:+replacement} — use replacement if defined and non-empty
 //   - ${var:KEY}          — variable store reference (canonical)
-//   - ${vault:KEY}        — deprecated alias for ${var:KEY}; warned once per process
+//   - ${vault:KEY}        — alias for ${var:KEY}, retained for back-compat
 //
 // The alternation tries the braced form first (longer match), then the bare $VAR form.
 var expandRegex = regexp.MustCompile(
@@ -56,21 +54,6 @@ var expandRegex = regexp.MustCompile(
 		`|` +
 		`\$([a-zA-Z_][a-zA-Z0-9_]*)`, // $VAR form
 )
-
-// vaultSyntaxDeprecationOnce ensures the "${vault:KEY}" syntax deprecation
-// banner prints at most once per process, even if a stack has dozens of
-// references. Resetting is exposed for tests; production code should never
-// touch it.
-var vaultSyntaxDeprecationOnce sync.Once
-
-// warnVaultSyntaxDeprecated logs the once-per-process deprecation warning for
-// stack files that still use ${vault:KEY}. The canonical syntax going forward
-// is ${var:KEY}; both resolve identically through the beta cycle.
-func warnVaultSyntaxDeprecated() {
-	vaultSyntaxDeprecationOnce.Do(func() {
-		slog.Warn(`"${vault:KEY}" syntax is deprecated, use "${var:KEY}" instead. Removal at v1.0.`)
-	})
-}
 
 // ExpandString expands variable references in a string using the given resolver.
 // All patterns are matched in a single pass to prevent double-expansion of values
@@ -113,13 +96,10 @@ func ExpandStringRefs(s string, resolve Resolver) (expanded string, storeRefs []
 		}
 
 		// Braced ${...} form. `var` and `vault` are both store-prefixed
-		// references; `var` is canonical and `vault` is the deprecated alias
-		// retained through beta.
+		// references; `var` is canonical and `vault` is a back-compat alias
+		// that resolves identically.
 		prefix := parts[1]
 		isStoreRef := prefix == "vault" || prefix == "var"
-		if prefix == "vault" {
-			warnVaultSyntaxDeprecated()
-		}
 		varName := parts[2]
 		op := parts[3]
 		operand := parts[4]

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 )
 
@@ -362,13 +361,11 @@ mcp-servers:
 	}
 }
 
-// TestVaultSyntaxDeprecation verifies that ${vault:KEY} produces the
-// deprecation warning exactly once per process even when the input has
-// multiple ${vault:KEY} occurrences (Article XIV: no per-occurrence spam).
-func TestVaultSyntaxDeprecation(t *testing.T) {
-	// Reset the once so this test can observe its own first invocation.
-	vaultSyntaxDeprecationOnce = sync.Once{}
-
+// TestVaultSyntaxNoDeprecationWarning verifies that ${vault:KEY} still resolves
+// correctly and no longer emits a deprecation warning. The alias is retained for
+// back-compat; the prior once-per-process warning was removed because it was
+// noisy on every stack stand-up.
+func TestVaultSyntaxNoDeprecationWarning(t *testing.T) {
 	var buf bytes.Buffer
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
@@ -376,28 +373,12 @@ func TestVaultSyntaxDeprecation(t *testing.T) {
 
 	vault := &mockVault{secrets: map[string]string{"A": "1", "B": "2"}}
 
-	// Many vault refs in one expansion → one warning.
-	_, _, _ = ExpandString("${vault:A}-${vault:B}-${vault:A}", VaultResolver(vault))
-
-	out := buf.String()
-	count := strings.Count(out, "syntax is deprecated")
-	if count != 1 {
-		t.Errorf("deprecation warning count = %d, want 1; buf=%q", count, out)
+	out, _, _ := ExpandString("${vault:A}-${vault:B}-${vault:A}", VaultResolver(vault))
+	if out != "1-2-1" {
+		t.Errorf("expansion = %q, want %q", out, "1-2-1")
 	}
-
-	// Second expansion in the same process → still exactly one warning.
-	buf.Reset()
-	_, _, _ = ExpandString("${vault:A}", VaultResolver(vault))
 	if strings.Contains(buf.String(), "deprecated") {
-		t.Errorf("deprecation warning fired again on subsequent call; output: %q", buf.String())
-	}
-
-	// ${var:KEY} must NOT produce a warning.
-	vaultSyntaxDeprecationOnce = sync.Once{}
-	buf.Reset()
-	_, _, _ = ExpandString("${var:A}", VaultResolver(vault))
-	if strings.Contains(buf.String(), "deprecated") {
-		t.Errorf("${var:KEY} produced a deprecation warning; output: %q", buf.String())
+		t.Errorf("${vault:KEY} emitted a deprecation warning; output: %q", buf.String())
 	}
 }
 

--- a/web/src/components/graph/CustomNode.tsx
+++ b/web/src/components/graph/CustomNode.tsx
@@ -73,7 +73,7 @@ const CustomNode = memo(({ data, selected }: CustomNodeProps) => {
   return (
     <div
       className={cn(
-        'w-64 rounded-xl relative',
+        'w-64 rounded-xl relative frost-surface',
         'backdrop-blur-xl border transition-all duration-200 ease-out',
         'shadow-bevel',
         isServer

--- a/web/src/components/graph/GatewayNode.tsx
+++ b/web/src/components/graph/GatewayNode.tsx
@@ -17,7 +17,7 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
   return (
     <div
       className={cn(
-        'w-60 rounded-2xl',
+        'w-60 rounded-2xl frost-surface',
         'bg-gradient-to-b from-surface/95 via-surface/90 to-primary/[0.03]',
         'backdrop-blur-xl border border-border',
         'shadow-lg-bevel transition-all duration-300 ease-out',

--- a/web/src/components/graph/ToolDetailPopover.tsx
+++ b/web/src/components/graph/ToolDetailPopover.tsx
@@ -81,7 +81,7 @@ const ToolDetailPopover = memo(({ serverName, toolName, onClose }: ToolDetailPop
       // pane/node handlers; dismissal is the parent's job via useDismiss.
       onClick={(e) => e.stopPropagation()}
       className={cn(
-        'nodrag absolute left-full top-0 ml-2 z-50 w-72',
+        'nodrag absolute left-full top-0 ml-2 z-50 w-72 frost-surface',
         'rounded-lg border border-border bg-surface-elevated/95',
         'backdrop-blur-xl shadow-bevel animate-fade-in-scale',
       )}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -194,6 +194,16 @@ html, body, #root {
   background-color: var(--color-background);
 }
 
+/* Frosted-glass surfaces in light theme. Topology nodes and the tool-detail
+   popover paint an opaque Tailwind surface (from-surface/95, bg-surface-
+   elevated/95) that reads as a flat white card on the bright canvas. In light
+   only, drop them to a translucent white so the existing backdrop-blur frosts
+   the canvas/grid behind them — cohesive with the dark glass language. Dark
+   keeps its opaque surfaces (no rule), since glass fades into the inky bg. */
+:root[data-theme='light'] .frost-surface {
+  background: rgba(255, 255, 255, 0.6) !important;
+}
+
 body {
   background-color: var(--color-background);
   color: var(--color-text-primary);


### PR DESCRIPTION
## Description

Two light-theme polish items: translate the topology node and tool-detail glass surfaces to frosted (translucent) glass so they read as glass rather than flat white cards, and remove the noisy one-time `${vault:KEY}` deprecation warning logged on every stack stand-up.

## Type of Change

- [x] New feature (non-breaking) + log-noise cleanup

## Changes Made

- Frosted glass (light only): tag the gateway/server/resource nodes and the tool-detail popover with `frost-surface`; a `[data-theme='light']` rule drops them to translucent white so the existing backdrop-blur frosts the canvas behind them. Dark theme is untouched (its opaque surfaces stay)
- Remove the `${vault:KEY}` deprecation warning and its once-per-process guard from `pkg/config/expand.go` (the alias still resolves to `${var:KEY}`); replace the deprecation test with one asserting no warning is emitted

## Testing

`go test ./pkg/config/...` and `cd web && npm test` pass; `make build` succeeds with the UI embedded. Manually verified frosted nodes/popover in the light theme and confirmed the deprecation WARN no longer logs on stack load.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed