### PR TITLE
fix: stop Tools workspace blanking when no servers attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to gridctl will be documented in this file.
 
 - Add a theme picker to the web UI with a Light / Dark / System triad: the dark "Obsidian Observatory" stays the default, a new hand-keyed light theme ("Observatory Day") is added, and System follows the OS `prefers-color-scheme` live. Choose it from the header (Appearance) or the command palette ("Appearance: …"); the choice persists, applies before first paint (no flash), and syncs across detached windows
 
+### Fixed
+
+- Stop the Tools workspace from crashing to a blank screen when no MCP servers are attached. The tool-catalog endpoint now returns an empty array (never null) in stackless mode, the store and fuzzy-search hook coalesce a missing list to empty, and a shared error boundary now wraps the workspace outlet (and the app root) so a render error degrades to a recoverable message with the navigation intact instead of unmounting the whole UI
+
 ### Changed
 
 - Translate the topology node and tool-detail glass surfaces to frosted (translucent) glass in the light theme, so the canvas shows through softly and the glass language stays consistent with the dark theme

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -609,6 +609,11 @@ func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result, _ := s.gateway.HandleToolsListUnscoped()
+	// Always serialize an empty inventory as [], never null: web consumers
+	// index into the list (e.g. fuzzy search) where a null would throw.
+	if result != nil && result.Tools == nil {
+		result.Tools = []mcp.Tool{}
+	}
 	writeJSON(w, result)
 }
 
@@ -623,6 +628,10 @@ func (s *Server) handleToolsCatalog(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result, _ := s.gateway.HandleToolsCatalog()
+	// Always serialize an empty catalog as [], never null (see handleTools).
+	if result != nil && result.Tools == nil {
+		result.Tools = []mcp.Tool{}
+	}
 	writeJSON(w, result)
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -419,6 +419,33 @@ func TestHandleTools_Empty(t *testing.T) {
 	}
 }
 
+// TestHandleTools_EmptySerializesArrayNotNull guards the contract that an
+// empty tool inventory serializes as [] rather than null. A null body reached
+// the web UI's fuzzy search (new Fuse(null)) and crashed the Tools workspace
+// to a blank screen. Decoding JSON can't catch this (null and [] both decode
+// to a zero-length slice), so assert on the raw body.
+func TestHandleTools_EmptySerializesArrayNotNull(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Handler()
+
+	for _, path := range []string{"/api/tools", "/api/tools/catalog"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s: expected 200, got %d", path, rec.Code)
+		}
+		body := strings.TrimSpace(rec.Body.String())
+		if strings.Contains(body, `"tools":null`) {
+			t.Errorf("%s: tools serialized as null: %s", path, body)
+		}
+		if !strings.Contains(body, `"tools":[]`) {
+			t.Errorf("%s: expected \"tools\":[] in body, got %s", path, body)
+		}
+	}
+}
+
 func TestHandleTools_WithTools(t *testing.T) {
 	srv := newTestServer(t)
 

--- a/web/src/__tests__/ToolsWorkspace.test.tsx
+++ b/web/src/__tests__/ToolsWorkspace.test.tsx
@@ -150,6 +150,22 @@ describe('ToolsWorkspace', () => {
   });
 });
 
+describe('ToolsWorkspace — empty stack', () => {
+  it('renders the empty state without crashing when there are no servers and the catalog is null', () => {
+    // Regression: in stackless mode the catalog API returns {"tools": null}.
+    // That null used to reach new Fuse(null) via useFuzzySearch and throw
+    // during render, unmounting the whole app to a blank screen.
+    useStackStore.setState({
+      isLoading: false,
+      mcpServers: [],
+      tools: null as unknown as Tool[],
+      toolCatalog: null as unknown as Tool[],
+    });
+    expect(() => renderAt('/tools')).not.toThrow();
+    expect(screen.getByText(/no mcp servers yet/i)).toBeInTheDocument();
+  });
+});
+
 describe('ToolsWorkspace — Audit Mode', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/web/src/__tests__/useFuzzySearch.test.ts
+++ b/web/src/__tests__/useFuzzySearch.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useFuzzySearch } from '../hooks/useFuzzySearch';
+
+interface Item {
+  name: string;
+  description?: string;
+}
+
+const items: Item[] = [
+  { name: 'create_issue', description: 'Create a GitHub issue' },
+  { name: 'list_repos', description: 'List repositories' },
+  { name: 'get_page', description: 'Get a Confluence page' },
+];
+
+describe('useFuzzySearch', () => {
+  it('returns the full list unchanged when the query is blank', () => {
+    const { result } = renderHook(() => useFuzzySearch(items, ''));
+    expect(result.current).toEqual(items);
+  });
+
+  it('fuzzy-filters by name and description', () => {
+    const { result } = renderHook(() => useFuzzySearch(items, 'repos'));
+    expect(result.current.map((i) => i.name)).toEqual(['list_repos']);
+  });
+
+  // Regression: a null/undefined list (e.g. the stackless tool catalog the
+  // gateway returns as null) must not reach new Fuse(null), which throws on
+  // `.length` and would unmount the whole app.
+  it('treats a null list as empty without throwing', () => {
+    const { result } = renderHook(() =>
+      useFuzzySearch(null as unknown as Item[], ''),
+    );
+    expect(result.current).toEqual([]);
+  });
+
+  it('treats an undefined list as empty without throwing, even with a query', () => {
+    const { result } = renderHook(() =>
+      useFuzzySearch(undefined as unknown as Item[], 'anything'),
+    );
+    expect(result.current).toEqual([]);
+  });
+});

--- a/web/src/components/shell/AppShell.tsx
+++ b/web/src/components/shell/AppShell.tsx
@@ -8,6 +8,7 @@ import { AuthPrompt } from '../auth/AuthPrompt';
 import { ResizeHandle } from '../ui/ResizeHandle';
 import { CommandPalette } from '../palette/CommandPalette';
 import { ToastContainer } from '../ui/Toast';
+import { ErrorBoundary } from '../ui/ErrorBoundary';
 import { useStackStore } from '../../stores/useStackStore';
 import { useUIStore } from '../../stores/useUIStore';
 import { useAuthStore } from '../../stores/useAuthStore';
@@ -145,7 +146,13 @@ function AppShellInner() {
       <Header onRefresh={handleRefresh} isRefreshing={isRefreshing} />
 
       <main className="relative overflow-hidden" style={{ minHeight: 100 }}>
-        <Outlet />
+        {/* Contain a workspace render throw so the shell (header, nav, status
+            bar) stays mounted and the user can navigate away. Resetting on the
+            route path lets navigation recover a crashed workspace without a
+            full reload. */}
+        <ErrorBoundary variant="inline" resetKey={pathname}>
+          <Outlet />
+        </ErrorBoundary>
       </main>
 
       <div className="flex flex-col h-full overflow-hidden">

--- a/web/src/components/ui/ErrorBoundary.tsx
+++ b/web/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,80 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { AlertCircle } from 'lucide-react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  // 'window' fills the viewport and offers a full reload — for the detached
+  // popouts and the last-resort top-level boundary. 'inline' fills its parent
+  // container and offers an in-place retry — for the in-shell workspace outlet,
+  // so a crashing workspace keeps the surrounding shell (header, nav, status
+  // bar) mounted and recoverable.
+  variant?: 'window' | 'inline';
+  // When this value changes, a tripped boundary resets itself. The shell passes
+  // the route path so navigating away from a crashed workspace recovers without
+  // a full page reload (an unmounted tree otherwise leaves in-app nav inert).
+  resetKey?: unknown;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+// ErrorBoundary contains a render-time throw so it degrades to a recoverable
+// fallback instead of unmounting the whole React tree to a blank page. It is
+// the single implementation behind both the detached popout windows and the
+// main app shell.
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // The fallback only shows the message; log the full error + component
+    // stack so a render crash is debuggable from the console.
+    console.error('ErrorBoundary caught a render error', error, info.componentStack);
+  }
+
+  componentDidUpdate(prev: ErrorBoundaryProps) {
+    // Clear the error when the reset key changes (e.g. the route) so the next
+    // render attempts the new subtree.
+    if (this.state.error && prev.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  private handleRetry = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    const inline = this.props.variant === 'inline';
+    const container = inline
+      ? 'h-full w-full bg-background flex items-center justify-center p-8'
+      : 'h-screen w-screen bg-background flex items-center justify-center';
+
+    return (
+      <div className={container}>
+        <div className="text-center p-8 max-w-md">
+          <div className="p-4 rounded-xl bg-status-error/10 border border-status-error/20 inline-block mb-4">
+            <AlertCircle size={32} className="text-status-error" />
+          </div>
+          <h1 className="text-lg text-status-error mb-2">Something went wrong</h1>
+          <pre className="text-xs text-text-muted bg-surface p-4 rounded-lg overflow-auto max-h-32 mb-4">
+            {error.message}
+          </pre>
+          <button
+            onClick={inline ? this.handleRetry : () => window.location.reload()}
+            className="px-4 py-2 bg-primary text-background rounded-lg font-medium hover:bg-primary-light transition-colors"
+          >
+            {inline ? 'Try again' : 'Reload Window'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/web/src/hooks/useFuzzySearch.ts
+++ b/web/src/hooks/useFuzzySearch.ts
@@ -12,14 +12,20 @@ export interface FuzzySearchable {
 // Fuzzy-filter a list of name/description records by query, returning the full
 // list unchanged when the query is blank. Memoized on the source list and the
 // query so re-renders that change neither are free.
+//
+// `items` is coalesced to an empty list defensively: callers can pass a store
+// value that is momentarily null/undefined (e.g. a catalog the gateway returns
+// as null in stackless mode), and `new Fuse(null)` would throw on `.length`.
 export function useFuzzySearch<T extends FuzzySearchable>(items: T[], query: string): T[] {
+  const list = useMemo(() => items ?? [], [items]);
+
   const fuse = useMemo(
-    () => new Fuse(items, { keys: ['name', 'description'], threshold: 0.4 }),
-    [items],
+    () => new Fuse(list, { keys: ['name', 'description'], threshold: 0.4 }),
+    [list],
   );
 
   return useMemo(() => {
-    if (!query.trim()) return items;
+    if (!query.trim()) return list;
     return fuse.search(query).map((r) => r.item);
-  }, [fuse, query, items]);
+  }, [fuse, query, list]);
 }

--- a/web/src/hooks/usePolling.ts
+++ b/web/src/hooks/usePolling.ts
@@ -35,8 +35,11 @@ export function usePolling() {
       ]);
 
       setGatewayStatus(status);
-      setTools(toolsResult.tools);
-      setToolCatalog(catalogResult.tools);
+      // Coalesce to []: these endpoints serialize an empty inventory as null
+      // (nil Go slice) in stackless mode, and downstream consumers index into
+      // the catalog (e.g. useFuzzySearch → new Fuse) where null would throw.
+      setTools(toolsResult.tools ?? []);
+      setToolCatalog(catalogResult.tools ?? []);
       setAuthRequired(false);
 
       // Fetch clients separately — failure should not block core updates

--- a/web/src/hooks/useToolsEditor.ts
+++ b/web/src/hooks/useToolsEditor.ts
@@ -224,8 +224,10 @@ export function useToolsEditor(
           fetchToolCatalog(),
         ]);
         useStackStore.getState().setGatewayStatus(status);
-        useStackStore.getState().setTools(toolsList.tools);
-        useStackStore.getState().setToolCatalog(catalogList.tools);
+        // Coalesce to []: stackless responses carry null tool lists (nil Go
+        // slice) that would crash list/search consumers downstream.
+        useStackStore.getState().setTools(toolsList.tools ?? []);
+        useStackStore.getState().setToolCatalog(catalogList.tools ?? []);
       } catch {
         /* ignore refresh failures — the page will re-poll shortly */
       }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,14 +3,19 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import { CommandRegistryProvider } from './hooks/useCommandRegistry';
+import { ErrorBoundary } from './components/ui/ErrorBoundary';
 import { AppRoutes } from './routes';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <CommandRegistryProvider>
-        <AppRoutes />
-      </CommandRegistryProvider>
-    </BrowserRouter>
+    {/* Last-resort net: a throw above the shell (router, providers) still
+        renders a recoverable page instead of a blank #root. */}
+    <ErrorBoundary variant="window">
+      <BrowserRouter>
+        <CommandRegistryProvider>
+          <AppRoutes />
+        </CommandRegistryProvider>
+      </BrowserRouter>
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/web/src/pages/DetachedEditorPage.tsx
+++ b/web/src/pages/DetachedEditorPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, useCallback, Component, type ReactNode } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { AlertCircle, Wrench } from 'lucide-react';
 import { SkillEditor } from '../components/registry/SkillEditor';
 import { ToastContainer } from '../components/ui/Toast';
+import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
 import {
   fetchRegistrySkill,
@@ -11,48 +12,6 @@ import {
 } from '../lib/api';
 import { useRegistryStore } from '../stores/useRegistryStore';
 import type { AgentSkill } from '../types';
-
-// Error boundary for detached window
-interface ErrorBoundaryState {
-  hasError: boolean;
-  error: Error | null;
-}
-
-class DetachedErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryState> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { hasError: false, error: null };
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="h-screen w-screen bg-background flex items-center justify-center">
-          <div className="text-center p-8 max-w-md">
-            <div className="p-4 rounded-xl bg-status-error/10 border border-status-error/20 inline-block mb-4">
-              <AlertCircle size={32} className="text-status-error" />
-            </div>
-            <h1 className="text-lg text-status-error mb-2">Something went wrong</h1>
-            <pre className="text-xs text-text-muted bg-surface p-4 rounded-lg overflow-auto max-h-32 mb-4">
-              {this.state.error?.message}
-            </pre>
-            <button
-              onClick={() => window.location.reload()}
-              className="px-4 py-2 bg-primary text-background rounded-lg font-medium hover:bg-primary/90 transition-colors"
-            >
-              Reload Window
-            </button>
-          </div>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
 
 function DetachedEditorContent() {
   const [searchParams] = useSearchParams();
@@ -191,8 +150,8 @@ function DetachedEditorContent() {
 
 export function DetachedEditorPage() {
   return (
-    <DetachedErrorBoundary>
+    <ErrorBoundary variant="window">
       <DetachedEditorContent />
-    </DetachedErrorBoundary>
+    </ErrorBoundary>
   );
 }

--- a/web/src/pages/DetachedLogsPage.tsx
+++ b/web/src/pages/DetachedLogsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback, useMemo, Component, type ReactNode } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   Terminal,
@@ -10,7 +10,6 @@ import {
   RefreshCw,
   Maximize2,
   Minimize2,
-  AlertCircle,
   Search,
   Radio,
 } from 'lucide-react';
@@ -23,48 +22,7 @@ import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
 import { useLogFontSize } from '../hooks/useLogFontSize';
 import { POLLING } from '../lib/constants';
 import type { GatewayStatus } from '../types';
-
-// Error boundary for detached window
-interface ErrorBoundaryState {
-  hasError: boolean;
-  error: Error | null;
-}
-
-class DetachedErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryState> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { hasError: false, error: null };
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="h-screen w-screen bg-background flex items-center justify-center">
-          <div className="text-center p-8 max-w-md">
-            <div className="p-4 rounded-xl bg-status-error/10 border border-status-error/20 inline-block mb-4">
-              <AlertCircle size={32} className="text-status-error" />
-            </div>
-            <h1 className="text-lg text-status-error mb-2">Something went wrong</h1>
-            <pre className="text-xs text-text-muted bg-surface p-4 rounded-lg overflow-auto max-h-32 mb-4">
-              {this.state.error?.message}
-            </pre>
-            <button
-              onClick={() => window.location.reload()}
-              className="px-4 py-2 bg-primary text-background rounded-lg font-medium hover:bg-primary-light transition-colors"
-            >
-              Reload Window
-            </button>
-          </div>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
+import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 
 interface NodeOption {
   name: string;
@@ -550,8 +508,8 @@ function DetachedLogsPageContent() {
 // Export with error boundary wrapper
 export function DetachedLogsPage() {
   return (
-    <DetachedErrorBoundary>
+    <ErrorBoundary variant="window">
       <DetachedLogsPageContent />
-    </DetachedErrorBoundary>
+    </ErrorBoundary>
   );
 }

--- a/web/src/pages/DetachedMetricsPage.tsx
+++ b/web/src/pages/DetachedMetricsPage.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, useCallback, Component, type ReactNode } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { BarChart3, AlertCircle, Maximize2, Minimize2, Users, Server } from 'lucide-react';
 import { IconButton } from '../components/ui/IconButton';
+import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
 import { fetchStatus } from '../lib/api';
 import { formatCompactNumber, formatUSD } from '../lib/format';
@@ -23,48 +24,6 @@ import {
   type SortDirection,
 } from '../components/metrics/metricsData';
 import type { GatewayStatus, TokenUsage, CostUsage, EffectiveModel } from '../types';
-
-// Error boundary for detached window
-interface ErrorBoundaryState {
-  hasError: boolean;
-  error: Error | null;
-}
-
-class DetachedErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryState> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { hasError: false, error: null };
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="h-screen w-screen bg-background flex items-center justify-center">
-          <div className="text-center p-8 max-w-md">
-            <div className="p-4 rounded-xl bg-status-error/10 border border-status-error/20 inline-block mb-4">
-              <AlertCircle size={32} className="text-status-error" />
-            </div>
-            <h1 className="text-lg text-status-error mb-2">Something went wrong</h1>
-            <pre className="text-xs text-text-muted bg-surface p-4 rounded-lg overflow-auto max-h-32 mb-4">
-              {this.state.error?.message}
-            </pre>
-            <button
-              onClick={() => window.location.reload()}
-              className="px-4 py-2 bg-primary text-background rounded-lg font-medium hover:bg-primary-light transition-colors"
-            >
-              Reload Window
-            </button>
-          </div>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
 
 function DetachedMetricsPageContent() {
   // Real-time status snapshot — the detached window lives outside the app
@@ -373,8 +332,8 @@ function DetachedMetricsPageContent() {
 
 export function DetachedMetricsPage() {
   return (
-    <DetachedErrorBoundary>
+    <ErrorBoundary variant="window">
       <DetachedMetricsPageContent />
-    </DetachedErrorBoundary>
+    </ErrorBoundary>
   );
 }

--- a/web/src/pages/DetachedRegistryPage.tsx
+++ b/web/src/pages/DetachedRegistryPage.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState, useCallback, useRef, useMemo, Component, type ReactNode } from 'react';
+import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import {
   Library,
   BookOpen,
   Plus,
   RefreshCw,
-  AlertCircle,
   Search,
   X,
 } from 'lucide-react';
@@ -28,48 +27,7 @@ import {
 } from '../lib/api';
 import { POLLING } from '../lib/constants';
 import type { AgentSkill, RegistryStatus, ItemState } from '../types';
-
-// Error boundary for detached window
-interface ErrorBoundaryState {
-  hasError: boolean;
-  error: Error | null;
-}
-
-class DetachedErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryState> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { hasError: false, error: null };
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="h-screen w-screen bg-background flex items-center justify-center">
-          <div className="text-center p-8 max-w-md">
-            <div className="p-4 rounded-xl bg-status-error/10 border border-status-error/20 inline-block mb-4">
-              <AlertCircle size={32} className="text-status-error" />
-            </div>
-            <h1 className="text-lg text-status-error mb-2">Something went wrong</h1>
-            <pre className="text-xs text-text-muted bg-surface p-4 rounded-lg overflow-auto max-h-32 mb-4">
-              {this.state.error?.message}
-            </pre>
-            <button
-              onClick={() => window.location.reload()}
-              className="px-4 py-2 bg-primary text-background rounded-lg font-medium hover:bg-primary/90 transition-colors"
-            >
-              Reload Window
-            </button>
-          </div>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
+import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 
 type FilterTab = 'all' | ItemState;
 
@@ -387,8 +345,8 @@ function DetachedRegistryContent() {
 
 export function DetachedRegistryPage() {
   return (
-    <DetachedErrorBoundary>
+    <ErrorBoundary variant="window">
       <DetachedRegistryContent />
-    </DetachedErrorBoundary>
+    </ErrorBoundary>
   );
 }

--- a/web/src/pages/DetachedSidebarPage.tsx
+++ b/web/src/pages/DetachedSidebarPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef, Component, type ReactNode } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   Terminal,
@@ -10,7 +10,6 @@ import {
   Cpu,
   KeyRound,
   RefreshCw,
-  AlertCircle,
   Server,
   Layers,
 } from 'lucide-react';
@@ -30,48 +29,7 @@ import type {
   ResourceStatus,
 } from '../types';
 import { InspectorSection } from '../components/inspector';
-
-// Error boundary for detached window
-interface ErrorBoundaryState {
-  hasError: boolean;
-  error: Error | null;
-}
-
-class DetachedErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryState> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { hasError: false, error: null };
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="h-screen w-screen bg-background flex items-center justify-center">
-          <div className="text-center p-8 max-w-md">
-            <div className="p-4 rounded-xl bg-status-error/10 border border-status-error/20 inline-block mb-4">
-              <AlertCircle size={32} className="text-status-error" />
-            </div>
-            <h1 className="text-lg text-status-error mb-2">Something went wrong</h1>
-            <pre className="text-xs text-text-muted bg-surface p-4 rounded-lg overflow-auto max-h-32 mb-4">
-              {this.state.error?.message}
-            </pre>
-            <button
-              onClick={() => window.location.reload()}
-              className="px-4 py-2 bg-primary text-background rounded-lg font-medium hover:bg-primary-light transition-colors"
-            >
-              Reload Window
-            </button>
-          </div>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
+import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 
 interface NodeOption {
   name: string;
@@ -289,9 +247,9 @@ function DetachedSidebarPageContent() {
 // Export with error boundary wrapper.
 export function DetachedSidebarPage() {
   return (
-    <DetachedErrorBoundary>
+    <ErrorBoundary variant="window">
       <DetachedSidebarPageContent />
-    </DetachedErrorBoundary>
+    </ErrorBoundary>
   );
 }
 

--- a/web/src/pages/DetachedTracesPage.tsx
+++ b/web/src/pages/DetachedTracesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback, Component, type ReactNode } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import {
   Activity,
   AlertCircle,
@@ -17,47 +17,7 @@ import { fetchTraces, fetchTraceDetail, fetchMCPServers } from '../lib/api';
 import type { TraceSummary, TraceDetail } from '../lib/api';
 import { TraceWaterfall } from '../components/traces/TraceWaterfall';
 import { POLLING } from '../lib/constants';
-
-interface ErrorBoundaryState {
-  hasError: boolean;
-  error: Error | null;
-}
-
-class DetachedErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryState> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { hasError: false, error: null };
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="h-screen w-screen bg-background flex items-center justify-center">
-          <div className="text-center p-8 max-w-md">
-            <div className="p-4 rounded-xl bg-status-error/10 border border-status-error/20 inline-block mb-4">
-              <AlertCircle size={32} className="text-status-error" />
-            </div>
-            <h1 className="text-lg text-status-error mb-2">Something went wrong</h1>
-            <pre className="text-xs text-text-muted bg-surface p-4 rounded-lg overflow-auto max-h-32 mb-4">
-              {this.state.error?.message}
-            </pre>
-            <button
-              onClick={() => window.location.reload()}
-              className="px-4 py-2 bg-primary text-background rounded-lg font-medium hover:bg-primary-light transition-colors"
-            >
-              Reload Window
-            </button>
-          </div>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
+import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 
 function formatTime(iso: string): string {
   try {
@@ -398,8 +358,8 @@ function DetachedTracesPageContent() {
 
 export function DetachedTracesPage() {
   return (
-    <DetachedErrorBoundary>
+    <ErrorBoundary variant="window">
       <DetachedTracesPageContent />
-    </DetachedErrorBoundary>
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## Description

With no MCP servers attached (stackless mode or an empty stack), opening the Tools workspace threw an uncaught `TypeError` that unmounted the whole React app, leaving a blank screen with no navigation. This fixes the crash at its source and adds an error boundary so a future render error degrades gracefully instead of blanking the UI.

## Root Cause

The tool-catalog API returned `{"tools": null}` in stackless mode. The frontend stored that null and passed it into `new Fuse(null)` in `useFuzzySearch`, which reads `.length` of null and throws during `ToolsWorkspace` render. With no error boundary on the main tree, React unmounted the entire app; the body background then read as a blank (black, in dark theme) screen, and in-app navigation was inert until a full reload.

## Type of Change

- [x] Bug fix

## Changes Made

- Backend: `/api/tools` and `/api/tools/catalog` now serialize an empty inventory as `[]`, never `null`
- Frontend: coalesce a missing tool list to `[]` in `useFuzzySearch`, `usePolling`, and `useToolsEditor`
- Add a shared `ErrorBoundary` component; wrap the workspace `<Outlet/>` (keeps header/nav mounted, resets on route change) and the app root
- Consolidate the six copy-pasted detached-popout error boundaries onto the shared component

## Testing

- New unit tests: `useFuzzySearch` with null/undefined input; `ToolsWorkspace` with a null catalog and zero servers renders the empty state; backend asserts `"tools":[]` (not null) in stackless mode
- Full frontend suite (1068) and touched Go packages pass
- Verified end-to-end against a real browser on a stackless instance: `/tools` shows the empty state with nav intact, console clean, and navigation works

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #834