### PR TITLE
chore: align CI toolchain pins with go.mod and Node 22

### DIFF
--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -12,10 +12,10 @@ jobs:
     timeout-minutes: 8
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -81,10 +81,10 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -101,10 +101,10 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -139,12 +139,12 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/install-smoke.yaml
+++ b/.github/workflows/install-smoke.yaml
@@ -31,7 +31,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve latest release tag
         id: latest
@@ -63,7 +63,7 @@ jobs:
           gridctl version
 
       - name: Set up Go (for upgrade subcommand smoke)
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run shellcheck
         run: shellcheck -s sh install.sh
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,20 +15,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
           cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Fetches upstream, validates the candidate (JSON / non-empty / model
       # floor / shrink guard), and replaces the committed file only on success.


### PR DESCRIPTION
## Description

The release workflow pinned Go 1.24 while go.mod requires 1.26 (GOTOOLCHAIN=auto silently downloaded the real toolchain, defeating the setup-go cache), and Node 20 (EOL April 2026) was pinned in the release and gatekeeper workflows. This aligns every workflow with the actual toolchain.

## Type of Change

- [x] CI / tooling (chore)

## Changes Made

- `release.yaml`: `go-version: "1.24"` → `go-version-file: go.mod` (the pattern every other workflow already uses)
- Node 20 → 22 (Active LTS) in `release.yaml` and `gatekeeper.yaml`
- Trivial action major bumps everywhere: `actions/checkout` v4→v5, `actions/setup-go` v5→v6, `actions/setup-node` v4→v5 (all exercised by gatekeeper on this PR)
- Left alone: `golangci-lint-action@v7` (version-input semantics change in v8), `goreleaser-action@v6` and `create-pull-request@v8` (current majors)

## Testing

- Frontend verified on Node 22.23.1 locally via mise: 1083 Vitest tests pass, `npm run build` succeeds
- All four workflow files parse as valid YAML; gatekeeper on this PR exercises the bumped actions and Node 22
- Note: the `release.yaml` changes are exercised by the next tagged release

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #863