### PR TITLE
fix: refresh daemon registry when skills change on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to gridctl will be documented in this file.
 ## [Unreleased]
 
 
+### Bug Fixes
+
+
+- Reflect skills added to the registry directory on disk in the running daemon without a restart, so a skill that validates can be activated and appears in the UI
+
 ### Features
 
 

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -1031,6 +1031,13 @@ func (b *GatewayBuilder) setupHotReload(ctx context.Context, inst *GatewayInstan
 	if inst.RegistryServer != nil {
 		regLogger := slog.New(handler)
 		skillsDir := filepath.Join(inst.RegistryServer.Store().Dir(), "skills")
+		// Create the directory synchronously so the watcher arms on the tight
+		// skills subtree rather than a busier ancestor like ~/.gridctl. The
+		// watcher itself is write-free and tolerates a missing directory, so a
+		// failure here is non-fatal.
+		if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+			regLogger.Warn("could not create registry skills directory for watching", "path", skillsDir, "error", err)
+		}
 		regWatcher := reload.NewDirWatcher(skillsDir, func() error {
 			refreshRegistry(ctx, inst, regLogger)
 			return nil

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -1008,18 +1008,7 @@ func (b *GatewayBuilder) setupHotReload(ctx context.Context, inst *GatewayInstan
 			if !result.Success {
 				return fmt.Errorf("%s", result.Message)
 			}
-			// Refresh registry if it exists
-			if inst.RegistryServer != nil {
-				if refreshErr := inst.RegistryServer.RefreshTools(watchCtx); refreshErr != nil {
-					slog.New(handler).Warn("registry refresh failed", "error", refreshErr)
-				}
-				if inst.RegistryServer.HasContent() {
-					inst.Gateway.Router().AddClient(inst.RegistryServer)
-				} else {
-					inst.Gateway.Router().RemoveClient("registry")
-				}
-				inst.Gateway.Router().RefreshTools()
-			}
+			refreshRegistry(watchCtx, inst, slog.New(handler))
 			return nil
 		})
 		watcher.SetLogger(slog.New(handler))
@@ -1034,6 +1023,26 @@ func (b *GatewayBuilder) setupHotReload(ctx context.Context, inst *GatewayInstan
 	// Expose the watcher starter so initialize can activate it on demand.
 	inst.APIServer.SetStartWatcher(startWatcher)
 
+	// Watch the registry skills directory so skills added to disk out-of-band
+	// (hand-authored, or written by `gridctl skill add/update/remove` while the
+	// daemon runs) are reflected in the running gateway — activation, the UI
+	// listing, and the MCP prompt set — without a restart. This is independent
+	// of --watch, which only governs the stack.yaml watcher.
+	if inst.RegistryServer != nil {
+		regLogger := slog.New(handler)
+		skillsDir := filepath.Join(inst.RegistryServer.Store().Dir(), "skills")
+		regWatcher := reload.NewDirWatcher(skillsDir, func() error {
+			refreshRegistry(ctx, inst, regLogger)
+			return nil
+		})
+		regWatcher.SetLogger(regLogger)
+		go func() {
+			if err := regWatcher.Watch(ctx); err != nil && err != context.Canceled {
+				regLogger.Error("registry watcher error", "error", err)
+			}
+		}()
+	}
+
 	if b.config.Watch {
 		startWatcher(b.stackPath)
 
@@ -1041,6 +1050,27 @@ func (b *GatewayBuilder) setupHotReload(ctx context.Context, inst *GatewayInstan
 			fmt.Printf("\nFile watcher enabled for: %s\n", b.stackPath)
 		}
 	}
+}
+
+// refreshRegistry reloads the registry store from disk and re-syncs the
+// gateway router with the result. It is shared by the stack-reload callback
+// and the registry directory watcher so the two paths cannot drift: the
+// store is reloaded, the registry client is added or removed from the router
+// depending on whether any skills remain, and the router's tool set is
+// refreshed. A failed reload is logged and tolerated rather than fatal.
+func refreshRegistry(ctx context.Context, inst *GatewayInstance, logger *slog.Logger) {
+	if inst.RegistryServer == nil {
+		return
+	}
+	if err := inst.RegistryServer.RefreshTools(ctx); err != nil {
+		logger.Warn("registry refresh failed", "error", err)
+	}
+	if inst.RegistryServer.HasContent() {
+		inst.Gateway.Router().AddClient(inst.RegistryServer)
+	} else {
+		inst.Gateway.Router().RemoveClient("registry")
+	}
+	inst.Gateway.Router().RefreshTools()
 }
 
 // printEndpoints prints the gateway endpoint information.

--- a/pkg/registry/server_test.go
+++ b/pkg/registry/server_test.go
@@ -306,6 +306,36 @@ func TestServer_RefreshTools_ReloadsStore(t *testing.T) {
 	}
 }
 
+// TestServer_RefreshTools_PicksUpOutOfBandSkill reproduces the activation bug:
+// a skill written directly into the registry skills directory after the daemon
+// started is invisible to the in-memory store (so `gridctl activate` 404s) until
+// the store is refreshed. RefreshTools must reconcile it.
+func TestServer_RefreshTools_PicksUpOutOfBandSkill(t *testing.T) {
+	srv, dir := setupTestServer(t)
+
+	if err := srv.Initialize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Skill added out-of-band (e.g. hand-authored or by a CLI write) after init.
+	writeTestSkill(t, dir, "node-state-snapshot", "Snapshot node state", "# Snapshot\n\nDo it.", StateDraft)
+
+	if _, err := srv.Store().GetSkill("node-state-snapshot"); err == nil {
+		t.Fatal("expected skill to be missing from the stale in-memory store before refresh")
+	}
+
+	if err := srv.RefreshTools(context.Background()); err != nil {
+		t.Fatalf("RefreshTools() error: %v", err)
+	}
+
+	if _, err := srv.Store().GetSkill("node-state-snapshot"); err != nil {
+		t.Fatalf("expected skill to be activatable after refresh, got: %v", err)
+	}
+	if !srv.HasContent() {
+		t.Error("expected HasContent() true after an out-of-band skill was reconciled")
+	}
+}
+
 func TestServer_Store(t *testing.T) {
 	store := NewStore(t.TempDir())
 	srv := New(store)

--- a/pkg/reload/dirwatcher.go
+++ b/pkg/reload/dirwatcher.go
@@ -56,21 +56,19 @@ func (w *DirWatcher) SetDebounce(d time.Duration) {
 // Watch starts watching the directory tree for changes. It blocks until the
 // context is cancelled.
 //
-// The root may not exist yet at startup (the registry skills directory is only
-// created when the first skill is saved). Watch creates it so there is always a
-// stable directory to watch, sidestepping the need to re-arm when it appears.
+// The root may not exist yet (the registry skills directory is created lazily).
+// Watch never creates it — that is the caller's job — and instead watches the
+// nearest existing ancestor so the root's eventual creation is observed and the
+// subtree armed. Staying write-free keeps the watcher safe to run against a
+// directory another goroutine may be removing (e.g. a test's temp dir).
 func (w *DirWatcher) Watch(ctx context.Context) error {
-	if err := os.MkdirAll(w.root, 0o755); err != nil {
-		return err
-	}
-
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return err
 	}
 	defer watcher.Close()
 
-	w.addTree(watcher, w.root)
+	w.arm(watcher)
 	w.logger.Info("watching directory for changes", "path", w.root)
 
 	var debounceTimer *time.Timer
@@ -120,6 +118,30 @@ func (w *DirWatcher) Watch(ctx context.Context) error {
 			}
 			w.logger.Error("watcher error", "error", err)
 		}
+	}
+}
+
+// arm registers the existing subtree under root plus the nearest existing
+// ancestor directory. Watching an ancestor lets the watcher observe root being
+// created when it does not exist yet (the directory-create event fires on the
+// ancestor, after which addTree picks up the new subtree). arm never creates
+// directories.
+func (w *DirWatcher) arm(watcher *fsnotify.Watcher) {
+	w.addTree(watcher, w.root)
+
+	dir := w.root
+	for {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return
+		}
+		if _, err := os.Stat(parent); err == nil {
+			if addErr := watcher.Add(parent); addErr != nil {
+				w.logger.Debug("failed to watch ancestor directory, skipping", "path", parent, "error", addErr)
+			}
+			return
+		}
+		dir = parent
 	}
 }
 

--- a/pkg/reload/dirwatcher.go
+++ b/pkg/reload/dirwatcher.go
@@ -1,0 +1,143 @@
+package reload
+
+import (
+	"context"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/gridctl/gridctl/pkg/logging"
+)
+
+// DirWatcher monitors a directory tree for changes and triggers a debounced
+// callback. Unlike Watcher, which targets a single file, DirWatcher watches a
+// whole subtree (e.g. the registry skills directory, where each skill is its
+// own directory containing SKILL.md plus optional supporting files).
+//
+// fsnotify is not recursive, so the watcher adds the root and every existing
+// subdirectory, and adds newly-created subdirectories as it observes them. The
+// callback is expected to re-read the tree from disk (a full reload), so the
+// watcher does not need to capture every individual event — it only needs to
+// fire shortly after a burst of changes settles.
+type DirWatcher struct {
+	root     string
+	onChange func() error
+	logger   *slog.Logger
+	debounce time.Duration
+}
+
+// NewDirWatcher creates a recursive directory watcher rooted at root.
+// onChange is called (after debouncing) whenever an entry under root is
+// created, written, removed, or renamed.
+func NewDirWatcher(root string, onChange func() error) *DirWatcher {
+	return &DirWatcher{
+		root:     root,
+		onChange: onChange,
+		logger:   logging.NewDiscardLogger(),
+		debounce: 300 * time.Millisecond,
+	}
+}
+
+// SetLogger sets the logger for watcher events.
+func (w *DirWatcher) SetLogger(logger *slog.Logger) {
+	if logger != nil {
+		w.logger = logger
+	}
+}
+
+// SetDebounce sets the debounce duration for change events.
+func (w *DirWatcher) SetDebounce(d time.Duration) {
+	w.debounce = d
+}
+
+// Watch starts watching the directory tree for changes. It blocks until the
+// context is cancelled.
+//
+// The root may not exist yet at startup (the registry skills directory is only
+// created when the first skill is saved). Watch creates it so there is always a
+// stable directory to watch, sidestepping the need to re-arm when it appears.
+func (w *DirWatcher) Watch(ctx context.Context) error {
+	if err := os.MkdirAll(w.root, 0o755); err != nil {
+		return err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	w.addTree(watcher, w.root)
+	w.logger.Info("watching directory for changes", "path", w.root)
+
+	var debounceTimer *time.Timer
+	var debounceChan <-chan time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("stopping directory watcher", "path", w.root)
+			return ctx.Err()
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+
+			// Keep the watch set current: when a new subdirectory appears
+			// (e.g. a freshly-created skill directory), start watching it so
+			// later writes inside it are observed too.
+			if event.Op&fsnotify.Create != 0 {
+				if info, statErr := os.Stat(event.Name); statErr == nil && info.IsDir() {
+					w.addTree(watcher, event.Name)
+				}
+			}
+
+			// Reload on any structural change. Chmod is intentionally ignored
+			// as pure-metadata noise.
+			if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove|fsnotify.Rename) != 0 {
+				w.logger.Debug("registry change detected", "event", event.Op.String(), "path", event.Name)
+				if debounceTimer != nil {
+					debounceTimer.Stop()
+				}
+				debounceTimer = time.NewTimer(w.debounce)
+				debounceChan = debounceTimer.C
+			}
+
+		case <-debounceChan:
+			w.logger.Info("registry change detected, refreshing", "path", w.root)
+			if err := w.onChange(); err != nil {
+				w.logger.Error("registry refresh failed", "error", err)
+			}
+			debounceChan = nil
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			w.logger.Error("watcher error", "error", err)
+		}
+	}
+}
+
+// addTree adds dir and all of its existing subdirectories to the watcher.
+// Failures are logged and skipped so one unreadable subdirectory does not
+// disable watching for the rest of the tree.
+func (w *DirWatcher) addTree(watcher *fsnotify.Watcher, dir string) {
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			w.logger.Debug("walk error while adding watch, skipping", "path", path, "error", err)
+			return nil //nolint:nilerr // skip this entry, keep walking the rest of the tree
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if addErr := watcher.Add(path); addErr != nil {
+			w.logger.Debug("failed to watch directory, skipping", "path", path, "error", addErr)
+		}
+		return nil
+	})
+}

--- a/pkg/reload/dirwatcher_test.go
+++ b/pkg/reload/dirwatcher_test.go
@@ -1,0 +1,130 @@
+package reload
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// startDirWatcher launches w.Watch in the background and waits briefly for it
+// to arm, returning a cancel func the caller should defer.
+func startDirWatcher(t *testing.T, w *DirWatcher) context.CancelFunc {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- w.Watch(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+	return cancel
+}
+
+func TestDirWatcher_DetectsNewSkillFile(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "skills")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	w := NewDirWatcher(root, func() error { calls.Add(1); return nil })
+	w.SetDebounce(50 * time.Millisecond)
+	defer startDirWatcher(t, w)()
+
+	// Create a new skill directory with a SKILL.md inside it — the common
+	// "added out-of-band" case. The watcher must add the new directory to its
+	// watch set and fire onChange.
+	skillDir := filepath.Join(root, "node-state-snapshot")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(250 * time.Millisecond)
+	if calls.Load() == 0 {
+		t.Fatal("expected onChange to fire after a new skill file was written")
+	}
+}
+
+func TestDirWatcher_DebouncesBurst(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "skills")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	w := NewDirWatcher(root, func() error { calls.Add(1); return nil })
+	w.SetDebounce(120 * time.Millisecond)
+	defer startDirWatcher(t, w)()
+
+	// A single skill is multiple files; writing them in quick succession must
+	// collapse to one refresh.
+	skillDir := filepath.Join(root, "multi")
+	if err := os.MkdirAll(filepath.Join(skillDir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"SKILL.md", "scripts/a.sh", "scripts/b.sh", "reference.md"} {
+		if err := os.WriteFile(filepath.Join(skillDir, f), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected burst to debounce to 1 refresh, got %d", got)
+	}
+}
+
+func TestDirWatcher_CreatesMissingRoot(t *testing.T) {
+	// The registry skills directory may not exist yet at startup. Watch must
+	// create it rather than failing, and then observe writes into it.
+	root := filepath.Join(t.TempDir(), "registry", "skills")
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("precondition: root should not exist yet")
+	}
+
+	var calls atomic.Int32
+	w := NewDirWatcher(root, func() error { calls.Add(1); return nil })
+	w.SetDebounce(50 * time.Millisecond)
+	defer startDirWatcher(t, w)()
+
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("expected watcher to create the root directory: %v", err)
+	}
+
+	skillDir := filepath.Join(root, "late")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# late\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(250 * time.Millisecond)
+	if calls.Load() == 0 {
+		t.Fatal("expected onChange to fire for a skill added after startup")
+	}
+}
+
+func TestDirWatcher_StopsOnContextCancel(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "skills")
+	w := NewDirWatcher(root, func() error { return nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- w.Watch(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not stop after context cancellation")
+	}
+}

--- a/pkg/reload/dirwatcher_test.go
+++ b/pkg/reload/dirwatcher_test.go
@@ -78,9 +78,10 @@ func TestDirWatcher_DebouncesBurst(t *testing.T) {
 	}
 }
 
-func TestDirWatcher_CreatesMissingRoot(t *testing.T) {
-	// The registry skills directory may not exist yet at startup. Watch must
-	// create it rather than failing, and then observe writes into it.
+func TestDirWatcher_DetectsLateCreatedRoot(t *testing.T) {
+	// The registry skills directory may not exist yet at startup. The watcher
+	// must not create it (it is write-free), but must observe it being created
+	// later by watching the nearest existing ancestor, then pick up writes.
 	root := filepath.Join(t.TempDir(), "registry", "skills")
 	if _, err := os.Stat(root); !os.IsNotExist(err) {
 		t.Fatalf("precondition: root should not exist yet")
@@ -91,10 +92,12 @@ func TestDirWatcher_CreatesMissingRoot(t *testing.T) {
 	w.SetDebounce(50 * time.Millisecond)
 	defer startDirWatcher(t, w)()
 
-	if _, err := os.Stat(root); err != nil {
-		t.Fatalf("expected watcher to create the root directory: %v", err)
+	// The watcher must not have created the directory.
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("watcher should not create the root directory")
 	}
 
+	// Create the root and a skill inside it after the watcher started.
 	skillDir := filepath.Join(root, "late")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -103,7 +106,7 @@ func TestDirWatcher_CreatesMissingRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 	if calls.Load() == 0 {
 		t.Fatal("expected onChange to fire for a skill added after startup")
 	}

--- a/tests/integration/registry_disk_watch_test.go
+++ b/tests/integration/registry_disk_watch_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/registry"
+	"github.com/gridctl/gridctl/pkg/reload"
+)
+
+// writeSkill writes a minimal valid SKILL.md into <registryDir>/skills/<name>/.
+func writeSkill(t *testing.T, registryDir, name, state string) {
+	t.Helper()
+	skillDir := filepath.Join(registryDir, "skills", name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	content := "---\nname: " + name + "\ndescription: " + name + " skill\nstate: " + state + "\n---\n\n# " + name + "\n\nBody.\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+}
+
+// TestRegistryDiskWatch_PicksUpOutOfBandSkill exercises the real DirWatcher
+// wired to a real registry.Server and mcp.Gateway router, reproducing the bug
+// where a skill written directly to the registry directory while the daemon is
+// running could be validated but not activated or seen by the gateway. After
+// the fix, the watcher refreshes the store and the router so the skill becomes
+// available without a restart. This test is filesystem-only and does not need a
+// container runtime.
+func TestRegistryDiskWatch_PicksUpOutOfBandSkill(t *testing.T) {
+	registryDir := t.TempDir()
+	store := registry.NewStore(registryDir)
+	srv := registry.New(store)
+	gw := mcp.NewGateway()
+
+	if err := srv.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	// Mirror the production refresh sequence (controller.refreshRegistry): reload
+	// the store from disk, then add/remove the registry client and refresh tools.
+	refresh := func() error {
+		if err := srv.RefreshTools(context.Background()); err != nil {
+			return err
+		}
+		if srv.HasContent() {
+			gw.Router().AddClient(srv)
+		} else {
+			gw.Router().RemoveClient("registry")
+		}
+		gw.Router().RefreshTools()
+		return nil
+	}
+
+	skillsDir := filepath.Join(store.Dir(), "skills")
+	watcher := reload.NewDirWatcher(skillsDir, refresh)
+	watcher.SetDebounce(100 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = watcher.Watch(ctx) }()
+	time.Sleep(150 * time.Millisecond)
+
+	// Precondition: the skill is not yet known to the running gateway.
+	if _, err := srv.Store().GetSkill("node-state-snapshot"); err == nil {
+		t.Fatal("precondition: skill should not exist before it is written")
+	}
+	if gw.Router().GetClient("registry") != nil {
+		t.Fatal("precondition: registry client should be absent with no skills")
+	}
+
+	// Write a skill directly to disk, out-of-band — the reported scenario.
+	writeSkill(t, registryDir, "node-state-snapshot", "active")
+
+	// The watcher should reconcile it within the debounce window.
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if _, lastErr = srv.Store().GetSkill("node-state-snapshot"); lastErr == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if lastErr != nil {
+		t.Fatalf("skill not picked up by watcher within deadline: %v", lastErr)
+	}
+
+	if gw.Router().GetClient("registry") == nil {
+		t.Error("expected registry client registered with the router after the skill appeared")
+	}
+}
+
+// TestRegistryDiskWatch_DebouncesMultiFileSkill verifies that writing a skill
+// made of several files in quick succession results in a consistent final state
+// (the skill is present), exercising the debounce path against real components.
+func TestRegistryDiskWatch_DebouncesMultiFileSkill(t *testing.T) {
+	registryDir := t.TempDir()
+	store := registry.NewStore(registryDir)
+	srv := registry.New(store)
+
+	if err := srv.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	var refreshes int
+	refresh := func() error {
+		refreshes++
+		return srv.RefreshTools(context.Background())
+	}
+
+	skillsDir := filepath.Join(store.Dir(), "skills")
+	watcher := reload.NewDirWatcher(skillsDir, refresh)
+	watcher.SetDebounce(150 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = watcher.Watch(ctx) }()
+	time.Sleep(150 * time.Millisecond)
+
+	skillDir := filepath.Join(registryDir, "skills", "multi")
+	if err := os.MkdirAll(filepath.Join(skillDir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := []string{"SKILL.md", "scripts/run.sh", "reference.md"}
+	content := "---\nname: multi\ndescription: multi skill\nstate: active\n---\n\n# multi\n\nBody.\n"
+	for _, f := range files {
+		payload := []byte("x")
+		if f == "SKILL.md" {
+			payload = []byte(content)
+		}
+		if err := os.WriteFile(filepath.Join(skillDir, f), payload, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := srv.Store().GetSkill("multi"); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if _, err := srv.Store().GetSkill("multi"); err != nil {
+		t.Fatalf("multi-file skill not reconciled: %v", err)
+	}
+	if refreshes == 0 {
+		t.Error("expected at least one debounced refresh")
+	}
+}


### PR DESCRIPTION
## Description

A skill added to the registry directory while the gateway daemon is running could be validated but not activated, and did not appear in the web UI, until the daemon was restarted. The daemon's in-memory registry store was only reconciled with disk at startup, on API-mediated mutations, or via the `stack.yaml` watcher — never on a direct write into the registry skills directory. This adds a debounced, recursive watcher on that directory so out-of-band skill changes take effect on the running daemon without a restart.

## Type of Change

- [x] Bug fix

## Changes Made

- Add `reload.DirWatcher`: a recursive, debounced directory watcher that creates the root if missing, arms watches on newly-created subdirectories, and reloads on create/write/remove/rename.
- Start a registry-directory watcher in the daemon bootstrap (independent of `--watch`), tied to the daemon lifecycle context.
- Factor the registry-refresh sequence into a shared `refreshRegistry()` helper reused by both the stack-reload callback and the new watcher, so the two paths cannot drift.
- Also covers `gridctl skill add/update/remove` while the daemon runs, which previously left the daemon's view stale.

## Testing

- `go test ./...` (unit) passes; new `pkg/reload` tests pass under `-race`.
- New `tests/integration/registry_disk_watch_test.go` (build tag `integration`) wires the real watcher to a real gateway + registry and asserts a skill written to disk becomes activatable without a restart; passes under `-race`.
- Reproduce manually: with a daemon running, write a valid `SKILL.md` into `~/.gridctl/registry/skills/<name>/`, then `gridctl activate <name>` succeeds within the debounce window.

Closes #843

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed