### PR TITLE
fix: complete structuredContent support across gateway surfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gridctl/gridctl
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/internal/api/probe.go
+++ b/internal/api/probe.go
@@ -216,9 +216,10 @@ func (r probeRequest) toMCPServer() config.MCPServer {
 }
 
 type probeToolWire struct {
-	Name        string          `json:"name"`
-	Description string          `json:"description,omitempty"`
-	InputSchema json.RawMessage `json:"inputSchema"`
+	Name         string          `json:"name"`
+	Description  string          `json:"description,omitempty"`
+	InputSchema  json.RawMessage `json:"inputSchema"`
+	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
 }
 
 type probeResponse struct {
@@ -266,9 +267,10 @@ func toToolsWire(tools []mcp.Tool) []probeToolWire {
 	out := make([]probeToolWire, len(tools))
 	for i, t := range tools {
 		out[i] = probeToolWire{
-			Name:        t.Name,
-			Description: t.Description,
-			InputSchema: t.InputSchema,
+			Name:         t.Name,
+			Description:  t.Description,
+			InputSchema:  t.InputSchema,
+			OutputSchema: t.OutputSchema,
 		}
 	}
 	return out

--- a/internal/api/probe_test.go
+++ b/internal/api/probe_test.go
@@ -79,8 +79,9 @@ func postProbe(t *testing.T, handler http.Handler, body any, sessionID string) *
 
 func TestProbeHandler_ExternalURL_Success(t *testing.T) {
 	schema := json.RawMessage(`{"type":"object"}`)
+	outputSchema := json.RawMessage(`{"type":"object","properties":{"status":{"type":"string"}}}`)
 	srv := newProbeServer(t, &recordingClient{tools: []mcp.Tool{
-		{Name: "search", Description: "web search", InputSchema: schema},
+		{Name: "search", Description: "web search", InputSchema: schema, OutputSchema: outputSchema},
 	}})
 	rec := postProbe(t, srv.Handler(), map[string]any{
 		"url": "https://example.com/mcp",
@@ -95,6 +96,9 @@ func TestProbeHandler_ExternalURL_Success(t *testing.T) {
 	}
 	if len(got.Tools) != 1 || got.Tools[0].Name != "search" {
 		t.Fatalf("tools mismatch: %+v", got.Tools)
+	}
+	if string(got.Tools[0].OutputSchema) != string(outputSchema) {
+		t.Fatalf("outputSchema not passed through: %s", got.Tools[0].OutputSchema)
 	}
 	if got.ProbedAt == "" {
 		t.Fatalf("probedAt missing")

--- a/pkg/mcp/codemode_sandbox.go
+++ b/pkg/mcp/codemode_sandbox.go
@@ -150,6 +150,17 @@ func (s *Sandbox) Execute(ctx context.Context, code string, caller ToolCaller, a
 				panic(vm.NewGoError(fmt.Errorf("tool error: %s", text)))
 			}
 
+			// Prefer structuredContent when the server provides it: it is the
+			// declared machine-readable result, not a text scrape. Falls back
+			// to parsing text content below, so the returned shape stays a
+			// native JS value either way.
+			if len(result.StructuredContent) > 0 {
+				var parsed any
+				if json.Unmarshal(result.StructuredContent, &parsed) == nil {
+					return vm.ToValue(parsed)
+				}
+			}
+
 			// Parse the tool result content into a native JS value
 			// so agents can immediately access fields (e.g., result.field)
 			for _, c := range result.Content {

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -1666,6 +1666,9 @@ const defaultMaxToolResultBytes = 65536
 
 // applyTruncation truncates oversized tool results before they enter the log buffer.
 // It modifies result.Content in place. Results at or under the limit are unchanged.
+// Oversized structuredContent is dropped rather than clipped: a byte-clipped JSON
+// document is invalid, and clients fall back to Content per the MCP spec. The drop
+// is surfaced as a text notice so it is never silent.
 func (g *Gateway) applyTruncation(serverName, toolName string, result *ToolCallResult) {
 	if result == nil {
 		return
@@ -1690,6 +1693,16 @@ func (g *Gateway) applyTruncation(serverName, toolName string, result *ToolCallR
 				"original_bytes", len(c.Text), "limit_bytes", limit)
 			result.Content[i].Text = truncated
 		}
+	}
+
+	if limit > 0 && len(result.StructuredContent) > limit {
+		g.logger.Warn("structured content dropped: exceeds result size limit",
+			"tool", toolName, "server", serverName,
+			"original_bytes", len(result.StructuredContent), "limit_bytes", limit)
+		result.Content = append(result.Content, NewTextContent(fmt.Sprintf(
+			"[structuredContent dropped: %d bytes exceeds the %d-byte result limit]",
+			len(result.StructuredContent), limit)))
+		result.StructuredContent = nil
 	}
 }
 

--- a/pkg/mcp/structured_content_test.go
+++ b/pkg/mcp/structured_content_test.go
@@ -3,9 +3,13 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/mock/gomock"
+
+	"github.com/gridctl/gridctl/pkg/logging"
 )
 
 // The MCP spec allows CallToolResult.structuredContent alongside content, and
@@ -79,6 +83,114 @@ func TestGateway_CallTool_StructuredContentPassthrough(t *testing.T) {
 	}
 	if result.Content[0].Text != "hello" {
 		t.Errorf("text content changed: %+v", result.Content)
+	}
+}
+
+func TestGateway_CallTool_StructuredContentDroppedOverLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+	g.SetLogger(logging.NewDiscardLogger())
+	g.SetMaxToolResultBytes(100)
+	ctx := context.Background()
+
+	oversized := json.RawMessage(`{"blob":"` + strings.Repeat("a", 500) + `"}`)
+	client := setupMockAgentClient(ctrl, "agent1", []Tool{
+		{Name: "probe", Description: "Probe tool"},
+	})
+	client.EXPECT().CallTool(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&ToolCallResult{
+			Content:           []Content{NewTextContent("ok")},
+			StructuredContent: oversized,
+		}, nil,
+	).AnyTimes()
+	g.Router().AddClient(client)
+	g.Router().RefreshTools()
+	g.SetServerMeta(MCPServerConfig{Name: "agent1"})
+
+	result, err := g.HandleToolsCall(ctx, ToolCallParams{Name: "agent1__probe", Arguments: map[string]any{}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.StructuredContent != nil {
+		t.Errorf("oversized structuredContent must be dropped, got %d bytes", len(result.StructuredContent))
+	}
+	notice := result.Content[len(result.Content)-1].Text
+	if !strings.Contains(notice, "structuredContent dropped") {
+		t.Errorf("expected a drop notice in content, got: %s", notice)
+	}
+}
+
+func TestGateway_CallTool_StructuredContentKeptUnderLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	g := NewGateway()
+	g.SetLogger(logging.NewDiscardLogger())
+	g.SetMaxToolResultBytes(1000)
+	ctx := context.Background()
+
+	structured := json.RawMessage(`{"status":"ok"}`)
+	client := setupMockAgentClient(ctrl, "agent1", []Tool{
+		{Name: "probe", Description: "Probe tool"},
+	})
+	client.EXPECT().CallTool(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&ToolCallResult{
+			Content:           []Content{NewTextContent("ok")},
+			StructuredContent: structured,
+		}, nil,
+	).AnyTimes()
+	g.Router().AddClient(client)
+	g.Router().RefreshTools()
+	g.SetServerMeta(MCPServerConfig{Name: "agent1"})
+
+	result, err := g.HandleToolsCall(ctx, ToolCallParams{Name: "agent1__probe", Arguments: map[string]any{}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.StructuredContent) != string(structured) {
+		t.Errorf("structuredContent under the limit must pass through unchanged: %s", result.StructuredContent)
+	}
+	if len(result.Content) != 1 {
+		t.Errorf("no drop notice expected, got content: %+v", result.Content)
+	}
+}
+
+func TestSandbox_ToolCall_StructuredContentPreferred(t *testing.T) {
+	sandbox := NewSandbox(5 * time.Second)
+	caller := &mockToolCaller{
+		callFn: func(context.Context, string, map[string]any) (*ToolCallResult, error) {
+			return &ToolCallResult{
+				Content:           []Content{NewTextContent("Verdict: pass (score 7)")},
+				StructuredContent: json.RawMessage(`{"verdict":"pass","score":7}`),
+			}, nil
+		},
+	}
+	allowedTools := []Tool{{Name: "myserver__probe"}}
+
+	code := `var r = mcp.callTool("myserver", "probe", {}); r.verdict + ":" + r.score;`
+	result, err := sandbox.Execute(context.Background(), code, caller, allowedTools)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if result.Value != `"pass:7"` {
+		t.Errorf("expected structuredContent fields, got %s", result.Value)
+	}
+}
+
+func TestSandbox_ToolCall_TextFallbackWithoutStructuredContent(t *testing.T) {
+	sandbox := NewSandbox(5 * time.Second)
+	caller := &mockToolCaller{
+		callFn: func(context.Context, string, map[string]any) (*ToolCallResult, error) {
+			return &ToolCallResult{Content: []Content{NewTextContent(`{"items":[1,2,3]}`)}}, nil
+		},
+	}
+	allowedTools := []Tool{{Name: "myserver__probe"}}
+
+	code := `mcp.callTool("myserver", "probe", {}).items.length;`
+	result, err := sandbox.Execute(context.Background(), code, caller, allowedTools)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if result.Value != "3" {
+		t.Errorf("expected text-content fallback to still parse, got %s", result.Value)
 	}
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1617,6 +1617,7 @@ export interface ProbedTool {
   name: string;
   description?: string;
   inputSchema: unknown;
+  outputSchema?: unknown;
 }
 
 export interface ProbeSuccess {


### PR DESCRIPTION
## Description

Follow-ups to #849, which added `structuredContent` and `outputSchema` pass-through on the core gateway path. This PR extends coverage to the three surfaces that path did not touch: the add-server probe preview, the result-size guard, and the code-mode sandbox.

## Type of Change

- [x] Bug fix
- [x] Enhancement

## Changes Made

- Probe endpoint (`internal/api/probe.go`) now forwards `outputSchema` in the tool preview, with the matching optional field on the `ProbedTool` TypeScript interface.
- `applyTruncation` covers `structuredContent`: an oversized payload is dropped rather than byte-clipped (clipped JSON is invalid, and clients fall back to `content` per the MCP spec), with a logged warning and a visible text notice appended to the result.
- Code-mode `mcp.callTool` prefers `structuredContent` when present, returning the server's declared machine-readable result instead of a best-effort parse of the text rendering. Text parsing remains the fallback.

## Testing

- Six new tests: probe wire assertion, over- and under-limit truncation behavior, sandbox preference and text fallback.
- `go test ./...` green; new tests pass with `-race`; `golangci-lint` reports 0 issues on the touched packages; `tsc --noEmit` and eslint clean on the frontend change.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed