### PR TITLE
chore: zero eslint baseline and gate lint in CI

### DIFF
--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -156,6 +156,10 @@ jobs:
         run: npx tsc --noEmit
         working-directory: web
 
+      - name: Lint
+        run: npm run lint
+        working-directory: web
+
       - name: Tests with coverage
         run: npx vitest run --coverage
         working-directory: web

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Lint:
 
 ```bash
 golangci-lint run                # backend (gosec is enabled; see .golangci.yml for the curated exclusions)
-cd web && npm run lint           # frontend; pre-existing errors live in src/pages/Detached*.tsx (scope review to files you touched)
+cd web && npm run lint           # frontend; zero-error baseline, enforced by the gatekeeper frontend CI job
 ```
 
 ## Code architecture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to gridctl will be documented in this file.
 
 
 - Fail the integration test suite when the mock MCP server binaries do not compile, instead of silently skipping the dependent tests and reporting green
+- Update keyboard list-navigation state via an effect instead of during render, removing a latent concurrent-rendering hazard
+
+### Features
+
+
+- Enforce a zero-error frontend lint baseline in CI (gatekeeper now runs eslint on every PR)
 
 ## [0.1.0-beta.13] - 2026-06-30
 

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'coverage']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -18,6 +18,19 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+    rules: {
+      // Underscore prefix marks intentionally unused bindings (noop handler
+      // args, ignored destructured props).
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
     },
   },
 ])

--- a/web/src/__tests__/MCPServerForm.test.tsx
+++ b/web/src/__tests__/MCPServerForm.test.tsx
@@ -9,13 +9,13 @@ function defaultData(overrides?: Partial<MCPServerFormData>): MCPServerFormData 
   return { name: '', serverType: 'container', ...overrides };
 }
 
-const noop = (_data: Partial<MCPServerFormData>) => {};
+type OnChange = (data: Partial<MCPServerFormData>) => void;
 
 describe('MCPServerForm', () => {
-  let onChange: typeof noop;
+  let onChange: OnChange;
 
   beforeEach(() => {
-    onChange = vi.fn<typeof noop>();
+    onChange = vi.fn<OnChange>();
   });
 
   it('renders all 5 accordion sections', () => {
@@ -202,7 +202,7 @@ describe('MCPServerForm', () => {
 });
 
 describe('MCPServerForm field visibility', () => {
-  const onChange = vi.fn<typeof noop>();
+  const onChange = vi.fn<OnChange>();
 
   it('hides image/port/transport for local process type', () => {
     render(<MCPServerForm data={defaultData({ serverType: 'local' })} onChange={onChange} />);
@@ -233,7 +233,7 @@ describe('MCPServerForm field visibility', () => {
 });
 
 describe('MCPServerForm SSH advanced fields', () => {
-  const onChange = vi.fn<typeof noop>();
+  const onChange = vi.fn<OnChange>();
 
   it('shows knownHostsFile and jumpHost fields for ssh type', () => {
     render(<MCPServerForm data={defaultData({ serverType: 'ssh' })} onChange={onChange} />);
@@ -249,7 +249,7 @@ describe('MCPServerForm SSH advanced fields', () => {
 });
 
 describe('MCPServerForm OpenAPI new auth types', () => {
-  const onChange = vi.fn<typeof noop>();
+  const onChange = vi.fn<OnChange>();
 
   it('shows query auth fields when query is selected', () => {
     render(
@@ -311,7 +311,7 @@ describe('MCPServerForm OpenAPI new auth types', () => {
 });
 
 describe('MCPServerForm TLS section', () => {
-  const onChange = vi.fn<typeof noop>();
+  const onChange = vi.fn<OnChange>();
 
   it('shows TLS / mTLS section header for OpenAPI type', () => {
     render(<MCPServerForm data={defaultData({ serverType: 'openapi' })} onChange={onChange} />);
@@ -342,7 +342,7 @@ describe('MCPServerForm TLS section', () => {
 });
 
 describe('MCPServerForm pin_schemas select', () => {
-  const onChange = vi.fn<typeof noop>();
+  const onChange = vi.fn<OnChange>();
 
   it('shows schema pinning select in advanced section', () => {
     render(<MCPServerForm data={defaultData()} onChange={onChange} />);

--- a/web/src/__tests__/ResourceForm.test.tsx
+++ b/web/src/__tests__/ResourceForm.test.tsx
@@ -8,13 +8,13 @@ function defaultData(overrides?: Partial<ResourceFormData>): ResourceFormData {
   return { name: '', image: '', ...overrides };
 }
 
-const noop = (_data: Partial<ResourceFormData>) => {};
+type OnChange = (data: Partial<ResourceFormData>) => void;
 
 describe('ResourceForm', () => {
-  let onChange: typeof noop;
+  let onChange: OnChange;
 
   beforeEach(() => {
-    onChange = vi.fn<typeof noop>();
+    onChange = vi.fn<OnChange>();
   });
 
   it('renders all 6 accordion sections', () => {

--- a/web/src/__tests__/StackForm.test.tsx
+++ b/web/src/__tests__/StackForm.test.tsx
@@ -24,13 +24,13 @@ function defaultData(overrides?: Partial<StackFormData>): StackFormData {
   return { name: '', version: '1', ...overrides };
 }
 
-const noop = (_data: Partial<StackFormData>) => {};
+type OnChange = (data: Partial<StackFormData>) => void;
 
 describe('StackForm', () => {
-  let onChange: typeof noop;
+  let onChange: OnChange;
 
   beforeEach(() => {
-    onChange = vi.fn<typeof noop>();
+    onChange = vi.fn<OnChange>();
   });
 
   it('renders all 8 accordion sections', () => {
@@ -225,8 +225,8 @@ describe('StackForm', () => {
 });
 
 describe('StackForm gateway api_key auth', () => {
-  let onChange: typeof noop;
-  beforeEach(() => { onChange = vi.fn<typeof noop>(); });
+  let onChange: OnChange;
+  beforeEach(() => { onChange = vi.fn<OnChange>(); });
 
   it('shows api_key option in auth dropdown when gateway section is expanded', () => {
     render(<StackForm data={defaultData()} onChange={onChange} />);
@@ -260,8 +260,8 @@ describe('StackForm gateway api_key auth', () => {
 });
 
 describe('StackForm Gateway Advanced section', () => {
-  let onChange: typeof noop;
-  beforeEach(() => { onChange = vi.fn<typeof noop>(); });
+  let onChange: OnChange;
+  beforeEach(() => { onChange = vi.fn<OnChange>(); });
 
   it('shows Gateway Advanced section collapsed by default', () => {
     render(<StackForm data={defaultData()} onChange={onChange} />);
@@ -507,8 +507,8 @@ describe('YAML serialization — gateway advanced fields', () => {
 });
 
 describe('StackForm Logging section', () => {
-  let onChange: typeof noop;
-  beforeEach(() => { onChange = vi.fn<typeof noop>(); });
+  let onChange: OnChange;
+  beforeEach(() => { onChange = vi.fn<OnChange>(); });
 
   it('renders Logging accordion collapsed by default', () => {
     render(<StackForm data={defaultData()} onChange={onChange} />);

--- a/web/src/__tests__/VariablesPopover.test.tsx
+++ b/web/src/__tests__/VariablesPopover.test.tsx
@@ -13,13 +13,13 @@ vi.mock('../lib/api', () => ({
   createVariable: vi.fn().mockResolvedValue(undefined),
 }));
 
-const selectNoop = (_reference: string) => {};
+type OnSelect = (reference: string) => void;
 
 describe('VariablesPopover', () => {
-  let onSelect: typeof selectNoop;
+  let onSelect: OnSelect;
 
   beforeEach(() => {
-    onSelect = vi.fn<typeof selectNoop>();
+    onSelect = vi.fn<OnSelect>();
     useVaultStore.setState({ variables: null });
   });
 

--- a/web/src/components/chart/SparkChart.tsx
+++ b/web/src/components/chart/SparkChart.tsx
@@ -44,7 +44,7 @@ const SparkChart = React.forwardRef<HTMLDivElement, SparkChartProps>(
     {
       data,
       categories,
-      index,
+      index: _index,
       colors = ["teal", "amber"],
       type = "default",
       className,

--- a/web/src/components/graph/nodeTypes.ts
+++ b/web/src/components/graph/nodeTypes.ts
@@ -1,4 +1,4 @@
-import type { ComponentType } from 'react';
+import type { NodeTypes } from '@xyflow/react';
 import CustomNode from './CustomNode';
 import GatewayNode from './GatewayNode';
 import ClientNode from './ClientNode';
@@ -7,9 +7,9 @@ import SkillGroupNode from './SkillGroupNode';
 import ToolNode from './ToolNode';
 import ToolOverflowNode from './ToolOverflowNode';
 
-// Use 'any' to bypass React Flow's strict typing
-// The components receive props correctly at runtime
-export const nodeTypes: Record<string, ComponentType<any>> = {
+// NodeTypes erases each component's concrete node-data generic, which is why
+// the components can be registered here without casting.
+export const nodeTypes: NodeTypes = {
   mcpServer: CustomNode,
   resource: CustomNode,
   gateway: GatewayNode,

--- a/web/src/components/log/LogsTab.tsx
+++ b/web/src/components/log/LogsTab.tsx
@@ -30,10 +30,18 @@ export function LogsTab() {
 
   const selectedData = useSelectedNodeData() as NodeData | undefined;
 
+  // Determine log source: gateway or agent
+  const isGateway = selectedData?.type === 'gateway';
+  const agentName: string | null =
+    selectedData && selectedData.type !== 'gateway' && selectedData.type !== 'skill-group' && selectedData.type !== 'skill'
+      ? (selectedData as { name: string }).name
+      : null;
+  const hasSource = isGateway || agentName !== null;
+
   const [logs, setLogs] = useState<ParsedLog[]>([]);
   const [isPaused, setIsPaused] = useState(false);
   const [autoScroll, setAutoScroll] = useState(true);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(hasSource);
   const [error, setError] = useState<string | null>(null);
 
   // Filter state
@@ -50,13 +58,18 @@ export function LogsTab() {
   const { fontSize, zoomIn, zoomOut, resetZoom, isMin, isMax, isDefault } =
     useLogFontSize(containerRef);
 
-  // Determine log source: gateway or agent
-  const isGateway = selectedData?.type === 'gateway';
-  const agentName: string | null =
-    selectedData && selectedData.type !== 'gateway' && selectedData.type !== 'skill-group' && selectedData.type !== 'skill'
-      ? (selectedData as { name: string }).name
-      : null;
-  const hasSource = isGateway || agentName !== null;
+  // Reset log state when the source changes (state adjustment during render,
+  // so the reset commits together with the source switch).
+  const sourceKey = `${isGateway}:${agentName ?? ''}`;
+  const [prevSourceKey, setPrevSourceKey] = useState(sourceKey);
+  if (prevSourceKey !== sourceKey) {
+    setPrevSourceKey(sourceKey);
+    setLogs([]);
+    setError(null);
+    setExpandedIndex(null);
+    setSearchQuery('');
+    setIsLoading(hasSource);
+  }
 
   const fetchLogs = useCallback(async () => {
     try {
@@ -75,19 +88,11 @@ export function LogsTab() {
     }
   }, [isGateway, agentName]);
 
-  // Reset logs when source changes
+  // Fetch on mount and whenever the source changes
   useEffect(() => {
-    setLogs([]);
-    setError(null);
-    setExpandedIndex(null);
-    setSearchQuery('');
-    if (hasSource) {
-      setIsLoading(true);
-      fetchLogs();
-    } else {
-      setIsLoading(false);
-    }
-  }, [hasSource, isGateway, agentName, fetchLogs]);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async callback; state is set only after await, not synchronously
+    if (hasSource) fetchLogs();
+  }, [hasSource, fetchLogs]);
 
   // Polling for logs — only when logs tab is active
   useEffect(() => {

--- a/web/src/components/palette/CommandPalette.tsx
+++ b/web/src/components/palette/CommandPalette.tsx
@@ -132,13 +132,19 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
   const bottomPanelTab = useUIStore((s) => s.bottomPanelTab);
   const activeWorkspace = useUIStore((s) => s.activeWorkspace);
 
+  // Clear the query when the palette closes (state adjustment during render,
+  // so the reset commits with the close instead of one render later).
+  const [wasOpen, setWasOpen] = useState(isOpen);
+  if (wasOpen !== isOpen) {
+    setWasOpen(isOpen);
+    if (!isOpen) setInputValue('');
+  }
+
   // Capture focused element before opening
   useEffect(() => {
     if (isOpen) {
       previousFocusRef.current =
         document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    } else {
-      setInputValue('');
     }
   }, [isOpen]);
 

--- a/web/src/components/registry/RegistrySidebar.tsx
+++ b/web/src/components/registry/RegistrySidebar.tsx
@@ -153,13 +153,11 @@ export function RegistrySidebar({ embedded = false }: { embedded?: boolean } = {
     }
   }, [confirmDelete, refreshRegistry]);
 
-  // Clamp selected index when the filtered list shrinks
-  useEffect(() => {
-    if (filteredSkills.length === 0) return;
-    if (selectedIndex >= filteredSkills.length) {
-      setSelectedIndex(filteredSkills.length - 1);
-    }
-  }, [filteredSkills.length, selectedIndex]);
+  // Clamp selected index when the filtered list shrinks (state adjustment
+  // during render; converges in one pass, no extra committed frame).
+  if (filteredSkills.length > 0 && selectedIndex >= filteredSkills.length) {
+    setSelectedIndex(filteredSkills.length - 1);
+  }
 
   // Scroll the selected row into view on change
   useEffect(() => {

--- a/web/src/components/registry/SkillEditor.tsx
+++ b/web/src/components/registry/SkillEditor.tsx
@@ -484,6 +484,11 @@ export function SkillEditor({
 
   // --- Initialize from skill prop ---
 
+  // Deliberate reset-on-open: this effect re-initializes the whole editor
+  // whenever the skill object or isOpen changes (including refetch-after-save
+  // and reopen-with-same-skill). A key-based remount from the four call sites
+  // would drop those semantics, so the sync setState here is intentional.
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     idCounter.current = 0;
     if (skill) {
@@ -537,6 +542,7 @@ export function SkillEditor({
     setForkName('');
     setShowFiles(false);
   }, [skill, isOpen]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // --- Metadata management ---
 

--- a/web/src/components/registry/SkillFileTree.tsx
+++ b/web/src/components/registry/SkillFileTree.tsx
@@ -22,15 +22,22 @@ interface SkillFileTreeProps {
 
 export function SkillFileTree({ skillName, onSelectFile, readOnly = false }: SkillFileTreeProps) {
   const [files, setFiles] = useState<SkillFile[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(!!skillName);
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set(['scripts', 'references', 'assets']));
   const [showNewFile, setShowNewFile] = useState(false);
   const [newFilePath, setNewFilePath] = useState('');
 
+  // Flag loading when the skill changes (state adjustment during render, so
+  // the spinner commits together with the switch).
+  const [prevSkillName, setPrevSkillName] = useState(skillName);
+  if (prevSkillName !== skillName) {
+    setPrevSkillName(skillName);
+    setLoading(!!skillName);
+  }
+
   // Fetch files on mount and when skill changes
   useEffect(() => {
     if (!skillName) return;
-    setLoading(true);
     fetchSkillFiles(skillName)
       .then(setFiles)
       .catch(() => setFiles([]))

--- a/web/src/components/sidebar/OptimizeSection.tsx
+++ b/web/src/components/sidebar/OptimizeSection.tsx
@@ -83,6 +83,7 @@ export function OptimizeSection() {
   }, []);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async callback; state is set only after await, not synchronously
     load();
     intervalRef.current = window.setInterval(load, POLLING.METRICS);
     return () => {

--- a/web/src/components/sidebar/TokenUsageSection.tsx
+++ b/web/src/components/sidebar/TokenUsageSection.tsx
@@ -36,6 +36,7 @@ export function TokenUsageSection({ serverName }: TokenUsageSectionProps) {
   useEffect(() => {
     if (!sidebarOpen || !serverTokens) return;
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async callback; state is set only after await, not synchronously
     loadSparkline();
     intervalRef.current = window.setInterval(loadSparkline, POLLING.METRICS);
 

--- a/web/src/components/status/AutoscalePanel.tsx
+++ b/web/src/components/status/AutoscalePanel.tsx
@@ -45,6 +45,7 @@ function DwellPhrase({ status }: { status: AutoscaleStatus }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components -- test seam; exported for unit tests alongside the panel
 export function dwellPhrase(status: AutoscaleStatus): string {
   if (status.idleToZero && status.current === 0) {
     return 'Idle · scaled to zero';

--- a/web/src/components/telemetry/HeaderTelemetryPill.tsx
+++ b/web/src/components/telemetry/HeaderTelemetryPill.tsx
@@ -33,6 +33,7 @@ const ABBREV: Record<TelemetrySignal, string> = {
   traces: 'Traces',
 };
 
+// eslint-disable-next-line react-refresh/only-export-components -- test seam; exported for unit tests alongside the pill
 export function buildPillLabel(global: Partial<Record<TelemetrySignal, boolean>>): string {
   const on = SIGNALS.filter((s) => global[s] === true);
   if (on.length === 0) return 'Persistence: Off';

--- a/web/src/components/telemetry/WipeTelemetryDialog.tsx
+++ b/web/src/components/telemetry/WipeTelemetryDialog.tsx
@@ -71,6 +71,7 @@ export function WipeTelemetryDialog({ isOpen, onClose, onConfirm, scope, title, 
 
 // Used by tests so the wipe modal renders deterministic text from a
 // fixture without standing up the whole telemetry store.
+// eslint-disable-next-line react-refresh/only-export-components -- test seam; exported for unit tests alongside the dialog
 export function _testFormatScope(scope: InventoryRecord[]): {
   totalBytes: string;
   servers: number;

--- a/web/src/components/ui/LogViewer.tsx
+++ b/web/src/components/ui/LogViewer.tsx
@@ -33,6 +33,7 @@ export function LogViewer({ agentName, onClose }: LogViewerProps) {
 
   // Initial fetch and polling
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async callback; state is set only after await, not synchronously
     fetchLogs();
 
     if (!isPaused) {

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -51,6 +51,14 @@ export function Modal({
   const titleId = useId();
   const panelRef = useFocusTrap<HTMLDivElement>({ active: isOpen });
 
+  // Reset expanded state when the modal closes (state adjustment during
+  // render, so the reset commits with the close instead of one render later).
+  const [wasOpen, setWasOpen] = useState(isOpen);
+  if (wasOpen !== isOpen) {
+    setWasOpen(isOpen);
+    if (!isOpen) setExpanded(false);
+  }
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
@@ -71,11 +79,6 @@ export function Modal({
       return () => document.removeEventListener('keydown', handleKeyDown);
     }
   }, [isOpen, handleKeyDown]);
-
-  // Reset expanded state when modal closes
-  useEffect(() => {
-    if (!isOpen) setExpanded(false);
-  }, [isOpen]);
 
   if (!isOpen) return null;
 

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -24,6 +24,7 @@ let toasts: Toast[] = [];
 let listeners: (() => void)[] = [];
 let nextId = 0;
 
+// eslint-disable-next-line react-refresh/only-export-components -- imperative toast API lives with its container by design; HMR falls back to a full reload for this module
 export function showToast(type: 'success' | 'error' | 'warning', message: string, options?: ToastOptions) {
   const id = String(++nextId);
   const duration = options?.duration ?? 3000;

--- a/web/src/components/wizard/CreationWizard.tsx
+++ b/web/src/components/wizard/CreationWizard.tsx
@@ -131,8 +131,10 @@ export function CreationWizard({ onOpenVault, onDeploy }: CreationWizardProps) {
     reset,
   } = useWizardStore();
 
-  const mcpServers = useStackStore((s) => s.mcpServers) ?? [];
-  const resources = useStackStore((s) => s.resources) ?? [];
+  const mcpServersRaw = useStackStore((s) => s.mcpServers);
+  const resourcesRaw = useStackStore((s) => s.resources);
+  const mcpServers = useMemo(() => mcpServersRaw ?? [], [mcpServersRaw]);
+  const resources = useMemo(() => resourcesRaw ?? [], [resourcesRaw]);
   const skills = useRegistryStore((s) => s.skills);
   const counts = useMemo(
     () => getResourceCounts(mcpServers, resources, skills),

--- a/web/src/components/wizard/VariablesPopover.tsx
+++ b/web/src/components/wizard/VariablesPopover.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { KeyRound, Search, Plus, X, Loader2, Check } from 'lucide-react';
 import { cn } from '../../lib/cn';
@@ -70,12 +70,15 @@ export function VariablesPopover({ onSelect, className }: VariablesPopoverProps)
       .catch(() => {});
   }, [open, setVariables]);
 
-  // Compute position on open; reposition on scroll or resize
-  useEffect(() => {
-    if (!open) {
-      setPosition(null);
-      return;
-    }
+  // Drop the stale position when the popover closes (state adjustment during
+  // render; commits with the close, no extra frame).
+  if (!open && position !== null) setPosition(null);
+
+  // Compute position on open; reposition on scroll or resize. Layout effect
+  // because the position comes from a DOM measurement and must land before
+  // paint to avoid a misplaced first frame.
+  useLayoutEffect(() => {
+    if (!open) return;
     updatePosition();
     window.addEventListener('scroll', updatePosition, true);
     window.addEventListener('resize', updatePosition);

--- a/web/src/components/wizard/VaultSetSelector.tsx
+++ b/web/src/components/wizard/VaultSetSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { Search, Plus, X, Loader2, Check } from 'lucide-react';
 import { cn } from '../../lib/cn';
@@ -48,12 +48,15 @@ export function VaultSetSelector({ value, onChange }: VaultSetSelectorProps) {
     }
   }, []);
 
-  // Reposition on scroll or resize while open
-  useEffect(() => {
-    if (!open) {
-      setPosition(null);
-      return;
-    }
+  // Drop the stale position when the popover closes (state adjustment during
+  // render; commits with the close, no extra frame).
+  if (!open && position !== null) setPosition(null);
+
+  // Reposition on scroll or resize while open. Layout effect because the
+  // position comes from a DOM measurement and must land before paint to
+  // avoid a misplaced first frame.
+  useLayoutEffect(() => {
+    if (!open) return;
     updatePosition();
     window.addEventListener('scroll', updatePosition, true);
     window.addEventListener('resize', updatePosition);

--- a/web/src/components/wizard/YAMLPreview.tsx
+++ b/web/src/components/wizard/YAMLPreview.tsx
@@ -12,7 +12,7 @@ interface YAMLPreviewProps {
 // Syntax highlighting for YAML
 function highlightYAML(yaml: string): Array<{ lineNum: number; html: string }> {
   return yaml.split('\n').map((line, i) => {
-    let html = line
+    const html = line
       // Variable store references — canonical ${var:KEY} plus the
       // deprecated ${vault:KEY} alias still in flight.
       .replace(/(\$\{(?:vault|var):[^}]+\})/, '<span class="text-tertiary font-medium">$1</span>')

--- a/web/src/components/wizard/steps/ReviewStep.tsx
+++ b/web/src/components/wizard/steps/ReviewStep.tsx
@@ -29,13 +29,18 @@ export function ReviewStep({ yaml, resourceType, resourceName, onDeploy }: Revie
   const [copied, setCopied] = useState(false);
   const [deploying, setDeploying] = useState(false);
 
+  // Flag validation pending when the YAML changes (state adjustment during
+  // render, so the spinner commits together with the change). Runs on first
+  // render too, replacing the old validate-on-mount effect prefix.
+  const [prevYaml, setPrevYaml] = useState<string | null>(null);
+  if (prevYaml !== yaml) {
+    setPrevYaml(yaml);
+    setValidating(yaml.trim().length > 0);
+    if (!yaml.trim()) setIssues([]);
+  }
+
   const validate = useCallback(async () => {
-    if (!yaml.trim()) {
-      setIssues([]);
-      setValidating(false);
-      return;
-    }
-    setValidating(true);
+    if (!yaml.trim()) return;
     try {
       const result = await validateStackSpec(yaml);
       setIssues(result.issues || []);
@@ -49,6 +54,7 @@ export function ReviewStep({ yaml, resourceType, resourceName, onDeploy }: Revie
   }, [yaml]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async callback; state is set only after await, not synchronously
     validate();
   }, [validate]);
 

--- a/web/src/components/workspaces/LibraryWorkspace.tsx
+++ b/web/src/components/workspaces/LibraryWorkspace.tsx
@@ -334,6 +334,7 @@ export function LibraryWorkspace() {
     const found = (skills ?? []).find((s) => s.name === skillName);
     lastResolvedSkillRef.current = skillName;
     if (found) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- deep-link resolution must wait for the async registry load; guarded by lastResolvedSkillRef so it runs once per param change
       setEditingSkill(found);
       setShowEditor(true);
     } else {

--- a/web/src/hooks/useCommandRegistry.tsx
+++ b/web/src/hooks/useCommandRegistry.tsx
@@ -174,6 +174,7 @@ export function CommandRegistryProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components -- context provider + hook pair; splitting the file would separate the API from its provider
 export function useCommandRegistry(): CommandRegistryContextValue {
   const ctx = useContext(CommandRegistryContext);
   if (!ctx) throw new Error('useCommandRegistry must be used within a CommandRegistryProvider');

--- a/web/src/hooks/useListNav.ts
+++ b/web/src/hooks/useListNav.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 
 interface UseListNavOptions {
   itemCount: number;
@@ -47,10 +47,12 @@ export function useListNav({
   enabled = true,
 }: UseListNavOptions): void {
   // Keep latest values in a ref so the listener doesn't need to re-bind every
-  // time selectedIndex changes. Written in an effect (not during render) so an
-  // abandoned concurrent render can't leak values into the committed tree.
+  // time selectedIndex changes. Written in a layout effect (not during render,
+  // so an abandoned concurrent render can't leak values; not a passive effect,
+  // because the document-level listener can fire between commit and passive
+  // flush and must never read a stale selectedIndex).
   const state = useRef({ itemCount, selectedIndex, setSelectedIndex, onEnter, onEdit, onToggle });
-  useEffect(() => {
+  useLayoutEffect(() => {
     state.current = { itemCount, selectedIndex, setSelectedIndex, onEnter, onEdit, onToggle };
   });
 

--- a/web/src/hooks/useListNav.ts
+++ b/web/src/hooks/useListNav.ts
@@ -47,9 +47,12 @@ export function useListNav({
   enabled = true,
 }: UseListNavOptions): void {
   // Keep latest values in a ref so the listener doesn't need to re-bind every
-  // time selectedIndex changes.
+  // time selectedIndex changes. Written in an effect (not during render) so an
+  // abandoned concurrent render can't leak values into the committed tree.
   const state = useRef({ itemCount, selectedIndex, setSelectedIndex, onEnter, onEdit, onToggle });
-  state.current = { itemCount, selectedIndex, setSelectedIndex, onEnter, onEdit, onToggle };
+  useEffect(() => {
+    state.current = { itemCount, selectedIndex, setSelectedIndex, onEnter, onEdit, onToggle };
+  });
 
   useEffect(() => {
     if (!enabled) return;

--- a/web/src/hooks/useMetricsSeries.ts
+++ b/web/src/hooks/useMetricsSeries.ts
@@ -91,6 +91,7 @@ export function useMetricsSeries({
   // loading flag itself, so the effect body stays free of synchronous setState.
   useEffect(() => {
     if (!enabled) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async callback; state is set only after await, not synchronously
     void loadMetrics();
   }, [enabled, loadMetrics]);
 

--- a/web/src/lib/yaml-builder.ts
+++ b/web/src/lib/yaml-builder.ts
@@ -347,7 +347,7 @@ function stripListItem(yaml: string): string {
   return yaml
     .replace(/^- /, '')
     .split('\n')
-    .map((line) => line.replace(/^  /, ''))
+    .map((line) => line.replace(/^ {2}/, ''))
     .join('\n');
 }
 

--- a/web/src/pages/DetachedEditorPage.tsx
+++ b/web/src/pages/DetachedEditorPage.tsx
@@ -40,12 +40,13 @@ function DetachedEditorContent() {
     }
   }, []);
 
+  // No item to load means nothing pending (state adjustment during render;
+  // converges in one pass).
+  if (!itemName && loading) setLoading(false);
+
   // Load the item being edited
   useEffect(() => {
-    if (!itemName) {
-      setLoading(false);
-      return;
-    }
+    if (!itemName) return;
 
     const loadItem = async () => {
       try {

--- a/web/src/pages/DetachedLogsPage.tsx
+++ b/web/src/pages/DetachedLogsPage.tsx
@@ -36,7 +36,7 @@ function DetachedLogsPageContent() {
   const [logs, setLogs] = useState<ParsedLog[]>([]);
   const [isPaused, setIsPaused] = useState(false);
   const [autoScroll, setAutoScroll] = useState(true);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(initialAgent !== null);
   const [error, setError] = useState<string | null>(null);
   const [selectedAgent, setSelectedAgent] = useState<string | null>(initialAgent);
   const [nodes, setNodes] = useState<NodeOption[]>([]);
@@ -99,6 +99,18 @@ function DetachedLogsPageContent() {
   // Determine if selected is gateway
   const isGateway = selectedAgent === 'Gateway';
 
+  // Reset log state when the selected agent changes (state adjustment during
+  // render, so the reset commits together with the switch).
+  const [prevAgent, setPrevAgent] = useState(selectedAgent);
+  if (prevAgent !== selectedAgent) {
+    setPrevAgent(selectedAgent);
+    setLogs([]);
+    setError(null);
+    setExpandedIndex(null);
+    setSearchQuery('');
+    setIsLoading(selectedAgent !== null);
+  }
+
   const fetchLogs = useCallback(async () => {
     if (!selectedAgent) return;
 
@@ -118,19 +130,13 @@ function DetachedLogsPageContent() {
     }
   }, [selectedAgent, isGateway]);
 
-  // Reset logs when agent changes
+  // Fetch and mirror the selection into the URL on mount and agent change
   useEffect(() => {
-    setLogs([]);
-    setError(null);
-    setExpandedIndex(null);
-    setSearchQuery('');
-    setIsLoading(true);
     if (selectedAgent) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- async callback; state is set only after await, not synchronously
       fetchLogs();
-      // Update URL
       setSearchParams({ agent: selectedAgent });
     } else {
-      setIsLoading(false);
       setSearchParams({});
     }
   }, [selectedAgent, fetchLogs, setSearchParams]);

--- a/web/src/pages/DetachedTracesPage.tsx
+++ b/web/src/pages/DetachedTracesPage.tsx
@@ -76,9 +76,18 @@ function DetachedTracesPageContent() {
     }
   }, [serverFilter, errorsOnly]);
 
-  // Initial load
-  useEffect(() => {
+  // Flag loading when the filters change (state adjustment during render, so
+  // the spinner commits together with the filter switch).
+  const filterKey = `${serverFilter}|${errorsOnly}`;
+  const [prevFilterKey, setPrevFilterKey] = useState(filterKey);
+  if (prevFilterKey !== filterKey) {
+    setPrevFilterKey(filterKey);
     setIsLoading(true);
+  }
+
+  // Initial load and reload on filter change
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async callback; state is set only after await, not synchronously
     load();
   }, [load]);
 


### PR DESCRIPTION
## Description

`npm run lint` failed on main with 43 problems (37 errors) across 34 files, and no CI job ran eslint, so the documented lint gate did not exist. This PR fixes the baseline to zero errors and adds a lint step to the gatekeeper frontend job so it stays there.

## Type of Change

- [x] Code quality / tooling (chore)
- [x] Bug fix (one latent defect: render-phase ref write)

## Changes Made

- `react-hooks/set-state-in-effect` (17): reset/clamp/loading-flag shapes converted to the React-documented "adjust state during render" pattern (LogsTab, DetachedLogsPage, DetachedTracesPage, CommandPalette, Modal, RegistrySidebar, SkillFileTree, ReviewStep, popovers); popover positioning moved to `useLayoutEffect` (measurement must land before paint); calls to purely-async fetch callbacks carry a justified inline disable (state lands only after `await`; the rule cannot see across the async boundary); SkillEditor's deliberate init-from-prop reset and LibraryWorkspace's deep-link resolution are annotated as intentional
- `react-hooks/refs`: `useListNav` no longer writes its latest-values ref during render (concurrent-rendering hazard); written in an effect instead
- `no-unused-vars` (11): `^_` ignore patterns in the flat config plus type aliases replacing value-level `noop` mocks in four test files
- `react-refresh/only-export-components` (5): annotated test-seam exports, the imperative toast API, and the context hook/provider pairing
- Singles: `NodeTypes` typing for the React Flow registry (drops the `any`), memoized wizard store fallbacks (`exhaustive-deps`), two auto-fixes
- eslint now ignores `coverage/` output; gatekeeper frontend job runs `npm run lint`; AGENTS.md drops the stale pre-existing-errors caveat

## Testing

- `npm run lint`: 0 errors (one remaining warning is the known react-virtual `incompatible-library` notice in ModelPicker)
- `npx tsc --noEmit`, `vitest run` (1083 tests), and `npm run build` all pass
- Exercised the restructured flows against a locally built binary with the embedded UI: command palette clears its query on close/reopen, detached logs page syncs `?agent=` and loads without a stuck spinner, all routes render with zero console errors

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #859