### PR TITLE
fix: gate detail-pane anchor to selected state

### DIFF
--- a/web/src/components/metrics/MetricsInspector.tsx
+++ b/web/src/components/metrics/MetricsInspector.tsx
@@ -197,7 +197,6 @@ function InspectorStat({ label, value, className }: { label: string; value: stri
 function InspectorOverview({ onOpenManager }: { onOpenManager: () => void }) {
   return (
     <aside className="relative h-full flex flex-col bg-surface-elevated border-l border-border">
-      <PaneAnchor />
       <div className="flex-shrink-0 px-4 py-3 border-b border-border-subtle">
         <div className="text-[10px] uppercase tracking-[0.3em] text-text-muted/60">about cost</div>
       </div>

--- a/web/src/components/registry/SkillDetailPanel.tsx
+++ b/web/src/components/registry/SkillDetailPanel.tsx
@@ -84,7 +84,6 @@ export function SkillDetailPanel({
   if (!skill) {
     return (
       <aside className="relative h-full flex flex-col bg-surface-elevated border-l border-border">
-        <PaneAnchor />
         <SkillDetailEmpty />
       </aside>
     );

--- a/web/src/components/vault/VariableInspector.tsx
+++ b/web/src/components/vault/VariableInspector.tsx
@@ -266,7 +266,6 @@ export function VariableInspector({
         aria-label="Variable inspector"
         className="relative h-full flex flex-col bg-surface-elevated border-l border-border"
       >
-        <PaneAnchor />
         <InspectorOverview
           variables={allVariables}
           usage={usage}

--- a/web/src/components/workspaces/ToolDetailPanel.tsx
+++ b/web/src/components/workspaces/ToolDetailPanel.tsx
@@ -43,9 +43,9 @@ export function ToolDetailPanel({
 }: ToolDetailPanelProps) {
   return (
     <aside className="relative h-full flex flex-col bg-surface-elevated border-l border-border">
-      <PaneAnchor />
       {tool ? (
         <>
+          <PaneAnchor />
           <InspectorHeader
             title={tool.name}
             icon={Wrench}


### PR DESCRIPTION
## Description

The amber leading-edge anchor on detail/inspector panes (added in #831) rendered unconditionally, so it showed on the empty/no-selection state — which is the default landing view of every workspace. This gates it to the selected state so it only appears when there is an item to anchor.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Render `PaneAnchor` only in each pane's content branch (Library, Variables, Tools, Metrics); empty states fall back to the neutral pane border.
- The depth treatment (elevated surface, `shadow-pane-left`, neutral border) is unchanged in both states — only the amber anchor is now selection-gated, so the list item's accent and the pane's accent appear and disappear together.

## Testing

`make build` then `./gridctl serve -f`. Enter each workspace with nothing selected (the default) and confirm the right pane reads neutral; select an item and confirm the amber anchor appears in sync with the card/row accent. Check both light and dark themes.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #832