### PR TITLE
fix: surface swallowed errors on vault and status paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to gridctl will be documented in this file.
 
 - Fail the integration test suite when the mock MCP server binaries do not compile, instead of silently skipping the dependent tests and reporting green
 - Update keyboard list-navigation state via an effect instead of during render, removing a latent concurrent-rendering hazard
+- Log vault reload failures, resource-listing failures, and registry refresh failures instead of silently discarding them; a corrupt vault file or Docker outage is now diagnosable from the logs
 
 ### Features
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -533,7 +534,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 			Tokenizer: s.tokenizerName,
 		},
 		MCPServers: s.getMCPServerStatuses(),
-		Resources:  s.getResourceStatuses(),
+		Resources:  s.getResourceStatuses(r.Context()),
 		Sessions:   s.gateway.SessionCount(),
 	}
 	// Only expose stack_name when a user-defined stack is loaded.
@@ -784,15 +785,19 @@ type ResourceStatus struct {
 	Status string `json:"status"`
 }
 
-// getResourceStatuses returns status of all resource containers.
-func (s *Server) getResourceStatuses() []ResourceStatus {
+// getResourceStatuses returns status of all resource containers. A listing
+// failure is logged and reported as an empty slice so /api/status stays
+// serveable during a runtime outage; the warning distinguishes that outage
+// from a stack with no resources.
+func (s *Server) getResourceStatuses(ctx context.Context) []ResourceStatus {
 	if s.dockerClient == nil || s.stackName == "" {
 		return []ResourceStatus{}
 	}
 
-	ctx := context.Background()
 	containers, err := docker.ListManagedContainers(ctx, s.dockerClient, s.stackName)
 	if err != nil {
+		slog.Warn("status: failed to list resource containers; reporting none",
+			"stack", s.stackName, "error", err)
 		return []ResourceStatus{}
 	}
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1736,4 +1739,39 @@ func mapKeys(m map[string]json.RawMessage) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// captureSlog swaps the default slog logger for one writing to the returned
+// buffer, restoring the previous logger when the test ends.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// A container-list failure must degrade to an empty resource list (so
+// /api/status stays serveable) while logging the outage, and must not be
+// silently identical to an empty stack.
+func TestGetResourceStatuses_ListErrorLogsWarning(t *testing.T) {
+	srv := newTestServer(t)
+	srv.SetDockerClient(&mockDockerClient{listError: errors.New("docker daemon unreachable")})
+	srv.SetStackName("test-stack")
+
+	logs := captureSlog(t)
+
+	statuses := srv.getResourceStatuses(context.Background())
+	if len(statuses) != 0 {
+		t.Fatalf("expected empty statuses on list error, got %d", len(statuses))
+	}
+
+	out := logs.String()
+	if !strings.Contains(out, "failed to list resource containers") {
+		t.Errorf("expected list-failure warning in log, got: %q", out)
+	}
+	if !strings.Contains(out, "docker daemon unreachable") {
+		t.Errorf("expected underlying error in log, got: %q", out)
+	}
 }

--- a/internal/api/registry.go
+++ b/internal/api/registry.go
@@ -443,7 +443,11 @@ func (s *Server) refreshRegistryRouter() {
 	if s.registryServer == nil {
 		return
 	}
-	_ = s.registryServer.RefreshTools(context.Background())
+	// Background context on purpose: the refresh mutates shared router state
+	// and must run to completion even if the triggering request is cancelled.
+	if err := s.registryServer.RefreshTools(context.Background()); err != nil {
+		slog.Warn("registry: tool refresh failed; router keeps previous tool set", "error", err)
+	}
 	if s.registryServer.HasContent() {
 		s.gateway.Router().AddClient(s.registryServer)
 	} else {

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -198,7 +199,7 @@ func skipJSONWhitespace(b []byte) []byte {
 func (s *Store) Get(key string) (string, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_ = s.reloadIfChanged()
+	s.reloadOrWarn()
 
 	v, ok := s.variables[key]
 	if !ok {
@@ -212,7 +213,7 @@ func (s *Store) Get(key string) (string, bool) {
 func (s *Store) GetVariable(key string) (Variable, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_ = s.reloadIfChanged()
+	s.reloadOrWarn()
 
 	v, ok := s.variables[key]
 	return v, ok
@@ -330,7 +331,7 @@ func (s *Store) Delete(key string) error {
 func (s *Store) List() []Variable {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_ = s.reloadIfChanged()
+	s.reloadOrWarn()
 
 	result := make([]Variable, 0, len(s.variables))
 	for _, v := range s.variables {
@@ -390,7 +391,7 @@ func (s *Store) ImportVariables(vars []Variable) (int, error) {
 func (s *Store) Export() map[string]string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_ = s.reloadIfChanged()
+	s.reloadOrWarn()
 
 	result := make(map[string]string, len(s.variables))
 	for k, v := range s.variables {
@@ -403,7 +404,7 @@ func (s *Store) Export() map[string]string {
 func (s *Store) Keys() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_ = s.reloadIfChanged()
+	s.reloadOrWarn()
 
 	keys := make([]string, 0, len(s.variables))
 	for k := range s.variables {
@@ -417,7 +418,7 @@ func (s *Store) Keys() []string {
 func (s *Store) Has(key string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_ = s.reloadIfChanged()
+	s.reloadOrWarn()
 	_, ok := s.variables[key]
 	return ok
 }
@@ -428,7 +429,7 @@ func (s *Store) Has(key string) bool {
 func (s *Store) Values() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_ = s.reloadIfChanged()
+	s.reloadOrWarn()
 
 	vals := make([]string, 0, len(s.variables))
 	for _, v := range s.variables {
@@ -472,7 +473,7 @@ func (s *Store) SetSecretSet(key, setName string) error {
 func (s *Store) ListSets() []SetSummary {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_ = s.reloadIfChanged()
+	s.reloadOrWarn()
 
 	// Count members per set
 	counts := make(map[string]int)
@@ -547,7 +548,7 @@ func (s *Store) DeleteSet(name string) error {
 func (s *Store) GetSetSecrets(setName string) []Variable {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_ = s.reloadIfChanged()
+	s.reloadOrWarn()
 
 	var result []Variable
 	for _, v := range s.variables {
@@ -565,7 +566,7 @@ func (s *Store) GetSetSecrets(setName string) []Variable {
 func (s *Store) IsLocked() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_ = s.reloadIfChanged()
+	s.reloadOrWarn()
 	return s.locked
 }
 
@@ -575,7 +576,7 @@ func (s *Store) IsLocked() bool {
 func (s *Store) IsEncrypted() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_ = s.reloadIfChanged()
+	s.reloadOrWarn()
 	return s.encrypted
 }
 
@@ -788,6 +789,17 @@ func (s *Store) stampMtimeLocked() {
 	}
 	s.mtime = info.ModTime()
 	s.size = info.Size()
+}
+
+// reloadOrWarn refreshes in-memory state from disk, logging (rather than
+// discarding) a reload failure so a corrupt or unreadable backing file is
+// observable instead of silently serving stale variables. Logs the base
+// directory only; never variable values. The caller must hold the write lock.
+func (s *Store) reloadOrWarn() {
+	if err := s.reloadIfChanged(); err != nil {
+		slog.Warn("vault: reload from disk failed; serving last known state",
+			"dir", s.baseDir, "error", err)
+	}
 }
 
 // reloadIfChanged refreshes in-memory state to match the current shape of

--- a/pkg/vault/store_test.go
+++ b/pkg/vault/store_test.go
@@ -1,9 +1,12 @@
 package vault
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -1215,6 +1218,46 @@ func TestStore_ReloadIgnoresCorruptFile(t *testing.T) {
 	val, ok := store.Get("KEY")
 	if !ok || val != "val" {
 		t.Errorf("Get(KEY) after corrupt overwrite = %q, %v; want %q, true", val, ok, "val")
+	}
+}
+
+// captureSlog swaps the default slog logger for one writing to the returned
+// buffer, restoring the previous logger when the test ends.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+func TestStore_ReloadFailureLogsWarning(t *testing.T) {
+	// A failing reload must keep serving the last known state (covered by
+	// TestStore_ReloadIgnoresCorruptFile) AND leave a diagnosable warning in
+	// the log instead of discarding the error.
+	dir := t.TempDir()
+
+	store := NewStore(dir)
+	if err := store.Set("KEY", "val"); err != nil {
+		t.Fatalf("Set(): %v", err)
+	}
+
+	logs := captureSlog(t)
+
+	path := filepath.Join(dir, "secrets.json")
+	if err := os.WriteFile(path, []byte("not valid json {{{"), 0600); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+
+	val, ok := store.Get("KEY")
+	if !ok || val != "val" {
+		t.Errorf("Get(KEY) after corrupt overwrite = %q, %v; want %q, true", val, ok, "val")
+	}
+
+	out := logs.String()
+	if !strings.Contains(out, "reload from disk failed") {
+		t.Errorf("expected reload-failure warning in log, got: %q", out)
 	}
 }
 


### PR DESCRIPTION
## Description

Three state paths silently discarded errors: every vault entry point ignored `reloadIfChanged()` failures (a corrupt `secrets.enc` meant serving stale variables with no signal), `getResourceStatuses` swallowed container-list errors (a Docker outage rendered as "no resources") while minting `context.Background()` inside a request path, and the registry refresh handler discarded `RefreshTools` errors. All three now log via `slog`; observable behavior is otherwise unchanged.

## Type of Change

- [x] Bug fix (observability of silent failure paths)

## Changes Made

- `pkg/vault/store.go`: new `reloadOrWarn()` helper replaces all 11 `_ = s.reloadIfChanged()` call sites; logs the base directory and error only, never variable values
- `internal/api/api.go`: `getResourceStatuses` takes `ctx context.Context` (passed `r.Context()` from `handleStatus`, closing an Article VI gap) and logs list failures before returning the empty slice, so an outage is distinguishable from an empty stack in the logs
- `internal/api/registry.go`: `refreshRegistryRouter` logs `RefreshTools` errors; keeps `context.Background()` deliberately (the refresh mutates shared router state and must outlive the triggering request), now with a comment saying so

## Testing

- New regression tests: vault reload failure emits the warning while still serving the last known state (corrupt-ciphertext scenario); resource-list failure returns an empty slice and logs the underlying error (mock `listError`)
- The registry refresh error path has no test: the current store's `Load` is deliberately fault-tolerant and cannot realistically fail, so the log line is a defensive guard (a forced-failure test would permanently skip)
- `go build ./...`, `golangci-lint run` (0 issues), and the full unit suite pass

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #865