### PR TITLE
fix: keep tool overflow popover content inside its panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to gridctl will be documented in this file.
 - Update keyboard list-navigation state via an effect instead of during render, removing a latent concurrent-rendering hazard
 - Log vault reload failures, resource-listing failures, and registry refresh failures instead of silently discarding them; a corrupt vault file or Docker outage is now diagnosable from the logs
 - Generate canonical `${var:KEY}` placeholders from `gridctl export` and `skill --vault-key` instead of the deprecated `${vault:KEY}` syntax; both syntaxes still resolve
+- Keep the topology "+N more" tool popover's content inside its panel instead of painting past the border and off the viewport; hidden tools now lay out in columns of 10 (up to four, scrolling beyond that), the tool detail card opens beside the panel instead of covering it, and both popovers scroll with the mouse wheel instead of zooming the canvas
 
 ### Features
 

--- a/web/src/__tests__/ToolOverflowNode.test.tsx
+++ b/web/src/__tests__/ToolOverflowNode.test.tsx
@@ -26,12 +26,17 @@ const data: ToolOverflowNodeData = {
   hiddenTools: ['create-issue', 'delete-repo'],
 };
 
-function renderNode() {
+function renderNode(nodeData: ToolOverflowNodeData = data) {
   return render(
     <MemoryRouter initialEntries={['/']}>
-      <ToolOverflowNode data={data} />
+      <ToolOverflowNode data={nodeData} />
     </MemoryRouter>,
   );
+}
+
+function makeData(count: number): ToolOverflowNodeData {
+  const hiddenTools = Array.from({ length: count }, (_, i) => `tool-${i}`);
+  return { ...data, overflowCount: count, hiddenTools };
 }
 
 beforeEach(() => {
@@ -74,6 +79,60 @@ describe('ToolOverflowNode', () => {
     fireEvent.click(screen.getByRole('button', { name: /show details for github tool delete-repo/i }));
     expect(await screen.findByText('github__delete-repo')).toBeInTheDocument();
     expect(screen.getByText(/No description available/i)).toBeInTheDocument();
+  });
+
+  it('marks the open panel scrollable inside react-flow', () => {
+    const { container } = renderNode();
+    fireEvent.click(screen.getByRole('button', { name: /show 2 more github tools/i }));
+    // node-scroll wins overflow back from the react-flow overflow:visible
+    // !important rule; nowheel keeps the wheel from zooming the canvas.
+    const panel = container.querySelector('.node-scroll');
+    expect(panel).not.toBeNull();
+    expect(panel).toHaveClass('nowheel');
+  });
+
+  it('lays hidden tools out in columns of 10', () => {
+    const { container } = renderNode(makeData(30));
+    fireEvent.click(screen.getByRole('button', { name: /show 30 more github tools/i }));
+    const list = container.querySelector('ul');
+    expect(list).toHaveStyle({
+      gridTemplateRows: 'repeat(10, min-content)',
+      gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+    });
+    const panel = container.querySelector('.node-scroll');
+    expect(panel).toHaveStyle({ width: '600px' });
+  });
+
+  it('caps the grid at four columns and grows rows past 40 tools', () => {
+    const { container } = renderNode(makeData(100));
+    fireEvent.click(screen.getByRole('button', { name: /show 100 more github tools/i }));
+    const list = container.querySelector('ul');
+    expect(list).toHaveStyle({
+      gridTemplateRows: 'repeat(25, min-content)',
+      gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+    });
+  });
+
+  it('opens the detail popover past the panel edge so the tool list stays visible', async () => {
+    const { container } = renderNode();
+    fireEvent.click(screen.getByRole('button', { name: /show 2 more github tools/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show details for github tool create-issue/i }));
+    const card = (await screen.findByText('github__create-issue')).closest('.w-72');
+    // One column of hidden tools -> the panel is 200px wide; the card starts
+    // just past its right edge instead of the pill default (left-full), which
+    // would cover the panel.
+    expect(card).toHaveStyle({ left: '208px', top: '100%' });
+    expect(container.querySelector('.left-full')).toBeNull();
+  });
+
+  it('marks the detail popover scroller scrollable inside react-flow', async () => {
+    const { container } = renderNode();
+    fireEvent.click(screen.getByRole('button', { name: /show 2 more github tools/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show details for github tool create-issue/i }));
+    expect(await screen.findByText('github__create-issue')).toBeInTheDocument();
+    const scrollers = container.querySelectorAll('.node-scroll.nowheel');
+    // The overflow list panel plus the detail popover's body.
+    expect(scrollers.length).toBe(2);
   });
 
   it('dismisses overlays on Escape', async () => {

--- a/web/src/__tests__/toolFanout.test.ts
+++ b/web/src/__tests__/toolFanout.test.ts
@@ -6,6 +6,7 @@ import {
   computeToolFanout,
   createToolFanout,
   appendToolFanout,
+  overflowGridShape,
   toolNodeId,
   overflowNodeId,
 } from '../lib/graph/toolFanout';
@@ -53,6 +54,31 @@ describe('computeToolFanout (cap logic)', () => {
     const { visible, overflow } = computeToolFanout(names(4), 2);
     expect(visible).toEqual(['tool-0', 'tool-1']);
     expect(overflow).toEqual(['tool-2', 'tool-3']);
+  });
+});
+
+describe('overflowGridShape (popover grid)', () => {
+  it.each([
+    { count: 0, rows: 0, cols: 0 },
+    { count: 1, rows: 1, cols: 1 },
+    { count: 10, rows: 10, cols: 1 },
+    { count: 11, rows: 6, cols: 2 },
+    { count: 30, rows: 10, cols: 3 },
+    { count: 40, rows: 10, cols: 4 },
+    // Past the column cap the grid grows rows (the panel scrolls) not columns.
+    { count: 41, rows: 11, cols: 4 },
+    { count: 100, rows: 25, cols: 4 },
+  ])('shapes $count tools into $rows rows x $cols cols', ({ count, rows, cols }) => {
+    expect(overflowGridShape(count)).toEqual({ rows, cols });
+  });
+
+  it('never leaves an empty column', () => {
+    for (let count = 1; count <= 120; count++) {
+      const { rows, cols } = overflowGridShape(count);
+      expect(rows * cols).toBeGreaterThanOrEqual(count);
+      // Dropping a column must not still fit every tool.
+      expect(rows * (cols - 1)).toBeLessThan(count);
+    }
   });
 });
 

--- a/web/src/components/graph/ToolDetailPopover.tsx
+++ b/web/src/components/graph/ToolDetailPopover.tsx
@@ -12,6 +12,10 @@ interface ToolDetailPopoverProps {
   serverName: string;
   // Unprefixed tool name (as carried by fan-out nodes).
   toolName: string;
+  // Positioning override for the card root. Tool pills use the default anchor
+  // (just right of the pill); the overflow node positions the card past the
+  // right edge of its tool-list panel, whose width the popover cannot know.
+  positionStyle?: React.CSSProperties;
   onClose: () => void;
 }
 
@@ -28,7 +32,7 @@ interface ToolDetailPopoverProps {
  * compact canvas popover. "Open in Tools" deep-links to the workspace rail,
  * which shows the full schema with room to read it.
  */
-const ToolDetailPopover = memo(({ serverName, toolName, onClose }: ToolDetailPopoverProps) => {
+const ToolDetailPopover = memo(({ serverName, toolName, positionStyle, onClose }: ToolDetailPopoverProps) => {
   const navigate = useNavigate();
   const prefixedName = `${serverName}${TOOL_NAME_DELIMITER}${toolName}`;
 
@@ -80,8 +84,10 @@ const ToolDetailPopover = memo(({ serverName, toolName, onClose }: ToolDetailPop
       // stopPropagation so a click inside the card never reaches the canvas
       // pane/node handlers; dismissal is the parent's job via useDismiss.
       onClick={(e) => e.stopPropagation()}
+      style={positionStyle}
       className={cn(
-        'nodrag absolute left-full top-0 ml-2 z-50 w-72 frost-surface',
+        'nodrag absolute z-50 w-72 frost-surface',
+        !positionStyle && 'left-full top-0 ml-2',
         'rounded-lg border border-border bg-surface-elevated/95',
         'backdrop-blur-xl shadow-bevel animate-fade-in-scale',
       )}
@@ -107,7 +113,7 @@ const ToolDetailPopover = memo(({ serverName, toolName, onClose }: ToolDetailPop
         </button>
       </div>
 
-      <div className="px-3 py-2.5 space-y-3 max-h-80 overflow-y-auto scrollbar-dark">
+      <div className="px-3 py-2.5 space-y-3 max-h-80 overflow-y-auto scrollbar-dark node-scroll nowheel">
         <section className="space-y-1">
           <h4 className="text-[9px] uppercase tracking-[0.18em] text-text-muted/70">Description</h4>
           {entry?.description ? (

--- a/web/src/components/graph/ToolOverflowNode.tsx
+++ b/web/src/components/graph/ToolOverflowNode.tsx
@@ -3,6 +3,7 @@ import { Handle, Position } from '@xyflow/react';
 import { Check, MoreHorizontal, Wrench } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { LAYOUT } from '../../lib/constants';
+import { overflowGridShape } from '../../lib/graph/toolFanout';
 import { useDismiss } from '../../hooks/useDismiss';
 import { useAccessLensTool } from '../../hooks/useAccessLensTool';
 import ToolDetailPopover from './ToolDetailPopover';
@@ -49,6 +50,11 @@ const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
   // the slide-over). Outside edit mode the rows open the detail popover.
   const { editMode, isOn, toggle: toggleScope } = useAccessLensTool(data.serverName);
 
+  // Hidden tools lay out in columns of 10 growing rightward, so typical lists
+  // are fully visible with no scrolling; beyond the column cap the panel
+  // scrolls vertically.
+  const { rows, cols } = overflowGridShape(data.hiddenTools.length);
+
   return (
     <div ref={wrapperRef} className="relative nodrag" style={{ width: LAYOUT.TOOL_WIDTH }}>
       <button
@@ -74,16 +80,27 @@ const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
       {open && (
         <div
           className={cn(
-            'absolute left-0 top-full mt-1.5 z-50 w-full',
+            'absolute left-0 top-full mt-1.5 z-50',
             'rounded-lg border border-border bg-surface-elevated/95',
             'backdrop-blur-xl shadow-bevel p-1.5',
-            'max-h-48 overflow-y-auto animate-fade-in-scale'
+            // node-scroll wins overflow-y:auto back from the react-flow
+            // overflow:visible !important rule; nowheel lets the wheel scroll
+            // the list instead of zooming the canvas.
+            'max-h-80 node-scroll nowheel scrollbar-dark animate-fade-in-scale'
           )}
+          style={{ width: cols * LAYOUT.TOOL_WIDTH }}
         >
           <div className="px-1.5 py-1 text-[9px] uppercase tracking-widest text-text-muted">
             {data.serverName} · {data.overflowCount} more
           </div>
-          <ul className="space-y-0.5">
+          <ul
+            className="grid gap-y-0.5 gap-x-1.5"
+            style={{
+              gridAutoFlow: 'column',
+              gridTemplateRows: `repeat(${rows}, min-content)`,
+              gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+            }}
+          >
             {data.hiddenTools.map((tool) => {
               const on = isOn(tool);
               return (
@@ -146,6 +163,9 @@ const ToolOverflowNode = memo(({ data }: ToolOverflowNodeProps) => {
         <ToolDetailPopover
           serverName={data.serverName}
           toolName={selectedTool}
+          // Top-aligned with the panel (top-full + its mt-1.5), just past its
+          // right edge, so the card never covers the list being browsed.
+          positionStyle={{ left: cols * LAYOUT.TOOL_WIDTH + 8, top: '100%', marginTop: 6 }}
           onClose={() => setSelectedTool(null)}
         />
       )}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -774,6 +774,14 @@ body::before {
   overflow: hidden !important;
 }
 
+/* Re-assert scrolling for in-node popovers (tool overflow list, tool detail).
+   Same conflict as .tool-label: the blanket rule above forces overflow:visible
+   on every node descendant, which defeats overflow-y-auto and lets popover
+   content paint past the panel border onto the canvas. */
+.react-flow__node .node-scroll {
+  overflow-y: auto !important;
+}
+
 .react-flow__edge.animated .react-flow__edge-path {
   transform: translateZ(0);
   backface-visibility: hidden;

--- a/web/src/lib/graph/toolFanout.ts
+++ b/web/src/lib/graph/toolFanout.ts
@@ -21,6 +21,26 @@ import { getNodeDimensions } from './utils';
 /** Maximum number of tool nodes mounted per expanded server. */
 export const TOOL_FANOUT_CAP = 10;
 
+/** Rows per column in the "+N more" popover grid. */
+export const OVERFLOW_GRID_ROWS = 10;
+
+/** Maximum columns in the "+N more" popover grid. */
+export const OVERFLOW_GRID_MAX_COLS = 4;
+
+/**
+ * Column-grid shape for the overflow popover: hidden tools stack
+ * OVERFLOW_GRID_ROWS per column and columns grow rightward, capped at
+ * OVERFLOW_GRID_MAX_COLS. Beyond the cap (count > 40) rows exceed 10 and the
+ * panel scrolls vertically instead of widening further.
+ */
+export function overflowGridShape(count: number): { rows: number; cols: number } {
+  if (count <= 0) {
+    return { rows: 0, cols: 0 };
+  }
+  const cols = Math.min(OVERFLOW_GRID_MAX_COLS, Math.ceil(count / OVERFLOW_GRID_ROWS));
+  return { rows: Math.ceil(count / cols), cols };
+}
+
 /** Stable id for a tool fan-out node. */
 export function toolNodeId(serverNodeId: string, toolName: string): string {
   return `tool-${serverNodeId}-${toolName}`;


### PR DESCRIPTION
## Description

The "+N more" tool popover on the topology canvas painted its list past the panel border and off the viewport: the blanket `.react-flow__node * { overflow: visible !important; }` rule (needed so node badges and hover effects are not clipped) silently defeats the popover's `overflow-y-auto`, leaving `max-height` to cap the box while content spills. The same rule affects the tool detail popover's scroller, and neither popover had React Flow's `nowheel` class, so the wheel zoomed the canvas instead of scrolling.

## Type of Change

- [x] Bug fix

## Changes Made

- Add a scoped `.node-scroll` re-assert (`overflow-y: auto !important`) next to the existing `.tool-label` precedent, and tag both in-node popovers with `node-scroll nowheel`
- Lay the hidden-tool list out as a column grid: 10 rows per column growing rightward, capped at four columns, vertical scroll fallback past 40 tools (`overflowGridShape` helper in `toolFanout.ts`)
- Open the tool detail card just past the panel's right edge (new `positionStyle` override on `ToolDetailPopover`) so it no longer covers the list being browsed; tool pills keep their default anchor
- Regression tests for the grid-shape math (including a no-empty-column invariant) and for the scroll/placement classes on both popovers

## Testing

- `make test-frontend`: 1097 tests pass
- `cd web && npm run lint`: zero errors
- Verified live: expanded github (40 tools), opened "+30 more" (three columns of 10, no spill), opened a tool detail card (lands right of the panel), wheel scrolls the >40-tool fallback without zooming the canvas

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #884