### PR TITLE
feat: consistent depth hierarchy across workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to gridctl will be documented in this file.
 ### Changed
 
 - Translate the topology node and tool-detail glass surfaces to frosted (translucent) glass in the light theme, so the canvas shows through softly and the glass language stays consistent with the dark theme
+- Give every workspace a consistent depth hierarchy: detail/inspector panes now read as an opaque elevated surface (pure white in the light theme) lifted above a recessed list canvas, the pane divider is stronger, and a soft shadow falls from the detail pane onto the list. A thin amber leading edge ties each detail pane to the active list item, and the selected skill card's left accent warms to amber. Applies across Topology, Library, Variables, Tools, and Metrics in both themes
 
 ### Removed
 

--- a/web/src/components/inspector/PaneAnchor.tsx
+++ b/web/src/components/inspector/PaneAnchor.tsx
@@ -1,0 +1,14 @@
+/**
+ * PaneAnchor draws a thin amber bar down the leading (left) edge of a
+ * detail/inspector pane. It rhymes with the active list item's own left accent
+ * (e.g. SkillCard), forming a visual breadcrumb from the selected object to its
+ * expanded properties. Purely decorative — the owning pane must be `relative`.
+ */
+export function PaneAnchor() {
+  return (
+    <span
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-y-0 left-0 w-0.5 bg-primary/40"
+    />
+  );
+}

--- a/web/src/components/inspector/index.ts
+++ b/web/src/components/inspector/index.ts
@@ -1,3 +1,4 @@
 export { InspectorHeader } from './InspectorHeader';
 export { InspectorSection } from './InspectorSection';
+export { PaneAnchor } from './PaneAnchor';
 export { InspectorTabList, InspectorTabButton } from './InspectorTabList';

--- a/web/src/components/layout/WorkspaceShell.tsx
+++ b/web/src/components/layout/WorkspaceShell.tsx
@@ -149,7 +149,10 @@ export function WorkspaceShell({
           collapsedSize={0}
           panelRef={rightPanelRef}
         >
-          <div className="h-full overflow-hidden">{right}</div>
+          {/* Elevated detail pane: the leftward edge shadow lets it read as
+              lifted above the recessed list. Lives on the wrapper so the cast
+              shadow is not clipped by the pane's own internal overflow. */}
+          <div className="h-full overflow-hidden shadow-pane-left">{right}</div>
         </Panel>
       )}
     </Group>
@@ -179,7 +182,7 @@ function SeparatorBody({ orientation }: SeparatorBodyProps) {
       <div
         className={cn(
           'absolute transition-colors duration-150',
-          'bg-border/40',
+          'bg-border',
           'group-hover/separator:bg-primary/30',
           'group-data-[separator-active=true]/separator:bg-primary/50',
           isVertical ? 'w-px inset-y-0 left-1/2 -translate-x-px' : 'h-px inset-x-0 top-1/2 -translate-y-px',

--- a/web/src/components/metrics/MetricsInspector.tsx
+++ b/web/src/components/metrics/MetricsInspector.tsx
@@ -2,6 +2,7 @@ import { X, DollarSign } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { formatCompactNumber, formatUSD } from '../../lib/format';
 import { AreaChart } from '../chart/AreaChart';
+import { PaneAnchor } from '../inspector';
 import { ClientModelCell } from '../pricing/ClientModelCell';
 import { ServerModelCell } from '../pricing/ServerModelCell';
 import {
@@ -65,7 +66,8 @@ export function MetricsInspector({
   const costSeriesHasData = costSeries.some((d) => d['Cost (USD)'] > 0);
 
   return (
-    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle">
+    <aside className="relative h-full flex flex-col bg-surface-elevated border-l border-border">
+      <PaneAnchor />
       <div className="flex-shrink-0 flex items-center gap-2 px-4 py-3 border-b border-border-subtle">
         <div className="min-w-0">
           <div className="text-[10px] uppercase tracking-[0.3em] text-text-muted/60">
@@ -194,7 +196,8 @@ function InspectorStat({ label, value, className }: { label: string; value: stri
 // empty rail, carrying the same honesty copy the cards use.
 function InspectorOverview({ onOpenManager }: { onOpenManager: () => void }) {
   return (
-    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle">
+    <aside className="relative h-full flex flex-col bg-surface-elevated border-l border-border">
+      <PaneAnchor />
       <div className="flex-shrink-0 px-4 py-3 border-b border-border-subtle">
         <div className="text-[10px] uppercase tracking-[0.3em] text-text-muted/60">about cost</div>
       </div>

--- a/web/src/components/registry/SkillCard.tsx
+++ b/web/src/components/registry/SkillCard.tsx
@@ -77,10 +77,18 @@ export const SkillCard = memo(({
         isActive && 'via-primary/50',
       )} />
 
-      {/* Left accent — a single neutral, static anchor for cross-card scanning.
-          Category-agnostic (not a per-category color), conveyed only as visual
-          rhythm; the category itself reads as text in the metadata line. */}
-      <div aria-hidden="true" className="absolute top-0 bottom-0 left-0 w-0.5 bg-white/10" />
+      {/* Left accent — neutral at rest for cross-card scanning rhythm, warming
+          to amber only while this card is the active selection. The amber bar
+          rhymes with the detail pane's leading edge (PaneAnchor), tracing a
+          breadcrumb from the selected card to its expanded properties. It marks
+          transient selection, not category identity (which reads as text). */}
+      <div
+        aria-hidden="true"
+        className={cn(
+          'absolute top-0 bottom-0 left-0 w-0.5 transition-colors duration-200',
+          isActive ? 'bg-primary' : 'bg-white/10',
+        )}
+      />
 
       {/* Card body — clickable to open the inspector */}
       <div

--- a/web/src/components/registry/SkillDetailPanel.tsx
+++ b/web/src/components/registry/SkillDetailPanel.tsx
@@ -5,7 +5,7 @@ import { extractRepoInfo } from '../../lib/repo';
 import { toTitleCase } from '../../lib/text';
 import { parseAcceptanceCriterion } from '../../lib/skillCriteria';
 import { formatLastUsed } from '../../lib/toolAudit';
-import { InspectorHeader, InspectorTabList, InspectorTabButton } from '../inspector';
+import { InspectorHeader, InspectorTabList, InspectorTabButton, PaneAnchor } from '../inspector';
 import { IconButton } from '../ui/IconButton';
 import { StateBadge } from './StateBadge';
 import { MarkdownPreview } from './MarkdownPreview';
@@ -83,7 +83,8 @@ export function SkillDetailPanel({
 
   if (!skill) {
     return (
-      <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle">
+      <aside className="relative h-full flex flex-col bg-surface-elevated border-l border-border">
+        <PaneAnchor />
         <SkillDetailEmpty />
       </aside>
     );
@@ -108,7 +109,8 @@ export function SkillDetailPanel({
   const hasLocalEdits = source?.driftedSkills?.includes(skill.name) ?? false;
 
   return (
-    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle">
+    <aside className="relative h-full flex flex-col bg-surface-elevated border-l border-border">
+      <PaneAnchor />
       <InspectorHeader
         title={skill.name}
         icon={BookOpen}

--- a/web/src/components/vault/VariableInspector.tsx
+++ b/web/src/components/vault/VariableInspector.tsx
@@ -21,7 +21,7 @@ import { CodeViewer } from '../ui/CodeViewer';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import { IconButton } from '../ui/IconButton';
 import { showToast } from '../ui/Toast';
-import { InspectorHeader } from '../inspector';
+import { InspectorHeader, PaneAnchor } from '../inspector';
 import { generateSecret } from '../../lib/generateSecret';
 import { useRevealedValues } from '../../hooks/useRevealedValues';
 import { ConsumerList } from './ConsumerList';
@@ -264,8 +264,9 @@ export function VariableInspector({
     return (
       <aside
         aria-label="Variable inspector"
-        className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle"
+        className="relative h-full flex flex-col bg-surface-elevated border-l border-border"
       >
+        <PaneAnchor />
         <InspectorOverview
           variables={allVariables}
           usage={usage}
@@ -282,8 +283,9 @@ export function VariableInspector({
   return (
     <aside
       aria-label="Variable inspector"
-      className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle"
+      className="relative h-full flex flex-col bg-surface-elevated border-l border-border"
     >
+      <PaneAnchor />
       <InspectorHeader
         title={variable.key}
         icon={variable.is_secret ? Lock : Eye}

--- a/web/src/components/workspaces/MetricsWorkspace.tsx
+++ b/web/src/components/workspaces/MetricsWorkspace.tsx
@@ -385,7 +385,7 @@ interface ScopeRailProps {
 
 function ScopeRail({ compact, scope, onSelectScope, clientCount, serverCount, modelCount }: ScopeRailProps) {
   return (
-    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-r border-border-subtle">
+    <aside className="h-full flex flex-col bg-surface border-r border-border-subtle">
       <div className={cn('flex-shrink-0 px-3 border-b border-border-subtle/60', compact ? 'py-2' : 'py-3')}>
         <div className="text-[10px] font-medium text-text-muted/60 uppercase tracking-[0.3em]">breakdown</div>
       </div>

--- a/web/src/components/workspaces/ToolDetailPanel.tsx
+++ b/web/src/components/workspaces/ToolDetailPanel.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { Wrench } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { CodeViewer } from '../ui/CodeViewer';
-import { InspectorHeader } from '../inspector';
+import { InspectorHeader, PaneAnchor } from '../inspector';
 import { formatLastUsed, type AuditState } from '../../lib/toolAudit';
 import type { ToolRow } from '../../hooks/useToolsEditor';
 
@@ -42,7 +42,8 @@ export function ToolDetailPanel({
   onClose,
 }: ToolDetailPanelProps) {
   return (
-    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-l border-border-subtle">
+    <aside className="relative h-full flex flex-col bg-surface-elevated border-l border-border">
+      <PaneAnchor />
       {tool ? (
         <>
           <InspectorHeader

--- a/web/src/components/workspaces/ToolsWorkspace.tsx
+++ b/web/src/components/workspaces/ToolsWorkspace.tsx
@@ -509,7 +509,7 @@ function ServerRail({
   unusedByServer,
 }: ServerRailProps) {
   return (
-    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-r border-border-subtle">
+    <aside className="h-full flex flex-col bg-surface border-r border-border-subtle">
       <div
         className={cn(
           'flex-shrink-0 px-3 border-b border-border-subtle/60',

--- a/web/src/components/workspaces/TopologyWorkspace.tsx
+++ b/web/src/components/workspaces/TopologyWorkspace.tsx
@@ -122,7 +122,7 @@ export function TopologyWorkspace() {
         </div>
 
         {sidebarOpen && (
-          <aside className="flex flex-row overflow-hidden bg-surface/80 backdrop-blur-xl border-l border-border/50">
+          <aside className="flex flex-row overflow-hidden bg-surface-elevated border-l border-border shadow-pane-left">
             <ResizeHandle
               direction="vertical"
               onResize={handleSidebarResize}

--- a/web/src/components/workspaces/VaultWorkspace.tsx
+++ b/web/src/components/workspaces/VaultWorkspace.tsx
@@ -831,7 +831,7 @@ function VaultLeftRail({
   locked,
 }: VaultLeftRailProps) {
   return (
-    <aside className="h-full flex flex-col bg-surface/40 backdrop-blur-sm border-r border-border-subtle">
+    <aside className="h-full flex flex-col bg-surface border-r border-border-subtle">
       <div
         className={cn(
           'flex-shrink-0 px-3 border-b border-border-subtle/60',

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -74,6 +74,9 @@
   --selection-border: rgba(245, 158, 11, 0.3);
   --shadow-node: 0 4px 24px rgba(0, 0, 0, 0.4);
   --shadow-node-hover: 0 8px 40px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  /* Soft directional shadow cast leftward by an elevated detail/inspector pane
+     onto the recessed list behind it. Tight, diffuse, no spread. */
+  --shadow-pane-left: -12px 0 28px -16px rgba(0, 0, 0, 0.7);
   --grain-opacity: 0.015;
 }
 
@@ -149,6 +152,8 @@
   --shadow-lg: 0 10px 32px rgba(15, 23, 42, 0.11), 0 4px 12px rgba(15, 23, 42, 0.07);
   --shadow-node: 0 4px 20px rgba(15, 23, 42, 0.09);
   --shadow-node-hover: 0 8px 32px rgba(15, 23, 42, 0.13), 0 0 0 1px rgba(15, 23, 42, 0.06);
+  /* Cool-slate edge shadow (matches the light palette's other elevation cues) */
+  --shadow-pane-left: -12px 0 26px -16px rgba(15, 23, 42, 0.16);
 
   /* Glow dropped on light — map glow tokens to soft accent drop-shadows. */
   --shadow-glow-primary: 0 2px 10px var(--color-primary-glow);

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -74,6 +74,7 @@ export default {
         'lg': 'var(--shadow-lg)',
         'node': 'var(--shadow-node)',
         'node-hover': 'var(--shadow-node-hover)',
+        'pane-left': 'var(--shadow-pane-left)',
         'glow-primary': 'var(--shadow-glow-primary)',
         'glow-secondary': 'var(--shadow-glow-secondary)',
         'glow-tertiary': 'var(--shadow-glow-tertiary)',


### PR DESCRIPTION
## Description

Gives every workspace a consistent three-tier depth hierarchy so master-detail surfaces no longer read as a single focal plane. Driven entirely by existing design tokens, so both themes re-key automatically; the flatness was worst in the light theme.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Detail/inspector panes now read as an opaque elevated surface (pure white in the light theme) lifted above a recessed list canvas, replacing the translucent `bg-surface/40` glass.
- Strengthened the shared `WorkspaceShell` rail divider and added a soft `pane-left` shadow cast from the detail pane onto the list (new theme-aware token).
- Added a shared `PaneAnchor` amber leading edge on each detail pane, and warmed the active skill card's left accent to amber, tracing a breadcrumb from selection to detail.
- Applied across Topology, Library, Variables, Tools, and Metrics in both light and dark themes.

## Testing

`make build` then `./gridctl serve -f`, open the UI, and toggle the theme picker (header, top-right). Verify on each workspace that the detail pane reads as forward/elevated, the divider and pane shadow are visible, and selecting an item lights the amber anchor. Check both light and dark.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #830