### PR TITLE
Release v0.1.0-beta.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,18 @@
 
 All notable changes to gridctl will be documented in this file.
 
-## [Unreleased]
+## [0.1.0-beta.13] - 2026-06-30
 
 
 ### Bug Fixes
 
 
-- Reflect skills added to the registry directory on disk in the running daemon without a restart, so a skill that validates can be activated and appears in the UI
+- Refresh daemon registry when skills change on disk ([#844](https://github.com/gridctl/gridctl/pull/844))
 
 ### Features
 
 
-- Add a text-size control to the Library Instructions and Tools detail panes
-
-## [0.1.0-beta.12] - 2026-06-25
+- Text-size control for reading-heavy detail panes ([#841](https://github.com/gridctl/gridctl/pull/841))## [0.1.0-beta.12] - 2026-06-25
 
 
 ### Bug Fixes


### PR DESCRIPTION
## Release v0.1.0-beta.13

Updates CHANGELOG.md for release.

### Included since v0.1.0-beta.12

- **Bug Fixes:** Refresh daemon registry when skills change on disk (#844)
- **Features:** Text-size control for reading-heavy detail panes (#841)

## Checklist

- [x] All checks passed (lint, test -race, build, web build)
- [x] Changelog generated with git-cliff
- [ ] PR reviewed and approved
- [ ] After merge, run `/release-gridctl --tag` to create the release tag