### PR TITLE
chore: suppress no-fix docker cp vulnerabilities

### DIFF
--- a/scripts/govulncheck.sh
+++ b/scripts/govulncheck.sh
@@ -25,9 +25,29 @@ set -euo pipefail
 #              reachable via Docker client SDK calls.
 #              Fixed in Moby v29.3.1 but v29+ not yet published to Go module
 #              proxy. Remove suppression once github.com/docker/docker@v29+ lands.
+#
+# GO-2026-5746 # CVE-2026-41567 | Moby `PUT /containers/{id}/archive` executes a
+#              container binary on the host (`docker cp` into a container). Not
+#              reachable: gridctl never calls CopyToContainer/CopyFromContainer/
+#              ContainerArchive. No fixed release (govulncheck "Fixed in: N/A");
+#              flagged at import/init level only. Revisit once a fixed
+#              github.com/docker/docker release lands.
+#
+# GO-2026-5668 # CVE-2026-41568 | Moby `docker cp` race condition allows creating
+#              arbitrary empty files on the host via symlink swap. Not reachable:
+#              gridctl uses no container copy/archive APIs. No fixed release
+#              ("Fixed in: N/A"). Revisit once a fixed docker release lands.
+#
+# GO-2026-5617 # CVE-2026-42306 | Moby `docker cp` race condition allows bind
+#              mount redirection to a host path. Not reachable: gridctl uses no
+#              container copy/archive APIs. No fixed release ("Fixed in: N/A").
+#              Revisit once a fixed docker release lands.
 SUPPRESSED=(
   "GO-2026-4887"
   "GO-2026-4883"
+  "GO-2026-5746"
+  "GO-2026-5668"
+  "GO-2026-5617"
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

govulncheck (the `test` job) is failing across all PRs and `main` after three newly-disclosed `github.com/docker/docker` CVEs landed in the Go vuln database. All three report **Fixed in: N/A** — there is no patched `docker/docker` release, so the dependency cannot be upgraded to clear them. This adds them to the existing suppression allowlist in `scripts/govulncheck.sh`, matching the two docker CVEs already suppressed there.

## Type of Change

- [x] Chore (CI / tooling)

## Changes Made

- Suppress `GO-2026-5746` (CVE-2026-41567), `GO-2026-5668` (CVE-2026-41568), and `GO-2026-5617` (CVE-2026-42306), all `docker cp`/archive issues in `github.com/docker/docker`.
- Each entry documents the justification: gridctl never calls the vulnerable APIs (no `CopyToContainer`/`CopyFromContainer`/`ContainerArchive` in the codebase; govulncheck flags them only at import/init level), and no fixed release exists. Marked to revisit once a fixed docker release lands.

## Testing

`bash scripts/govulncheck.sh` exits 0 (all findings suppressed).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed