### PR TITLE
feat: use official MCP logo on gateway node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to gridctl will be documented in this file.
 
 
 - Enforce a zero-error frontend lint baseline in CI (gatekeeper now runs eslint on every PR)
-- Show the official Model Context Protocol mark on the gateway node and gateway sidebar headers in the web UI, replacing the generic pulse icon
+- Show the official Model Context Protocol mark on the gateway node and gateway sidebar headers in the web UI, replacing the generic pulse icon and its looping ping animation; liveness stays with the "Gateway Active" status pill
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to gridctl will be documented in this file.
 
 
 - Enforce a zero-error frontend lint baseline in CI (gatekeeper now runs eslint on every PR)
+- Show the official Model Context Protocol mark on the gateway node and gateway sidebar headers in the web UI, replacing the generic pulse icon
 
 ### Removed
 

--- a/web/src/components/gateway/GatewaySidebar.tsx
+++ b/web/src/components/gateway/GatewaySidebar.tsx
@@ -1,6 +1,7 @@
 import { memo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Activity, ArrowRight, ChevronDown, ChevronRight, Library, Lightbulb, X } from 'lucide-react';
+import { ArrowRight, ChevronDown, ChevronRight, Library, Lightbulb, X } from 'lucide-react';
+import { MCP } from '@lobehub/icons';
 import { OptimizeSection } from '../sidebar/OptimizeSection';
 import { cn } from '../../lib/cn';
 import { useSelectedNodeData } from '../../stores/useStackStore';
@@ -26,7 +27,7 @@ const GatewaySidebar = memo(({ onClose }: GatewaySidebarProps) => {
       <div className="flex items-center justify-between p-4 border-b border-border/50 bg-surface-elevated/30">
         <div className="flex items-center gap-3 min-w-0">
           <div className="p-2 rounded-xl flex-shrink-0 border bg-primary/10 border-primary/20">
-            <Activity size={16} className="text-primary" />
+            <MCP size={16} className="text-primary" />
           </div>
           <div className="min-w-0">
             <h2 className="font-semibold text-text-primary truncate tracking-tight">

--- a/web/src/components/graph/GatewayNode.tsx
+++ b/web/src/components/graph/GatewayNode.tsx
@@ -33,16 +33,10 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
 
       {/* Header */}
       <div className="px-4 py-3.5 flex items-center gap-3 border-b border-primary/10 bg-primary/[0.02] relative">
-        {/* Glowing logo */}
-        <div className="relative">
-          <div className="p-2.5 bg-gradient-to-br from-primary/20 to-primary/5 rounded-xl border border-primary/30 shadow-glow-primary">
-            <MCP size={20} className="text-primary" />
-          </div>
-          {/* Pulse effect */}
-          <div
-            className="absolute inset-0 rounded-xl bg-primary/20 animate-ping"
-            style={{ animationDuration: '4s', animationIterationCount: 'infinite' }}
-          />
+        {/* Glowing logo. Liveness is signaled by the "Gateway Active" pill's
+            StatusDot ring below, so the mark itself stays static. */}
+        <div className="p-2.5 bg-gradient-to-br from-primary/20 to-primary/5 rounded-xl border border-primary/30 shadow-glow-primary">
+          <MCP size={20} className="text-primary" />
         </div>
         <div>
           <h3 className="font-bold text-sm text-text-primary tracking-tight">{data.name}</h3>

--- a/web/src/components/graph/GatewayNode.tsx
+++ b/web/src/components/graph/GatewayNode.tsx
@@ -1,6 +1,9 @@
 import { memo } from 'react';
 import { Handle, Position } from '@xyflow/react';
-import { Activity, Server, Database, Wrench, Radio, Monitor, Code, Library, ExternalLink } from 'lucide-react';
+import { Server, Database, Wrench, Radio, Monitor, Code, Library, ExternalLink } from 'lucide-react';
+// Named import only — @lobehub/icons sets `sideEffects: false`, so Vite
+// tree-shakes this down to the MCP icon module (see lib/clientIcons.tsx).
+import { MCP } from '@lobehub/icons';
 import { cn } from '../../lib/cn';
 import { StatusDot } from '../ui/StatusDot';
 import { useWindowManager } from '../../hooks/useWindowManager';
@@ -33,7 +36,7 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
         {/* Glowing logo */}
         <div className="relative">
           <div className="p-2.5 bg-gradient-to-br from-primary/20 to-primary/5 rounded-xl border border-primary/30 shadow-glow-primary">
-            <Activity size={20} className="text-primary" />
+            <MCP size={20} className="text-primary" />
           </div>
           {/* Pulse effect */}
           <div

--- a/web/src/components/graph/GatewayNode.tsx
+++ b/web/src/components/graph/GatewayNode.tsx
@@ -41,7 +41,7 @@ const GatewayNode = memo(({ data, selected }: GatewayNodeProps) => {
           {/* Pulse effect */}
           <div
             className="absolute inset-0 rounded-xl bg-primary/20 animate-ping"
-            style={{ animationDuration: '2s', animationIterationCount: 'infinite' }}
+            style={{ animationDuration: '4s', animationIterationCount: 'infinite' }}
           />
         </div>
         <div>

--- a/web/src/test/lobehubStub.tsx
+++ b/web/src/test/lobehubStub.tsx
@@ -1,0 +1,42 @@
+// Test stub for @lobehub/icons. Under vitest the package's barrel is
+// externalized and transitively imports an @emoji-mart/data JSON module that
+// Node ESM rejects without an import attribute, so we swap every icon for a
+// minimal svg honoring the same size/className contract. Aliased in
+// vitest.config.ts.
+interface IconStubProps {
+  size?: number;
+  className?: string;
+}
+
+function makeIcon(name: string) {
+  function IconStub({ size, className }: IconStubProps) {
+    return <svg data-icon={name} width={size} height={size} className={className} />;
+  }
+  IconStub.displayName = name;
+  return IconStub;
+}
+
+// Mirrors lobehub's CompoundedIcon shape: the base component IS the mono
+// variant; there is no .Mono property.
+function makeCompoundIcon(name: string) {
+  return Object.assign(makeIcon(name), {
+    Avatar: makeIcon(`${name}.Avatar`),
+    Combine: makeIcon(`${name}.Combine`),
+    Text: makeIcon(`${name}.Text`),
+    colorPrimary: '#000',
+    title: name,
+  });
+}
+
+export const MCP = makeCompoundIcon('MCP');
+export const Claude = makeCompoundIcon('Claude');
+export const Cursor = makeCompoundIcon('Cursor');
+export const Windsurf = makeCompoundIcon('Windsurf');
+export const Gemini = makeCompoundIcon('Gemini');
+export const Antigravity = makeCompoundIcon('Antigravity');
+export const OpenCode = makeCompoundIcon('OpenCode');
+export const Grok = makeCompoundIcon('Grok');
+export const Cline = makeCompoundIcon('Cline');
+export const RooCode = makeCompoundIcon('RooCode');
+export const Goose = makeCompoundIcon('Goose');
+export const Codex = makeCompoundIcon('Codex');

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
       '@uiw/react-codemirror': fileURLToPath(
         new URL('./src/test/codemirrorStub.tsx', import.meta.url),
       ),
+      // The @lobehub/icons barrel drags in JSON modules Node ESM can't load
+      // under vitest; swap every icon for a plain svg stub.
+      '@lobehub/icons': fileURLToPath(
+        new URL('./src/test/lobehubStub.tsx', import.meta.url),
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Description

Replaces the generic pulse (lucide `Activity`) icon with the official Model Context Protocol mark in the two gateway-identity spots: the gateway node header on the Topology canvas and the gateway sidebar header. The mark comes from `@lobehub/icons` (already a dependency for client brand icons), renders via `currentColor`, and keeps the existing `text-primary` tint and glow tile. The looping ping overlay is removed: liveness is already signaled by the "Gateway Active" pill's StatusDot ring, and a static identity mark keeps motion reserved for status indicators and edge data-flow.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `GatewayNode.tsx`: swap `Activity` (size 20) for the lobehub `MCP` mono mark inside the unchanged glow tile
- `GatewaySidebar.tsx`: same swap at size 16 in the detail-pane header
- Add a vitest alias stubbing `@lobehub/icons` (its barrel transitively imports a JSON module Node ESM rejects under vitest), following the existing CodeMirror stub pattern
- CHANGELOG entry under `[Unreleased]`

Other `Activity` usages (traces, scaling) are intentionally untouched; the swap frees that glyph for its health/activity semantics. No new dependencies, no layout changes.

## Testing

- `cd web && npm test`: 108 files, 1083 tests pass (the stub un-breaks the four suites that transitively import the icon barrel)
- `cd web && npm run lint`: zero errors
- `make build`: typechecks and builds with embedded UI

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #869