### PR TITLE
fix: forward structuredContent and outputSchema through the gateway

### DIFF
--- a/pkg/mcp/router.go
+++ b/pkg/mcp/router.go
@@ -165,10 +165,11 @@ func (r *Router) AggregatedTools() []Tool {
 		for _, tool := range toolsOf(r.sets[name]) {
 			prefixedName := PrefixTool(name, tool.Name)
 			prefixedTool := Tool{
-				Name:        prefixedName,
-				Title:       prefixedName,
-				Description: fmt.Sprintf("MCP server: %s. Call using the exact tool name %q. %s", name, prefixedName, tool.Description),
-				InputSchema: tool.InputSchema,
+				Name:         prefixedName,
+				Title:        prefixedName,
+				Description:  fmt.Sprintf("MCP server: %s. Call using the exact tool name %q. %s", name, prefixedName, tool.Description),
+				InputSchema:  tool.InputSchema,
+				OutputSchema: tool.OutputSchema,
 			}
 			tools = append(tools, prefixedTool)
 		}
@@ -195,10 +196,11 @@ func (r *Router) CatalogTools() []Tool {
 	for _, name := range names {
 		for _, tool := range toolsOf(r.sets[name]) {
 			tools = append(tools, Tool{
-				Name:        PrefixTool(name, tool.Name),
-				Title:       tool.Title,
-				Description: tool.Description,
-				InputSchema: tool.InputSchema,
+				Name:         PrefixTool(name, tool.Name),
+				Title:        tool.Title,
+				Description:  tool.Description,
+				InputSchema:  tool.InputSchema,
+				OutputSchema: tool.OutputSchema,
 			})
 		}
 	}

--- a/pkg/mcp/structured_content_test.go
+++ b/pkg/mcp/structured_content_test.go
@@ -1,0 +1,106 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+)
+
+// The MCP spec allows CallToolResult.structuredContent alongside content, and
+// Tool.outputSchema alongside inputSchema. The gateway must forward both
+// byte-for-byte, exactly as it already does for text content and isError —
+// upstream servers own the shapes.
+
+func TestToolCallResult_StructuredContentRoundTrip(t *testing.T) {
+	// Wire shape in (as an upstream server sends it) …
+	upstream := []byte(`{"content":[{"type":"text","text":"hello"}],"structuredContent":{"status":"ok","score":7}}`)
+	var result ToolCallResult
+	if err := json.Unmarshal(upstream, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(result.StructuredContent) == 0 {
+		t.Fatal("structuredContent lost on unmarshal")
+	}
+
+	// … and back out (as the gateway re-encodes it for the client).
+	out, err := json.Marshal(&result)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(out, &wire); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if string(wire["structuredContent"]) != `{"status":"ok","score":7}` {
+		t.Errorf("structuredContent not preserved on the wire: %s", wire["structuredContent"])
+	}
+}
+
+func TestToolCallResult_StructuredContentOmittedWhenAbsent(t *testing.T) {
+	out, err := json.Marshal(&ToolCallResult{Content: []Content{NewTextContent("x")}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(out, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := wire["structuredContent"]; present {
+		t.Error("structuredContent must be omitted when the upstream result has none")
+	}
+}
+
+func TestGateway_CallTool_StructuredContentPassthrough(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+	ctx := context.Background()
+
+	structured := json.RawMessage(`{"status":"ok","verdict":{"result":"pass"}}`)
+	client := setupMockAgentClient(ctrl, "agent1", []Tool{
+		{Name: "probe", Description: "Probe tool"},
+	})
+	client.EXPECT().CallTool(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&ToolCallResult{
+			Content:           []Content{NewTextContent("hello")},
+			StructuredContent: structured,
+		}, nil,
+	).AnyTimes()
+	g.Router().AddClient(client)
+	g.Router().RefreshTools()
+
+	result, err := g.CallTool(ctx, "agent1__probe", map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.StructuredContent) != string(structured) {
+		t.Errorf("structuredContent not passed through the gateway: %s", result.StructuredContent)
+	}
+	if result.Content[0].Text != "hello" {
+		t.Errorf("text content changed: %+v", result.Content)
+	}
+}
+
+func TestRouter_ToolOutputSchemaPreserved(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	r := NewRouter()
+	outputSchema := json.RawMessage(`{"type":"object","properties":{"status":{"type":"string"}}}`)
+	client := setupMockAgentClient(ctrl, "agent1", []Tool{
+		{Name: "probe", Description: "Probe tool", OutputSchema: outputSchema},
+	})
+	r.AddClient(client)
+	r.RefreshTools()
+
+	for _, tools := range map[string][]Tool{
+		"AggregatedTools": r.AggregatedTools(),
+		"CatalogTools":    r.CatalogTools(),
+	} {
+		if len(tools) != 1 {
+			t.Fatalf("expected 1 tool, got %d", len(tools))
+		}
+		if string(tools[0].OutputSchema) != string(outputSchema) {
+			t.Errorf("outputSchema not preserved: %s", tools[0].OutputSchema)
+		}
+	}
+}

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -269,6 +269,12 @@ type Tool struct {
 	Title       string          `json:"title,omitempty"`
 	Description string          `json:"description,omitempty"`
 	InputSchema json.RawMessage `json:"inputSchema"`
+
+	// OutputSchema is the optional JSON Schema describing the tool's
+	// structuredContent. Raw pass-through (same rationale as InputSchema):
+	// the gateway must forward it without loss for clients that validate
+	// structured results against it.
+	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
 }
 
 // InputSchemaObject is a helper for building simple input schemas.
@@ -312,6 +318,12 @@ type ToolCallParams struct {
 type ToolCallResult struct {
 	Content []Content `json:"content"`
 	IsError bool      `json:"isError,omitempty"`
+
+	// StructuredContent is the optional machine-readable result that the
+	// MCP spec allows alongside Content. Raw pass-through: the gateway
+	// forwards it byte-for-byte, exactly as it does for text content and
+	// IsError — upstream servers own the shape.
+	StructuredContent json.RawMessage `json:"structuredContent,omitempty"`
 
 	// Usage carries optional usage metadata reported alongside a tool
 	// result — model ID, cache-read/cache-write tokens. The field is


### PR DESCRIPTION
Fixes #848

`ToolCallResult` did not model the MCP spec's `structuredContent` field, so the gateway's decode→re-encode silently dropped it from tool results. `Tool` likewise lacked `outputSchema`, so `tools/list` stripped output schemas.

**Change** (pkg/mcp, +128/−8):
- `ToolCallResult.StructuredContent` and `Tool.OutputSchema` as `json.RawMessage` pass-through fields — same rationale as the existing `InputSchema`: forward without loss, upstream servers own the shapes. `omitempty` keeps the wire clean when absent.
- The two `Router` sites that rebuild `Tool` values (`AggregatedTools`, `CatalogTools`) copy `OutputSchema` through.
- No behavior change for text content, `isError`, truncation, or format conversion (they operate on `Content` only).

**Testing:**
- New `pkg/mcp/structured_content_test.go`: wire round-trip, `omitempty` when absent, gateway pass-through (mock client), router `outputSchema` preservation.
- Full suite green: `go test ./...` — 28 packages pass.
- End-to-end with the reproduction from the issue: before, a client through the gateway received `structuredContent: None` (intact direct); with this patch, `{'status': 'ok', 'score': 7}` is forwarded byte-for-byte. Also verified against our production MCP server (26 tools): a machine-readable verdict now travels through the gateway unchanged.
