### PR TITLE
feat: text-size control for reading-heavy detail panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to gridctl will be documented in this file.
 
+## [Unreleased]
+
+
+### Features
+
+
+- Add a text-size control to the Library Instructions and Tools detail panes
+
 ## [0.1.0-beta.12] - 2026-06-25
 
 

--- a/web/src/__tests__/SkillDetailPanel.test.tsx
+++ b/web/src/__tests__/SkillDetailPanel.test.tsx
@@ -121,4 +121,16 @@ describe('SkillDetailPanel', () => {
     fireEvent.click(screen.getByText('incident-postmortem'));
     expect(onSelectRelated).toHaveBeenCalledWith('incident-postmortem');
   });
+
+  it('shows the text-size control only on the rendered Instructions view', () => {
+    renderPanel();
+    // Not on Overview.
+    expect(screen.queryByTitle(/increase font size/i)).not.toBeInTheDocument();
+    // Present on the rendered Instructions tab.
+    fireEvent.click(screen.getByRole('tab', { name: 'Instructions' }));
+    expect(screen.getByTitle(/increase font size/i)).toBeInTheDocument();
+    // Hidden when viewing raw source (where it would do nothing).
+    fireEvent.click(screen.getByRole('button', { name: /view source/i }));
+    expect(screen.queryByTitle(/increase font size/i)).not.toBeInTheDocument();
+  });
 });

--- a/web/src/__tests__/ToolDetailPanel.test.tsx
+++ b/web/src/__tests__/ToolDetailPanel.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ToolDetailPanel } from '../components/workspaces/ToolDetailPanel';
+import type { ToolRow } from '../hooks/useToolsEditor';
+
+const TOOL: ToolRow = {
+  name: 'getThing',
+  description: 'Fetch a thing by id',
+} as ToolRow;
+
+const SCHEMA = { type: 'object', properties: { id: { type: 'string' } } };
+
+function renderPanel(overrides = {}) {
+  return render(
+    <ToolDetailPanel
+      serverName="atlassian"
+      tool={TOOL}
+      schema={SCHEMA}
+      enabled
+      auditMode={false}
+      auditState={null}
+      onClose={() => {}}
+      {...overrides}
+    />,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('ToolDetailPanel', () => {
+  it('shows an empty state when no tool is selected', () => {
+    render(
+      <ToolDetailPanel
+        serverName="atlassian"
+        tool={null}
+        enabled={false}
+        auditMode={false}
+        auditState={null}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText(/select a tool to view/i)).toBeInTheDocument();
+    // No control without a tool.
+    expect(screen.queryByTitle(/increase font size/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the description, schema, and the text-size control', () => {
+    renderPanel();
+    expect(screen.getByText('Fetch a thing by id')).toBeInTheDocument();
+    expect(screen.getByTitle(/increase font size/i)).toBeInTheDocument();
+    // Default reflects the pane default (12px).
+    expect(screen.getByText('12px')).toBeInTheDocument();
+  });
+
+  it('scales the displayed size when zooming in', () => {
+    renderPanel();
+    fireEvent.click(screen.getByTitle(/increase font size/i));
+    expect(screen.getByText('13px')).toBeInTheDocument();
+    expect(localStorage.getItem('gridctl-tools-zoom')).toBe('13');
+  });
+});

--- a/web/src/__tests__/ZoomControls.test.tsx
+++ b/web/src/__tests__/ZoomControls.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ZoomControls } from '../components/ui/ZoomControls';
+
+function setup(overrides = {}) {
+  const props = {
+    fontSize: 13,
+    onZoomIn: vi.fn(),
+    onZoomOut: vi.fn(),
+    onReset: vi.fn(),
+    isMin: false,
+    isMax: false,
+    isDefault: false,
+    ...overrides,
+  };
+  render(<ZoomControls {...props} />);
+  return props;
+}
+
+describe('ZoomControls', () => {
+  it('shows the current font size in px', () => {
+    setup({ fontSize: 16 });
+    expect(screen.getByText('16px')).toBeInTheDocument();
+  });
+
+  it('calls the handlers for decrease, reset, and increase', () => {
+    const props = setup();
+    fireEvent.click(screen.getByTitle(/decrease font size/i));
+    fireEvent.click(screen.getByTitle(/reset font size/i));
+    fireEvent.click(screen.getByTitle(/increase font size/i));
+    expect(props.onZoomOut).toHaveBeenCalledTimes(1);
+    expect(props.onReset).toHaveBeenCalledTimes(1);
+    expect(props.onZoomIn).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables decrease at min and increase at max', () => {
+    setup({ isMin: true, isMax: true });
+    expect(screen.getByTitle(/decrease font size/i)).toBeDisabled();
+    expect(screen.getByTitle(/increase font size/i)).toBeDisabled();
+  });
+
+  it('disables reset when already at the default size', () => {
+    setup({ isDefault: true });
+    expect(screen.getByTitle(/reset font size/i)).toBeDisabled();
+  });
+});

--- a/web/src/__tests__/useTextZoom.test.ts
+++ b/web/src/__tests__/useTextZoom.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTextZoom } from '../hooks/useTextZoom';
+
+const KEY = 'gridctl-test-zoom';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useTextZoom', () => {
+  it('starts at the default size when nothing is stored', () => {
+    const { result } = renderHook(() => useTextZoom({ storageKey: KEY, defaultSize: 13 }));
+    expect(result.current.fontSize).toBe(13);
+    expect(result.current.isDefault).toBe(true);
+  });
+
+  it('restores a valid persisted size', () => {
+    localStorage.setItem(KEY, '17');
+    const { result } = renderHook(() => useTextZoom({ storageKey: KEY, defaultSize: 13 }));
+    expect(result.current.fontSize).toBe(17);
+    expect(result.current.isDefault).toBe(false);
+  });
+
+  it('ignores an out-of-range persisted size and falls back to the default', () => {
+    localStorage.setItem(KEY, '999');
+    const { result } = renderHook(() =>
+      useTextZoom({ storageKey: KEY, defaultSize: 13, maxSize: 22 }),
+    );
+    expect(result.current.fontSize).toBe(13);
+  });
+
+  it('zooms in and out by the step and persists the new size', () => {
+    const { result } = renderHook(() =>
+      useTextZoom({ storageKey: KEY, defaultSize: 13, step: 2 }),
+    );
+    act(() => result.current.zoomIn());
+    expect(result.current.fontSize).toBe(15);
+    expect(localStorage.getItem(KEY)).toBe('15');
+
+    act(() => result.current.zoomOut());
+    expect(result.current.fontSize).toBe(13);
+    expect(localStorage.getItem(KEY)).toBe('13');
+  });
+
+  it('clamps at the min and max bounds and flips isMin/isMax', () => {
+    const { result } = renderHook(() =>
+      useTextZoom({ storageKey: KEY, defaultSize: 13, minSize: 12, maxSize: 14, step: 1 }),
+    );
+    act(() => result.current.zoomIn());
+    expect(result.current.fontSize).toBe(14);
+    expect(result.current.isMax).toBe(true);
+    act(() => result.current.zoomIn());
+    expect(result.current.fontSize).toBe(14); // clamped, no overflow
+
+    act(() => result.current.zoomOut());
+    act(() => result.current.zoomOut());
+    expect(result.current.fontSize).toBe(12);
+    expect(result.current.isMin).toBe(true);
+    act(() => result.current.zoomOut());
+    expect(result.current.fontSize).toBe(12); // clamped
+  });
+
+  it('resets back to the default size', () => {
+    const { result } = renderHook(() => useTextZoom({ storageKey: KEY, defaultSize: 13 }));
+    act(() => result.current.zoomIn());
+    expect(result.current.isDefault).toBe(false);
+    act(() => result.current.resetZoom());
+    expect(result.current.fontSize).toBe(13);
+    expect(result.current.isDefault).toBe(true);
+    expect(localStorage.getItem(KEY)).toBe('13');
+  });
+
+  it('exposes the current size as the --text-zoom-size custom property', () => {
+    const { result } = renderHook(() => useTextZoom({ storageKey: KEY, defaultSize: 13 }));
+    const style = result.current.containerProps.style as Record<string, string>;
+    expect(style['--text-zoom-size']).toBe('13px');
+    act(() => result.current.zoomIn());
+    const next = result.current.containerProps.style as Record<string, string>;
+    expect(next['--text-zoom-size']).toBe('14px');
+  });
+});

--- a/web/src/components/registry/SkillDetailPanel.tsx
+++ b/web/src/components/registry/SkillDetailPanel.tsx
@@ -7,9 +7,11 @@ import { parseAcceptanceCriterion } from '../../lib/skillCriteria';
 import { formatLastUsed } from '../../lib/toolAudit';
 import { InspectorHeader, InspectorTabList, InspectorTabButton, PaneAnchor } from '../inspector';
 import { IconButton } from '../ui/IconButton';
+import { ZoomControls } from '../ui/ZoomControls';
 import { StateBadge } from './StateBadge';
 import { MarkdownPreview } from './MarkdownPreview';
 import { SkillFileTree } from './SkillFileTree';
+import { useTextZoom } from '../../hooks/useTextZoom';
 import type { AgentSkill, SkillSourceStatus, SkillUsageStat } from '../../types';
 
 type SkillTab = 'overview' | 'instructions' | 'files';
@@ -70,6 +72,24 @@ export function SkillDetailPanel({
   const [viewSource, setViewSource] = useState(false);
   const [prevName, setPrevName] = useState(skill?.name);
   const tablistRef = useRef<HTMLDivElement>(null);
+
+  // Content text-size control for the rendered Instructions markdown. Scoped to
+  // this pane (own storageKey) like the Logs/Traces zoom; the .skill-md scope
+  // reads --text-zoom-size off the wrapper, so 13px stays the default.
+  const instructionsRef = useRef<HTMLDivElement>(null);
+  const {
+    fontSize: instrFontSize,
+    zoomIn: instrZoomIn,
+    zoomOut: instrZoomOut,
+    resetZoom: instrResetZoom,
+    isMin: instrIsMin,
+    isMax: instrIsMax,
+    isDefault: instrIsDefault,
+  } = useTextZoom({
+    storageKey: 'gridctl-library-zoom',
+    defaultSize: 13,
+    containerRef: instructionsRef,
+  });
 
   // Reset to Overview (and rendered view) when the selected skill changes, so
   // switching skills never strands the user on Files (which would refetch for
@@ -209,11 +229,28 @@ export function SkillDetailPanel({
           aria-labelledby={tabBtnId('instructions')}
           hidden={activeTab !== 'instructions'}
           className="px-4 py-4 space-y-3"
+          ref={instructionsRef}
+          style={{ '--text-zoom-size': `${instrFontSize}px` } as React.CSSProperties}
         >
           {activeTab === 'instructions' && (
             <>
               {skill.body && (
-                <div className="flex items-center justify-end">
+                <div className="flex items-center justify-between gap-2">
+                  {/* Text-size control acts on the rendered markdown only, so
+                      hide it in raw-source view where it would do nothing. */}
+                  {viewSource ? (
+                    <span />
+                  ) : (
+                    <ZoomControls
+                      fontSize={instrFontSize}
+                      onZoomIn={instrZoomIn}
+                      onZoomOut={instrZoomOut}
+                      onReset={instrResetZoom}
+                      isMin={instrIsMin}
+                      isMax={instrIsMax}
+                      isDefault={instrIsDefault}
+                    />
+                  )}
                   <button
                     type="button"
                     onClick={() => setViewSource((v) => !v)}

--- a/web/src/components/workspaces/ToolDetailPanel.tsx
+++ b/web/src/components/workspaces/ToolDetailPanel.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from 'react';
+import { useRef, type ReactNode } from 'react';
 import { Wrench } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { CodeViewer } from '../ui/CodeViewer';
+import { ZoomControls } from '../ui/ZoomControls';
 import { InspectorHeader, PaneAnchor } from '../inspector';
 import { formatLastUsed, type AuditState } from '../../lib/toolAudit';
+import { useTextZoom } from '../../hooks/useTextZoom';
 import type { ToolRow } from '../../hooks/useToolsEditor';
 
 // Per-state styling for the audit row, mirroring the list's AUDIT_STYLES.
@@ -41,6 +43,15 @@ export function ToolDetailPanel({
   lastCalledAt,
   onClose,
 }: ToolDetailPanelProps) {
+  // Content text-size control for the description + JSON schema, scoped to this
+  // pane (own storageKey) like the Logs/Traces zoom; 12px stays the default.
+  const contentRef = useRef<HTMLDivElement>(null);
+  const { fontSize, zoomIn, zoomOut, resetZoom, isMin, isMax, isDefault } = useTextZoom({
+    storageKey: 'gridctl-tools-zoom',
+    defaultSize: 12,
+    containerRef: contentRef,
+  });
+
   return (
     <aside className="relative h-full flex flex-col bg-surface-elevated border-l border-border">
       {tool ? (
@@ -51,6 +62,17 @@ export function ToolDetailPanel({
             icon={Wrench}
             accent="primary"
             onClose={onClose}
+            actions={
+              <ZoomControls
+                fontSize={fontSize}
+                onZoomIn={zoomIn}
+                onZoomOut={zoomOut}
+                onReset={resetZoom}
+                isMin={isMin}
+                isMax={isMax}
+                isDefault={isDefault}
+              />
+            }
             subtitle={
               <div className="flex items-center gap-1.5 flex-wrap mt-0.5">
                 <span className="text-[10px] font-mono text-primary/80 truncate">{serverName}</span>
@@ -68,10 +90,16 @@ export function ToolDetailPanel({
             }
           />
 
-          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark px-4 py-4 space-y-5">
+          <div
+            ref={contentRef}
+            className="flex-1 min-h-0 overflow-y-auto scrollbar-dark px-4 py-4 space-y-5"
+          >
             <Section title="Description">
               {tool.description ? (
-                <p className="text-xs text-text-secondary leading-relaxed whitespace-pre-wrap break-words">
+                <p
+                  className="text-text-secondary leading-relaxed whitespace-pre-wrap break-words"
+                  style={{ fontSize }}
+                >
                   {tool.description}
                 </p>
               ) : (
@@ -84,6 +112,7 @@ export function ToolDetailPanel({
                 <CodeViewer
                   language="json"
                   content={JSON.stringify(schema, null, 2)}
+                  fontSize={fontSize}
                   ariaLabel={`${tool.name} input schema`}
                   className="rounded-md border border-border/30 bg-background/80 max-h-[45vh]"
                 />

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -976,7 +976,10 @@ body::before {
    ============================================ */
 .skill-md {
   color: var(--color-text-secondary);
-  font-size: 13px;
+  /* Scales with the reading-pane text-size control (useTextZoom sets
+     --text-zoom-size on the wrapping container). Children below use em so the
+     whole hierarchy scales from this single base; 13px stays the default. */
+  font-size: var(--text-zoom-size, 13px);
   line-height: 1.6;
   word-break: break-word;
 }
@@ -993,14 +996,14 @@ body::before {
   line-height: 1.3;
 }
 .skill-md h1 {
-  font-size: 18px;
+  font-size: 1.385em;
   margin: 0 0 0.75em;
   padding-bottom: 0.4em;
   border-bottom: 1px solid var(--color-border-subtle);
 }
-.skill-md h2 { font-size: 15px; margin: 1.4em 0 0.5em; }
-.skill-md h3 { font-size: 13px; margin: 1.1em 0 0.35em; }
-.skill-md h4 { font-size: 12px; margin: 1em 0 0.3em; color: var(--color-text-secondary); }
+.skill-md h2 { font-size: 1.154em; margin: 1.4em 0 0.5em; }
+.skill-md h3 { font-size: 1em; margin: 1.1em 0 0.35em; }
+.skill-md h4 { font-size: 0.923em; margin: 1em 0 0.3em; color: var(--color-text-secondary); }
 
 .skill-md p { margin: 0 0 0.7em; }
 .skill-md strong { color: var(--color-text-primary); font-weight: 600; }
@@ -1042,7 +1045,7 @@ body::before {
   border-collapse: collapse;
   overflow-x: auto;
   margin: 0.7em 0;
-  font-size: 12px;
+  font-size: 0.923em;
 }
 .skill-md th,
 .skill-md td {
@@ -1075,14 +1078,14 @@ body::before {
 }
 .skill-md .md-code__lang {
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 10px;
+  font-size: 0.769em;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--color-text-muted);
 }
 .skill-md .md-code__copy {
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 10px;
+  font-size: 0.769em;
   color: var(--color-text-muted);
   background: transparent;
   border: 1px solid var(--color-border);
@@ -1109,7 +1112,7 @@ body::before {
 }
 .skill-md .md-code code {
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 12px;
+  font-size: 0.923em;
   line-height: 1.55;
   background: none;
   padding: 0;


### PR DESCRIPTION
## Description

Adds the existing +/- text-size control (the same `ZoomControls`/`useTextZoom` used by Logs and Traces) to the two reading-heavy detail panes so users can scale only the content, which browser zoom cannot do.

## Type of Change

- [x] New feature (enhancement)

## Changes Made

- Library -> Instructions: text-size control in the tab header; scales the rendered markdown (headings, body, lists, inline and fenced code). Hidden in raw-source view.
- Tools detail: control in the pane header; scales the description and the JSON input schema (via `CodeViewer`'s existing `fontSize` prop).
- Refactored the `.skill-md` scope from fixed px to `em` relative to a single `--text-zoom-size` base, so the hierarchy scales from one variable and stays pixel-equivalent at the 13px default.
- Each pane persists its size (`gridctl-library-zoom`, `gridctl-tools-zoom`) and supports Ctrl/Cmd+Scroll.
- Scope is deliberate: Variables and Metrics inspectors are intentionally untouched.

## Testing

- `npm test` (Vitest): full suite passes, including new tests for `useTextZoom`, `ZoomControls`, and the pane wiring.
- `tsc --noEmit` and ESLint clean on touched files.
- `make build` succeeds.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #840