### PR TITLE
fix: fail integration suite on mock build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to gridctl will be documented in this file.
 
+## [Unreleased]
+
+
+### Bug Fixes
+
+
+- Fail the integration test suite when the mock MCP server binaries do not compile, instead of silently skipping the dependent tests and reporting green
+
 ## [0.1.0-beta.13] - 2026-06-30
 
 

--- a/tests/integration/autoscaler_test.go
+++ b/tests/integration/autoscaler_test.go
@@ -48,9 +48,6 @@ func TestAutoscaler_ColdStart_IdleToZero(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if mockStdioBin == "" {
-		t.Skip("mock stdio server binary not available")
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -107,9 +104,6 @@ func TestAutoscaler_ColdStart_IdleToZero(t *testing.T) {
 func TestAutoscaler_TickScalesUp_SustainedLoad(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-	}
-	if mockStdioBin == "" {
-		t.Skip("mock stdio server binary not available")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -176,9 +170,6 @@ func TestAutoscaler_TickScalesDown_IdleShrinksToMin(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if mockStdioBin == "" {
-		t.Skip("mock stdio server binary not available")
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -240,9 +231,6 @@ func TestAutoscaler_TickScalesDown_IdleShrinksToMin(t *testing.T) {
 func TestAutoscaler_UpdatePolicy_TakesEffectOnNextTick(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-	}
-	if mockStdioBin == "" {
-		t.Skip("mock stdio server binary not available")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -342,9 +330,6 @@ func (f *faultySpawner) Reap(ctx context.Context, r *mcp.Replica) error {
 func TestAutoscaler_SpawnerError_Recovers(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-	}
-	if mockStdioBin == "" {
-		t.Skip("mock stdio server binary not available")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/tests/integration/codemode_cost_test.go
+++ b/tests/integration/codemode_cost_test.go
@@ -26,9 +26,6 @@ func TestCodeMode_CostAttributionThroughSandbox(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if mockHTTPServerBin == "" {
-		t.Skip("mock server binary not available")
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/tests/integration/gateway_lifecycle_test.go
+++ b/tests/integration/gateway_lifecycle_test.go
@@ -21,9 +21,6 @@ func TestGatewayRegisterHTTPServer(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if mockHTTPServerBin == "" {
-		t.Skip("mock server binary not available")
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -78,9 +75,6 @@ func TestGatewayUnregisterServer(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if mockHTTPServerBin == "" {
-		t.Skip("mock server binary not available")
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -130,9 +124,6 @@ func TestGatewayUnregisterServer(t *testing.T) {
 func TestGatewayHealthMonitor(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-	}
-	if mockHTTPServerBin == "" {
-		t.Skip("mock server binary not available")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -201,9 +192,6 @@ func TestGatewayHealthMonitor(t *testing.T) {
 func TestGatewayGracefulShutdown(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-	}
-	if mockHTTPServerBin == "" {
-		t.Skip("mock server binary not available")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/tests/integration/per_client_scope_test.go
+++ b/tests/integration/per_client_scope_test.go
@@ -23,9 +23,6 @@ func TestPerClientScope_EnforcedAcrossPaths(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if mockHTTPServerBin == "" {
-		t.Skip("mock server binary not available")
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()

--- a/tests/integration/replica_all_down_test.go
+++ b/tests/integration/replica_all_down_test.go
@@ -19,9 +19,6 @@ func TestReplicas_AllReplicasDown(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if mockHTTPServerBin == "" {
-		t.Skip("mock server binary not available")
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/tests/integration/replica_kill_one_test.go
+++ b/tests/integration/replica_kill_one_test.go
@@ -19,9 +19,6 @@ func TestReplicas_KillOneReplica(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if mockHTTPServerBin == "" {
-		t.Skip("mock server binary not available")
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/tests/integration/replica_mixed_counts_test.go
+++ b/tests/integration/replica_mixed_counts_test.go
@@ -20,9 +20,6 @@ func TestReplicas_MixedCounts(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if mockHTTPServerBin == "" {
-		t.Skip("mock server binary not available")
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/tests/integration/replica_stackless_mode_test.go
+++ b/tests/integration/replica_stackless_mode_test.go
@@ -25,9 +25,6 @@ func TestReplicas_StacklessMode(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if mockHTTPServerBin == "" {
-		t.Skip("mock server binary not available")
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/tests/integration/schema_pinning_test.go
+++ b/tests/integration/schema_pinning_test.go
@@ -20,9 +20,6 @@ import (
 // scenario can be simulated across two connects.
 func startMockServerEnv(t *testing.T, port int, env ...string) {
 	t.Helper()
-	if mockHTTPServerBin == "" {
-		t.Skip("mock server binary not available")
-	}
 	cmd := exec.Command(mockHTTPServerBin, "-port", fmt.Sprintf("%d", port))
 	cmd.Env = append(os.Environ(), env...)
 	cmd.Stderr = os.Stderr

--- a/tests/integration/transport_test.go
+++ b/tests/integration/transport_test.go
@@ -18,14 +18,16 @@ import (
 )
 
 // Package-level paths to compiled mock server binaries.
-// Set by TestMain; individual tests skip if empty.
+// Set by TestMain before any test runs; a build failure fails the suite.
 var (
 	mockHTTPServerBin string
 	mockStdioBin      string
 )
 
 // TestMain compiles the mock server binaries once for the entire integration
-// test suite and cleans up after all tests complete.
+// test suite and cleans up after all tests complete. A failure to prepare the
+// binaries fails the whole suite rather than letting dependent tests skip,
+// so CI cannot go green while the mock servers do not compile.
 func TestMain(m *testing.M) {
 	os.Exit(runIntegrationTests(m))
 }
@@ -33,15 +35,15 @@ func TestMain(m *testing.M) {
 func runIntegrationTests(m *testing.M) int {
 	tmpDir, err := os.MkdirTemp("", "gridctl-transport-*")
 	if err != nil {
-		log.Printf("warning: failed to create temp dir for mock binaries: %v", err)
-		return m.Run()
+		log.Printf("failed to create temp dir for mock binaries: %v", err)
+		return 1
 	}
 	defer os.RemoveAll(tmpDir)
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		log.Printf("warning: failed to get working directory: %v", err)
-		return m.Run()
+		log.Printf("failed to get working directory: %v", err)
+		return 1
 	}
 
 	// Build mock HTTP/SSE server.
@@ -50,10 +52,10 @@ func runIntegrationTests(m *testing.M) int {
 	buildCmd := exec.Command("go", "build", "-o", httpBin, ".")
 	buildCmd.Dir = httpSrc
 	if out, err := buildCmd.CombinedOutput(); err != nil {
-		log.Printf("warning: failed to build mock-mcp-server: %v\n%s", err, out)
-	} else {
-		mockHTTPServerBin = httpBin
+		log.Printf("failed to build mock-mcp-server: %v\n%s", err, out)
+		return 1
 	}
+	mockHTTPServerBin = httpBin
 
 	// Build mock stdio server.
 	stdioSrc := filepath.Join(cwd, "..", "..", "examples", "_mock-servers", "local-stdio-server")
@@ -61,10 +63,10 @@ func runIntegrationTests(m *testing.M) int {
 	buildCmd = exec.Command("go", "build", "-o", stdioBin, ".")
 	buildCmd.Dir = stdioSrc
 	if out, err := buildCmd.CombinedOutput(); err != nil {
-		log.Printf("warning: failed to build local-stdio-server: %v\n%s", err, out)
-	} else {
-		mockStdioBin = stdioBin
+		log.Printf("failed to build local-stdio-server: %v\n%s", err, out)
+		return 1
 	}
+	mockStdioBin = stdioBin
 
 	return m.Run()
 }
@@ -82,12 +84,9 @@ func freePort(t *testing.T) int {
 }
 
 // startMockServer starts a mock server binary as a subprocess and registers
-// cleanup. The test is skipped if the binary path is empty.
+// cleanup.
 func startMockServer(t *testing.T, bin string, args ...string) {
 	t.Helper()
-	if bin == "" {
-		t.Skip("mock server binary not available")
-	}
 	cmd := exec.Command(bin, args...)
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
@@ -227,9 +226,6 @@ func TestSSETransportConnect(t *testing.T) {
 func TestStdioTransportConnect(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-	}
-	if mockStdioBin == "" {
-		t.Skip("mock stdio server binary not available")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
## Description

`TestMain` for the integration suite logged a warning and kept running when the mock MCP server binaries failed to compile; the ~15 dependent tests then skipped themselves and CI reported green. A broken `examples/_mock-servers/` could silently disable the gateway, autoscaler, replica, schema pinning, per-client scope, code-mode, and transport gates. Build failures (and temp-dir/cwd setup failures) now fail the suite with the compiler output in the log.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `runIntegrationTests` returns exit code 1 on mock build, `os.MkdirTemp`, or `os.Getwd` failure instead of continuing to `m.Run()` (cleanup `defer` still runs)
- Removed the 16 now-unreachable `t.Skip("mock ... binary not available")` guards across ten test files; short-mode and Podman environment skips are untouched
- CHANGELOG entry under Unreleased

## Testing

- Introduced a syntax error in `examples/_mock-servers/mock-mcp-server` locally: the suite now exits non-zero with the compiler output (previously passed with mass skips)
- Full suite passes against Docker: `go test -race -tags=integration ./tests/integration/...` (146s, zero skips for missing binaries)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #857