### PR TITLE
fix: always send an arguments object on outbound tools/call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to gridctl will be documented in this file.
 
 ### Fixed
 
+- Stop dropping empty tool arguments on the gateway's outbound `tools/call`. An empty (or absent) argument object was omitted from the request entirely, so strict downstream servers (e.g. the Atlassian remote) rejected no-argument tools with `expected object, received undefined` — which looked like an authentication failure. The `arguments` field is now always sent as an object (`{}` when empty), so tools like `getAccessibleAtlassianResources` work in code mode
 - Stop the Tools workspace from crashing to a blank screen when no MCP servers are attached. The tool-catalog endpoint now returns an empty array (never null) in stackless mode, the store and fuzzy-search hook coalesce a missing list to empty, and a shared error boundary now wraps the workspace outlet (and the app root) so a render error degrades to a recoverable message with the navigation intact instead of unmounting the whole UI
 
 ### Changed

--- a/pkg/mcp/client_base.go
+++ b/pkg/mcp/client_base.go
@@ -199,6 +199,14 @@ func (r *RPCClient) RefreshTools(ctx context.Context) error {
 
 // CallTool invokes a tool on the downstream agent.
 func (r *RPCClient) CallTool(ctx context.Context, name string, arguments map[string]any) (*ToolCallResult, error) {
+	// Normalize a nil map to an empty one so the request always carries an
+	// arguments object ({}) rather than null. Strict downstream servers reject
+	// both a missing field and null for no-argument tools. A caller-provided
+	// map is left untouched.
+	if arguments == nil {
+		arguments = map[string]any{}
+	}
+
 	params := ToolCallParams{
 		Name:      name,
 		Arguments: arguments,

--- a/pkg/mcp/client_base_test.go
+++ b/pkg/mcp/client_base_test.go
@@ -227,6 +227,50 @@ func newFakeRPCClient(name string, ft *fakeTransport) *RPCClient {
 	return r
 }
 
+// TestRPCClient_CallTool_AlwaysSendsArgumentsObject is a regression test for a
+// bug where empty or nil tool arguments were dropped from (or sent as null in)
+// the outbound tools/call request, causing strict downstream servers to fail
+// with "expected object, received undefined". The arguments field must always
+// marshal as an object: {} when empty or nil, and the populated map otherwise.
+func TestRPCClient_CallTool_AlwaysSendsArgumentsObject(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		wantJSON  string
+	}{
+		{"empty map", map[string]any{}, `{"name":"server__echo","arguments":{}}`},
+		{"nil map", nil, `{"name":"server__echo","arguments":{}}`},
+		{"populated map", map[string]any{"a": float64(1)}, `{"name":"server__echo","arguments":{"a":1}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedParams []byte
+			ft := &fakeTransport{
+				callFn: func(_ context.Context, method string, params any, _ any) error {
+					if method != "tools/call" {
+						t.Errorf("expected method 'tools/call', got %q", method)
+					}
+					b, err := json.Marshal(params)
+					if err != nil {
+						t.Fatalf("marshal params: %v", err)
+					}
+					capturedParams = b
+					return nil
+				},
+			}
+			r := newFakeRPCClient("test", ft)
+
+			if _, err := r.CallTool(context.Background(), "server__echo", tt.arguments); err != nil {
+				t.Fatalf("CallTool() error = %v", err)
+			}
+			if got := string(capturedParams); got != tt.wantJSON {
+				t.Errorf("outbound params = %s, want %s", got, tt.wantJSON)
+			}
+		})
+	}
+}
+
 func TestRPCClient_Name(t *testing.T) {
 	ft := &fakeTransport{}
 	r := newFakeRPCClient("test-server", ft)

--- a/pkg/mcp/codemode_test.go
+++ b/pkg/mcp/codemode_test.go
@@ -202,6 +202,76 @@ func TestSandbox_ToolCall(t *testing.T) {
 	}
 }
 
+// TestSandbox_ToolCall_EmptyArgsForwardedAsObject is a regression test: an
+// empty object literal {} passed to mcp.callTool must reach the caller as a
+// non-nil, empty map. A nil map would serialize downstream as a missing
+// arguments field (or null), which strict servers reject with
+// "expected object, received undefined".
+func TestSandbox_ToolCall_EmptyArgsForwardedAsObject(t *testing.T) {
+	sandbox := NewSandbox(5 * time.Second)
+
+	var captured map[string]any
+	var capturedSet bool
+	caller := &mockToolCaller{
+		callFn: func(_ context.Context, _ string, arguments map[string]any) (*ToolCallResult, error) {
+			captured = arguments
+			capturedSet = true
+			return &ToolCallResult{Content: []Content{NewTextContent(`"ok"`)}}, nil
+		},
+	}
+
+	allowedTools := []Tool{
+		{Name: "server__echo"},
+	}
+
+	code := `mcp.callTool("server", "echo", {}); "done";`
+	result, err := sandbox.Execute(context.Background(), code, caller, allowedTools)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if result.Value != `"done"` {
+		t.Errorf("Expected '\"done\"', got '%s'", result.Value)
+	}
+	if !capturedSet {
+		t.Fatal("caller was never invoked")
+	}
+	if captured == nil {
+		t.Fatal("arguments forwarded as nil; expected a non-nil empty map")
+	}
+	if len(captured) != 0 {
+		t.Errorf("arguments should be empty, got %v", captured)
+	}
+}
+
+// TestSandbox_ToolCall_NonEmptyArgsForwarded confirms the empty-args fix does
+// not disturb forwarding of populated argument objects.
+func TestSandbox_ToolCall_NonEmptyArgsForwarded(t *testing.T) {
+	sandbox := NewSandbox(5 * time.Second)
+
+	var captured map[string]any
+	caller := &mockToolCaller{
+		callFn: func(_ context.Context, _ string, arguments map[string]any) (*ToolCallResult, error) {
+			captured = arguments
+			return &ToolCallResult{Content: []Content{NewTextContent(`"ok"`)}}, nil
+		},
+	}
+
+	allowedTools := []Tool{
+		{Name: "server__echo"},
+	}
+
+	code := `mcp.callTool("server", "echo", {a: 1}); "done";`
+	if _, err := sandbox.Execute(context.Background(), code, caller, allowedTools); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("expected one argument, got %v", captured)
+	}
+	if _, ok := captured["a"]; !ok {
+		t.Errorf("expected argument key 'a', got %v", captured)
+	}
+}
+
 func TestSandbox_ACLEnforcement(t *testing.T) {
 	sandbox := NewSandbox(5 * time.Second)
 	caller := &mockToolCaller{

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -296,9 +296,16 @@ type ToolsListResult struct {
 }
 
 // ToolCallParams contains parameters for tools/call.
+//
+// Arguments is intentionally not tagged omitempty: the MCP tools/call contract
+// expects arguments to always be present as an object, and strict downstream
+// servers reject a missing field as "expected object, received undefined". An
+// empty map therefore marshals as {}. Callers must pass a non-nil map; the
+// outbound chokepoint in RPCClient.CallTool normalizes nil to an empty map so
+// it never serializes as null.
 type ToolCallParams struct {
 	Name      string         `json:"name"`
-	Arguments map[string]any `json:"arguments,omitempty"`
+	Arguments map[string]any `json:"arguments"`
 }
 
 // ToolCallResult is the response to tools/call.


### PR DESCRIPTION
## Description

The gateway dropped the `arguments` field from an outbound `tools/call` whenever the argument object was empty (`json:",omitempty"` on a len-0 map). Strict downstream servers (e.g. the Atlassian remote) then received `undefined` and rejected no-argument tools with `expected object, received undefined`, which presented as an authentication failure even though OAuth was healthy. The `arguments` field is now always serialized as an object.

## Type of Change

- [x] Bug fix (`fix`)

## Changes Made

- Drop `,omitempty` from `ToolCallParams.Arguments` so a non-nil empty map marshals as `"arguments":{}`
- Normalize a nil arguments map to `{}` in `RPCClient.CallTool` (the outbound chokepoint inherited by all downstream clients), so the no-argument path never serializes as `null`
- Regression tests: wire-level assertion that empty and nil arguments both send `"arguments":{}` (and populated maps are unchanged), plus a code-mode binding test that `{}` is forwarded as a non-nil empty map

## Testing

- `go test ./pkg/mcp/...` passes; new tests fail against the pre-fix code (verified by reverting)
- `golangci-lint run pkg/mcp/...` clean
- Both changes are required together: removing `omitempty` alone would regress the nil path to `"arguments":null`, which strict servers also reject

## Note

`PromptsGetParams.Arguments` (`pkg/mcp/types.go`) has the same `omitempty` pattern and is a known sibling, left out of scope here for a possible follow-up.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #836