### PR TITLE
feat: terminal experience v1 (errors, help groups, JSON, day-2 verbs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ All notable changes to gridctl will be documented in this file.
 ### Features
 
 
+- Add `gridctl logs` (daemon log tail/follow, container logs via `--server`), `gridctl doctor` (verdict-style environment checks with remediation hints and meaningful exit codes), and `gridctl open` / `gridctl ui` (open the web UI, `--print` / `--json` supported)
+- Group `gridctl --help` by domain with a quick-start block, add `Example:` sections to core commands, and drop the subcommand footer from leaf commands
+- Print runtime errors once with no usage dump; flag and argument mistakes keep a short help pointer, and unknown commands and `link`/`unlink` client slugs get "did you mean" suggestions
+- Add `--json` to `status` and `info` (experimental schemas) and as a `--format json` alias on `validate`, `plan`, `optimize`, `activate`, `skill list`, and `var list`
+- Colorize `gridctl plan` diffs with Terraform-style `+`/`~`/`-` symbols on TTYs
+- Accept a stack name or file path in `gridctl destroy`, print a notice when bare `gridctl apply` starts stackless mode, and add next-step hints after `status`, `destroy`, and `apply`
+- Honor `NO_COLOR`, `TERM=dumb`, and a new global `--no-color` flag across all CLI output, including help text
 - Enforce a zero-error frontend lint baseline in CI (gatekeeper now runs eslint on every PR)
 - Show the official Model Context Protocol mark on the gateway node and gateway sidebar headers in the web UI, replacing the generic pulse icon and its looping ping animation; liveness stays with the "Gateway Active" status pill
 

--- a/cmd/gridctl/activate.go
+++ b/cmd/gridctl/activate.go
@@ -48,7 +48,11 @@ Exit codes:
   1  skill not found
   2  infrastructure error (gateway unreachable, conflict, registry unavailable)`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		if activateFormat, err = resolveFormat(activateFormat, cmd.Flags().Changed("format"), *activateJSON); err != nil {
+			return err
+		}
 		port, err := resolveActivatePort(activateStack)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -64,10 +68,13 @@ Exit codes:
 	},
 }
 
+var activateJSON *bool
+
 func init() {
 	activateCmd.Flags().StringVarP(&activateStack, "stack", "s", "", "Stack to query (auto-detected when only one stack is running)")
 	activateCmd.Flags().StringVar(&activateFormat, "format", "", "Output format: 'json' for machine-readable output")
 	activateCmd.Flags().BoolVarP(&activateQuiet, "quiet", "q", false, "Suppress the human-readable success line")
+	activateJSON = addJSONAlias(activateCmd)
 }
 
 // resolveActivatePort mirrors resolveTestPort. Kept separate so error

--- a/cmd/gridctl/apply.go
+++ b/cmd/gridctl/apply.go
@@ -18,37 +18,46 @@ import (
 )
 
 var (
-	applyVerbose      bool
-	applyQuiet        bool
-	applyNoCache      bool
-	applyPort         int
-	applyBasePort     int
-	applyForeground   bool
-	applyDaemonChild  bool
-	applyNoExpand     bool
-	applyWatch        bool
-	applyFlash        bool
-	applyCodeMode     bool
-	applyLogFile      string
+	applyVerbose     bool
+	applyQuiet       bool
+	applyNoCache     bool
+	applyPort        int
+	applyBasePort    int
+	applyForeground  bool
+	applyDaemonChild bool
+	applyNoExpand    bool
+	applyWatch       bool
+	applyFlash       bool
+	applyCodeMode    bool
+	applyLogFile     string
 )
 
 var applyCmd = &cobra.Command{
 	Use:   "apply [stack.yaml]",
 	Short: "Start MCP servers defined in a stack file",
 	Long: `Reads a stack YAML file and starts all defined MCP servers and resources.
+When called without a stack file, starts the API server and web UI in
+stackless mode instead (the same as 'gridctl serve'); a notice is printed
+so the fallback is never silent.
 
 Creates a Docker network, pulls/builds images as needed, and starts containers.
 The MCP gateway runs as a background daemon by default.
 
-When called without a stack file, starts the API server and web UI in stackless
-mode. Vault and wizard endpoints are fully functional; stack-dependent endpoints
-return 503 until a stack is loaded.
+In stackless mode, vault and wizard endpoints are fully functional;
+stack-dependent endpoints return 503 until a stack is loaded.
 
 Use --foreground (-f) to run in foreground with verbose output.
 Use --flash to auto-link detected LLM clients after apply.`,
+	Example: `  gridctl apply stack.yaml             Deploy a stack as a background daemon
+  gridctl apply stack.yaml -f          Run in foreground (ctrl-C to stop)
+  gridctl apply stack.yaml --watch     Hot reload on stack file changes
+  gridctl apply                        Start the API and web UI without a stack`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
+			if !applyDaemonChild {
+				fmt.Fprintln(os.Stderr, "No stack file given; starting stackless API/UI (same as 'gridctl serve').")
+			}
 			return runServeStackless()
 		}
 		return runApply(args[0])
@@ -199,6 +208,6 @@ func flashLinkClients(port int) {
 func showLinkHint() {
 	registry := provisioner.NewRegistry()
 	if !registry.IsAnyLinked("gridctl") {
-		fmt.Println("\n  Tip: Run 'gridctl link' to connect your LLM client to this gateway")
+		output.New().Hint("Tip: run 'gridctl link' to connect your LLM client, or 'gridctl open' for the web UI")
 	}
 }

--- a/cmd/gridctl/destroy.go
+++ b/cmd/gridctl/destroy.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/gridctl/gridctl/pkg/config"
@@ -15,31 +17,73 @@ import (
 )
 
 var destroyCmd = &cobra.Command{
-	Use:   "destroy <stack.yaml>",
+	Use:   "destroy <stack.yaml|stack-name>",
 	Short: "Stop gateway daemon and remove containers",
 	Long: `Stops the MCP gateway daemon and removes all containers for a stack.
 
-Requires the stack file to identify which stack to stop.`,
+Accepts either the stack YAML file or the stack name shown by
+'gridctl status', so a moved or renamed file never blocks a teardown.`,
+	Example: `  gridctl destroy stack.yaml   Destroy by file
+  gridctl destroy mystack      Destroy by stack name (see 'gridctl status')`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runDestroy(args[0])
 	},
 }
 
-func runDestroy(stackPath string) error {
-	printer := output.New()
-
-	// Load stack to get its name
-	stack, err := config.LoadStack(stackPath)
-	if err != nil {
-		return fmt.Errorf("failed to load stack: %w", err)
+// resolveDestroyTarget resolves the destroy argument to a stack name and,
+// when available, the loaded spec. A readable stack file takes precedence
+// (the original behavior); anything else falls back to a stack name from
+// state, so an unrelated file or directory with the same name never blocks
+// a by-name teardown. When resolved by name, the spec is loaded best-effort
+// from the recorded stack file so container-runtime warnings keep their
+// gating.
+func resolveDestroyTarget(arg string) (string, *config.Stack, error) {
+	var fileErr error
+	if info, err := os.Stat(arg); err == nil && info.Mode().IsRegular() {
+		stack, loadErr := config.LoadStack(arg)
+		if loadErr == nil {
+			return stack.Name, stack, nil
+		}
+		fileErr = loadErr
 	}
 
-	printer.Info("Stopping stack", "name", stack.Name)
+	st, err := state.Load(arg)
+	if err != nil {
+		if fileErr != nil {
+			return "", nil, fmt.Errorf("failed to load stack: %w", fileErr)
+		}
+		states, _ := state.List()
+		var names []string
+		for _, s := range states {
+			names = append(names, s.StackName)
+		}
+		if len(names) > 0 {
+			return "", nil, fmt.Errorf("stack %q not found; known stacks: %s", arg, strings.Join(names, ", "))
+		}
+		return "", nil, fmt.Errorf("stack %q not found (not a stack file or a known stack name)", arg)
+	}
+
+	// Best-effort spec load; the recorded file may have moved since apply.
+	if stack, loadErr := config.LoadStack(st.StackFile); loadErr == nil {
+		return st.StackName, stack, nil
+	}
+	return st.StackName, nil, nil
+}
+
+func runDestroy(target string) error {
+	printer := output.New()
+
+	name, stack, err := resolveDestroyTarget(target)
+	if err != nil {
+		return err
+	}
+
+	printer.Info("Stopping stack", "name", name)
 
 	// Check for running daemon (with lock to prevent races with deploy)
-	err = state.WithLock(stack.Name, 5*time.Second, func() error {
-		st, loadErr := state.Load(stack.Name)
+	err = state.WithLock(name, 5*time.Second, func() error {
+		st, loadErr := state.Load(name)
 		if loadErr != nil || st == nil {
 			return nil // No state file, nothing to kill
 		}
@@ -53,7 +97,7 @@ func runDestroy(stackPath string) error {
 		}
 
 		// Clean up state file
-		if delErr := state.Delete(stack.Name); delErr != nil {
+		if delErr := state.Delete(name); delErr != nil {
 			printer.Warn("could not delete state file", "error", delErr)
 		}
 		return nil
@@ -62,22 +106,27 @@ func runDestroy(stackPath string) error {
 		printer.Warn("could not acquire lock", "error", err)
 	}
 
+	// Without a loaded spec (destroy by name with a moved stack file) we
+	// cannot tell whether the stack needed a container runtime; warn anyway.
+	needsRuntime := stack == nil || stack.NeedsContainerRuntime()
+
 	// Stop containers (best-effort when Docker is unavailable)
 	rt, err := runtime.New()
 	if err != nil {
-		if stack.NeedsContainerRuntime() {
+		if needsRuntime {
 			printer.Warn("could not initialize runtime — container cleanup skipped", "error", err)
 		}
 	} else {
 		defer rt.Close()
 		ctx := context.Background()
-		if err := rt.Down(ctx, stack.Name); err != nil {
-			if stack.NeedsContainerRuntime() {
+		if err := rt.Down(ctx, name); err != nil {
+			if needsRuntime {
 				printer.Warn("container runtime unavailable — could not remove containers", "error", err)
 			}
 		}
 	}
 
-	printer.Info("Stack stopped", "name", stack.Name)
+	printer.Info("Stack stopped", "name", name)
+	printer.Hint("Verify with 'gridctl status'")
 	return nil
 }

--- a/cmd/gridctl/destroy_test.go
+++ b/cmd/gridctl/destroy_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/state"
+)
+
+func TestResolveDestroyTargetByFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stack.yaml")
+	if err := os.WriteFile(path, []byte("name: filestack\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	name, stack, err := resolveDestroyTarget(path)
+	if err != nil {
+		t.Fatalf("resolveDestroyTarget(file): %v", err)
+	}
+	if name != "filestack" {
+		t.Errorf("name = %q, want filestack", name)
+	}
+	if stack == nil {
+		t.Error("expected the loaded spec for a file target")
+	}
+}
+
+func TestResolveDestroyTargetByName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	st := &state.DaemonState{
+		StackName: "namedstack",
+		StackFile: "/moved/away.yaml",
+		PID:       os.Getpid(),
+		Port:      8181,
+		StartedAt: time.Now(),
+	}
+	if err := state.Save(st); err != nil {
+		t.Fatal(err)
+	}
+
+	name, stack, err := resolveDestroyTarget("namedstack")
+	if err != nil {
+		t.Fatalf("resolveDestroyTarget(name): %v", err)
+	}
+	if name != "namedstack" {
+		t.Errorf("name = %q, want namedstack", name)
+	}
+	if stack != nil {
+		t.Error("expected nil spec when the recorded stack file is gone")
+	}
+}
+
+func TestResolveDestroyTargetNameShadowedByDirectory(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	st := &state.DaemonState{StackName: "examples", StackFile: "/moved.yaml", PID: os.Getpid(), Port: 8181, StartedAt: time.Now()}
+	if err := state.Save(st); err != nil {
+		t.Fatal(err)
+	}
+
+	// A directory named like the stack in cwd must not block by-name teardown.
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "examples"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	name, _, err := resolveDestroyTarget("examples")
+	if err != nil {
+		t.Fatalf("resolveDestroyTarget: %v", err)
+	}
+	if name != "examples" {
+		t.Errorf("name = %q, want examples", name)
+	}
+}
+
+func TestResolveDestroyTargetUnknownListsKnown(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	st := &state.DaemonState{StackName: "known", StackFile: "/x.yaml", PID: os.Getpid(), Port: 8181, StartedAt: time.Now()}
+	if err := state.Save(st); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := resolveDestroyTarget("nope")
+	if err == nil {
+		t.Fatal("expected an error for an unknown stack")
+	}
+	if !strings.Contains(err.Error(), "not found") || !strings.Contains(err.Error(), "known") {
+		t.Errorf("error should mention known stacks, got %q", err)
+	}
+}

--- a/cmd/gridctl/doctor.go
+++ b/cmd/gridctl/doctor.go
@@ -1,0 +1,363 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/gridctl/gridctl/pkg/output"
+	"github.com/gridctl/gridctl/pkg/provisioner"
+	"github.com/gridctl/gridctl/pkg/runtime"
+	"github.com/gridctl/gridctl/pkg/runtime/docker"
+	"github.com/gridctl/gridctl/pkg/state"
+	"github.com/gridctl/gridctl/pkg/vault"
+
+	"github.com/spf13/cobra"
+)
+
+// Exit codes — matched against the conventions in cmd/gridctl/optimize.go
+// and cmd/gridctl/activate.go so CI scripts can rely on a stable contract.
+const (
+	doctorExitOK     = 0
+	doctorExitErrors = 1
+	doctorExitFailed = 2
+)
+
+// Check statuses. Words, not just colors, so meaning survives NO_COLOR.
+const (
+	doctorStatusOK   = "ok"
+	doctorStatusWarn = "warn"
+	doctorStatusFail = "fail"
+	doctorStatusInfo = "info"
+)
+
+const doctorProbeTimeout = 2 * time.Second
+
+var (
+	doctorJSON  bool
+	doctorQuiet bool
+)
+
+// doctorCheck is one verdict line of the report.
+type doctorCheck struct {
+	ID      string `json:"id"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+// doctorReport is the machine-readable shape of `gridctl doctor --json`.
+// The schema is experimental until 1.0.
+type doctorReport struct {
+	OK           bool          `json:"ok"`
+	ErrorCount   int           `json:"error_count"`
+	WarningCount int           `json:"warning_count"`
+	Checks       []doctorCheck `json:"checks"`
+}
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check the environment and report actionable problems",
+	Long: `Runs opinionated health checks against the local environment: container
+runtime, socket reachability, gateway port, Node.js availability for client
+bridges, state directory hygiene, and vault status. Each check renders a
+verdict with a remediation hint.
+
+Where 'gridctl info' reports facts and always exits 0, doctor judges and
+exits non-zero when something needs fixing.
+
+Exit codes:
+  0  no errors (warnings allowed)
+  1  one or more errors
+  2  doctor itself failed to run`,
+	Example: `  gridctl doctor               Run all checks
+  gridctl doctor --json        Machine-readable report (experimental schema)
+  gridctl doctor -q            Only print failures and warnings`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		defer cancel()
+
+		report := runDoctorChecks(ctx)
+		exit := renderDoctorReport(os.Stdout, report, doctorJSON, doctorQuiet)
+		if exit != doctorExitOK {
+			os.Exit(exit)
+		}
+		return nil
+	},
+}
+
+func init() {
+	doctorCmd.Flags().BoolVar(&doctorJSON, "json", false, "Output the report as JSON")
+	doctorCmd.Flags().BoolVarP(&doctorQuiet, "quiet", "q", false, "Only print failing and warning checks")
+}
+
+// runDoctorChecks executes every check and aggregates the report.
+func runDoctorChecks(ctx context.Context) doctorReport {
+	var checks []doctorCheck
+
+	info := checkRuntimeDetect(&checks)
+	checkRuntimeSocket(ctx, &checks, info)
+	checkRuntimeVersion(&checks, info)
+	checkGatewayPort(ctx, &checks)
+	checkNpx(&checks)
+	checkStateDir(ctx, &checks)
+	checkStaleState(ctx, &checks)
+	checkVault(ctx, &checks)
+
+	return summarizeDoctor(checks)
+}
+
+// summarizeDoctor folds check statuses into the report counters.
+func summarizeDoctor(checks []doctorCheck) doctorReport {
+	report := doctorReport{Checks: checks}
+	for _, c := range checks {
+		switch c.Status {
+		case doctorStatusFail:
+			report.ErrorCount++
+		case doctorStatusWarn:
+			report.WarningCount++
+		}
+	}
+	report.OK = report.ErrorCount == 0
+	return report
+}
+
+func checkRuntimeDetect(checks *[]doctorCheck) *runtime.RuntimeInfo {
+	info, err := runtime.DetectRuntime(runtime.DetectOptions{Explicit: runtimeFlag})
+	if err != nil {
+		*checks = append(*checks, doctorCheck{
+			ID:      "runtime.detect",
+			Status:  doctorStatusFail,
+			Message: "no container runtime detected; install Docker or Podman",
+		})
+		return nil
+	}
+	msg := info.DisplayName()
+	if info.Version != "" {
+		msg += " " + info.Version
+	}
+	*checks = append(*checks, doctorCheck{ID: "runtime.detect", Status: doctorStatusOK, Message: msg})
+	return info
+}
+
+func checkRuntimeSocket(ctx context.Context, checks *[]doctorCheck, info *runtime.RuntimeInfo) {
+	if info == nil {
+		*checks = append(*checks, doctorCheck{ID: "runtime.socket", Status: doctorStatusInfo, Message: "skipped (no runtime detected)"})
+		return
+	}
+	dr, err := docker.NewWithInfo(info)
+	if err != nil {
+		*checks = append(*checks, doctorCheck{
+			ID:      "runtime.socket",
+			Status:  doctorStatusFail,
+			Message: fmt.Sprintf("could not create client for %s: %v", info.SocketPath, err),
+		})
+		return
+	}
+	defer func() { _ = dr.Client().Close() }()
+
+	pingCtx, cancel := context.WithTimeout(ctx, doctorProbeTimeout)
+	defer cancel()
+	if _, err := dr.Client().Ping(pingCtx); err != nil {
+		*checks = append(*checks, doctorCheck{
+			ID:      "runtime.socket",
+			Status:  doctorStatusFail,
+			Message: fmt.Sprintf("%s not responding (is the %s daemon running?)", info.SocketPath, info.DisplayName()),
+		})
+		return
+	}
+	*checks = append(*checks, doctorCheck{ID: "runtime.socket", Status: doctorStatusOK, Message: info.SocketPath})
+}
+
+func checkRuntimeVersion(checks *[]doctorCheck, info *runtime.RuntimeInfo) {
+	if info == nil {
+		*checks = append(*checks, doctorCheck{ID: "runtime.version", Status: doctorStatusInfo, Message: "skipped (no runtime detected)"})
+		return
+	}
+	if !info.IsSupportedPodmanVersion() {
+		*checks = append(*checks, doctorCheck{
+			ID:      "runtime.version",
+			Status:  doctorStatusWarn,
+			Message: fmt.Sprintf("podman %s is below 4.0; multi-container networking needs netavark (podman 4+)", info.Version),
+		})
+		return
+	}
+	if info.IsRootless() && !info.HasNetavark {
+		*checks = append(*checks, doctorCheck{
+			ID:      "runtime.version",
+			Status:  doctorStatusWarn,
+			Message: "rootless podman without netavark; install netavark and aardvark-dns for inter-container networking",
+		})
+		return
+	}
+	msg := "meets the supported version floor"
+	if info.Version != "" {
+		msg = fmt.Sprintf("%s %s meets the supported version floor", info.DisplayName(), info.Version)
+	}
+	*checks = append(*checks, doctorCheck{ID: "runtime.version", Status: doctorStatusOK, Message: msg})
+}
+
+func checkGatewayPort(ctx context.Context, checks *[]doctorCheck) {
+	const port = 8180
+	dialCtx, cancel := context.WithTimeout(ctx, doctorProbeTimeout)
+	defer cancel()
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(dialCtx, "tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		*checks = append(*checks, doctorCheck{ID: "port.gateway", Status: doctorStatusOK, Message: fmt.Sprintf("port %d is free", port)})
+		return
+	}
+	_ = conn.Close()
+
+	// Something is listening; fine if it is one of our own daemons.
+	states, _ := state.List()
+	for _, s := range states {
+		if s.Port == port && state.IsRunning(&s) {
+			*checks = append(*checks, doctorCheck{
+				ID:      "port.gateway",
+				Status:  doctorStatusOK,
+				Message: fmt.Sprintf("port %d is served by gridctl stack %q", port, s.StackName),
+			})
+			return
+		}
+	}
+	*checks = append(*checks, doctorCheck{
+		ID:      "port.gateway",
+		Status:  doctorStatusWarn,
+		Message: fmt.Sprintf("port %d is in use by another process; pass --port to 'gridctl apply' or 'gridctl serve'", port),
+	})
+}
+
+func checkNpx(checks *[]doctorCheck) {
+	if provisioner.NpxAvailable() {
+		*checks = append(*checks, doctorCheck{ID: "npx", Status: doctorStatusOK, Message: "npx found (mcp-remote bridges available)"})
+		return
+	}
+	*checks = append(*checks, doctorCheck{
+		ID:      "npx",
+		Status:  doctorStatusWarn,
+		Message: "npx not found; some 'gridctl link' targets need the mcp-remote bridge (install Node.js: https://nodejs.org/)",
+	})
+}
+
+func checkStateDir(ctx context.Context, checks *[]doctorCheck) {
+	if err := ctx.Err(); err != nil {
+		*checks = append(*checks, doctorCheck{ID: "state.dir", Status: doctorStatusInfo, Message: "skipped (cancelled)"})
+		return
+	}
+	dir := state.StateDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		*checks = append(*checks, doctorCheck{ID: "state.dir", Status: doctorStatusFail, Message: fmt.Sprintf("%s not writable: %v", dir, err)})
+		return
+	}
+	probe, err := os.CreateTemp(dir, ".doctor-*")
+	if err != nil {
+		*checks = append(*checks, doctorCheck{ID: "state.dir", Status: doctorStatusFail, Message: fmt.Sprintf("%s not writable: %v", dir, err)})
+		return
+	}
+	name := probe.Name()
+	_ = probe.Close()
+	_ = os.Remove(name)
+	*checks = append(*checks, doctorCheck{ID: "state.dir", Status: doctorStatusOK, Message: dir + " is writable"})
+}
+
+func checkStaleState(ctx context.Context, checks *[]doctorCheck) {
+	if err := ctx.Err(); err != nil {
+		*checks = append(*checks, doctorCheck{ID: "state.stale", Status: doctorStatusInfo, Message: "skipped (cancelled)"})
+		return
+	}
+	states, err := state.List()
+	if err != nil {
+		*checks = append(*checks, doctorCheck{ID: "state.stale", Status: doctorStatusWarn, Message: fmt.Sprintf("could not read state files: %v", err)})
+		return
+	}
+	var stale []string
+	for _, s := range states {
+		if !state.IsRunning(&s) {
+			stale = append(stale, s.StackName)
+		}
+	}
+	if len(stale) > 0 {
+		*checks = append(*checks, doctorCheck{
+			ID:      "state.stale",
+			Status:  doctorStatusWarn,
+			Message: fmt.Sprintf("stale state for stopped stack(s): %s (clean up with 'gridctl destroy <name>')", strings.Join(stale, ", ")),
+		})
+		return
+	}
+	*checks = append(*checks, doctorCheck{ID: "state.stale", Status: doctorStatusOK, Message: "no stale state files"})
+}
+
+func checkVault(ctx context.Context, checks *[]doctorCheck) {
+	if err := ctx.Err(); err != nil {
+		*checks = append(*checks, doctorCheck{ID: "vault", Status: doctorStatusInfo, Message: "skipped (cancelled)"})
+		return
+	}
+	store := vault.NewStore(state.VaultDir())
+	if err := store.Load(); err != nil {
+		*checks = append(*checks, doctorCheck{ID: "vault", Status: doctorStatusWarn, Message: fmt.Sprintf("could not read vault: %v", err)})
+		return
+	}
+	switch {
+	case store.IsLocked():
+		*checks = append(*checks, doctorCheck{ID: "vault", Status: doctorStatusInfo, Message: "vault is locked (encrypted at rest); unlock via the web UI or GRIDCTL_VAULT_PASSPHRASE"})
+	case len(store.Keys()) > 0:
+		*checks = append(*checks, doctorCheck{ID: "vault", Status: doctorStatusInfo, Message: fmt.Sprintf("vault is unlocked (%d variable(s), plaintext on disk)", len(store.Keys()))})
+	default:
+		*checks = append(*checks, doctorCheck{ID: "vault", Status: doctorStatusInfo, Message: "no vault configured"})
+	}
+}
+
+// renderDoctorReport writes the report and returns the process exit code.
+func renderDoctorReport(w io.Writer, report doctorReport, asJSON, quiet bool) int {
+	if asJSON {
+		if err := output.EncodeJSON(w, report); err != nil {
+			fmt.Fprintln(os.Stderr, "doctor: encoding report:", err)
+			return doctorExitFailed
+		}
+	} else {
+		renderDoctorHuman(w, report, quiet)
+	}
+	if report.ErrorCount > 0 {
+		return doctorExitErrors
+	}
+	return doctorExitOK
+}
+
+func renderDoctorHuman(w io.Writer, report doctorReport, quiet bool) {
+	color := output.ColorEnabled(os.Stdout)
+	fmt.Fprintln(w)
+	for _, c := range report.Checks {
+		if quiet && c.Status != doctorStatusFail && c.Status != doctorStatusWarn {
+			continue
+		}
+		fmt.Fprintf(w, "  %s %-16s %s\n", doctorStatusLabel(c.Status, color), c.ID, c.Message)
+	}
+	fmt.Fprintf(w, "\nResult: %d error(s), %d warning(s)\n", report.ErrorCount, report.WarningCount)
+}
+
+// doctorStatusLabel pads the status word to a fixed width before styling so
+// alignment survives the ANSI escapes.
+func doctorStatusLabel(status string, color bool) string {
+	padded := fmt.Sprintf("%-4s", status)
+	if !color {
+		return padded
+	}
+	var c lipgloss.Color
+	switch status {
+	case doctorStatusOK:
+		c = output.ColorGreen
+	case doctorStatusWarn:
+		c = output.ColorAmber
+	case doctorStatusFail:
+		c = output.ColorRed
+	default:
+		c = output.ColorMuted
+	}
+	return lipgloss.NewStyle().Foreground(c).Bold(true).Render(padded)
+}

--- a/cmd/gridctl/doctor_test.go
+++ b/cmd/gridctl/doctor_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSummarizeDoctor(t *testing.T) {
+	checks := []doctorCheck{
+		{ID: "a", Status: doctorStatusOK},
+		{ID: "b", Status: doctorStatusWarn},
+		{ID: "c", Status: doctorStatusFail},
+		{ID: "d", Status: doctorStatusInfo},
+		{ID: "e", Status: doctorStatusWarn},
+	}
+	report := summarizeDoctor(checks)
+
+	if report.ErrorCount != 1 {
+		t.Errorf("ErrorCount = %d, want 1", report.ErrorCount)
+	}
+	if report.WarningCount != 2 {
+		t.Errorf("WarningCount = %d, want 2", report.WarningCount)
+	}
+	if report.OK {
+		t.Error("OK should be false with a failing check")
+	}
+
+	clean := summarizeDoctor([]doctorCheck{{ID: "a", Status: doctorStatusOK}, {ID: "b", Status: doctorStatusWarn}})
+	if !clean.OK {
+		t.Error("OK should be true with warnings only")
+	}
+}
+
+func TestRenderDoctorReportJSON(t *testing.T) {
+	report := summarizeDoctor([]doctorCheck{
+		{ID: "npx", Status: doctorStatusWarn, Message: "not found"},
+	})
+
+	var buf bytes.Buffer
+	exit := renderDoctorReport(&buf, report, true, false)
+	if exit != doctorExitOK {
+		t.Errorf("exit = %d, want %d (warnings only)", exit, doctorExitOK)
+	}
+
+	var decoded doctorReport
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if !decoded.OK || decoded.WarningCount != 1 || len(decoded.Checks) != 1 {
+		t.Errorf("decoded report mismatch: %+v", decoded)
+	}
+	if strings.Contains(buf.String(), "\033") {
+		t.Error("JSON report must not contain ANSI escapes")
+	}
+}
+
+func TestRenderDoctorReportExitCodes(t *testing.T) {
+	failing := summarizeDoctor([]doctorCheck{{ID: "x", Status: doctorStatusFail}})
+	var buf bytes.Buffer
+	if exit := renderDoctorReport(&buf, failing, false, false); exit != doctorExitErrors {
+		t.Errorf("exit = %d, want %d for a failing check", exit, doctorExitErrors)
+	}
+}
+
+func TestRenderDoctorHumanQuiet(t *testing.T) {
+	report := summarizeDoctor([]doctorCheck{
+		{ID: "good", Status: doctorStatusOK, Message: "fine"},
+		{ID: "bad", Status: doctorStatusFail, Message: "broken"},
+	})
+
+	var buf bytes.Buffer
+	renderDoctorHuman(&buf, report, true)
+	out := buf.String()
+	if strings.Contains(out, "good") {
+		t.Errorf("quiet mode should hide passing checks, got %q", out)
+	}
+	if !strings.Contains(out, "bad") {
+		t.Errorf("quiet mode should keep failing checks, got %q", out)
+	}
+	if !strings.Contains(out, "Result: 1 error(s)") {
+		t.Errorf("summary line missing, got %q", out)
+	}
+}
+
+func TestDoctorStatusLabelPlainWhenNoColor(t *testing.T) {
+	label := doctorStatusLabel(doctorStatusFail, false)
+	if label != "fail" {
+		t.Errorf("label = %q, want padded plain word", label)
+	}
+	if strings.Contains(label, "\033") {
+		t.Error("label must be colorless when color is off")
+	}
+}

--- a/cmd/gridctl/format.go
+++ b/cmd/gridctl/format.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// resolveFormat merges the legacy --format flag with the boolean --json
+// alias. Passing --json is equivalent to --format json; explicitly combining
+// --json with a different --format value is an error. formatChanged reports
+// whether the user set --format (defaults never conflict with --json).
+func resolveFormat(format string, formatChanged, asJSON bool) (string, error) {
+	if !asJSON {
+		return format, nil
+	}
+	if formatChanged && !strings.EqualFold(format, "json") {
+		return "", fmt.Errorf("cannot combine --json with --format=%s", format)
+	}
+	return "json", nil
+}
+
+// addJSONAlias registers a --json boolean alias next to an existing
+// --format flag on cmd. The returned pointer reports whether it was set.
+func addJSONAlias(cmd *cobra.Command) *bool {
+	var asJSON bool
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Shorthand for --format json")
+	return &asJSON
+}

--- a/cmd/gridctl/format_test.go
+++ b/cmd/gridctl/format_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestJSONAliasRegistered guards against a command gaining resolveFormat
+// wiring without the matching --json flag registration (or vice versa).
+func TestJSONAliasRegistered(t *testing.T) {
+	for _, cmd := range []*cobra.Command{validateCmd, planCmd, optimizeCmd, activateCmd, skillListCmd, varListCmd, statusCmd, infoCmd, doctorCmd, openCmd} {
+		if cmd.Flags().Lookup("json") == nil {
+			t.Errorf("command %q is missing its --json flag", cmd.Name())
+		}
+	}
+}
+
+func TestResolveFormat(t *testing.T) {
+	tests := []struct {
+		name          string
+		format        string
+		formatChanged bool
+		asJSON        bool
+		want          string
+		wantErr       bool
+	}{
+		{name: "neither set", format: "", want: ""},
+		{name: "format json only", format: "json", formatChanged: true, want: "json"},
+		{name: "json alias only", asJSON: true, want: "json"},
+		{name: "both json", format: "json", formatChanged: true, asJSON: true, want: "json"},
+		{name: "alias with unchanged default", format: "table", asJSON: true, want: "json"},
+		{name: "conflicting explicit format", format: "yaml", formatChanged: true, asJSON: true, wantErr: true},
+		{name: "explicit non-json without alias", format: "yaml", formatChanged: true, want: "yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveFormat(tt.format, tt.formatChanged, tt.asJSON)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveFormat() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Errorf("resolveFormat() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/gridctl/help.go
+++ b/cmd/gridctl/help.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"os"
 	"strings"
+
+	"github.com/gridctl/gridctl/pkg/output"
 
 	"github.com/spf13/cobra"
 )
@@ -16,30 +19,65 @@ const (
 	colorReset  = "\033[0m"
 )
 
-// colorize applies color to text
+// helpColorEnabled reports whether help output should carry ANSI colors.
+// Checked lazily at render time because --help bypasses PersistentPreRun,
+// so the --no-color flag must be consulted directly.
+func helpColorEnabled() bool {
+	return !noColorFlag && output.ColorEnabled(os.Stdout)
+}
+
+// colorize applies color to text when color output is enabled.
 func colorize(color, text string) string {
+	if !helpColorEnabled() {
+		return text
+	}
 	return color + text + colorReset
 }
 
-// Custom help template matching Containerlab style with Obsidian Observatory colors
+// Custom help template matching Containerlab style with Obsidian Observatory
+// colors. Sections render via the header func so colors respect the color
+// contract (TTY, NO_COLOR, TERM=dumb, --no-color). Commands render under
+// cobra groups on the root; ungrouped subcommands keep a flat list. The
+// trailing subcommand footer only renders for commands that have them.
 var helpTemplate = `{{with .Long}}{{. | trimTrailingWhitespaces}}
 
-{{end}}` + colorAmber + `USAGE` + colorReset + `
-  {{.UseLine | colorizeUsage}}
+{{end}}{{if not .HasParent}}{{header "QUICK START"}}
+  gridctl apply stack.yaml    Deploy a stack of MCP servers
+  gridctl link                Connect your LLM client
+  gridctl status              See what is running
 
-{{if .HasAvailableSubCommands}}` + colorAmber + `COMMANDS` + colorReset + `
+{{end}}{{header "USAGE"}}
+  {{.UseLine | colorizeUsage}}
+{{if and .HasAvailableSubCommands .Groups}}{{$root := .}}{{range $grp := .Groups}}
+{{header $grp.Title}}
+{{range $root.Commands}}{{if and (eq .GroupID $grp.ID) .IsAvailableCommand}}  {{colorizeCmd .Name}} {{.Short}}
+{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+{{header "OTHER"}}
+{{range .Commands}}{{if and (eq .GroupID "") .IsAvailableCommand}}  {{colorizeCmd .Name}} {{.Short}}
+{{end}}{{end}}{{end}}{{else if .HasAvailableSubCommands}}
+{{header "COMMANDS"}}
 {{range .Commands}}{{if .IsAvailableCommand}}  {{colorizeCmd .Name}} {{.Short}}
-{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}` + colorAmber + `FLAGS` + colorReset + `
+{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+{{header "FLAGS"}}
 {{.LocalFlags.FlagUsages | colorizeFlags}}{{end}}{{if .HasAvailableInheritedFlags}}
-` + colorAmber + `GLOBAL FLAGS` + colorReset + `
+{{header "GLOBAL FLAGS"}}
 {{.InheritedFlags.FlagUsages | colorizeFlags}}{{end}}{{if .HasExample}}
-` + colorAmber + `EXAMPLES` + colorReset + `
-{{.Example}}{{end}}
+{{header "EXAMPLES"}}
+{{.Example}}
+{{end}}{{if .HasAvailableSubCommands}}
 Use "{{.CommandPath}} [command] --help" for more information about a command.
-`
+{{end}}`
+
+// header renders a section header in amber when color is enabled.
+func header(title string) string {
+	return colorize(colorAmber, title)
+}
 
 // colorizeUsage colors the usage line
 func colorizeUsage(usage string) string {
+	if !helpColorEnabled() {
+		return usage
+	}
 	// Color the command name in teal, arguments in purple, flags in muted
 	parts := strings.Fields(usage)
 	if len(parts) == 0 {
@@ -77,6 +115,9 @@ func colorizeCmd(name string) string {
 
 // colorizeFlags colors flag definitions
 func colorizeFlags(flags string) string {
+	if !helpColorEnabled() {
+		return flags
+	}
 	lines := strings.Split(flags, "\n")
 	var result []string
 
@@ -146,6 +187,7 @@ func initHelp() {
 	cobra.AddTemplateFunc("colorizeUsage", colorizeUsage)
 	cobra.AddTemplateFunc("colorizeCmd", colorizeCmd)
 	cobra.AddTemplateFunc("colorizeFlags", colorizeFlags)
+	cobra.AddTemplateFunc("header", header)
 
 	rootCmd.SetHelpTemplate(helpTemplate)
 }

--- a/cmd/gridctl/info.go
+++ b/cmd/gridctl/info.go
@@ -2,28 +2,71 @@ package main
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/gridctl/gridctl/pkg/output"
 	"github.com/gridctl/gridctl/pkg/runtime"
 	_ "github.com/gridctl/gridctl/pkg/runtime/docker" // Register DockerRuntime factory
 
 	"github.com/spf13/cobra"
 )
 
+var infoJSONFlag bool
+
+// infoJSON is the machine-readable shape of `gridctl info --json`.
+// The schema is experimental until 1.0.
+type infoJSON struct {
+	Runtime  string `json:"runtime"`
+	Socket   string `json:"socket,omitempty"`
+	Version  string `json:"version,omitempty"`
+	Host     string `json:"host,omitempty"`
+	SELinux  bool   `json:"selinux"`
+	Rootless bool   `json:"rootless"`
+	Network  string `json:"network,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
 var infoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Show runtime and environment information",
-	Long:  "Displays detected container runtime, socket path, version, and platform details for diagnostics.",
+	Long: `Displays detected container runtime, socket path, version, and platform
+details for diagnostics.
+
+Info reports facts and always exits 0. For pass/fail judgments with
+remediation hints, run 'gridctl doctor'.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runInfo()
+		return runInfo(infoJSONFlag)
 	},
 }
 
-func runInfo() error {
+func init() {
+	infoCmd.Flags().BoolVar(&infoJSONFlag, "json", false, "Output as JSON (experimental schema)")
+}
+
+func runInfo(asJSON bool) error {
 	info, err := runtime.DetectRuntime(runtime.DetectOptions{Explicit: runtimeFlag})
 	if err != nil {
+		if asJSON {
+			return output.EncodeJSON(os.Stdout, infoJSON{Error: err.Error()})
+		}
 		fmt.Println("Runtime:  not detected")
 		fmt.Printf("Error:    %v\n", err)
 		return nil
+	}
+
+	if asJSON {
+		doc := infoJSON{
+			Runtime:  info.DisplayName(),
+			Socket:   info.SocketPath,
+			Version:  info.Version,
+			Host:     info.HostAliasHostname(),
+			SELinux:  info.SELinux,
+			Rootless: info.IsRootless(),
+		}
+		if info.IsRootless() {
+			doc.Network = rootlessNetworkStack(info)
+		}
+		return output.EncodeJSON(os.Stdout, doc)
 	}
 
 	fmt.Printf("Runtime:  %s\n", info.DisplayName())
@@ -36,17 +79,21 @@ func runInfo() error {
 		fmt.Println("SELinux:  enforcing")
 	}
 	if info.IsRootless() {
-		var netstack string
-		if info.HasNetavark && info.HasAardvarkDNS {
-			netstack = "netavark + aardvark-dns"
-		} else if info.HasNetavark {
-			netstack = "netavark (aardvark-dns missing)"
-		} else {
-			netstack = "netavark not found"
-		}
 		fmt.Printf("Mode:     rootless\n")
-		fmt.Printf("Network:  %s\n", netstack)
+		fmt.Printf("Network:  %s\n", rootlessNetworkStack(info))
 	}
 
 	return nil
+}
+
+// rootlessNetworkStack describes the rootless Podman networking stack.
+func rootlessNetworkStack(info *runtime.RuntimeInfo) string {
+	switch {
+	case info.HasNetavark && info.HasAardvarkDNS:
+		return "netavark + aardvark-dns"
+	case info.HasNetavark:
+		return "netavark (aardvark-dns missing)"
+	default:
+		return "netavark not found"
+	}
 }

--- a/cmd/gridctl/link.go
+++ b/cmd/gridctl/link.go
@@ -32,6 +32,10 @@ Without arguments, detects installed LLM clients and presents a selection list.
 With a client name, links that specific client directly.
 
 Supported clients: claude, claude-code, cursor, windsurf, vscode, gemini, antigravity, opencode, grok, continue, cline, anythingllm, roo, zed, goose`,
+	Example: `  gridctl link                 Pick from detected clients interactively
+  gridctl link claude          Link Claude Desktop directly
+  gridctl link --all           Link every detected client
+  gridctl link claude --dry-run  Preview the config change`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var client string
@@ -87,9 +91,7 @@ func runLink(client string) error {
 func linkSingleClient(printer *output.Printer, registry *provisioner.Registry, slug string, opts provisioner.LinkOptions) error {
 	prov, ok := registry.FindBySlug(slug)
 	if !ok {
-		printer.Error(fmt.Sprintf("%s is not a supported client", slug))
-		printer.Print("Supported clients: %s\n", strings.Join(registry.AllSlugs(), ", "))
-		return fmt.Errorf("%s: not a supported client", slug)
+		return unknownClientError(registry, slug)
 	}
 
 	configPath, found := prov.Detect()
@@ -266,6 +268,18 @@ func showDryRun(printer *output.Printer, prov provisioner.ClientProvisioner, con
 	printer.Print("  %s\n\n", strings.ReplaceAll(after, "\n", "\n  "))
 	printer.Print("  No changes made (dry run).\n\n")
 	return nil
+}
+
+// unknownClientError builds the single-print error for an unrecognized
+// client slug, including a "did you mean" suggestion within edit distance
+// two. The suggestion is never auto-run.
+func unknownClientError(registry *provisioner.Registry, slug string) error {
+	msg := fmt.Sprintf("unknown client %q", slug)
+	if s := output.Suggest(slug, registry.AllSlugs()); s != "" {
+		msg += fmt.Sprintf("\nDid you mean %q?", s)
+	}
+	msg += "\nSupported clients: " + strings.Join(registry.AllSlugs(), ", ")
+	return errors.New(msg)
 }
 
 // resolveGatewayPort auto-detects the port from a running stack, falls back to 8180.

--- a/cmd/gridctl/link_suggest_test.go
+++ b/cmd/gridctl/link_suggest_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/provisioner"
+)
+
+func TestUnknownClientErrorSuggests(t *testing.T) {
+	err := unknownClientError(provisioner.NewRegistry(), "claud")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `Did you mean "claude"?`) {
+		t.Errorf("expected a claude suggestion, got %q", msg)
+	}
+	if !strings.Contains(msg, "Supported clients:") {
+		t.Errorf("expected the supported-clients list, got %q", msg)
+	}
+}
+
+func TestUnknownClientErrorNoWildGuess(t *testing.T) {
+	err := unknownClientError(provisioner.NewRegistry(), "totally-unrelated-thing")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), "Did you mean") {
+		t.Errorf("distance too large for a suggestion, got %q", err)
+	}
+}

--- a/cmd/gridctl/logs.go
+++ b/cmd/gridctl/logs.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/gridctl/gridctl/pkg/dockerclient"
+	"github.com/gridctl/gridctl/pkg/runtime"
+	_ "github.com/gridctl/gridctl/pkg/runtime/docker" // Register DockerRuntime factory
+	"github.com/gridctl/gridctl/pkg/state"
+
+	"github.com/spf13/cobra"
+)
+
+const logsFollowPollInterval = 250 * time.Millisecond
+
+var (
+	logsFollow bool
+	logsTail   int
+	logsServer string
+	logsStack  string
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs [stack]",
+	Short: "Show gateway daemon or MCP server logs",
+	Long: `Prints logs for a stack.
+
+By default this tails the gateway daemon log (~/.gridctl/logs/<stack>.log),
+the same file 'gridctl apply' reports after a deploy. Use --server to stream
+a containerized MCP server's logs from the container runtime instead.
+
+The stack is auto-detected when exactly one is running.`,
+	Example: `  gridctl logs                     Last 100 daemon log lines
+  gridctl logs mystack -f          Follow the daemon log
+  gridctl logs --server github     Container logs for the github server
+  gridctl logs -n 20               Last 20 lines`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := logsStack
+		if len(args) == 1 {
+			name = args[0]
+		}
+
+		// SIGINT/SIGTERM cancel the context so --follow stops cleanly.
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		return runLogs(ctx, os.Stdout, name)
+	},
+}
+
+func init() {
+	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "Follow log output")
+	logsCmd.Flags().IntVarP(&logsTail, "tail", "n", 100, "Number of lines to show from the end of the log (0 or negative for all)")
+	logsCmd.Flags().StringVar(&logsServer, "server", "", "Stream container logs for this MCP server instead of the daemon log")
+	logsCmd.Flags().StringVarP(&logsStack, "stack", "s", "", "Stack name (auto-detected when only one stack is running)")
+}
+
+func runLogs(ctx context.Context, w io.Writer, name string) error {
+	name, err := resolveLogsStack(name)
+	if err != nil {
+		return err
+	}
+
+	if logsServer != "" {
+		return streamContainerLogs(ctx, w, name, logsServer, logsTail, logsFollow)
+	}
+
+	path := state.LogPath(name)
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("no daemon log for stack %q at %s (deploy it with 'gridctl apply <stack.yaml>')", name, path)
+	}
+	return tailDaemonLog(ctx, w, path, logsTail, logsFollow)
+}
+
+// resolveLogsStack picks the stack whose logs to show. An explicit name is
+// accepted even for a stopped stack (its log file may still exist); with no
+// name, exactly one running stack must be present.
+func resolveLogsStack(name string) (string, error) {
+	states, err := state.List()
+	if err != nil {
+		return "", fmt.Errorf("logs: could not read state: %w", err)
+	}
+
+	if name != "" {
+		for _, s := range states {
+			if s.StackName == name {
+				return name, nil
+			}
+		}
+		// No state file: still allow a leftover log file to be read.
+		if _, statErr := os.Stat(state.LogPath(name)); statErr == nil {
+			return name, nil
+		}
+		return "", fmt.Errorf("stack %q not found (try 'gridctl status')", name)
+	}
+
+	var running []string
+	for _, s := range states {
+		if state.IsRunning(&s) {
+			running = append(running, s.StackName)
+		}
+	}
+	switch len(running) {
+	case 0:
+		return "", errors.New("no running stacks; start one with 'gridctl apply <stack.yaml>' or 'gridctl serve'")
+	case 1:
+		return running[0], nil
+	default:
+		return "", fmt.Errorf("multiple stacks running (%s); pick one with 'gridctl logs <stack>'", strings.Join(running, ", "))
+	}
+}
+
+// tailDaemonLog prints the last n lines of the log at path and, when follow
+// is set, streams appended lines until ctx is cancelled.
+func tailDaemonLog(ctx context.Context, w io.Writer, path string, n int, follow bool) error {
+	f, err := os.Open(path) // #nosec G304 -- path is derived from the managed state directory
+	if err != nil {
+		return fmt.Errorf("opening log: %w", err)
+	}
+	defer f.Close()
+
+	offset, err := printTail(w, f, n)
+	if err != nil {
+		return err
+	}
+	if !follow {
+		return nil
+	}
+
+	return followLog(ctx, w, f, offset)
+}
+
+// printTail writes the last n lines of r to w (every line when n <= 0,
+// matching the docker logs convention for --tail) and returns the byte
+// offset reached (the end of the file at read time). Lines are read with
+// a bufio.Reader so arbitrarily long lines never abort the command.
+func printTail(w io.Writer, r io.ReadSeeker, n int) (int64, error) {
+	capacity := n
+	if capacity < 0 {
+		capacity = 0
+	}
+	lines := make([]string, 0, capacity)
+	reader := bufio.NewReader(r)
+	for {
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			if n > 0 && len(lines) == n {
+				lines = lines[1:]
+			}
+			lines = append(lines, strings.TrimSuffix(line, "\n"))
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, fmt.Errorf("reading log: %w", err)
+		}
+	}
+	for _, line := range lines {
+		fmt.Fprintln(w, line)
+	}
+	return r.Seek(0, io.SeekEnd)
+}
+
+// followLog polls the open log file for appended data until ctx is done.
+// Truncation (e.g. log rotation) resets the read offset to the new end.
+func followLog(ctx context.Context, w io.Writer, f *os.File, offset int64) error {
+	ticker := time.NewTicker(logsFollowPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			info, err := f.Stat()
+			if err != nil {
+				return fmt.Errorf("watching log: %w", err)
+			}
+			size := info.Size()
+			if size < offset {
+				offset = size // truncated or rotated in place
+				continue
+			}
+			if size == offset {
+				continue
+			}
+			if _, err := f.Seek(offset, io.SeekStart); err != nil {
+				return fmt.Errorf("watching log: %w", err)
+			}
+			// Advance by what was actually copied: the file may have grown
+			// past the Stat() size mid-copy, and re-reading those bytes on
+			// the next tick would duplicate output.
+			copied, err := io.Copy(w, f)
+			if err != nil {
+				return fmt.Errorf("watching log: %w", err)
+			}
+			offset += copied
+		}
+	}
+}
+
+// dockerClientProvider is the optional capability a runtime exposes when it
+// can stream container logs through a Docker-compatible API.
+type dockerClientProvider interface {
+	Client() dockerclient.DockerClient
+}
+
+// streamContainerLogs streams a containerized MCP server's logs via the
+// container runtime. Local-process and external servers have no container
+// to read from and get a clear error instead.
+func streamContainerLogs(ctx context.Context, w io.Writer, stack, server string, tail int, follow bool) error {
+	rt, err := runtime.New()
+	if err != nil {
+		return fmt.Errorf("container runtime unavailable: %w", err)
+	}
+	defer rt.Close()
+
+	statuses, err := rt.Status(ctx, stack)
+	if err != nil {
+		return fmt.Errorf("listing containers for stack %q: %w", stack, err)
+	}
+
+	var id string
+	var names []string
+	for _, s := range statuses {
+		workload := s.Labels[runtime.LabelMCPServer]
+		if workload == "" {
+			workload = s.Name
+		}
+		names = append(names, workload)
+		if workload == server {
+			id = string(s.ID)
+		}
+	}
+	if id == "" {
+		msg := fmt.Sprintf("server %q has no container in stack %q (local-process and external servers have no container logs)", server, stack)
+		if len(names) > 0 {
+			msg += fmt.Sprintf("; containers: %s", strings.Join(names, ", "))
+		}
+		return errors.New(msg)
+	}
+
+	provider, ok := rt.Runtime().(dockerClientProvider)
+	if !ok {
+		return errors.New("container logs are not supported by the active runtime")
+	}
+
+	tailArg := "all"
+	if tail > 0 {
+		tailArg = strconv.Itoa(tail)
+	}
+	rc, err := provider.Client().ContainerLogs(ctx, id, container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Tail:       tailArg,
+		Follow:     follow,
+	})
+	if err != nil {
+		return fmt.Errorf("streaming container logs: %w", err)
+	}
+	defer rc.Close()
+
+	// Container streams are multiplexed; demux both to w.
+	if _, err := stdcopy.StdCopy(w, w, rc); err != nil && ctx.Err() == nil {
+		return fmt.Errorf("reading container logs: %w", err)
+	}
+	return nil
+}

--- a/cmd/gridctl/logs_test.go
+++ b/cmd/gridctl/logs_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/state"
+)
+
+func TestPrintTailLastN(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	if err := os.WriteFile(path, []byte("one\ntwo\nthree\nfour\nfive\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	if _, err := printTail(&buf, f, 3); err != nil {
+		t.Fatalf("printTail: %v", err)
+	}
+	got := buf.String()
+	if got != "three\nfour\nfive\n" {
+		t.Errorf("printTail = %q, want last three lines", got)
+	}
+}
+
+func TestPrintTailNonPositiveMeansAll(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "all.log")
+	if err := os.WriteFile(path, []byte("one\ntwo\nthree\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, n := range []int{0, -1} {
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		if _, err := printTail(&buf, f, n); err != nil {
+			t.Fatalf("printTail(n=%d): %v", n, err)
+		}
+		f.Close()
+		if buf.String() != "one\ntwo\nthree\n" {
+			t.Errorf("printTail(n=%d) = %q, want all lines", n, buf.String())
+		}
+	}
+}
+
+func TestPrintTailHandlesVeryLongLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "long.log")
+	long := strings.Repeat("x", 2*1024*1024)
+	if err := os.WriteFile(path, []byte("before\n"+long+"\nafter\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	if _, err := printTail(&buf, f, 2); err != nil {
+		t.Fatalf("printTail with a 2MB line: %v", err)
+	}
+	if !strings.HasSuffix(buf.String(), "after\n") {
+		t.Error("expected the tail to include the final line after a long line")
+	}
+}
+
+func TestPrintTailFewerLinesThanRequested(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "short.log")
+	if err := os.WriteFile(path, []byte("only\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	if _, err := printTail(&buf, f, 100); err != nil {
+		t.Fatalf("printTail: %v", err)
+	}
+	if buf.String() != "only\n" {
+		t.Errorf("printTail = %q, want %q", buf.String(), "only\n")
+	}
+}
+
+func TestFollowLogSeesAppends(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "follow.log")
+	if err := os.WriteFile(path, []byte("start\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	info, _ := f.Stat()
+	offset := info.Size()
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		appendFile, appendErr := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+		if appendErr != nil {
+			return
+		}
+		defer appendFile.Close()
+		_, _ = appendFile.WriteString("appended\n")
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 800*time.Millisecond)
+	defer cancel()
+
+	var buf bytes.Buffer
+	if err := followLog(ctx, &buf, f, offset); err != nil {
+		t.Fatalf("followLog: %v", err)
+	}
+	if !strings.Contains(buf.String(), "appended") {
+		t.Errorf("followLog missed appended data, got %q", buf.String())
+	}
+}
+
+func TestResolveLogsStackNoneRunning(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	_, err := resolveLogsStack("")
+	if err == nil {
+		t.Fatal("expected an error with no running stacks")
+	}
+	if !strings.Contains(err.Error(), "gridctl apply") {
+		t.Errorf("error should suggest the next step, got %q", err)
+	}
+}
+
+func TestResolveLogsStackSingleRunning(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	st := &state.DaemonState{StackName: "solo", StackFile: "/x.yaml", PID: os.Getpid(), Port: 8181, StartedAt: time.Now()}
+	if err := state.Save(st); err != nil {
+		t.Fatal(err)
+	}
+
+	name, err := resolveLogsStack("")
+	if err != nil {
+		t.Fatalf("resolveLogsStack: %v", err)
+	}
+	if name != "solo" {
+		t.Errorf("name = %q, want solo", name)
+	}
+}
+
+func TestResolveLogsStackExplicitUnknown(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	_, err := resolveLogsStack("ghost")
+	if err == nil {
+		t.Fatal("expected an error for an unknown stack")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want not found", err)
+	}
+}
+
+func TestResolveLogsStackLeftoverLogFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := state.EnsureLogDir(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(state.LogPath("old"), []byte("history\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	name, err := resolveLogsStack("old")
+	if err != nil {
+		t.Fatalf("resolveLogsStack: %v", err)
+	}
+	if name != "old" {
+		t.Errorf("name = %q, want old", name)
+	}
+}

--- a/cmd/gridctl/open.go
+++ b/cmd/gridctl/open.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	goruntime "runtime"
+	"strings"
+
+	"github.com/gridctl/gridctl/pkg/output"
+	"github.com/gridctl/gridctl/pkg/state"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	openPort  int
+	openStack string
+	openPath  string
+	openPrint bool
+	openJSON  bool
+)
+
+// browserOpener launches the OS default browser; swapped in tests.
+var browserOpener = openInBrowser
+
+var openCmd = &cobra.Command{
+	Use:     "open",
+	Aliases: []string{"ui"},
+	Short:   "Open the gridctl web UI in a browser",
+	Long: `Opens the embedded web UI for a running gateway in the default browser.
+
+The port comes from the first running stack's state; use --stack to pick a
+specific stack or --port to override. When no gateway is running the URL is
+still printed (default port 8180) with a warning.
+
+Related: 'gridctl status' lists every running gateway and its port.`,
+	Example: `  gridctl open                 Open the web UI
+  gridctl ui                   Same, via the alias
+  gridctl open --print         Print the URL without opening a browser
+  gridctl open --stack demo    Open a specific stack's UI`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runOpen(os.Stdout, os.Stderr)
+	},
+}
+
+func init() {
+	openCmd.Flags().IntVarP(&openPort, "port", "p", 0, "Port to open (default: first running stack, else 8180)")
+	openCmd.Flags().StringVarP(&openStack, "stack", "s", "", "Stack whose UI to open when several are running")
+	openCmd.Flags().StringVar(&openPath, "path", "/", "URL path to open")
+	openCmd.Flags().BoolVar(&openPrint, "print", false, "Print the URL instead of opening a browser")
+	openCmd.Flags().BoolVar(&openJSON, "json", false, "Output the URL as JSON")
+}
+
+func runOpen(stdout, stderr io.Writer) error {
+	url, running, err := resolveOpenURL(openPort, openStack, openPath)
+	if err != nil {
+		return err
+	}
+
+	if !running && !openJSON {
+		fmt.Fprintln(stderr, "Warning: no running gateway detected; start one with 'gridctl apply <stack.yaml>' or 'gridctl serve'")
+	}
+
+	switch {
+	case openJSON:
+		return output.EncodeJSON(stdout, map[string]string{"url": url})
+	case openPrint:
+		fmt.Fprintln(stdout, url)
+		return nil
+	default:
+		if err := browserOpener(url); err != nil {
+			return fmt.Errorf("opening browser: %w (URL: %s)", err, url)
+		}
+		fmt.Fprintf(stdout, "Opening %s\n", url)
+		return nil
+	}
+}
+
+// resolveOpenURL resolves the UI URL and whether a running gateway backs it.
+func resolveOpenURL(port int, stackName, path string) (string, bool, error) {
+	states, err := state.List()
+	if err != nil && !os.IsNotExist(err) {
+		return "", false, fmt.Errorf("open: could not read state: %w", err)
+	}
+
+	running := false
+	resolved := port
+	switch {
+	case stackName != "":
+		found := false
+		for _, s := range states {
+			if s.StackName == stackName && state.IsRunning(&s) {
+				if resolved == 0 {
+					resolved = s.Port
+				}
+				found, running = true, true
+				break
+			}
+		}
+		if !found {
+			return "", false, fmt.Errorf("stack %q is not running (try 'gridctl status')", stackName)
+		}
+	case resolved != 0:
+		for _, s := range states {
+			if s.Port == resolved && state.IsRunning(&s) {
+				running = true
+				break
+			}
+		}
+	default:
+		for _, s := range states {
+			if state.IsRunning(&s) {
+				resolved = s.Port
+				running = true
+				break
+			}
+		}
+		if resolved == 0 {
+			resolved = 8180
+		}
+	}
+
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return fmt.Sprintf("http://localhost:%d%s", resolved, path), running, nil
+}
+
+// openInBrowser launches the OS default browser for the URL.
+func openInBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch goruntime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url) // #nosec G204 -- URL is built locally from a numeric port and path flag
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url) // #nosec G204 -- see above
+	default:
+		cmd = exec.Command("xdg-open", url) // #nosec G204 -- see above
+	}
+	return cmd.Start()
+}

--- a/cmd/gridctl/open_test.go
+++ b/cmd/gridctl/open_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/state"
+)
+
+func TestResolveOpenURLDefaults(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	url, running, err := resolveOpenURL(0, "", "/")
+	if err != nil {
+		t.Fatalf("resolveOpenURL: %v", err)
+	}
+	if url != "http://localhost:8180/" {
+		t.Errorf("url = %q, want default port 8180", url)
+	}
+	if running {
+		t.Error("running should be false with no state")
+	}
+}
+
+func TestResolveOpenURLPortOverrideAndPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	url, _, err := resolveOpenURL(8199, "", "dash")
+	if err != nil {
+		t.Fatalf("resolveOpenURL: %v", err)
+	}
+	if url != "http://localhost:8199/dash" {
+		t.Errorf("url = %q, want normalized path on port 8199", url)
+	}
+}
+
+func TestResolveOpenURLRunningStack(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	st := &state.DaemonState{StackName: "demo", StackFile: "/x.yaml", PID: os.Getpid(), Port: 8555, StartedAt: time.Now()}
+	if err := state.Save(st); err != nil {
+		t.Fatal(err)
+	}
+
+	url, running, err := resolveOpenURL(0, "", "/")
+	if err != nil {
+		t.Fatalf("resolveOpenURL: %v", err)
+	}
+	if url != "http://localhost:8555/" {
+		t.Errorf("url = %q, want the running stack's port", url)
+	}
+	if !running {
+		t.Error("running should be true for a live stack")
+	}
+}
+
+func TestResolveOpenURLUnknownStack(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	_, _, err := resolveOpenURL(0, "ghost", "/")
+	if err == nil {
+		t.Fatal("expected an error for a stack that is not running")
+	}
+	if !strings.Contains(err.Error(), "not running") {
+		t.Errorf("error = %q, want not running", err)
+	}
+}
+
+func TestRunOpenPrintDoesNotLaunchBrowser(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	launched := false
+	orig := browserOpener
+	browserOpener = func(string) error { launched = true; return nil }
+	t.Cleanup(func() { browserOpener = orig })
+
+	origPrint, origJSON, origPort, origStack, origPath := openPrint, openJSON, openPort, openStack, openPath
+	t.Cleanup(func() {
+		openPrint, openJSON, openPort, openStack, openPath = origPrint, origJSON, origPort, origStack, origPath
+	})
+	openPrint, openJSON, openPort, openStack, openPath = true, false, 0, "", "/"
+
+	var stdout, stderr bytes.Buffer
+	if err := runOpen(&stdout, &stderr); err != nil {
+		t.Fatalf("runOpen: %v", err)
+	}
+	if launched {
+		t.Error("--print must not launch a browser")
+	}
+	if !strings.Contains(stdout.String(), "http://localhost:8180/") {
+		t.Errorf("stdout = %q, want the URL", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "no running gateway") {
+		t.Errorf("stderr = %q, want the not-running warning", stderr.String())
+	}
+}
+
+func TestRunOpenJSON(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	orig := browserOpener
+	browserOpener = func(string) error { t.Error("JSON mode must not launch a browser"); return nil }
+	t.Cleanup(func() { browserOpener = orig })
+
+	origPrint, origJSON, origPort, origStack, origPath := openPrint, openJSON, openPort, openStack, openPath
+	t.Cleanup(func() {
+		openPrint, openJSON, openPort, openStack, openPath = origPrint, origJSON, origPort, origStack, origPath
+	})
+	openPrint, openJSON, openPort, openStack, openPath = false, true, 0, "", "/"
+
+	var stdout, stderr bytes.Buffer
+	if err := runOpen(&stdout, &stderr); err != nil {
+		t.Fatalf("runOpen: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"url": "http://localhost:8180/"`) {
+		t.Errorf("stdout = %q, want JSON url field", stdout.String())
+	}
+}
+
+func TestRunOpenLaunchesBrowser(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var opened string
+	orig := browserOpener
+	browserOpener = func(url string) error { opened = url; return nil }
+	t.Cleanup(func() { browserOpener = orig })
+
+	origPrint, origJSON, origPort, origStack, origPath := openPrint, openJSON, openPort, openStack, openPath
+	t.Cleanup(func() {
+		openPrint, openJSON, openPort, openStack, openPath = origPrint, origJSON, origPort, origStack, origPath
+	})
+	openPrint, openJSON, openPort, openStack, openPath = false, false, 8123, "", "/"
+
+	var stdout, stderr bytes.Buffer
+	if err := runOpen(&stdout, &stderr); err != nil {
+		t.Fatalf("runOpen: %v", err)
+	}
+	if opened != "http://localhost:8123/" {
+		t.Errorf("opened = %q, want the resolved URL", opened)
+	}
+}

--- a/cmd/gridctl/optimize.go
+++ b/cmd/gridctl/optimize.go
@@ -24,8 +24,8 @@ const optimizeHTTPTimeout = 10 * time.Second
 // and cmd/gridctl/validate.go so CI scripts can rely on a stable
 // contract.
 const (
-	optimizeExitOK            = 0
-	optimizeExitFindings      = 1
+	optimizeExitOK             = 0
+	optimizeExitFindings       = 1
 	optimizeExitInfrastructure = 2
 )
 
@@ -50,6 +50,10 @@ Exit codes:
   1  at least one warn or critical finding
   2  infrastructure error (gateway unreachable, wrong stack)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		if optimizeFormat, err = resolveFormat(optimizeFormat, cmd.Flags().Changed("format"), *optimizeJSON); err != nil {
+			return err
+		}
 		port, err := resolveOptimizePort(optimizeStack)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -83,7 +87,10 @@ func init() {
 	optimizeCmd.Flags().Float64Var(&optimizeMinImpact, "min-impact", 0, "Filter findings below this weekly USD impact (info findings always shown)")
 	optimizeCmd.Flags().StringVar(&optimizeSeverity, "severity", "", "Comma-separated severity allowlist: info,warn,critical")
 	optimizeCmd.Flags().StringVar(&optimizeFormat, "format", "", "Output format: 'json' for machine-readable output (default: table)")
+	optimizeJSON = addJSONAlias(optimizeCmd)
 }
+
+var optimizeJSON *bool
 
 // resolveOptimizePort finds the port of a running gateway, optionally
 // filtered by stack name. Mirrors resolveTracesPort, but emits errors

--- a/cmd/gridctl/plan.go
+++ b/cmd/gridctl/plan.go
@@ -3,13 +3,15 @@ package main
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/gridctl/gridctl/pkg/config"
 	"github.com/gridctl/gridctl/pkg/controller"
+	"github.com/gridctl/gridctl/pkg/output"
 	"github.com/gridctl/gridctl/pkg/state"
 
 	"github.com/spf13/cobra"
@@ -31,14 +33,21 @@ added, removed, and modified servers, agents, and resources.
 Use -y or --auto-approve to auto-approve and apply changes.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		if planFormat, err = resolveFormat(planFormat, cmd.Flags().Changed("format"), *planJSON); err != nil {
+			return err
+		}
 		return runPlan(args[0])
 	},
 }
+
+var planJSON *bool
 
 func init() {
 	planCmd.Flags().BoolVarP(&planAutoApprove, "yes", "y", false, "Auto-approve and apply changes")
 	planCmd.Flags().BoolVar(&planAutoApproveCI, "auto-approve", false, "Auto-approve and apply changes (CI/CD equivalent of -y)")
 	planCmd.Flags().StringVar(&planFormat, "format", "", "Output format: json for machine-readable output")
+	planJSON = addJSONAlias(planCmd)
 }
 
 func runPlan(stackPath string) error {
@@ -62,12 +71,10 @@ func runPlan(stackPath string) error {
 	diff := config.ComputePlan(proposed, current)
 
 	if planFormat == "json" {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(diff)
+		return output.EncodeJSON(os.Stdout, diff)
 	}
 
-	printPlanDiff(diff)
+	printPlanDiff(os.Stdout, diff)
 
 	if !diff.HasChanges {
 		return nil
@@ -126,31 +133,45 @@ func loadCurrentStack(stackName string) (*config.Stack, error) {
 	return current, nil
 }
 
-func printPlanDiff(diff *config.PlanDiff) {
+// printPlanDiff renders the human plan view. Symbols mirror the Terraform
+// convention: + add (green), - destroy (red), ~ update (amber). Colors
+// follow the color contract, so piped output stays plain.
+func printPlanDiff(w io.Writer, diff *config.PlanDiff) {
 	if !diff.HasChanges {
-		fmt.Println("No changes. Stack is up to date.")
+		fmt.Fprintln(w, "No changes. Stack is up to date.")
 		return
 	}
 
-	fmt.Printf("Plan: %s\n\n", diff.Summary)
+	color := output.ColorEnabled(w)
+	header := fmt.Sprintf("Plan: %s", diff.Summary)
+	if color {
+		header = lipgloss.NewStyle().Foreground(output.ColorAmber).Bold(true).Render(header)
+	}
+	fmt.Fprintf(w, "%s\n\n", header)
 
+	muted := lipgloss.NewStyle().Foreground(output.ColorMuted)
 	for _, item := range diff.Items {
 		var symbol, label string
+		var symbolColor lipgloss.Color
 		switch item.Action {
 		case config.DiffAdd:
-			symbol = "+"
-			label = "add"
+			symbol, label, symbolColor = "+", "add", output.ColorGreen
 		case config.DiffRemove:
-			symbol = "-"
-			label = "destroy"
+			symbol, label, symbolColor = "-", "destroy", output.ColorRed
 		case config.DiffChange:
-			symbol = "~"
-			label = "update"
+			symbol, label, symbolColor = "~", "update", output.ColorAmber
 		}
 
-		fmt.Printf("  %s %s %q (%s)\n", symbol, item.Kind, item.Name, label)
+		line := fmt.Sprintf("%s %s %q (%s)", symbol, item.Kind, item.Name, label)
+		if color {
+			line = lipgloss.NewStyle().Foreground(symbolColor).Render(line)
+		}
+		fmt.Fprintf(w, "  %s\n", line)
 		for _, detail := range item.Details {
-			fmt.Printf("      %s\n", detail)
+			if color {
+				detail = muted.Render(detail)
+			}
+			fmt.Fprintf(w, "      %s\n", detail)
 		}
 	}
 }

--- a/cmd/gridctl/plan_color_test.go
+++ b/cmd/gridctl/plan_color_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/config"
+)
+
+func TestPrintPlanDiffSymbolsNoColorWhenPiped(t *testing.T) {
+	diff := &config.PlanDiff{
+		HasChanges: true,
+		Summary:    "1 to add, 1 to change, 1 to destroy",
+		Items: []config.DiffItem{
+			{Action: config.DiffAdd, Kind: "mcp-server", Name: "foo"},
+			{Action: config.DiffChange, Kind: "mcp-server", Name: "bar", Details: []string{"image: a -> b"}},
+			{Action: config.DiffRemove, Kind: "mcp-server", Name: "baz"},
+		},
+	}
+
+	var buf bytes.Buffer
+	printPlanDiff(&buf, diff)
+	out := buf.String()
+
+	for _, want := range []string{`+ mcp-server "foo" (add)`, `~ mcp-server "bar" (update)`, `- mcp-server "baz" (destroy)`, "image: a -> b"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plan output missing %q in %q", want, out)
+		}
+	}
+	if strings.Contains(out, "\033") {
+		t.Errorf("plan output must be colorless on a non-TTY writer, got %q", out)
+	}
+}
+
+func TestPrintPlanDiffNoChanges(t *testing.T) {
+	var buf bytes.Buffer
+	printPlanDiff(&buf, &config.PlanDiff{HasChanges: false})
+	if !strings.Contains(buf.String(), "No changes") {
+		t.Errorf("expected no-changes message, got %q", buf.String())
+	}
+}

--- a/cmd/gridctl/root.go
+++ b/cmd/gridctl/root.go
@@ -2,12 +2,30 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/gridctl/gridctl/pkg/output"
 
 	"github.com/spf13/cobra"
 )
 
-var runtimeFlag string
+var (
+	runtimeFlag string
+	noColorFlag bool
+)
+
+// Command group IDs for the grouped root help (see help.go).
+const (
+	groupStack   = "stack"
+	groupClients = "clients"
+	groupSkills  = "skills"
+	groupConfig  = "config"
+	groupObserve = "observability"
+	groupSystem  = "system"
+)
 
 var rootCmd = &cobra.Command{
 	Use:   "gridctl",
@@ -17,42 +35,123 @@ var rootCmd = &cobra.Command{
 It allows you to define a stack of MCP servers, tools, and resources
 in a simple YAML file, then spins up, wires together, and exposes
 them via a single MCP gateway.`,
+	Example: `  gridctl apply stack.yaml     Deploy a stack of MCP servers
+  gridctl link claude          Connect Claude Desktop to the gateway
+  gridctl status               Show gateways and containers
+  gridctl destroy stack.yaml   Stop the stack and clean up`,
+	// Runtime errors are printed exactly once by Execute; usage dumps are
+	// reserved for flag and argument mistakes (see SetFlagErrorFunc below).
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		output.SetNoColor(noColorFlag)
+	},
 }
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&runtimeFlag, "runtime", "", "Container runtime to use (docker, podman). Auto-detected if not set.")
+	rootCmd.PersistentFlags().BoolVar(&noColorFlag, "no-color", false, "Disable colored output (also honors NO_COLOR and TERM=dumb)")
 
 	initHelp()
 
-	rootCmd.AddCommand(applyCmd)
-	rootCmd.AddCommand(destroyCmd)
-	rootCmd.AddCommand(statusCmd)
-	rootCmd.AddCommand(serveCmd)
-	rootCmd.AddCommand(stopCmd)
-	rootCmd.AddCommand(reloadCmd)
-	rootCmd.AddCommand(linkCmd)
-	rootCmd.AddCommand(unlinkCmd)
-	rootCmd.AddCommand(varCmd)
-	rootCmd.AddCommand(vaultCmd)
-	rootCmd.AddCommand(validateCmd)
-	rootCmd.AddCommand(planCmd)
-	rootCmd.AddCommand(infoCmd)
-	rootCmd.AddCommand(skillCmd)
-	rootCmd.AddCommand(pinsCmd)
-	rootCmd.AddCommand(optimizeCmd)
-	rootCmd.AddCommand(activateCmd)
-	rootCmd.AddCommand(exportCmd)
-	rootCmd.AddCommand(telemetryCmd)
-	rootCmd.AddCommand(tracesCmd)
-	rootCmd.AddCommand(upgradeCmd)
-	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddGroup(
+		&cobra.Group{ID: groupStack, Title: "STACK"},
+		&cobra.Group{ID: groupClients, Title: "CLIENTS"},
+		&cobra.Group{ID: groupSkills, Title: "SKILLS"},
+		&cobra.Group{ID: groupConfig, Title: "VARIABLES & PINS"},
+		&cobra.Group{ID: groupObserve, Title: "OBSERVABILITY"},
+		&cobra.Group{ID: groupSystem, Title: "SYSTEM"},
+	)
+	rootCmd.SetHelpCommandGroupID(groupSystem)
+	rootCmd.SetCompletionCommandGroupID(groupSystem)
+
+	// Flag mistakes keep a short usage pointer; runtime errors do not.
+	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return fmt.Errorf("%w\nRun '%s --help' for usage", err, cmd.CommandPath())
+	})
+
+	for cmd, group := range map[*cobra.Command]string{
+		applyCmd:     groupStack,
+		planCmd:      groupStack,
+		validateCmd:  groupStack,
+		reloadCmd:    groupStack,
+		destroyCmd:   groupStack,
+		exportCmd:    groupStack,
+		statusCmd:    groupStack,
+		serveCmd:     groupStack,
+		stopCmd:      groupStack,
+		logsCmd:      groupStack,
+		linkCmd:      groupClients,
+		unlinkCmd:    groupClients,
+		skillCmd:     groupSkills,
+		activateCmd:  groupSkills,
+		varCmd:       groupConfig,
+		vaultCmd:     groupConfig, // hidden; grouped for completeness
+		pinsCmd:      groupConfig,
+		tracesCmd:    groupObserve,
+		telemetryCmd: groupObserve,
+		optimizeCmd:  groupObserve,
+		infoCmd:      groupSystem,
+		doctorCmd:    groupSystem,
+		openCmd:      groupSystem,
+		versionCmd:   groupSystem,
+		upgradeCmd:   groupSystem,
+	} {
+		cmd.GroupID = group
+		rootCmd.AddCommand(cmd)
+	}
 }
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	// ExecuteC returns the command that was (or would have been) executed,
+	// so help pointers name the right command path.
+	cmd, err := rootCmd.ExecuteC()
+	if err != nil {
+		printCLIError(os.Stderr, cmd, err)
 		os.Exit(1)
 	}
+}
+
+// printCLIError writes the single user-facing error line(s) for a failed
+// command. Cobra's own printing is silenced globally, so this is the only
+// place errors reach the terminal.
+func printCLIError(w io.Writer, cmd *cobra.Command, err error) {
+	prefix := "Error:"
+	if output.ColorEnabled(w) {
+		prefix = lipgloss.NewStyle().Foreground(output.ColorRed).Bold(true).Render(prefix)
+	}
+	fmt.Fprintf(w, "%s %s\n", prefix, err)
+
+	// Unknown-command and argument-count mistakes lose cobra's own usage
+	// output once SilenceUsage/SilenceErrors are set; restore a short help
+	// pointer for them (flag mistakes carry theirs via SetFlagErrorFunc,
+	// and suggestions stay embedded in the error itself).
+	if !isUsageMistake(err) || strings.Contains(err.Error(), "--help' for usage") {
+		return
+	}
+	path := "gridctl"
+	if cmd != nil {
+		path = cmd.CommandPath()
+	}
+	fmt.Fprintf(w, "Run '%s --help' for usage\n", path)
+}
+
+// isUsageMistake reports whether err is an invocation mistake (unknown
+// command or wrong argument count) rather than a runtime failure. The
+// prefixes match cobra's args.go error strings.
+func isUsageMistake(err error) bool {
+	msg := err.Error()
+	for _, prefix := range []string{
+		"unknown command",
+		"accepts ",
+		"requires at least",
+		"requires exactly",
+	} {
+		if strings.HasPrefix(msg, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 var serveCmd = &cobra.Command{

--- a/cmd/gridctl/root_test.go
+++ b/cmd/gridctl/root_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// executeCommand runs the root command with args and returns captured
+// output. Cobra writes help to the configured out writer; errors are
+// returned, not printed, because SilenceErrors is set globally.
+func executeCommand(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+	err := rootCmd.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+func TestRootHelpGroupsAndQuickStart(t *testing.T) {
+	out, _, err := executeCommand(t, "--help")
+	if err != nil {
+		t.Fatalf("--help: %v", err)
+	}
+
+	for _, want := range []string{"QUICK START", "STACK", "CLIENTS", "SKILLS", "VARIABLES & PINS", "OBSERVABILITY", "SYSTEM", "gridctl apply stack.yaml", "EXAMPLES"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("root help missing %q", want)
+		}
+	}
+	if strings.Contains(out, "\033") {
+		t.Error("root help contains ANSI escapes on a non-TTY writer")
+	}
+	if strings.Contains(out, "vault") {
+		t.Error("deprecated vault command should stay hidden from root help")
+	}
+}
+
+func TestLeafHelpHasExamplesAndNoFooter(t *testing.T) {
+	out, _, err := executeCommand(t, "apply", "--help")
+	if err != nil {
+		t.Fatalf("apply --help: %v", err)
+	}
+	if !strings.Contains(out, "EXAMPLES") {
+		t.Error("apply help missing EXAMPLES section")
+	}
+	if strings.Contains(out, `gridctl apply [command] --help`) {
+		t.Error("leaf command help should not render the subcommand footer")
+	}
+}
+
+func TestParentHelpKeepsFooter(t *testing.T) {
+	out, _, err := executeCommand(t, "skill", "--help")
+	if err != nil {
+		t.Fatalf("skill --help: %v", err)
+	}
+	if !strings.Contains(out, `gridctl skill [command] --help`) {
+		t.Error("parent command help should keep the subcommand footer")
+	}
+}
+
+func TestRuntimeErrorPrintsNoUsage(t *testing.T) {
+	out, errOut, err := executeCommand(t, "validate", "/no/such/file.yaml")
+	if err == nil {
+		t.Fatal("expected an error for a missing stack file")
+	}
+	combined := out + errOut
+	if strings.Contains(combined, "Usage:") || strings.Contains(combined, "USAGE") {
+		t.Errorf("runtime error should not dump usage, got %q", combined)
+	}
+	// SilenceErrors means cobra prints nothing; Execute owns the print.
+	if strings.Contains(combined, err.Error()) {
+		t.Errorf("error should not be printed by cobra itself, got %q", combined)
+	}
+}
+
+func TestFlagErrorKeepsUsageGuidance(t *testing.T) {
+	_, _, err := executeCommand(t, "status", "--not-a-flag")
+	if err == nil {
+		t.Fatal("expected an error for an unknown flag")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("expected unknown flag error, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "--help' for usage") {
+		t.Errorf("flag error should point at --help, got %q", err)
+	}
+}
+
+func TestUnknownCommandSuggests(t *testing.T) {
+	_, _, err := executeCommand(t, "statuss")
+	if err == nil {
+		t.Fatal("expected an error for an unknown command")
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("expected unknown command error, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "status") || !strings.Contains(err.Error(), "Did you mean") {
+		t.Errorf("expected a suggestion for status, got %q", err)
+	}
+}
+
+func TestPrintCLIErrorSingleLine(t *testing.T) {
+	var buf bytes.Buffer
+	printCLIError(&buf, nil, errors.New("boom"))
+	out := buf.String()
+	if out != "Error: boom\n" {
+		t.Errorf("printCLIError = %q, want %q", out, "Error: boom\n")
+	}
+}
+
+func TestPrintCLIErrorUnknownCommandPointer(t *testing.T) {
+	var buf bytes.Buffer
+	printCLIError(&buf, nil, errors.New(`unknown command "foo" for "gridctl"`))
+	if !strings.Contains(buf.String(), "Run 'gridctl --help' for usage") {
+		t.Errorf("expected help pointer for unknown command, got %q", buf.String())
+	}
+}
+
+func TestPrintCLIErrorArgCountPointsAtCommandHelp(t *testing.T) {
+	var buf bytes.Buffer
+	printCLIError(&buf, destroyCmd, errors.New("accepts 1 arg(s), received 0"))
+	if !strings.Contains(buf.String(), "Run 'gridctl destroy --help' for usage") {
+		t.Errorf("expected a command-scoped help pointer, got %q", buf.String())
+	}
+}
+
+func TestPrintCLIErrorSubcommandPointer(t *testing.T) {
+	var buf bytes.Buffer
+	printCLIError(&buf, skillCmd, errors.New(`unknown command "lst" for "gridctl skill"`))
+	if !strings.Contains(buf.String(), "Run 'gridctl skill --help' for usage") {
+		t.Errorf("expected the parent command's help path, got %q", buf.String())
+	}
+}
+
+func TestPrintCLIErrorRuntimeErrorNoPointer(t *testing.T) {
+	var buf bytes.Buffer
+	printCLIError(&buf, destroyCmd, errors.New("reading stack file: no such file"))
+	if strings.Contains(buf.String(), "--help") {
+		t.Errorf("runtime errors must not carry a help pointer, got %q", buf.String())
+	}
+}

--- a/cmd/gridctl/skill.go
+++ b/cmd/gridctl/skill.go
@@ -53,9 +53,11 @@ var (
 )
 
 var skillAddCmd = &cobra.Command{
-	Use:     "add <repo-url>",
-	Short:   "Import skills from a git repository",
-	Long:    "Clone a repository, discover SKILL.md files, and import them into the local registry.",
+	Use:   "add <repo-url>",
+	Short: "Import skills from a git repository",
+	Long:  "Clone a repository, discover SKILL.md files, and import them into the local registry.",
+	Example: `  gridctl skill add https://github.com/acme/skills
+  gridctl skill add git@github.com:acme/private-skills.git --vault-key GH_TOKEN`,
 	Args:    cobra.ExactArgs(1),
 	PreRunE: validateSkillAuthFlags(&skillAddAuthToken, &skillAddVaultKey),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -68,9 +70,15 @@ var skillListCmd = &cobra.Command{
 	Short: "List all skills with origin info",
 	Long:  "List all skills showing source origin (local/remote) and update status.",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		if skillListFormat, err = resolveFormat(skillListFormat, cmd.Flags().Changed("format"), *skillListJSON); err != nil {
+			return err
+		}
 		return runSkillList()
 	},
 }
+
+var skillListJSON *bool
 
 var skillUpdateCmd = &cobra.Command{
 	Use:     "update [name]",
@@ -158,6 +166,7 @@ func init() {
 
 	skillListCmd.Flags().BoolVar(&skillListRemote, "remote", false, "Show only remote (imported) skills")
 	skillListCmd.Flags().StringVar(&skillListFormat, "format", "", "Output format (json)")
+	skillListJSON = addJSONAlias(skillListCmd)
 
 	skillUpdateCmd.Flags().BoolVar(&skillUpdateDryRun, "dry-run", false, "Show changes without applying")
 	skillUpdateCmd.Flags().BoolVar(&skillUpdateForce, "force", false, "Force update even if no changes detected")
@@ -553,7 +562,6 @@ func runSkillUpdate(name string) error {
 
 	return nil
 }
-
 
 func runSkillRemove(name string) error {
 	store, err := loadRegistry()

--- a/cmd/gridctl/status.go
+++ b/cmd/gridctl/status.go
@@ -19,9 +19,46 @@ import (
 )
 
 var (
-	statusStack          string
-	statusShowReplicas   bool
+	statusStack        string
+	statusShowReplicas bool
+	statusJSON         bool
 )
+
+// statusGatewayJSON is one gateway entry of `gridctl status --json`.
+// The schema is experimental until 1.0.
+type statusGatewayJSON struct {
+	Name      string    `json:"name"`
+	Port      int       `json:"port"`
+	PID       int       `json:"pid"`
+	Status    string    `json:"status"`
+	StartedAt time.Time `json:"started_at"`
+	CodeMode  string    `json:"code_mode,omitempty"`
+}
+
+// statusContainerJSON is one container entry of `gridctl status --json`.
+type statusContainerJSON struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Image     string `json:"image"`
+	State     string `json:"state"`
+	Message   string `json:"message,omitempty"`
+	PinStatus string `json:"pin_status,omitempty"`
+}
+
+// statusMCPServerJSON is one MCP server entry of `gridctl status --json`,
+// mirroring the gateway API payload plus the owning stack.
+type statusMCPServerJSON struct {
+	Stack string `json:"stack"`
+	mcpServerAPI
+}
+
+// statusReport is the machine-readable shape of `gridctl status --json`.
+type statusReport struct {
+	Gateways   []statusGatewayJSON   `json:"gateways"`
+	Containers []statusContainerJSON `json:"containers"`
+	MCPServers []statusMCPServerJSON `json:"mcp_servers"`
+}
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
@@ -31,18 +68,27 @@ var statusCmd = &cobra.Command{
 Shows running gateways with their ports, and container states.
 Use --stack to filter by a specific stack.
 Use --replicas to expand multi-replica servers to one row per replica.`,
+	Example: `  gridctl status               Show all gateways and containers
+  gridctl status --replicas    One row per replica
+  gridctl status --json        Machine-readable output (experimental schema)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runStatus(statusStack, statusShowReplicas)
+		return runStatus(statusStack, statusShowReplicas, statusJSON)
 	},
 }
 
 func init() {
 	statusCmd.Flags().StringVarP(&statusStack, "stack", "s", "", "Only show containers from this stack")
 	statusCmd.Flags().BoolVar(&statusShowReplicas, "replicas", false, "Expand to one row per replica instead of rolled-up per-server state")
+	statusCmd.Flags().BoolVar(&statusJSON, "json", false, "Output status as JSON (experimental schema)")
 }
 
-func runStatus(stack string, showReplicas bool) error {
+func runStatus(stack string, showReplicas, asJSON bool) error {
+	// In JSON mode all human chrome (warnings, hints) moves to stderr so
+	// stdout carries nothing but the document.
 	printer := output.New()
+	if asJSON {
+		printer = output.NewWithWriter(os.Stderr)
+	}
 
 	// Show gateway status from state files
 	states, err := state.List()
@@ -58,8 +104,9 @@ func runStatus(stack string, showReplicas bool) error {
 		}
 	}
 
-	// Build gateway summaries
+	// Build gateway summaries (table rows) and their JSON mirror
 	var gateways []output.GatewaySummary
+	gatewaysJSON := make([]statusGatewayJSON, 0, len(filteredStates))
 	for _, s := range filteredStates {
 		status := "stopped"
 		if state.IsRunning(&s) {
@@ -77,6 +124,14 @@ func runStatus(stack string, showReplicas bool) error {
 			gw.CodeMode = queryCodeMode(s.Port)
 		}
 		gateways = append(gateways, gw)
+		gatewaysJSON = append(gatewaysJSON, statusGatewayJSON{
+			Name:      s.StackName,
+			Port:      s.Port,
+			PID:       s.PID,
+			Status:    status,
+			StartedAt: s.StartedAt,
+			CodeMode:  gw.CodeMode,
+		})
 	}
 
 	// Load pin status for all filtered stacks (best-effort; errors are non-fatal).
@@ -84,6 +139,7 @@ func runStatus(stack string, showReplicas bool) error {
 
 	// Show container status (graceful degradation when Docker unavailable)
 	var containers []output.ContainerSummary
+	containersJSON := make([]statusContainerJSON, 0)
 	rt, err := runtime.New()
 	if err != nil {
 		printer.Warn("could not initialize runtime — container status unavailable", "error", err)
@@ -120,12 +176,39 @@ func runStatus(stack string, showReplicas bool) error {
 					Message:   s.Message,
 					PinStatus: pinLabels[workloadName],
 				})
+				containersJSON = append(containersJSON, statusContainerJSON{
+					ID:        id,
+					Name:      workloadName,
+					Type:      string(s.Type),
+					Image:     s.Image,
+					State:     string(s.State),
+					Message:   s.Message,
+					PinStatus: pinLabels[workloadName],
+				})
 			}
 		}
 	}
 
+	if asJSON {
+		report := statusReport{
+			Gateways:   gatewaysJSON,
+			Containers: containersJSON,
+			MCPServers: make([]statusMCPServerJSON, 0),
+		}
+		for _, s := range filteredStates {
+			if !state.IsRunning(&s) {
+				continue
+			}
+			for _, srv := range queryMCPServers(s.Port) {
+				report.MCPServers = append(report.MCPServers, statusMCPServerJSON{Stack: s.StackName, mcpServerAPI: srv})
+			}
+		}
+		return output.EncodeJSON(os.Stdout, report)
+	}
+
 	if len(containers) == 0 && len(gateways) == 0 {
 		printer.Info("No managed gateways or containers found")
+		printer.Hint("Try: gridctl apply <stack.yaml>  or  gridctl serve")
 		return nil
 	}
 
@@ -182,14 +265,14 @@ func queryTraceCount(port int) int {
 // to render rolled-up and per-replica views. Defined locally so the CLI does
 // not pull in the internal/api package.
 type mcpServerAPI struct {
-	Name         string            `json:"name"`
-	Transport    string            `json:"transport"`
-	External     bool              `json:"external"`
-	LocalProcess bool              `json:"localProcess"`
-	SSH          bool              `json:"ssh"`
-	OpenAPI      bool              `json:"openapi"`
-	Replicas     []mcpReplicaAPI   `json:"replicas,omitempty"`
-	Autoscale    *autoscaleAPI     `json:"autoscale,omitempty"`
+	Name         string          `json:"name"`
+	Transport    string          `json:"transport"`
+	External     bool            `json:"external"`
+	LocalProcess bool            `json:"localProcess"`
+	SSH          bool            `json:"ssh"`
+	OpenAPI      bool            `json:"openapi"`
+	Replicas     []mcpReplicaAPI `json:"replicas,omitempty"`
+	Autoscale    *autoscaleAPI   `json:"autoscale,omitempty"`
 }
 
 // autoscaleAPI mirrors the subset of mcp.AutoscaleStatus the CLI renders in

--- a/cmd/gridctl/unlink.go
+++ b/cmd/gridctl/unlink.go
@@ -65,9 +65,7 @@ func runUnlink(client string) error {
 func unlinkSingleClient(printer *output.Printer, registry *provisioner.Registry, slug string) error {
 	prov, ok := registry.FindBySlug(slug)
 	if !ok {
-		printer.Error(fmt.Sprintf("%s is not a supported client", slug))
-		printer.Print("Supported clients: %s\n", strings.Join(registry.AllSlugs(), ", "))
-		return fmt.Errorf("%s: not a supported client", slug)
+		return unknownClientError(registry, slug)
 	}
 
 	configPath, found := prov.Detect()

--- a/cmd/gridctl/validate.go
+++ b/cmd/gridctl/validate.go
@@ -24,12 +24,19 @@ Exit codes:
   2  Warnings only (no errors)`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		if validateFormat, err = resolveFormat(validateFormat, cmd.Flags().Changed("format"), *validateJSON); err != nil {
+			return err
+		}
 		return runValidate(args[0])
 	},
 }
 
+var validateJSON *bool
+
 func init() {
 	validateCmd.Flags().StringVar(&validateFormat, "format", "", "Output format: json for machine-readable output")
+	validateJSON = addJSONAlias(validateCmd)
 }
 
 func runValidate(stackPath string) error {

--- a/cmd/gridctl/var.go
+++ b/cmd/gridctl/var.go
@@ -60,6 +60,9 @@ in logs (e.g. REGION, CLUSTER_ID).
 
 Use --type to validate and tag the value's shape: string (default), json,
 list, number, or bool.`,
+	Example: `  gridctl var set GITHUB_TOKEN             Prompt for a secret value
+  gridctl var set REGION --value us-east-1 --plaintext
+  gridctl var set FEATURES --type list --value "a,b,c"`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runVarSet(args[0])
@@ -83,9 +86,15 @@ var varListCmd = &cobra.Command{
 	Short: "List all variables",
 	Long:  "List all variables with type and visibility. Values are never shown.",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		if varListFmt, err = resolveFormat(varListFmt, cmd.Flags().Changed("format"), *varListJSON); err != nil {
+			return err
+		}
 		return runVarList()
 	},
 }
+
+var varListJSON *bool
 
 var varDeleteCmd = &cobra.Command{
 	Use:   "delete <KEY>",
@@ -197,6 +206,7 @@ func init() {
 	varGetCmd.Flags().BoolVar(&varGetPlain, "plain", false, "Show unmasked value")
 	varDeleteCmd.Flags().BoolVar(&varDeleteForce, "force", false, "Skip confirmation")
 	varListCmd.Flags().StringVar(&varListFmt, "format", "table", "Output format (table, json)")
+	varListJSON = addJSONAlias(varListCmd)
 	varImportCmd.Flags().StringVar(&varImportFmt, "format", "", "File format (env, json). Auto-detected if omitted")
 	varExportCmd.Flags().StringVar(&varExportFmt, "format", "env", "Export format (env, json)")
 	varExportCmd.Flags().BoolVar(&varExportPlain, "plain", false, "Show unmasked values")

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,10 @@
 # CLI Reference
 
-Commands are grouped by domain. Run `gridctl <command> --help` for the full flag set; the tables below cover the high-value flags an operator reaches for daily.
+Commands are grouped by domain, matching the groups in `gridctl --help`. Run `gridctl <command> --help` for the full flag set; the tables below cover the high-value flags an operator reaches for daily.
+
+Global flags: `--runtime <docker|podman>` overrides runtime auto-detection, and `--no-color` disables styled output. Color is also suppressed automatically when output is piped, when `NO_COLOR` is set ([no-color.org](https://no-color.org/)), or when `TERM=dumb`.
+
+Machine-readable output: commands whose `--format` flag is a binary table-vs-JSON choice (`validate`, `plan`, `optimize`, `activate`, `skill list`, and `var list`) also accept `--json` as a boolean alias, and `status`, `info`, `doctor`, `open`, `traces`, and `telemetry status` support `--json` directly. `export` and `var export` keep `--format` only, since their format is multi-valued (`yaml|json`, `env|json`). JSON always goes to stdout with human messages on stderr. The `status`, `info`, and `doctor` JSON schemas are experimental until 1.0.
 
 ## Contents
 
@@ -12,23 +16,22 @@ Commands are grouped by domain. Run `gridctl <command> --help` for the full flag
 - [Traces](#traces)
 - [Optimize](#optimize)
 - [Telemetry](#telemetry)
-- [Upgrade](#upgrade)
+- [System](#system)
 
 ## Stack lifecycle
 
 | Command | Purpose |
 |---|---|
-| `gridctl validate <stack.yaml>` | Validate stack YAML (exit `0`/`1`/`2`); `--format json` for machine-readable output. |
-| `gridctl plan <stack.yaml>` | Preview changes against running state; `-y` / `--auto-approve` to apply. |
-| `gridctl apply <stack.yaml>` | Start containers and the MCP gateway. Flags: `-f` foreground, `-p` port, `--base-port`, `-w` / `--watch`, `--flash`, `--code-mode`, `--no-cache`, `--no-expand`, `-v` verbose (print full stack as JSON), `-q` quiet, `--log-file <path>`. |
-| `gridctl reload [stack-name]` | Hot reload a running stack's spec. |
-| `gridctl destroy <stack.yaml>` | Stop and remove all containers for the stack. |
+| `gridctl validate <stack.yaml>` | Validate stack YAML (exit `0`/`1`/`2`); `--format json` or `--json` for machine-readable output. |
+| `gridctl plan <stack.yaml>` | Preview changes against running state with Terraform-style colored `+`/`~`/`-` symbols; `-y` / `--auto-approve` to apply, `--format json` or `--json` for machine output. |
+| `gridctl apply <stack.yaml>` | Start containers and the MCP gateway. Without a stack file, starts stackless mode (same as `serve`) and prints a notice. Flags: `-f` foreground, `-p` port, `--base-port`, `-w` / `--watch`, `--flash`, `--code-mode`, `--no-cache`, `--no-expand`, `-v` verbose (print full stack as JSON), `-q` quiet, `--log-file <path>`. |
+| `gridctl reload [stack-name]` | Hot reload a running stack's spec (accepts a stack name or file path). |
+| `gridctl destroy <stack.yaml\|stack-name>` | Stop and remove all containers for the stack, by file or by the name shown in `gridctl status`. |
 | `gridctl export` | Reverse-engineer `stack.yaml` from running state; `-o <dir>` write to directory, `--format yaml\|json` (default `yaml`). |
 | `gridctl serve` | Start the web UI and API without managing a stack (stackless mode). |
 | `gridctl stop` | Stop the stackless gridctl daemon; `--force` kills the process if graceful shutdown fails. |
-| `gridctl status` | Show running stacks; `-s` / `--stack` filters to one stack, `--replicas` expands to one row per replica. |
-| `gridctl info` | Show runtime and environment information: detected runtime (Docker/Podman), socket path, version, host alias, SELinux state, and rootless network stack. |
-| `gridctl version` | Print version information. |
+| `gridctl status` | Show running stacks; `-s` / `--stack` filters to one stack, `--replicas` expands to one row per replica, `--json` for machine-readable output (experimental schema). |
+| `gridctl logs [stack]` | Tail the gateway daemon log (`~/.gridctl/logs/<stack>.log`). `-f` / `--follow` streams, `-n` / `--tail <N>` picks the line count (default 100), `--server <name>` streams a containerized MCP server's logs instead. Stack auto-detected when exactly one is running. |
 
 ## LLM clients
 
@@ -43,7 +46,7 @@ Skills are prose; the registry surfaces every active `SKILL.md` to MCP clients a
 
 | Command | Purpose |
 |---|---|
-| `gridctl skill list` | List skills in the registry (`--remote` for imported skills only). |
+| `gridctl skill list` | List skills in the registry (`--remote` for imported skills only, `--format json` or `--json` for machine output). |
 | `gridctl skill add <repo-url>` | Import skills from a git repository. `--ref` / `--path` pin branch or subdirectory; `--no-activate` imports as draft; `--trust` skips the security-scan confirmation; `--force` overwrites existing skills; `--rename <name>` renames on import (single skill only). Auth flags: `--auth-token <pat>` (ephemeral HTTPS PAT, CI), `--vault-key <key>` (resolves from `${var:KEY}`), `--ssh-key <path>` (SSH). |
 | `gridctl skill update [name]` | Update imported skills (all when name omitted); alias `gridctl skill sync`. `--dry-run` previews, `--force` updates even when no change is detected. |
 | `gridctl skill remove <name>` | Remove an imported skill. |
@@ -51,7 +54,7 @@ Skills are prose; the registry surfaces every active `SKILL.md` to MCP clients a
 | `gridctl skill info <name>` | Show origin and update status. |
 | `gridctl skill try <repo-url>` | Temporarily import a skill for evaluation (`--duration`, default `10m`, before auto-cleanup). Auth flags: `--auth-token <pat>`, `--vault-key <key>`, `--ssh-key <path>`. |
 | `gridctl skill validate <name>` | Validate a skill definition. |
-| `gridctl activate <skill-name>` | Promote a skill from draft to active (exit `0`/`1`/`2`); `-s` / `--stack` to target a stack (auto-detected when only one runs), `--format json` for machine output, `-q` / `--quiet` to suppress the success line. |
+| `gridctl activate <skill-name>` | Promote a skill from draft to active (exit `0`/`1`/`2`); `-s` / `--stack` to target a stack (auto-detected when only one runs), `--format json` or `--json` for machine output, `-q` / `--quiet` to suppress the success line. |
 
 ## Variables
 
@@ -61,7 +64,7 @@ The variable store holds both secrets (encrypted at rest, redacted in logs) and 
 |---|---|
 | `gridctl var set <key>` | Store a variable (interactive prompt, or `--value`). Secret by default (`--secret` makes that explicit); `--plaintext` for non-sensitive config visible in logs. `--type <string\|json\|list\|number\|bool>` tags the value's shape; `--set <name>` assigns it to a variable set. |
 | `gridctl var get <key>` | Retrieve a variable (secrets masked; `--plain` to unmask). |
-| `gridctl var list` | List all variables with type, visibility, and set assignment (`--format json`). |
+| `gridctl var list` | List all variables with type, visibility, and set assignment (`--format json` or `--json`). |
 | `gridctl var delete <key>` | Remove a variable (`--force` to skip confirmation). |
 | `gridctl var import <file>` | Import from `.env` or `.json` (`--format` to override auto-detection; `# @public` / `# @type=` markers tag entries). |
 | `gridctl var export` | Export variables (`--format env\|json`, `--plain` to unmask). |
@@ -105,7 +108,7 @@ All `pins` subcommands accept `--stack <name>` (auto-detected when only one stac
 | `gridctl optimize --stack <name>` | Pick a specific stack when more than one is running. |
 | `gridctl optimize --min-impact 0.10` | Filter findings below a weekly USD impact threshold (info findings always shown). |
 | `gridctl optimize --severity warn,critical` | Allowlist by severity. |
-| `gridctl optimize --format json` | Machine-readable `OptimizeReport` (exit `0`/`1`/`2`). |
+| `gridctl optimize --format json` | Machine-readable `OptimizeReport` (exit `0`/`1`/`2`); `--json` is an alias. |
 
 ## Telemetry
 
@@ -117,15 +120,15 @@ Inspect and manage opt-in telemetry persistence under `~/.gridctl/telemetry/`. O
 | `gridctl telemetry wipe [stack]` | Delete persisted telemetry files. `--server <name>` and `--signal <logs\|metrics\|traces>` scope the wipe; `-y` / `--yes` skips the prompt. |
 | `gridctl telemetry tail <stack> <server>` | Follow the active `<signal>.jsonl` file (lumberjack rotations detected automatically). `--signal <logs\|metrics\|traces>` is required. |
 
-## Upgrade
+## System
 
 | Command | Purpose |
 |---|---|
-| `gridctl upgrade` | Check + prompt + upgrade (standalone install). |
-| `gridctl upgrade --check` | Only check for updates; do not install. |
-| `gridctl upgrade --yes` | Non-interactive (CI / cron). |
-| `gridctl upgrade --version <tag>` | Install a specific release tag (allows downgrades). |
-| `gridctl upgrade --force` | Bypass Homebrew detection and the up-to-date short-circuit. |
+| `gridctl info` | Show runtime and environment facts: detected runtime (Docker/Podman), socket path, version, host alias, SELinux state, and rootless network stack. `--json` for machine output. Always exits 0; for judgments, use `doctor`. |
+| `gridctl doctor` | Run opinionated environment checks with remediation hints: runtime detection, socket reachability, version floor, gateway port, `npx` availability, state directory hygiene, stale state files, and vault status. `--json` for a machine-readable report, `-q` to print only failures. Exit `0` (no errors), `1` (errors), `2` (doctor failed). |
+| `gridctl open` | Open the web UI in the default browser (alias: `gridctl ui`). Port resolves from the first running stack; `-s` / `--stack` picks one, `-p` / `--port` overrides, `--path` sets the URL path, `--print` prints the URL only, `--json` emits `{"url": ...}`. |
+| `gridctl version` | Print version information. |
+| `gridctl upgrade` | Check + prompt + upgrade (standalone install). `--check` only checks; `--yes` non-interactive (CI / cron); `--version <tag>` installs a specific release tag (allows downgrades); `--force` bypasses Homebrew detection and the up-to-date short-circuit. |
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,8 @@
 
 Common issues and resolutions for gridctl.
 
+Start with `gridctl doctor`: it runs most of the environment checks below automatically (runtime detection, socket reachability, version floor, gateway port, `npx` availability, state hygiene, and vault status) and prints a verdict with a remediation hint for each.
+
 ---
 
 ## Container Runtime
@@ -521,7 +523,9 @@ The UI keeps showing the authentication prompt after entering a valid token.
 
 If your issue isn't covered here:
 
-1. Check `gridctl status` for the current state of your stack
-2. Review container logs: `docker logs gridctl-<stack>-<name>`
-3. Run with verbose logging: `gridctl apply <stack.yaml> --verbose`
-4. Open an issue at [github.com/gridctl/gridctl/issues](https://github.com/gridctl/gridctl/issues)
+1. Run `gridctl doctor` for automated environment checks with remediation hints
+2. Check `gridctl status` for the current state of your stack
+3. Tail the gateway daemon log: `gridctl logs [stack] -f`
+4. Review an MCP server's container logs: `gridctl logs --server <name>` (or `docker logs gridctl-<stack>-<name>`)
+5. Run with verbose logging: `gridctl apply <stack.yaml> --verbose`
+6. Open an issue at [github.com/gridctl/gridctl/issues](https://github.com/gridctl/gridctl/issues)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -182,7 +182,10 @@ func (sc *StackController) runStacklessDaemonMode() error {
 	fmt.Printf("  Web UI: http://localhost:%d\n", sc.config.Port)
 	fmt.Printf("  PID:    %d\n", pid)
 	fmt.Printf("  Logs:   %s\n", state.LogPath("gridctl"))
+	// Teardown instructions always print (scripts capture them); extra
+	// conversational hints go through Printer.Hint and are TTY-only.
 	fmt.Printf("\nUse 'gridctl stop' to stop.\n")
+	output.New().Hint("Load a stack with 'gridctl apply <stack.yaml>', or 'gridctl open' for the web UI")
 	return nil
 }
 
@@ -469,7 +472,10 @@ func (sc *StackController) runDaemonMode(ctx context.Context, stack *config.Stac
 		summaries := BuildWorkloadSummaries(stack, result)
 		printer.Summary(summaries)
 		printer.Info("Gateway running", "url", fmt.Sprintf("http://localhost:%d", st.Port))
+		// Teardown instructions always print (scripts capture them); extra
+		// conversational hints go through Printer.Hint and are TTY-only.
 		printer.Print("\nUse 'gridctl destroy %s' to stop\n", sc.config.StackPath)
+		printer.Hint("Follow the daemon with 'gridctl logs', or 'gridctl open' for the web UI")
 	} else {
 		fmt.Printf("Stack '%s' started successfully\n", stack.Name)
 		fmt.Printf("  Gateway: http://localhost:%d\n", st.Port)

--- a/pkg/output/color.go
+++ b/pkg/output/color.go
@@ -1,0 +1,38 @@
+package output
+
+import (
+	"io"
+	"os"
+)
+
+// noColor is the process-wide color kill switch, set by the global
+// --no-color flag before command output is produced.
+var noColor bool
+
+// SetNoColor disables (or re-enables) all styled output for the process,
+// regardless of TTY detection. Wired to the global --no-color flag.
+func SetNoColor(disabled bool) {
+	noColor = disabled
+}
+
+// ColorEnabled reports whether styled output should be emitted on w.
+// Color is disabled when SetNoColor(true) was called, NO_COLOR is set and
+// non-empty (https://no-color.org/), TERM is "dumb", or w is not a terminal.
+func ColorEnabled(w io.Writer) bool {
+	return colorAllowedByEnv() && isTerminal(w)
+}
+
+// colorAllowedByEnv applies every color gate that does not depend on the
+// output stream: the --no-color kill switch, NO_COLOR, and TERM=dumb.
+func colorAllowedByEnv() bool {
+	if noColor {
+		return false
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	return true
+}

--- a/pkg/output/color_test.go
+++ b/pkg/output/color_test.go
@@ -1,0 +1,69 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestColorEnabledNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	if ColorEnabled(&buf) {
+		t.Error("expected color disabled for a non-TTY writer")
+	}
+}
+
+func TestColorAllowedByEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		noColor bool
+		env     map[string]string
+		want    bool
+	}{
+		{name: "default allows color", want: true},
+		{name: "SetNoColor disables", noColor: true, want: false},
+		{name: "NO_COLOR disables", env: map[string]string{"NO_COLOR": "1"}, want: false},
+		{name: "NO_COLOR any value disables", env: map[string]string{"NO_COLOR": "true"}, want: false},
+		{name: "empty NO_COLOR allows", env: map[string]string{"NO_COLOR": ""}, want: true},
+		{name: "TERM dumb disables", env: map[string]string{"TERM": "dumb"}, want: false},
+		{name: "TERM xterm allows", env: map[string]string{"TERM": "xterm-256color"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("NO_COLOR", "")
+			t.Setenv("TERM", "xterm")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			SetNoColor(tt.noColor)
+			t.Cleanup(func() { SetNoColor(false) })
+
+			if got := colorAllowedByEnv(); got != tt.want {
+				t.Errorf("colorAllowedByEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHintSuppressedForNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewWithWriter(&buf)
+	p.Hint("Try: gridctl apply %s", "stack.yaml")
+	if buf.Len() != 0 {
+		t.Errorf("expected hint suppressed for non-TTY writer, got %q", buf.String())
+	}
+}
+
+func TestBannerNonTTYPlain(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewWithWriter(&buf)
+	p.Banner("v1.2.3")
+	out := buf.String()
+	if !strings.Contains(out, "gridctl v1.2.3") {
+		t.Errorf("expected plain banner, got %q", out)
+	}
+	if strings.Contains(out, "\033") {
+		t.Errorf("expected no ANSI escapes in non-TTY banner, got %q", out)
+	}
+}

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -1,0 +1,15 @@
+package output
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// EncodeJSON writes v to w as two-space-indented JSON. It is the shared
+// encoder for every command's machine-readable output so schemas render
+// consistently and never carry ANSI escapes.
+func EncodeJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/pkg/output/json_test.go
+++ b/pkg/output/json_test.go
@@ -1,0 +1,31 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestEncodeJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := EncodeJSON(&buf, map[string]any{"gateways": []string{}, "ok": true}); err != nil {
+		t.Fatalf("EncodeJSON: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "\033") {
+		t.Errorf("expected no ANSI escapes in JSON output, got %q", out)
+	}
+	if !strings.Contains(out, "  \"gateways\"") {
+		t.Errorf("expected two-space indentation, got %q", out)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if decoded["ok"] != true {
+		t.Errorf("round-trip mismatch: %v", decoded)
+	}
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -17,6 +17,7 @@ type Printer struct {
 	out    io.Writer
 	logger *log.Logger
 	isTTY  bool
+	color  bool
 }
 
 // New creates a Printer writing to stdout with amber theme.
@@ -27,13 +28,14 @@ func New() *Printer {
 // NewWithWriter creates a Printer with a custom writer.
 func NewWithWriter(w io.Writer) *Printer {
 	isTTY := isTerminal(w)
+	color := ColorEnabled(w)
 
 	logger := log.NewWithOptions(w, log.Options{
 		ReportTimestamp: true,
 		TimeFormat:      time.TimeOnly, // HH:MM:SS
 	})
 
-	if isTTY {
+	if color {
 		logger.SetStyles(amberStyles())
 	}
 
@@ -41,6 +43,7 @@ func NewWithWriter(w io.Writer) *Printer {
 		out:    w,
 		logger: logger,
 		isTTY:  isTTY,
+		color:  color,
 	}
 }
 
@@ -88,10 +91,15 @@ func (p *Printer) Banner(ver string) {
 		return
 	}
 
-	// Colors
-	amber := lipgloss.NewStyle().Foreground(ColorAmber)
-	white := lipgloss.NewStyle().Foreground(ColorWhite)
-	muted := lipgloss.NewStyle().Foreground(ColorMuted)
+	// Colors (no-ops when color is disabled, e.g. NO_COLOR or --no-color)
+	amber := lipgloss.NewStyle()
+	white := lipgloss.NewStyle()
+	muted := lipgloss.NewStyle()
+	if p.color {
+		amber = amber.Foreground(ColorAmber)
+		white = white.Foreground(ColorWhite)
+		muted = muted.Foreground(ColorMuted)
+	}
 
 	// "grid" part in amber
 	gridPart := []string{
@@ -127,6 +135,20 @@ func (p *Printer) Banner(ver string) {
 
 	// Version line
 	fmt.Fprintf(p.out, "\n  %s %s\n\n", muted.Render("version"), amber.Render(ver))
+}
+
+// Hint prints a short next-step suggestion. Hints are conversational
+// chrome: they are suppressed when the writer is not a terminal so
+// scripts, pipes, and JSON consumers never see them.
+func (p *Printer) Hint(format string, args ...any) {
+	if !p.isTTY {
+		return
+	}
+	msg := fmt.Sprintf(format, args...)
+	if p.color {
+		msg = lipgloss.NewStyle().Foreground(ColorMuted).Render(msg)
+	}
+	fmt.Fprintf(p.out, "\n%s\n", msg)
 }
 
 // Print writes a message directly to output without formatting.

--- a/pkg/output/suggest.go
+++ b/pkg/output/suggest.go
@@ -1,0 +1,68 @@
+package output
+
+import "strings"
+
+// suggestMaxDistance is the largest Levenshtein distance still considered
+// a plausible typo, matching cobra's default suggestion distance.
+const suggestMaxDistance = 2
+
+// Suggest returns the candidate closest to input within a Levenshtein
+// distance of suggestMaxDistance, or "" when nothing is close enough.
+// Matching is case-insensitive; ties resolve to the earliest candidate.
+func Suggest(input string, candidates []string) string {
+	best := ""
+	bestDist := suggestMaxDistance + 1
+	lowered := strings.ToLower(input)
+	for _, c := range candidates {
+		d := levenshtein(lowered, strings.ToLower(c))
+		if d < bestDist {
+			best = c
+			bestDist = d
+		}
+	}
+	if bestDist > suggestMaxDistance {
+		return ""
+	}
+	return best
+}
+
+// levenshtein computes the edit distance between two strings by rune.
+func levenshtein(a, b string) int {
+	ra := []rune(a)
+	rb := []rune(b)
+	if len(ra) == 0 {
+		return len(rb)
+	}
+	if len(rb) == 0 {
+		return len(ra)
+	}
+
+	prev := make([]int, len(rb)+1)
+	curr := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(ra); i++ {
+		curr[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[j] = minInt(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(rb)]
+}
+
+func minInt(nums ...int) int {
+	m := nums[0]
+	for _, n := range nums[1:] {
+		if n < m {
+			m = n
+		}
+	}
+	return m
+}

--- a/pkg/output/suggest_test.go
+++ b/pkg/output/suggest_test.go
@@ -1,0 +1,50 @@
+package output
+
+import "testing"
+
+func TestSuggest(t *testing.T) {
+	clients := []string{"claude", "claude-code", "cursor", "windsurf", "zed", "goose"}
+
+	tests := []struct {
+		name       string
+		input      string
+		candidates []string
+		want       string
+	}{
+		{name: "one deletion", input: "claud", candidates: clients, want: "claude"},
+		{name: "one substitution", input: "claude", candidates: clients, want: "claude"},
+		{name: "transposition-ish", input: "cursro", candidates: clients, want: "cursor"},
+		{name: "exact match", input: "zed", candidates: clients, want: "zed"},
+		{name: "case-insensitive", input: "CLAUD", candidates: clients, want: "claude"},
+		{name: "too far", input: "totally-unrelated", candidates: clients, want: ""},
+		{name: "no candidates", input: "claud", candidates: nil, want: ""},
+		{name: "empty input", input: "", candidates: clients, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Suggest(tt.input, tt.candidates); got != tt.want {
+				t.Errorf("Suggest(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"a", "", 1},
+		{"", "abc", 3},
+		{"kitten", "sitting", 3},
+		{"claud", "claude", 1},
+		{"status", "status", 0},
+	}
+	for _, tt := range tests {
+		if got := levenshtein(tt.a, tt.b); got != tt.want {
+			t.Errorf("levenshtein(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -75,7 +75,7 @@ func (p *Printer) Summary(workloads []WorkloadSummary) {
 
 	for _, w := range workloads {
 		state := w.State
-		if p.isTTY {
+		if p.color {
 			state = colorState(w.State)
 		}
 		t.AppendRow(table.Row{w.Name, w.Type, w.Transport, state})
@@ -132,7 +132,7 @@ func (p *Printer) Gateways(gateways []GatewaySummary) {
 
 	for _, g := range gateways {
 		status := g.Status
-		if p.isTTY {
+		if p.color {
 			status = colorState(g.Status)
 		}
 		if hasCodeMode {
@@ -175,12 +175,12 @@ func (p *Printer) Containers(containers []ContainerSummary) {
 
 	for _, c := range containers {
 		state := c.State
-		if p.isTTY {
+		if p.color {
 			state = colorState(c.State)
 		}
 		if hasPins {
 			pinStatus := c.PinStatus
-			if p.isTTY {
+			if p.color {
 				pinStatus = colorPinStatus(c.PinStatus)
 			}
 			t.AppendRow(table.Row{c.ID, c.Name, c.Type, c.Image, state, pinStatus, c.Message})
@@ -222,7 +222,7 @@ func (p *Printer) MCPServers(rows []MCPServerRollup) {
 	}
 	for _, r := range rows {
 		state := r.State
-		if p.isTTY {
+		if p.color {
 			state = colorReplicaState(r.State)
 		}
 		if hasAutoscale {
@@ -263,7 +263,7 @@ func (p *Printer) Replicas(rows []ReplicaDetail) {
 	}
 	for _, r := range rows {
 		state := r.State
-		if p.isTTY {
+		if p.color {
 			state = colorReplicaState(r.State)
 		}
 		if hasAutoscale {
@@ -311,7 +311,7 @@ func colorPinStatus(status string) string {
 // tableStyle returns the standard amber-themed table style.
 func (p *Printer) tableStyle() table.Style {
 	style := table.StyleRounded
-	if p.isTTY {
+	if p.color {
 		style.Color.Header = text.Colors{text.FgHiYellow, text.Bold}
 		style.Color.Border = text.Colors{text.FgHiBlack}
 	}
@@ -321,7 +321,7 @@ func (p *Printer) tableStyle() table.Style {
 
 // Section prints a section header.
 func (p *Printer) Section(title string) {
-	if p.isTTY {
+	if p.color {
 		style := lipgloss.NewStyle().Foreground(ColorAmber).Bold(true)
 		p.Println(style.Render(title))
 	} else {

--- a/tests/integration/cli_terminal_test.go
+++ b/tests/integration/cli_terminal_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildGridctlBinary compiles the CLI once per test into a temp dir. The
+// build runs before HOME is redirected so the module cache stays intact.
+func buildGridctlBinary(t *testing.T) string {
+	t.Helper()
+	binPath := filepath.Join(t.TempDir(), "gridctl")
+	build := exec.Command("go", "build", "-o", binPath, "../../cmd/gridctl")
+	var stderr bytes.Buffer
+	build.Stderr = &stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("building gridctl: %v\n%s", err, stderr.String())
+	}
+	return binPath
+}
+
+// TestDoctorAgainstRealRuntime runs `gridctl doctor --json` against the
+// real container runtime (Article IV: no mocks here) and asserts the
+// runtime and socket checks pass with a healthy daemon.
+func TestDoctorAgainstRealRuntime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	binPath := buildGridctlBinary(t)
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(binPath, "doctor", "--json")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	var report struct {
+		OK     bool `json:"ok"`
+		Checks []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"checks"`
+	}
+	if jsonErr := json.Unmarshal(stdout.Bytes(), &report); jsonErr != nil {
+		t.Fatalf("doctor --json produced invalid JSON: %v\nstdout: %s\nstderr: %s", jsonErr, stdout.String(), stderr.String())
+	}
+	if len(report.Checks) == 0 {
+		t.Fatal("doctor reported no checks")
+	}
+
+	statuses := map[string]string{}
+	for _, c := range report.Checks {
+		statuses[c.ID] = c.Status
+	}
+	// CI has a live Docker daemon, so detection and socket must pass; a
+	// doctor exit error must then come from somewhere legitimate.
+	if statuses["runtime.detect"] != "ok" {
+		t.Errorf("runtime.detect = %q, want ok (checks: %v)", statuses["runtime.detect"], statuses)
+	}
+	if statuses["runtime.socket"] != "ok" {
+		t.Errorf("runtime.socket = %q, want ok (checks: %v)", statuses["runtime.socket"], statuses)
+	}
+	if report.OK && err != nil {
+		t.Errorf("doctor exited non-zero (%v) despite ok=true", err)
+	}
+	if strings.Contains(stdout.String(), "\033") {
+		t.Error("doctor --json stdout contains ANSI escapes")
+	}
+}
+
+// TestLogsAfterServe daemonizes a stackless gateway, then asserts
+// `gridctl logs` can read the daemon log it produced and `gridctl stop`
+// tears it down.
+func TestLogsAfterServe(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	binPath := buildGridctlBinary(t)
+	t.Setenv("HOME", t.TempDir())
+
+	port := freeTCPPort(t)
+
+	var serveOut bytes.Buffer
+	serve := exec.Command(binPath, "serve", "--port", strconv.Itoa(port))
+	serve.Stdout = &serveOut
+	serve.Stderr = &serveOut
+	if err := serve.Run(); err != nil {
+		t.Fatalf("gridctl serve: %v\n%s", err, serveOut.String())
+	}
+
+	t.Cleanup(func() {
+		stop := exec.Command(binPath, "stop")
+		_ = stop.Run()
+	})
+
+	if !waitForHealthEndpoint(port, 15*time.Second) {
+		t.Fatalf("gateway never became healthy on :%d\n%s", port, serveOut.String())
+	}
+
+	var logsOut, logsErr bytes.Buffer
+	logs := exec.Command(binPath, "logs", "gridctl", "-n", "50")
+	logs.Stdout = &logsOut
+	logs.Stderr = &logsErr
+	if err := logs.Run(); err != nil {
+		t.Fatalf("gridctl logs: %v\nstderr: %s", err, logsErr.String())
+	}
+	if logsOut.Len() == 0 {
+		t.Error("gridctl logs printed nothing for a freshly started daemon")
+	}
+
+	var stopOut bytes.Buffer
+	stop := exec.Command(binPath, "stop")
+	stop.Stdout = &stopOut
+	stop.Stderr = &stopOut
+	if err := stop.Run(); err != nil {
+		t.Fatalf("gridctl stop: %v\n%s", err, stopOut.String())
+	}
+}
+
+// freeTCPPort finds an available TCP port for the test gateway.
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("finding free port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// waitForHealthEndpoint polls the gateway health endpoint until it
+// responds or the timeout elapses.
+func waitForHealthEndpoint(port int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	client := &http.Client{Timeout: time.Second}
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return true
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return false
+}


### PR DESCRIPTION
## Description

Ships the terminal experience v1 bundle: conversational error output, grouped and example-driven help, a consistent machine-readable JSON surface, typo suggestions, colorized plan diffs, next-step hints, destroy-by-name, and three new day-2 commands (`logs`, `doctor`, `open`).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Runtime errors print once to stderr with no usage dump (`SilenceUsage`/`SilenceErrors` at the root); flag and argument mistakes keep a command-scoped help pointer, and unknown commands get cobra's "did you mean" suggestions
- Root help renders under domain groups (STACK / CLIENTS / SKILLS / VARIABLES & PINS / OBSERVABILITY / SYSTEM) with a quick-start block; `Example:` sections added to core commands; the `[command] --help` footer only renders for commands with subcommands
- `status --json` and `info --json` (experimental schemas), plus a `--json` boolean alias wherever `--format json` is a binary choice (`validate`, `plan`, `optimize`, `activate`, `skill list`, `var list`); multi-valued `export` formats intentionally keep `--format` only
- Color contract: `NO_COLOR`, `TERM=dumb`, non-TTY, and a new global `--no-color` flag disable all styling, including the previously unconditional ANSI in help output
- `gridctl plan` renders Terraform-style colored `+`/`~`/`-` symbols on TTYs; JSON output unchanged
- `gridctl destroy` accepts a stack name or file path (mirroring `reload`); bare `gridctl apply` announces its stackless fallback; empty `status` and successful `destroy` print next-step hints (TTY-only via a new `Printer.Hint`, while teardown instructions still always print)
- `gridctl link claud` suggests `claude` via a shared Levenshtein helper
- New commands: `gridctl logs [stack]` (`-f`, `-n`, `--server` for container logs), `gridctl doctor` (verdict-style checks with remediation hints, `--json`, exit codes 0/1/2), and `gridctl open` / `gridctl ui` (`--print`, `--json`, port resolved from running state)

## Testing

- `go test ./...` passes; new unit coverage for error paths, help rendering, color contract, JSON aliases, plan rendering, destroy resolution, log tailing/following, doctor reporting, and open URL resolution
- `go test -race -tags=integration -run 'TestDoctorAgainstRealRuntime|TestLogsAfterServe' ./tests/integration/` passes against a real Docker daemon
- `golangci-lint run` clean; `make build` verified with the embedded web UI

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #881