### PR TITLE
feat: per-tool cost attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to gridctl will be documented in this file.
 - Honor `NO_COLOR`, `TERM=dumb`, and a new global `--no-color` flag across all CLI output, including help text
 - Enforce a zero-error frontend lint baseline in CI (gatekeeper now runs eslint on every PR)
 - Show the official Model Context Protocol mark on the gateway node and gateway sidebar headers in the web UI, replacing the generic pulse icon and its looping ping animation; liveness stays with the "Gateway Active" status pill
+- Attribute token cost per tool: the observer now records each tool's input/output tokens and estimated cost alongside its call count, `GET /api/tools/usage` carries `inputTokens`/`outputTokens`/`costUsd` (omitted when unpriced, never `$0`), per-tool history persists across gateway restarts, `gridctl optimize` unused-tool findings report a real weekly dollar impact (per-tool schema context tax instead of the previous `$0` stub), and the web UI gains a Tools scope on the Metrics workspace (server-qualified rows, cost-descending default sort, inspector on row select, detached-window parity) plus calls/tokens/cost in the Tools detail panel's Usage section outside Audit Mode
 
 ### Removed
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -259,7 +259,7 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/tools/catalog
 
 #### `GET /api/tools/usage`
 
-Returns per-(server, tool) usage observed by the gateway: cumulative call count and the last-called timestamp. Powers the Tools workspace **Audit Mode**, which separates actively-used, configured-but-unused, and disabled tools.
+Returns per-(server, tool) usage observed by the gateway: cumulative call count, last-called timestamp, token counts, and estimated cost. Powers the Tools workspace **Audit Mode** (which separates actively-used, configured-but-unused, and disabled tools), the Tools detail panel's Usage section, and the Metrics workspace's Tools scope.
 
 Usage is recorded for both direct tool calls and tools invoked through code mode's `execute` (both flow through the same observer). For servers with metrics persistence enabled, the data is restored from disk on startup so it survives gateway restarts; otherwise it reflects activity since the last gateway start.
 
@@ -277,14 +277,14 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/tools/usage
   "observedSince": "2026-05-20T10:00:00Z",
   "servers": {
     "github": {
-      "create_issue": { "calls": 42, "lastCalledAt": "2026-05-24T09:13:00Z" },
-      "list_repos": { "calls": 3, "lastCalledAt": "2026-05-21T08:00:00Z" }
+      "create_issue": { "calls": 42, "lastCalledAt": "2026-05-24T09:13:00Z", "inputTokens": 5120, "outputTokens": 18400, "costUsd": 0.291 },
+      "list_repos": { "calls": 3, "lastCalledAt": "2026-05-21T08:00:00Z", "inputTokens": 240, "outputTokens": 900 }
     }
   }
 }
 ```
 
-`servers` is an object keyed by server name; each value maps unprefixed tool names to their stats. Tools that have never been called are omitted. Returns `503` when no metrics accumulator is configured.
+`servers` is an object keyed by server name; each value maps unprefixed tool names to their stats. Tools that have never been called are omitted. `inputTokens` and `outputTokens` are the cumulative tokens of the tool's own calls (omitted when zero). `costUsd` is the cumulative estimated cost of the tool's priced calls and is omitted entirely (never `0`) when no call was priced, for example when no pricing model is declared. Returns `503` when no metrics accumulator is configured.
 
 #### `GET /api/skills/usage`
 

--- a/docs/cost-observability.md
+++ b/docs/cost-observability.md
@@ -61,6 +61,19 @@ Effective models appear in the Metrics tab's Top Clients and per-server tables (
 
 Effective-model history persists alongside cost, so the provenance you see after a gateway restart matches what it was before. `gridctl optimize`'s `expensive_model_on_cheap_task` finding names the dominant model that priced a server's traffic and labels its provenance in both the table detail and `--format json`.
 
+## Per-tool cost
+
+Cost attribution extends below server/client/model granularity to the individual tool. The observer records each call's input/output tokens and, when the call is priced, its cost against the (server, tool) pair at the same point per-server cost is recorded, so the two views always agree on the same traffic.
+
+Where it surfaces:
+
+- **Metrics workspace, Tools scope** - A fifth entry on the scope rail lists every tool with recorded calls, sorted by cost descending by default. Rows are server-qualified (`server › tool`) because tool names collide across servers; selecting a row opens the inspector with the tool's calls, tokens, and estimated cost. The detached metrics window carries the same Per-Tool table.
+- **Tools workspace** - The detail panel's Usage section shows calls, last-used time, tokens, and estimated cost for the selected tool whenever traffic exists (Audit Mode is not required).
+- **`GET /api/tools/usage`** - Each tool stat carries `inputTokens`, `outputTokens`, and `costUsd` alongside `calls` and `lastCalledAt`. `costUsd` is omitted (not zero) when no call was priced.
+- **`gridctl optimize`** - Unused-tool findings report a real weekly dollar impact (see the heuristic notes below).
+
+Per-tool cost inherits every honesty rule of the wider cost system: it is an estimate (token counts × the resolved model's rate), it appears only once a pricing model is declared, unpriced tools render an em dash rather than $0, and provenance stays the existing declared/mixed/none vocabulary. Tools have no pricing model of their own; their cost follows the client/server attribution that priced the call. Per-tool history persists alongside the other metrics, so counts and spend survive a gateway restart.
+
 ## Refreshing pricing data
 
 The pricing snapshot is embedded at build time via `//go:embed pkg/pricing/data/model_prices.json`. Refresh it when providers adjust rates or add new models:
@@ -105,7 +118,7 @@ The package-level `Lookup` and `Calculate` functions read through the active sou
 `gridctl optimize` analyzes the running gateway and prints actionable cost-reduction findings. The package ships **five heuristics** in `pkg/optimize`:
 
 - **`unused_server`** - A server is registered in the stack but no tool calls have been observed from it. Removing it (or excluding all its tools) frees the JSON Schema overhead the server adds to every prompt. The reported weekly USD impact uses the server's observed per-token rate when available, otherwise falls back to a conservative default; the formula always derives from measured data.
-- **`unused_tool`** - A server *is* receiving traffic but a specific tool it exposes has not been called inside the lookback window (default 7 days) and is not already excluded via the server's `tools:` filter. Remediation suggests adding the tool to the exclusion list.
+- **`unused_tool`** - A server *is* receiving traffic but a specific tool it exposes has not been called inside the lookback window (default 7 days) and is not already excluded via the server's `tools:` filter. Remediation suggests adding the tool to the exclusion list. The weekly USD impact prices the schema context tax of the unused tool's definition: measured per-tool schema tokens (from the live tool list) × estimated weekly prompts × the server's observed per-token rate, with a conservative fallback and cap when no measurement is available. An unused tool has no observed spend by definition, so this is a schema-tax projection, not measured spend.
 - **`schema_overhead`** - A server's tool-list payload (the schema sent on every initialize / tools/list) is large relative to the value the server's tools have produced. The detector measures schema bytes off the live gateway tool list, applies a chars-per-token heuristic, and fires when the ratio of observed output tokens to schema tokens falls below the floor. Remediation prunes unused tools via the server's `tools:` filter.
 - **`format_savings_shortfall`** - A server emits raw JSON (no `output_format`) while other servers in the same session have already demonstrated meaningful savings from converting to TOON or CSV. Projected impact = baseline savings rate × the candidate's measured output tokens × its measured per-token cost. Remediation adds `output_format: toon` (or `csv`) to the server entry.
 - **`expensive_model_on_cheap_task`** *(informational)* - An Opus-tier model dominates traffic on a server whose calls average tiny prompts and tiny results. The detector either reads the rate directly when the gateway resolves a per-server model, or infers the rate from observed cost ÷ tokens. Severity is `info` because model selection lives client-side; gridctl can suggest the migration but cannot enforce it.
@@ -120,7 +133,7 @@ The CLI calls `GET /api/optimize` and renders the same `OptimizeReport` either a
 
 - The list of MCP servers and tools the gateway has registered (`gateway.Status()`).
 - Per-server token + cost totals from the `pkg/metrics` accumulator.
-- Per-(server, tool) call counts and last-called timestamps captured by the observer's tool-name attribution (PR 4 added the per-tool counter; gateways without per-tool data skip the `unused_tool` heuristic).
+- Per-(server, tool) call counts, last-called timestamps, token counts, and estimated cost captured by the observer's tool-name attribution (gateways without per-tool data skip the `unused_tool` heuristic).
 
 It deliberately does **not** read:
 

--- a/internal/api/optimize.go
+++ b/internal/api/optimize.go
@@ -82,7 +82,13 @@ func (s *Server) optimizeStats() optimize.Stats {
 			for serverName, tools := range toolSnap {
 				inner := make(map[string]optimize.ToolStat, len(tools))
 				for toolName, stat := range tools {
-					inner[toolName] = optimize.ToolStat{Calls: stat.Calls, LastCalledAt: stat.LastCalledAt}
+					inner[toolName] = optimize.ToolStat{
+						Calls:        stat.Calls,
+						LastCalledAt: stat.LastCalledAt,
+						InputTokens:  stat.InputTokens,
+						OutputTokens: stat.OutputTokens,
+						CostUSD:      stat.CostUSD(),
+					}
 				}
 				stats.ToolUsage[serverName] = inner
 			}
@@ -100,7 +106,7 @@ func (s *Server) optimizeStats() optimize.Stats {
 				OutputFormat:  ms.OutputFormat,
 			})
 		}
-		stats.PinStats = computeSchemaTokens(s.gateway)
+		stats.PinStats, stats.ToolSchemaTokens = computeSchemaTokens(s.gateway)
 	}
 	if acc := s.metricsAccumulator; acc != nil {
 		snap := acc.Snapshot()
@@ -177,24 +183,26 @@ func mergeHistogramModelStats(declared map[string]optimize.ModelStat, histograms
 	return out
 }
 
-// computeSchemaTokens estimates per-server schema-overhead tokens by
-// marshaling the live tool list through the gateway and applying a
-// chars-per-token heuristic. The pin store's PinRecord has SHA256
-// hashes only, not byte counts, so we go to the live source. The
-// schema_overhead heuristic treats this as a measurement, not a
-// guess — every byte counted here is a byte the gateway actually
-// shipped on the last tools/list response.
-func computeSchemaTokens(gateway *mcp.Gateway) map[string]optimize.PinStat {
+// computeSchemaTokens estimates schema-overhead tokens by marshaling the
+// live tool list through the gateway and applying a chars-per-token
+// heuristic, aggregated per server (for schema_overhead) and per tool
+// (for unused_tool impact) in one pass. The pin store's PinRecord has
+// SHA256 hashes only, not byte counts, so we go to the live source. The
+// consuming heuristics treat this as a measurement, not a guess — every
+// byte counted here is a byte the gateway actually shipped on the last
+// tools/list response.
+func computeSchemaTokens(gateway *mcp.Gateway) (map[string]optimize.PinStat, map[string]map[string]int) {
 	if gateway == nil {
-		return nil
+		return nil, nil
 	}
 	result, err := gateway.HandleToolsListUnscoped()
 	if err != nil || result == nil || len(result.Tools) == 0 {
-		return nil
+		return nil, nil
 	}
 	bytesPerServer := make(map[string]int, len(result.Tools))
+	tokensPerTool := make(map[string]map[string]int, len(result.Tools))
 	for _, tool := range result.Tools {
-		serverName, _, ok := splitPrefixedTool(tool.Name)
+		serverName, toolName, ok := splitPrefixedTool(tool.Name)
 		if !ok {
 			continue
 		}
@@ -203,20 +211,26 @@ func computeSchemaTokens(gateway *mcp.Gateway) map[string]optimize.PinStat {
 			continue
 		}
 		bytesPerServer[serverName] += len(raw)
-	}
-	if len(bytesPerServer) == 0 {
-		return nil
-	}
-	out := make(map[string]optimize.PinStat, len(bytesPerServer))
-	for name, bytes := range bytesPerServer {
+		inner, ok := tokensPerTool[serverName]
+		if !ok {
+			inner = make(map[string]int)
+			tokensPerTool[serverName] = inner
+		}
 		// Approximate token count via the OpenAI rule-of-thumb of ~4
 		// characters per token. JSON Schemas trend slightly token-dense
 		// because of curly braces and quoting, but ~4 is the right
 		// order of magnitude and we don't need precision for a
 		// threshold-driven heuristic.
+		inner[toolName] = len(raw) / 4
+	}
+	if len(bytesPerServer) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]optimize.PinStat, len(bytesPerServer))
+	for name, bytes := range bytesPerServer {
 		out[name] = optimize.PinStat{SchemaTokens: bytes / 4}
 	}
-	return out
+	return out, tokensPerTool
 }
 
 // splitPrefixedTool extracts the server name from the gateway's

--- a/internal/api/tools_usage.go
+++ b/internal/api/tools_usage.go
@@ -9,10 +9,14 @@ import (
 // GET /api/tools/usage. LastCalledAt is a pointer so a tool that has a
 // recorded call count but a zero timestamp (or never-called tools the UI
 // cross-references from the status list) renders as null rather than the
-// Go zero time.
+// Go zero time. CostUSD is a pointer for the same honesty rule every cost
+// surface follows: absent means "no priced calls", never $0.
 type toolUsageStat struct {
 	Calls        int64      `json:"calls"`
 	LastCalledAt *time.Time `json:"lastCalledAt,omitempty"`
+	InputTokens  int64      `json:"inputTokens,omitempty"`
+	OutputTokens int64      `json:"outputTokens,omitempty"`
+	CostUSD      *float64   `json:"costUsd,omitempty"`
 }
 
 // toolUsageResponse is the GET /api/tools/usage envelope. Servers maps each
@@ -27,7 +31,8 @@ type toolUsageResponse struct {
 }
 
 // handleToolsUsage serves GET /api/tools/usage: per-(server, tool) cumulative
-// call counts and last-called timestamps from the metrics accumulator. The
+// call counts, last-called timestamps, token counts, and estimated cost from
+// the metrics accumulator. The
 // data is seeded from disk on startup (telemetry.MetricsFlusher.SeedFromFile)
 // so it survives gateway restarts for servers with metrics persistence
 // enabled. Returns 503 when no accumulator is wired (no observation data
@@ -49,10 +54,18 @@ func (s *Server) handleToolsUsage(w http.ResponseWriter, _ *http.Request) {
 	for serverName, tools := range s.metricsAccumulator.ToolUsageSnapshot() {
 		inner := make(map[string]toolUsageStat, len(tools))
 		for toolName, stat := range tools {
-			entry := toolUsageStat{Calls: stat.Calls}
+			entry := toolUsageStat{
+				Calls:        stat.Calls,
+				InputTokens:  stat.InputTokens,
+				OutputTokens: stat.OutputTokens,
+			}
 			if !stat.LastCalledAt.IsZero() {
 				t := stat.LastCalledAt.UTC()
 				entry.LastCalledAt = &t
+			}
+			if stat.CostMicroUSD > 0 {
+				usd := stat.CostUSD()
+				entry.CostUSD = &usd
 			}
 			inner[toolName] = entry
 		}

--- a/internal/api/tools_usage_test.go
+++ b/internal/api/tools_usage_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,6 +57,58 @@ func TestHandleToolsUsage_ReportsPerToolCounts(t *testing.T) {
 	}
 	if resp.ObservedSince == nil || resp.ObservedSince.IsZero() {
 		t.Error("observedSince should be set when an accumulator is wired")
+	}
+}
+
+// TestHandleToolsUsage_ReportsTokensAndCost covers the per-tool cost
+// extension: tokens ride every recorded call, costUsd appears only for
+// priced tools, and an unpriced tool omits the field entirely (never $0).
+func TestHandleToolsUsage_ReportsTokensAndCost(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	acc := srv.metricsAccumulator
+	acc.RecordToolCallUsage("github", "create_issue", 120, 80)
+	acc.RecordToolCost("github", "create_issue", metrics.CostBreakdown{Input: 0.001, Output: 0.002})
+	acc.RecordToolCallUsage("github", "list_repos", 30, 10)
+
+	resp, code := decodeToolUsage(t, srv)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+
+	priced := resp.Servers["github"]["create_issue"]
+	if priced.InputTokens != 120 || priced.OutputTokens != 80 {
+		t.Errorf("priced tokens = %d/%d, want 120/80", priced.InputTokens, priced.OutputTokens)
+	}
+	if priced.CostUSD == nil {
+		t.Fatal("priced tool costUsd missing")
+	}
+	if got, want := *priced.CostUSD, 0.003; got < want-1e-9 || got > want+1e-9 {
+		t.Errorf("costUsd = %v, want %v", got, want)
+	}
+
+	unpriced := resp.Servers["github"]["list_repos"]
+	if unpriced.InputTokens != 30 || unpriced.OutputTokens != 10 {
+		t.Errorf("unpriced tokens = %d/%d, want 30/10", unpriced.InputTokens, unpriced.OutputTokens)
+	}
+	if unpriced.CostUSD != nil {
+		t.Errorf("unpriced tool costUsd = %v, want absent", *unpriced.CostUSD)
+	}
+}
+
+// TestHandleToolsUsage_UnpricedOmitsCostKey pins the raw JSON contract:
+// the costUsd key is absent for unpriced tools, not null or 0.
+func TestHandleToolsUsage_UnpricedOmitsCostKey(t *testing.T) {
+	srv := newTestServerWithMetrics(t)
+	srv.metricsAccumulator.RecordToolCall("github", "list_repos")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tools/usage", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if body := rec.Body.String(); strings.Contains(body, "costUsd") {
+		t.Errorf("unpriced response must not carry costUsd: %s", body)
 	}
 }
 

--- a/pkg/metrics/accumulator.go
+++ b/pkg/metrics/accumulator.go
@@ -269,21 +269,39 @@ type modelCounters struct {
 
 // ToolStat is the snapshot shape for per-(server, tool) call tracking.
 // Used by pkg/optimize to detect tools that have not seen any calls
-// inside a freshness window. Calls is the cumulative count since the
-// accumulator was created or last cleared; LastCalledAt is the wall-clock
-// time the most recent call was recorded, or the zero value when no
-// calls have been recorded.
+// inside a freshness window and to attribute observed spend per tool.
+// Calls is the cumulative count since the accumulator was created or
+// last cleared; LastCalledAt is the wall-clock time the most recent call
+// was recorded, or the zero value when no calls have been recorded.
+// InputTokens/OutputTokens are the cumulative token counts of the tool's
+// own calls; CostMicroUSD is the cumulative priced cost of those calls
+// in micro-USD (zero when no call was priced). The token/cost fields are
+// omitempty so persisted lines written before per-tool cost attribution
+// stay byte-identical.
 type ToolStat struct {
 	Calls        int64     `json:"calls"`
 	LastCalledAt time.Time `json:"last_called_at,omitempty"`
+	InputTokens  int64     `json:"input_tokens,omitempty"`
+	OutputTokens int64     `json:"output_tokens,omitempty"`
+	CostMicroUSD int64     `json:"cost_micro_usd,omitempty"`
+}
+
+// CostUSD returns the tool's cumulative priced cost in USD.
+func (t ToolStat) CostUSD() float64 {
+	return microToUSD(t.CostMicroUSD)
 }
 
 // toolUsage holds per-(server, tool) atomic counters. lastCalledNanos
 // stores time.UnixNano so the read path can produce a time.Time without
-// taking a lock. Keyed by (serverName -> toolName) in the accumulator.
+// taking a lock. Cost is stored in micro-USD (matching modelCounters) so
+// the counter stays a lock-free integer. Keyed by (serverName -> toolName)
+// in the accumulator.
 type toolUsage struct {
 	calls           atomic.Int64
 	lastCalledNanos atomic.Int64
+	inputTokens     atomic.Int64
+	outputTokens    atomic.Int64
+	costMicroUSD    atomic.Int64
 }
 
 // promptUsage holds per-skill atomic counters for prompts/get serving. Same
@@ -539,6 +557,43 @@ func (a *Accumulator) RecordToolCall(serverName, toolName string) {
 	tu.lastCalledNanos.Store(time.Now().UnixNano())
 }
 
+// RecordToolCallUsage is RecordToolCall plus the call's token counts: one
+// bucket lookup increments the call counter, stamps the last-called
+// timestamp, and adds input/output tokens, so the observer's hot path
+// touches the tool-usage map once per call.
+//
+// An empty serverName or toolName is a no-op so callers without per-tool
+// attribution (legacy ToolCallObserver path) can invoke unconditionally.
+func (a *Accumulator) RecordToolCallUsage(serverName, toolName string, inputTokens, outputTokens int) {
+	if serverName == "" || toolName == "" {
+		return
+	}
+	tu := a.getOrCreateToolUsage(serverName, toolName)
+	tu.calls.Add(1)
+	tu.lastCalledNanos.Store(time.Now().UnixNano())
+	tu.inputTokens.Add(int64(inputTokens))
+	tu.outputTokens.Add(int64(outputTokens))
+}
+
+// RecordToolCost adds a priced call's USD cost to the per-(server, tool)
+// micro-USD counter. Called only when the observer priced the call, so an
+// unpriced call leaves the tool's cost untouched (never a fabricated $0).
+//
+// An empty serverName or toolName is a no-op so callers without per-tool
+// attribution (legacy ToolCallObserver path) can invoke unconditionally.
+func (a *Accumulator) RecordToolCost(serverName, toolName string, cost CostBreakdown) {
+	if serverName == "" || toolName == "" {
+		return
+	}
+	if cost.IsZero() || !cost.IsValid() {
+		return
+	}
+	totalMicro := usdToMicro(cost.Input) + usdToMicro(cost.Output) +
+		usdToMicro(cost.CacheRead) + usdToMicro(cost.CacheWrite)
+	tu := a.getOrCreateToolUsage(serverName, toolName)
+	tu.costMicroUSD.Add(totalMicro)
+}
+
 func (a *Accumulator) getOrCreateToolUsage(serverName, toolName string) *toolUsage {
 	a.toolUsageMu.RLock()
 	if m, ok := a.toolUsage[serverName]; ok {
@@ -582,7 +637,13 @@ func (a *Accumulator) ToolUsageSnapshot() map[string]map[string]ToolStat {
 			if nanos := tu.lastCalledNanos.Load(); nanos > 0 {
 				lastCalled = time.Unix(0, nanos)
 			}
-			inner[toolName] = ToolStat{Calls: calls, LastCalledAt: lastCalled}
+			inner[toolName] = ToolStat{
+				Calls:        calls,
+				LastCalledAt: lastCalled,
+				InputTokens:  tu.inputTokens.Load(),
+				OutputTokens: tu.outputTokens.Load(),
+				CostMicroUSD: tu.costMicroUSD.Load(),
+			}
 		}
 		out[serverName] = inner
 	}
@@ -600,10 +661,12 @@ func (a *Accumulator) ToolUsageSnapshot() map[string]map[string]ToolStat {
 // code-mode calls (Gateway.CallTool → HandleToolsCall → Observer →
 // RecordToolCall), so a restored snapshot reflects both equally.
 //
-// Restore is max-wins per counter: an existing in-memory value is kept when
-// it already exceeds the restored one (defensive against a seed racing late
-// initialization). Entries with no recorded calls are skipped so the snapshot
-// stays sparse. An empty map is a no-op.
+// Restore is max-wins per counter — calls, tokens, and micro-USD cost alike:
+// an existing in-memory value is kept when it already exceeds the restored one
+// (defensive against a seed racing late initialization; all four counters are
+// monotonic between resets, so max-wins never double-counts). Entries with no
+// recorded calls are skipped so the snapshot stays sparse. An empty map is a
+// no-op.
 func (a *Accumulator) RestoreToolUsage(perServer map[string]map[string]ToolStat) {
 	if len(perServer) == 0 {
 		return
@@ -635,6 +698,15 @@ func (a *Accumulator) RestoreToolUsage(perServer map[string]map[string]ToolStat)
 				if nanos := stat.LastCalledAt.UnixNano(); nanos > tu.lastCalledNanos.Load() {
 					tu.lastCalledNanos.Store(nanos)
 				}
+			}
+			if stat.InputTokens > tu.inputTokens.Load() {
+				tu.inputTokens.Store(stat.InputTokens)
+			}
+			if stat.OutputTokens > tu.outputTokens.Load() {
+				tu.outputTokens.Store(stat.OutputTokens)
+			}
+			if stat.CostMicroUSD > tu.costMicroUSD.Load() {
+				tu.costMicroUSD.Store(stat.CostMicroUSD)
 			}
 		}
 	}
@@ -1801,6 +1873,16 @@ func (a *Accumulator) ClearCost() {
 		cc.cacheWriteCostMicroUSD.Store(0)
 	}
 	a.clientMu.RUnlock()
+
+	// Per-tool cost is cost data; per-tool calls and tokens are usage data
+	// and survive a cost wipe (mirroring how server token counters persist).
+	a.toolUsageMu.RLock()
+	for _, tools := range a.toolUsage {
+		for _, tu := range tools {
+			tu.costMicroUSD.Store(0)
+		}
+	}
+	a.toolUsageMu.RUnlock()
 
 	// Model histograms are pure cost data — drop them entirely (rather than
 	// zeroing) so a cleared entity reports provenance `none`, not a `mixed`

--- a/pkg/metrics/accumulator_test.go
+++ b/pkg/metrics/accumulator_test.go
@@ -911,6 +911,86 @@ func TestAccumulator_RecordToolCall_EmptyArgsAreNoOp(t *testing.T) {
 	}
 }
 
+func TestAccumulator_RecordToolCallUsage(t *testing.T) {
+	acc := NewAccumulator(100)
+
+	acc.RecordToolCallUsage("github", "create_issue", 120, 340)
+	acc.RecordToolCallUsage("github", "create_issue", 80, 60)
+
+	stat := acc.ToolUsageSnapshot()["github"]["create_issue"]
+	if stat.Calls != 2 {
+		t.Errorf("Calls = %d, want 2", stat.Calls)
+	}
+	if stat.LastCalledAt.IsZero() {
+		t.Error("LastCalledAt should be non-zero")
+	}
+	if stat.InputTokens != 200 {
+		t.Errorf("InputTokens = %d, want 200", stat.InputTokens)
+	}
+	if stat.OutputTokens != 400 {
+		t.Errorf("OutputTokens = %d, want 400", stat.OutputTokens)
+	}
+	if stat.CostMicroUSD != 0 {
+		t.Errorf("CostMicroUSD = %d, want 0 (no priced call)", stat.CostMicroUSD)
+	}
+}
+
+func TestAccumulator_RecordToolCallUsage_EmptyArgsAreNoOp(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordToolCallUsage("", "create_issue", 10, 10)
+	acc.RecordToolCallUsage("github", "", 10, 10)
+	if snap := acc.ToolUsageSnapshot(); len(snap) != 0 {
+		t.Errorf("expected empty tool usage; got %v", snap)
+	}
+}
+
+func TestAccumulator_RecordToolCost(t *testing.T) {
+	acc := NewAccumulator(100)
+
+	acc.RecordToolCall("github", "create_issue")
+	acc.RecordToolCost("github", "create_issue", CostBreakdown{Input: 0.001, Output: 0.002})
+	acc.RecordToolCost("github", "create_issue", CostBreakdown{Input: 0.0005, CacheRead: 0.0001})
+
+	stat := acc.ToolUsageSnapshot()["github"]["create_issue"]
+	if want := int64(3600); stat.CostMicroUSD != want {
+		t.Errorf("CostMicroUSD = %d, want %d", stat.CostMicroUSD, want)
+	}
+	if got, want := stat.CostUSD(), 0.0036; got < want-1e-9 || got > want+1e-9 {
+		t.Errorf("CostUSD() = %v, want %v", got, want)
+	}
+}
+
+func TestAccumulator_RecordToolCost_GuardsInvalidInput(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordToolCost("", "create_issue", CostBreakdown{Input: 0.001})
+	acc.RecordToolCost("github", "", CostBreakdown{Input: 0.001})
+	if snap := acc.ToolUsageSnapshot(); len(snap) != 0 {
+		t.Errorf("expected empty tool usage after empty-name records; got %v", snap)
+	}
+	acc.RecordToolCall("github", "create_issue")
+	acc.RecordToolCost("github", "create_issue", CostBreakdown{})              // zero
+	acc.RecordToolCost("github", "create_issue", CostBreakdown{Input: -0.01}) // invalid
+	if got := acc.ToolUsageSnapshot()["github"]["create_issue"].CostMicroUSD; got != 0 {
+		t.Errorf("CostMicroUSD = %d, want 0 after zero/invalid records", got)
+	}
+}
+
+func TestAccumulator_ClearCost_ZeroesToolCostKeepsUsage(t *testing.T) {
+	acc := NewAccumulator(100)
+	acc.RecordToolCallUsage("github", "create_issue", 100, 200)
+	acc.RecordToolCost("github", "create_issue", CostBreakdown{Input: 0.001})
+
+	acc.ClearCost()
+
+	stat := acc.ToolUsageSnapshot()["github"]["create_issue"]
+	if stat.CostMicroUSD != 0 {
+		t.Errorf("CostMicroUSD = %d, want 0 after ClearCost", stat.CostMicroUSD)
+	}
+	if stat.Calls != 1 || stat.InputTokens != 100 || stat.OutputTokens != 200 {
+		t.Errorf("ClearCost must keep calls/tokens; got %+v", stat)
+	}
+}
+
 func TestAccumulator_ToolUsageSnapshot_EmptyAccumulator(t *testing.T) {
 	acc := NewAccumulator(100)
 	if snap := acc.ToolUsageSnapshot(); snap != nil {
@@ -986,6 +1066,47 @@ func TestAccumulator_RestoreToolUsage(t *testing.T) {
 		acc.RestoreToolUsage(nil)
 		if snap := acc.ToolUsageSnapshot(); snap != nil {
 			t.Errorf("nil restore should be no-op; got %v", snap)
+		}
+	})
+
+	t.Run("restores tokens and cost, then accumulates on top", func(t *testing.T) {
+		acc := NewAccumulator(100)
+		acc.RestoreToolUsage(map[string]map[string]ToolStat{
+			"github": {
+				"create_issue": {Calls: 5, InputTokens: 500, OutputTokens: 300, CostMicroUSD: 1200},
+			},
+		})
+
+		stat := acc.ToolUsageSnapshot()["github"]["create_issue"]
+		if stat.InputTokens != 500 || stat.OutputTokens != 300 || stat.CostMicroUSD != 1200 {
+			t.Fatalf("restored stat = %+v, want tokens 500/300 cost 1200", stat)
+		}
+
+		// Live traffic continues from the restored counters.
+		acc.RecordToolCallUsage("github", "create_issue", 10, 20)
+		acc.RecordToolCost("github", "create_issue", CostBreakdown{Input: 0.0001})
+		stat = acc.ToolUsageSnapshot()["github"]["create_issue"]
+		if stat.Calls != 6 || stat.InputTokens != 510 || stat.OutputTokens != 320 || stat.CostMicroUSD != 1300 {
+			t.Errorf("stat after restore+record = %+v, want calls 6, tokens 510/320, cost 1300", stat)
+		}
+	})
+
+	t.Run("max-wins per token and cost counter", func(t *testing.T) {
+		acc := NewAccumulator(100)
+		acc.RecordToolCallUsage("github", "create_issue", 1000, 1000)
+		acc.RecordToolCost("github", "create_issue", CostBreakdown{Input: 0.01}) // 10_000 micro
+		acc.RestoreToolUsage(map[string]map[string]ToolStat{
+			"github": {"create_issue": {Calls: 5, InputTokens: 100, OutputTokens: 2000, CostMicroUSD: 500}},
+		})
+		stat := acc.ToolUsageSnapshot()["github"]["create_issue"]
+		if stat.InputTokens != 1000 {
+			t.Errorf("InputTokens = %d, want 1000 (live wins over smaller restore)", stat.InputTokens)
+		}
+		if stat.OutputTokens != 2000 {
+			t.Errorf("OutputTokens = %d, want 2000 (larger restore wins)", stat.OutputTokens)
+		}
+		if stat.CostMicroUSD != 10_000 {
+			t.Errorf("CostMicroUSD = %d, want 10000 (live wins over smaller restore)", stat.CostMicroUSD)
 		}
 	})
 }

--- a/pkg/metrics/observer.go
+++ b/pkg/metrics/observer.go
@@ -90,7 +90,9 @@ func (o *Observer) observe(serverName string, replicaID int, clientID, toolName 
 	}
 
 	o.accumulator.RecordReplicaWithClient(serverName, replicaID, clientID, inputTokens, outputTokens)
-	o.accumulator.RecordToolCall(serverName, toolName)
+	// Per-tool attribution no-ops on the legacy path (empty toolName), so a
+	// legacy observer never creates a phantom "" tool entry.
+	o.accumulator.RecordToolCallUsage(serverName, toolName, inputTokens, outputTokens)
 
 	summary := mcp.ToolCallSummary{
 		InputTokens:  inputTokens,
@@ -117,12 +119,14 @@ func (o *Observer) observe(serverName string, replicaID int, clientID, toolName 
 	if !ok {
 		return summary
 	}
-	o.accumulator.RecordCostWithModel(serverName, replicaID, clientID, model, inputTokens, outputTokens, CostBreakdown{
+	breakdown := CostBreakdown{
 		Input:      cost.Input,
 		Output:     cost.Output,
 		CacheRead:  cost.CacheRead,
 		CacheWrite: cost.CacheWrite,
-	})
+	}
+	o.accumulator.RecordCostWithModel(serverName, replicaID, clientID, model, inputTokens, outputTokens, breakdown)
+	o.accumulator.RecordToolCost(serverName, toolName, breakdown)
 	summary.CostUSD = cost.Input + cost.Output + cost.CacheRead + cost.CacheWrite
 	summary.HasCost = summary.CostUSD > 0
 	return summary

--- a/pkg/metrics/observer_test.go
+++ b/pkg/metrics/observer_test.go
@@ -216,6 +216,92 @@ func TestObserver_SkipsCostWhenModelUnknown(t *testing.T) {
 	}
 }
 
+// TestObserver_PerToolAttribution verifies the client-aware path records
+// per-tool tokens for every call and per-tool cost only for priced calls,
+// with the tool's cost matching what the per-server counters recorded for
+// the same traffic.
+func TestObserver_PerToolAttribution(t *testing.T) {
+	prev := pricing.CurrentSource()
+	defer pricing.SetSource(prev)
+	pricing.SetSource(staticSource{name: "fixture", rates: map[string]pricing.Rates{
+		"claude-fixture": {InputPerToken: 3e-6, OutputPerToken: 15e-6},
+	}})
+
+	counter := token.NewHeuristicCounter(4)
+	acc := NewAccumulator(100)
+	obs := NewObserver(counter, acc)
+	obs.SetModelResolver(func(serverName, _ string) string {
+		if serverName == "priced" {
+			return "claude-fixture"
+		}
+		return ""
+	})
+
+	args := map[string]any{"q": "hello"}
+	result := &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent("response")}}
+
+	obs.ObserveToolCallWithClient(context.Background(), mcp.ToolCallObservation{
+		ServerName: "priced", ReplicaID: -1, ClientID: "client-a", ToolName: "create_issue",
+		Arguments: args, Result: result,
+	})
+	obs.ObserveToolCallWithClient(context.Background(), mcp.ToolCallObservation{
+		ServerName: "unpriced", ReplicaID: -1, ClientID: "client-a", ToolName: "read_file",
+		Arguments: args, Result: result,
+	})
+
+	snap := acc.ToolUsageSnapshot()
+
+	priced := snap["priced"]["create_issue"]
+	inputTokens := int64(token.CountJSON(counter, args))
+	outputTokens := int64(counter.Count("response"))
+	if priced.InputTokens != inputTokens || priced.OutputTokens != outputTokens {
+		t.Errorf("priced tool tokens = %d/%d, want %d/%d", priced.InputTokens, priced.OutputTokens, inputTokens, outputTokens)
+	}
+	if priced.CostMicroUSD <= 0 {
+		t.Errorf("priced tool CostMicroUSD = %d, want >0", priced.CostMicroUSD)
+	}
+	// The tool's cost equals the server's cost — it was the only call.
+	serverCost := acc.CostSnapshot().PerServer["priced"].TotalUSD
+	if !approxUSDEq(priced.CostUSD(), serverCost) {
+		t.Errorf("per-tool cost %v != per-server cost %v", priced.CostUSD(), serverCost)
+	}
+
+	unpriced := snap["unpriced"]["read_file"]
+	if unpriced.InputTokens != inputTokens || unpriced.OutputTokens != outputTokens {
+		t.Errorf("unpriced tool tokens = %d/%d, want %d/%d", unpriced.InputTokens, unpriced.OutputTokens, inputTokens, outputTokens)
+	}
+	if unpriced.CostMicroUSD != 0 {
+		t.Errorf("unpriced tool CostMicroUSD = %d, want 0", unpriced.CostMicroUSD)
+	}
+}
+
+// TestObserver_LegacyPathRecordsNoPhantomTool verifies the legacy observer
+// entry point (no tool name) never creates a "" tool entry — even when the
+// call is priced and per-server cost is recorded.
+func TestObserver_LegacyPathRecordsNoPhantomTool(t *testing.T) {
+	prev := pricing.CurrentSource()
+	defer pricing.SetSource(prev)
+	pricing.SetSource(staticSource{name: "fixture", rates: map[string]pricing.Rates{
+		"claude-fixture": {InputPerToken: 3e-6, OutputPerToken: 15e-6},
+	}})
+
+	counter := token.NewHeuristicCounter(4)
+	acc := NewAccumulator(100)
+	obs := NewObserver(counter, acc)
+	obs.SetModelResolver(func(string, string) string { return "claude-fixture" })
+
+	args := map[string]any{"q": "hello"}
+	result := &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent("response")}}
+	obs.ObserveToolCall("server-a", -1, args, result)
+
+	if cost := acc.CostSnapshot().PerServer["server-a"].TotalUSD; cost <= 0 {
+		t.Fatalf("per-server cost = %v, want >0 (the call itself is priced)", cost)
+	}
+	if snap := acc.ToolUsageSnapshot(); snap != nil {
+		t.Errorf("legacy path must not create per-tool entries; got %v", snap)
+	}
+}
+
 // TestObserver_CallLevelModelOverridesResolver confirms a model carried in
 // the call's CallUsage takes precedence over the server-level resolver —
 // gateway operators can override per-server defaults at the call site

--- a/pkg/optimize/optimize.go
+++ b/pkg/optimize/optimize.go
@@ -196,6 +196,14 @@ type Stats struct {
 	// data source is available so the heuristic skips silently.
 	PinStats map[string]PinStat
 
+	// ToolSchemaTokens is the estimated schema-token cost of each
+	// individual tool definition, keyed server -> tool. Populated from
+	// the same live tools/list measurement as PinStats. Used by
+	// unused_tool to price the context tax an unused tool's definition
+	// adds to every prompt. nil (or a missing tool) falls back to a
+	// conservative per-tool estimate.
+	ToolSchemaTokens map[string]map[string]int
+
 	// FormatBaseline is the session-wide format-conversion savings rate
 	// observed across servers that DO use `output_format: toon|csv`.
 	// Used by the format_savings_shortfall heuristic to project savings
@@ -276,10 +284,15 @@ type ModelStat struct {
 
 // ToolStat mirrors metrics.ToolStat so pkg/optimize stays free of an
 // import on pkg/metrics. Callers can populate it directly from
-// metrics.Accumulator.ToolUsageSnapshot().
+// metrics.Accumulator.ToolUsageSnapshot(). InputTokens/OutputTokens and
+// CostUSD carry the tool's observed traffic and priced spend; zero values
+// simply mean "nothing recorded" and no heuristic treats them as measured.
 type ToolStat struct {
 	Calls        int64
 	LastCalledAt time.Time
+	InputTokens  int64
+	OutputTokens int64
+	CostUSD      float64
 }
 
 // Options tunes the Analyze pass. All fields are optional.
@@ -316,6 +329,13 @@ const (
 	// tokens, the Anthropic Sonnet rate, is a defensible mid-range
 	// number across providers in 2026.
 	estimatedInputUSDPerToken = 3.0 / 1_000_000.0
+
+	// estimatedToolSchemaTokens is the fallback schema cost of a single
+	// tool definition when no measured per-tool count is available.
+	// Published measurements put real tools at roughly 100-1,000 tokens;
+	// 300 deliberately understates the median so unused_tool impact
+	// never over-promises on unmeasured tools.
+	estimatedToolSchemaTokens = 300
 
 	// schemaOverheadMinSchemaTokens is the floor on schema size below
 	// which schema_overhead never fires — small servers never push a
@@ -496,7 +516,7 @@ func detectUnusedTools(stats Stats, now, cutoff time.Time) []Finding {
 				Summary:          summaryUnusedTool(srv.Name, tool),
 				Server:           srv.Name,
 				Tool:             tool,
-				ImpactUSDPerWeek: 0, // per-tool schema savings land in PR 5
+				ImpactUSDPerWeek: unusedToolImpact(usage, stats.ToolSchemaTokens[srv.Name][tool]),
 				Remediation:      remediationUnusedTool(srv, tool),
 				DetectedAt:       now,
 			})
@@ -505,8 +525,37 @@ func detectUnusedTools(stats Stats, now, cutoff time.Time) []Finding {
 	return out
 }
 
+// observedPerTokenRate returns the server's effective per-token rate
+// (recorded cost ÷ recorded tokens) when it has priced traffic, and the
+// conservative default estimate otherwise. The impact heuristics share
+// this so a future correction to the rate derivation lands in one place.
+func observedPerTokenRate(usage ServerUsage) float64 {
+	if usage.TotalTokens > 0 && usage.TotalCostUSD > 0 {
+		return usage.TotalCostUSD / float64(usage.TotalTokens)
+	}
+	return estimatedInputUSDPerToken
+}
+
+// unusedToolImpact prices the context tax of one unused tool's schema:
+// the tokens its definition adds to every prompt × estimated weekly
+// prompts × the server's per-token rate. An unused tool has zero observed
+// spend by definition, so this is the schema-tax analogue of
+// unusedServerImpact, not a measured-spend number — the same discipline
+// applies: observed rate when the server has priced traffic, the
+// conservative default otherwise, and a cap so a single oversized schema
+// never over-promises.
+func unusedToolImpact(usage ServerUsage, schemaTokens int) float64 {
+	tokens := schemaTokens
+	if tokens <= 0 {
+		tokens = estimatedToolSchemaTokens
+	}
+	if tokens > estimatedSchemaOverheadTokens {
+		tokens = estimatedSchemaOverheadTokens // cap at the per-server estimate to stay conservative
+	}
+	return float64(tokens) * estimatedPromptsPerWeek * observedPerTokenRate(usage)
+}
+
 func unusedServerImpact(srv ServerInfo, usage ServerUsage) float64 {
-	rate := estimatedInputUSDPerToken
 	// If the server has any historic cost we use its observed per-token
 	// rate; otherwise we fall back to the conservative default. We do
 	// not invent numbers when there is no data — usage stays zero, so
@@ -515,9 +564,7 @@ func unusedServerImpact(srv ServerInfo, usage ServerUsage) float64 {
 	// defensible upper bound for the unused_server case (which has no
 	// usage data by definition) without claiming an impact we did not
 	// measure end-to-end.
-	if usage.TotalTokens > 0 && usage.TotalCostUSD > 0 {
-		rate = usage.TotalCostUSD / float64(usage.TotalTokens)
-	}
+	rate := observedPerTokenRate(usage)
 	tools := len(srv.Tools)
 	if tools <= 0 {
 		tools = 1
@@ -651,10 +698,7 @@ func detectFormatSavingsShortfall(stats Stats, now time.Time) []Finding {
 		// when no cost has been recorded yet (rare for a server with
 		// >5K output tokens but possible right after pricing data was
 		// cleared via DELETE /api/metrics/cost).
-		rate := estimatedInputUSDPerToken
-		if usage.TotalTokens > 0 && usage.TotalCostUSD > 0 {
-			rate = usage.TotalCostUSD / float64(usage.TotalTokens)
-		}
+		rate := observedPerTokenRate(usage)
 		projectedSavedTokens := float64(usage.OutputTokens) * stats.FormatBaseline.SavingsPercent / 100.0
 		impact := projectedSavedTokens * rate * formatShortfallProjectionWeeks
 		out = append(out, Finding{
@@ -729,11 +773,7 @@ func detectExpensiveModelOnCheapTask(stats Stats, now time.Time) []Finding {
 }
 
 func schemaOverheadImpact(schemaTokens int, usage ServerUsage) float64 {
-	rate := estimatedInputUSDPerToken
-	if usage.TotalTokens > 0 && usage.TotalCostUSD > 0 {
-		rate = usage.TotalCostUSD / float64(usage.TotalTokens)
-	}
-	return float64(schemaTokens) * estimatedPromptsPerWeek * rate
+	return float64(schemaTokens) * estimatedPromptsPerWeek * observedPerTokenRate(usage)
 }
 
 func summarySchemaOverhead(srv ServerInfo, pin PinStat, usage ServerUsage, ratio float64) string {

--- a/pkg/optimize/optimize_test.go
+++ b/pkg/optimize/optimize_test.go
@@ -146,6 +146,101 @@ func TestAnalyze_UnusedTool_FiresWhenToolColdInWindow(t *testing.T) {
 	if !strings.Contains(hit.Remediation, "list_issues") {
 		t.Errorf("remediation should reference tool name; got %q", hit.Remediation)
 	}
+	if hit.ImpactUSDPerWeek <= 0 {
+		t.Errorf("ImpactUSDPerWeek = %v, want >0 (schema-tax impact)", hit.ImpactUSDPerWeek)
+	}
+}
+
+func TestAnalyze_UnusedTool_ImpactFromMeasuredSchemaTokens(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "github", Tools: []string{"create_issue", "list_issues"}, Initialized: true},
+	}
+	// Observed rate = 0.001 / 100 = 1e-5 USD per token.
+	stats.Usage = map[string]ServerUsage{
+		"github": {TotalTokens: 100, TotalCostUSD: 0.001},
+	}
+	stats.ToolUsage = map[string]map[string]ToolStat{
+		"github": {
+			"create_issue": {Calls: 3, LastCalledAt: fixedNow.Add(-2 * time.Hour)},
+		},
+	}
+	stats.ToolSchemaTokens = map[string]map[string]int{
+		"github": {"list_issues": 800},
+	}
+
+	rep := Analyze(stats, Options{})
+
+	hit := findToolFinding(t, rep, "unused_tool", "list_issues")
+	// 800 schema tokens × 500 prompts/week × 1e-5 USD/token = $4.00/week.
+	want := 800.0 * estimatedPromptsPerWeek * 1e-5
+	if diff := hit.ImpactUSDPerWeek - want; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("ImpactUSDPerWeek = %v, want %v", hit.ImpactUSDPerWeek, want)
+	}
+}
+
+func TestAnalyze_UnusedTool_ImpactFallsBackWithoutSchemaTokens(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "github", Tools: []string{"create_issue", "list_issues"}, Initialized: true},
+	}
+	stats.Usage = map[string]ServerUsage{
+		"github": {TotalTokens: 100, TotalCostUSD: 0.001},
+	}
+	stats.ToolUsage = map[string]map[string]ToolStat{
+		"github": {
+			"create_issue": {Calls: 3, LastCalledAt: fixedNow.Add(-2 * time.Hour)},
+		},
+	}
+	// stats.ToolSchemaTokens intentionally nil — no live tools/list measurement.
+
+	rep := Analyze(stats, Options{})
+
+	hit := findToolFinding(t, rep, "unused_tool", "list_issues")
+	// estimatedToolSchemaTokens × 500 prompts/week × observed 1e-5 USD/token.
+	want := float64(estimatedToolSchemaTokens) * estimatedPromptsPerWeek * 1e-5
+	if diff := hit.ImpactUSDPerWeek - want; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("ImpactUSDPerWeek = %v, want %v (conservative fallback)", hit.ImpactUSDPerWeek, want)
+	}
+}
+
+func TestAnalyze_UnusedTool_ImpactCappedAtServerEstimate(t *testing.T) {
+	stats := baseStats()
+	stats.Servers = []ServerInfo{
+		{Name: "github", Tools: []string{"create_issue", "list_issues"}, Initialized: true},
+	}
+	stats.Usage = map[string]ServerUsage{
+		"github": {TotalTokens: 100, TotalCostUSD: 0.001},
+	}
+	stats.ToolUsage = map[string]map[string]ToolStat{
+		"github": {
+			"create_issue": {Calls: 3, LastCalledAt: fixedNow.Add(-2 * time.Hour)},
+		},
+	}
+	// An oversized single-tool schema must not over-promise.
+	stats.ToolSchemaTokens = map[string]map[string]int{
+		"github": {"list_issues": 50_000},
+	}
+
+	rep := Analyze(stats, Options{})
+
+	hit := findToolFinding(t, rep, "unused_tool", "list_issues")
+	want := float64(estimatedSchemaOverheadTokens) * estimatedPromptsPerWeek * 1e-5
+	if diff := hit.ImpactUSDPerWeek - want; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("ImpactUSDPerWeek = %v, want %v (capped)", hit.ImpactUSDPerWeek, want)
+	}
+}
+
+// findToolFinding returns the finding for (heuristic, tool) or fails the test.
+func findToolFinding(t *testing.T, rep OptimizeReport, heuristic, tool string) *Finding {
+	t.Helper()
+	for i := range rep.Findings {
+		if rep.Findings[i].Heuristic == heuristic && rep.Findings[i].Tool == tool {
+			return &rep.Findings[i]
+		}
+	}
+	t.Fatalf("expected %s finding for %s; findings: %+v", heuristic, tool, rep.Findings)
+	return nil
 }
 
 func TestAnalyze_UnusedTool_HonorsWhitelist(t *testing.T) {

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -37,12 +37,16 @@ type MetricsSnapshotLine struct {
 	Total     metrics.TokenCounts         `json:"total"`
 	CostDiff  *metrics.CostMicroUSDCounts `json:"cost_diff,omitempty"`
 	CostTotal *metrics.CostMicroUSDCounts `json:"cost_total,omitempty"`
-	// ToolUsage carries the server's *cumulative* per-tool call counters
-	// (toolName -> calls + last-called) at flush time — the analogue of
-	// Total for tools, not a per-minute diff. omitempty keeps token-only
-	// minutes and legacy pre-tool-usage files byte-identical; SeedFromFile
-	// takes the most recent non-nil ToolUsage per server (resetting on a
-	// token Reset) to rehydrate Audit Mode's usage history across restarts.
+	// ToolUsage carries the server's *cumulative* per-tool counters
+	// (toolName -> calls + last-called + tokens + micro-USD cost) at flush
+	// time — the analogue of Total for tools, not a per-minute diff. The
+	// token/cost fields on ToolStat are omitempty, so lines written before
+	// per-tool cost attribution parse cleanly (zero values) and token-only
+	// entries keep their legacy serialization. omitempty on the map keeps
+	// token-only minutes and legacy pre-tool-usage files byte-identical;
+	// SeedFromFile takes the most recent non-nil ToolUsage per server
+	// (resetting on a token Reset) to rehydrate Audit Mode's usage history
+	// and per-tool spend across restarts.
 	ToolUsage map[string]metrics.ToolStat `json:"tool_usage,omitempty"`
 	// PromptUsage carries *cumulative* per-skill prompts/get call counters
 	// (skillName -> calls + last-called) at flush time. Unlike ToolUsage it
@@ -528,7 +532,14 @@ func toolUsageChanged(prev, current map[string]metrics.ToolStat) bool {
 		return true
 	}
 	for tool, cur := range current {
-		if p, ok := prev[tool]; !ok || p.Calls != cur.Calls {
+		// Every counter participates: CostMicroUSD can move independently of
+		// Calls (ClearCost zeroes it), and a snapshot can land between the
+		// observer's calls-counter and token-counter updates — comparing
+		// tokens ensures the next flush corrects an understated line instead
+		// of persisting it forever.
+		p, ok := prev[tool]
+		if !ok || p.Calls != cur.Calls || p.InputTokens != cur.InputTokens ||
+			p.OutputTokens != cur.OutputTokens || p.CostMicroUSD != cur.CostMicroUSD {
 			return true
 		}
 	}

--- a/pkg/telemetry/metrics_test.go
+++ b/pkg/telemetry/metrics_test.go
@@ -615,6 +615,56 @@ func TestMetricsFlusher_ToolUsagePersistence(t *testing.T) {
 		}
 	})
 
+	t.Run("per-tool tokens and cost round-trip through flush and seed", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		acc := metrics.NewAccumulator(100)
+		acc.Record("github", 100, 50)
+		acc.RecordToolCallUsage("github", "create_issue", 100, 50)
+		acc.RecordToolCost("github", "create_issue", metrics.CostBreakdown{Input: 0.001, Output: 0.002})
+
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.AddServer("github", path, LogOpts{}); err != nil {
+			t.Fatalf("AddServer: %v", err)
+		}
+		f.flushOnce(time.Now())
+
+		acc2 := metrics.NewAccumulator(100)
+		f2 := NewMetricsFlusher(acc2, time.Hour)
+		if err := f2.SeedFromFile(path, 100); err != nil {
+			t.Fatalf("SeedFromFile: %v", err)
+		}
+		stat := acc2.ToolUsageSnapshot()["github"]["create_issue"]
+		if stat.InputTokens != 100 || stat.OutputTokens != 50 {
+			t.Errorf("restored tokens = %d/%d, want 100/50", stat.InputTokens, stat.OutputTokens)
+		}
+		if want := int64(3000); stat.CostMicroUSD != want {
+			t.Errorf("restored CostMicroUSD = %d, want %d", stat.CostMicroUSD, want)
+		}
+	})
+
+	t.Run("legacy tool_usage lines without token or cost fields seed cleanly", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "metrics.jsonl")
+
+		// A line written before per-tool cost attribution: calls only.
+		writeRawLine(t, path, `{"ts":"2026-05-06T00:00:00Z","server":"github","diff":{"input_tokens":100,"output_tokens":50,"total_tokens":150},"total":{"input_tokens":100,"output_tokens":50,"total_tokens":150},"tool_usage":{"create_issue":{"calls":4,"last_called_at":"2026-05-06T00:00:00Z"}}}`)
+
+		acc := metrics.NewAccumulator(100)
+		f := NewMetricsFlusher(acc, time.Hour)
+		if err := f.SeedFromFile(path, 100); err != nil {
+			t.Fatalf("SeedFromFile: %v", err)
+		}
+		stat := acc.ToolUsageSnapshot()["github"]["create_issue"]
+		if stat.Calls != 4 {
+			t.Errorf("restored calls = %d, want 4", stat.Calls)
+		}
+		if stat.InputTokens != 0 || stat.OutputTokens != 0 || stat.CostMicroUSD != 0 {
+			t.Errorf("legacy line must restore zero tokens/cost; got %+v", stat)
+		}
+	})
+
 	t.Run("tool-only delta forces a line without a token change", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "metrics.jsonl")

--- a/web/src/__tests__/MetricsWorkspace.test.tsx
+++ b/web/src/__tests__/MetricsWorkspace.test.tsx
@@ -23,6 +23,14 @@ vi.mock('../lib/api', async (importActual) => {
     fetchTokenMetrics: vi.fn().mockResolvedValue({ range: '30m', interval: '1m', data_points: [], per_server: {} }),
     fetchCostMetrics: vi.fn().mockResolvedValue({ range: '30m', interval: '1m', data_points: [], per_server: {}, per_client: {} }),
     clearTokenMetrics: vi.fn().mockResolvedValue(undefined),
+    fetchToolUsage: vi.fn().mockResolvedValue({
+      servers: {
+        github: {
+          create_issue: { calls: 4, lastCalledAt: '2026-07-01T00:00:00Z', inputTokens: 120, outputTokens: 80, costUsd: 0.02 },
+          list_repos: { calls: 1, inputTokens: 30, outputTokens: 10 },
+        },
+      },
+    }),
   };
 });
 
@@ -81,6 +89,7 @@ describe('MetricsWorkspace', () => {
     expect(screen.getByRole('button', { name: /^overview/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^clients/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^servers/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^tools/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^models/i })).toBeInTheDocument();
     // KPI row carries the session total.
     expect(screen.getByText('Total Tokens')).toBeInTheDocument();
@@ -109,6 +118,27 @@ describe('MetricsWorkspace', () => {
   it('shows the model-mix panel under the models scope', () => {
     renderAt('/metrics?scope=models');
     expect(screen.getByText('Cost by Model')).toBeInTheDocument();
+  });
+
+  it('shows the per-tool breakdown with server-qualified names under the tools scope', async () => {
+    renderAt('/metrics?scope=tools');
+    expect(await screen.findByText('Per-Tool')).toBeInTheDocument();
+    // Rows render server › tool so name collisions across servers stay distinct.
+    expect(await screen.findByText('create_issue')).toBeInTheDocument();
+    expect(screen.getByText('list_repos')).toBeInTheDocument();
+    // Priced tool shows a cost; unpriced tool shows the em dash, never $0.
+    expect(screen.getByText('$0.020')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.queryByText('$0.00')).not.toBeInTheDocument();
+  });
+
+  it('selects a tool row into the inspector without a pricing-model editor', async () => {
+    renderAt('/metrics?scope=tools');
+    fireEvent.click(await screen.findByText('create_issue'));
+    // The inspector shows the tool's KPI grid (Calls is tools-only)…
+    expect(await screen.findByText('Calls')).toBeInTheDocument();
+    // …but no pricing editor: a tool's cost inherits client/server attribution.
+    expect(screen.queryByText('Pricing model')).not.toBeInTheDocument();
   });
 
   it('shows the onboarding empty state when there is no traffic', async () => {

--- a/web/src/__tests__/OptimizeSection.test.tsx
+++ b/web/src/__tests__/OptimizeSection.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { OptimizeSection } from '../components/sidebar/OptimizeSection';
+import type { OptimizeFinding } from '../types';
+
+const findings: OptimizeFinding[] = vi.hoisted(() => [
+  {
+    id: 'unused-tool-github-list_repos',
+    heuristic: 'unused_tool',
+    severity: 'info',
+    title: 'Unused tool: github/list_repos',
+    summary: 'Not called in the lookback window.',
+    server: 'github',
+    tool: 'list_repos',
+    impact_usd_per_week: 4.2,
+    remediation: '# tools: filter',
+    detected_at: '2026-07-13T00:00:00Z',
+  },
+  {
+    id: 'expensive-model-cheap-task-github',
+    heuristic: 'expensive_model_on_cheap_task',
+    severity: 'info',
+    title: 'Expensive model on cheap task: github',
+    summary: 'Simple-lookup pattern on an Opus-tier rate.',
+    server: 'github',
+    impact_usd_per_week: 0,
+    remediation: '# pick a smaller model',
+    detected_at: '2026-07-13T00:00:00Z',
+  },
+]);
+
+vi.mock('../lib/api', async (importActual) => {
+  const actual = await importActual<typeof import('../lib/api')>();
+  return {
+    ...actual,
+    fetchOptimizeReport: vi.fn().mockResolvedValue({
+      findings,
+      health_score: 88,
+      generated_at: '2026-07-13T00:00:00Z',
+    }),
+  };
+});
+
+describe('OptimizeSection', () => {
+  it('renders the weekly-dollar chip for a tool finding with real impact', async () => {
+    render(<OptimizeSection />);
+    expect(await screen.findByText('Unused tool: github/list_repos')).toBeInTheDocument();
+    expect(screen.getByText('$4.20/wk')).toBeInTheDocument();
+  });
+
+  it('hides the chip for zero-impact findings', async () => {
+    render(<OptimizeSection />);
+    expect(await screen.findByText('Expensive model on cheap task: github')).toBeInTheDocument();
+    // Exactly one chip: the zero-impact finding renders none.
+    expect(screen.getAllByText(/\/wk$/)).toHaveLength(1);
+  });
+});

--- a/web/src/__tests__/ToolDetailPanel.test.tsx
+++ b/web/src/__tests__/ToolDetailPanel.test.tsx
@@ -61,4 +61,29 @@ describe('ToolDetailPanel', () => {
     expect(screen.getByText('13px')).toBeInTheDocument();
     expect(localStorage.getItem('gridctl-tools-zoom')).toBe('13');
   });
+
+  it('shows the Usage section with calls, tokens, and cost outside audit mode', () => {
+    renderPanel({
+      usage: { calls: 12, lastCalledAt: '2026-07-01T00:00:00Z', inputTokens: 1200, outputTokens: 400, costUsd: 0.0345 },
+    });
+    expect(screen.getByText('Usage')).toBeInTheDocument();
+    expect(screen.getByText('Calls')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('1.2k')).toBeInTheDocument();
+    expect(screen.getByText('400')).toBeInTheDocument();
+    // Priced usage shows an estimated cost with the est. label.
+    expect(screen.getByText('Cost · est.')).toBeInTheDocument();
+    expect(screen.getByText('$0.035')).toBeInTheDocument();
+  });
+
+  it('renders an em dash, never $0, when usage is unpriced', () => {
+    renderPanel({ usage: { calls: 3, inputTokens: 100, outputTokens: 50 } });
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.queryByText(/\$0\.00/)).not.toBeInTheDocument();
+  });
+
+  it('hides the Usage section without usage data or audit state', () => {
+    renderPanel();
+    expect(screen.queryByText('Usage')).not.toBeInTheDocument();
+  });
 });

--- a/web/src/__tests__/fetchToolUsage.test.ts
+++ b/web/src/__tests__/fetchToolUsage.test.ts
@@ -11,7 +11,11 @@ describe('fetchToolUsage', () => {
     const payload: ToolUsageResponse = {
       observedSince: '2026-05-20T10:00:00Z',
       servers: {
-        github: { create_issue: { calls: 2, lastCalledAt: '2026-05-24T09:00:00Z' } },
+        github: {
+          // Priced tool carries tokens + costUsd; unpriced omits costUsd.
+          create_issue: { calls: 2, lastCalledAt: '2026-05-24T09:00:00Z', inputTokens: 120, outputTokens: 80, costUsd: 0.003 },
+          list_repos: { calls: 1, inputTokens: 30, outputTokens: 10 },
+        },
       },
     };
     const fetchMock = vi.fn().mockResolvedValue({

--- a/web/src/__tests__/metricsData.test.ts
+++ b/web/src/__tests__/metricsData.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   derivePerServerRows,
   derivePerClientRows,
+  derivePerToolRows,
   sortBreakdownRows,
   aggregateModelMix,
   deriveSessionKpis,
@@ -16,6 +17,7 @@ import type {
   EffectiveModel,
   TokenMetricsResponse,
   CostMetricsResponse,
+  ToolUsageResponse,
 } from '../types';
 
 function tokenUsage(over: Partial<TokenUsage> = {}): TokenUsage {
@@ -67,6 +69,54 @@ describe('derivePerClientRows', () => {
     expect(rows.find((r) => r.name === 'claude')!.cost).toBeUndefined();
     expect(rows.find((r) => r.name === 'cursor')!.cost).toBe(0.01);
     expect(rows.find((r) => r.name === 'cursor')!.total).toBe(0);
+  });
+});
+
+describe('derivePerToolRows', () => {
+  const usage: ToolUsageResponse = {
+    servers: {
+      github: {
+        create_issue: { calls: 4, lastCalledAt: '2026-07-01T00:00:00Z', inputTokens: 120, outputTokens: 80, costUsd: 0.003 },
+        list_repos: { calls: 1, inputTokens: 30, outputTokens: 10 },
+      },
+      atlassian: {
+        // Same tool name on another server must stay a distinct row.
+        create_issue: { calls: 2, inputTokens: 5, outputTokens: 5 },
+      },
+    },
+  };
+
+  it('flattens server→tool usage into rows with unique server-prefixed names', () => {
+    const rows = derivePerToolRows(usage);
+    expect(rows).toHaveLength(3);
+    const names = rows.map((r) => r.name).sort();
+    expect(names).toEqual(['atlassian__create_issue', 'github__create_issue', 'github__list_repos']);
+    const gh = rows.find((r) => r.name === 'github__create_issue')!;
+    expect(gh.server).toBe('github');
+    expect(gh.tool).toBe('create_issue');
+    expect(gh.calls).toBe(4);
+    expect(gh.input).toBe(120);
+    expect(gh.output).toBe(80);
+    expect(gh.total).toBe(200);
+    expect(gh.cost).toBe(0.003);
+  });
+
+  it('leaves cost undefined for unpriced tools (em-dash rule)', () => {
+    const rows = derivePerToolRows(usage);
+    expect(rows.find((r) => r.name === 'github__list_repos')!.cost).toBeUndefined();
+  });
+
+  it('defaults missing token fields to zero (legacy gateway responses)', () => {
+    const legacy: ToolUsageResponse = { servers: { github: { old_tool: { calls: 7 } } } };
+    const row = derivePerToolRows(legacy)[0];
+    expect(row.input).toBe(0);
+    expect(row.output).toBe(0);
+    expect(row.total).toBe(0);
+    expect(row.calls).toBe(7);
+  });
+
+  it('returns [] for null usage', () => {
+    expect(derivePerToolRows(null)).toEqual([]);
   });
 });
 

--- a/web/src/components/metrics/MetricsInspector.tsx
+++ b/web/src/components/metrics/MetricsInspector.tsx
@@ -1,7 +1,7 @@
 import { X, DollarSign } from 'lucide-react';
-import { cn } from '../../lib/cn';
 import { formatCompactNumber, formatUSD } from '../../lib/format';
 import { AreaChart } from '../chart/AreaChart';
+import { InspectorStat } from './metricsShared';
 import { PaneAnchor } from '../inspector';
 import { ClientModelCell } from '../pricing/ClientModelCell';
 import { ServerModelCell } from '../pricing/ServerModelCell';
@@ -14,7 +14,7 @@ import {
 import type { BreakdownRow } from './metricsData';
 import type { CostDataPoint, EffectiveModel, TokenDataPoint } from '../../types';
 
-export type MetricsInspectorScope = 'clients' | 'servers';
+export type MetricsInspectorScope = 'clients' | 'servers' | 'tools';
 
 interface MetricsInspectorProps {
   scope: MetricsInspectorScope;
@@ -34,10 +34,13 @@ interface MetricsInspectorProps {
 }
 
 // MetricsInspector is the workspace right rail: a per-entity detail view for
-// the selected client or server. It hosts the inline model editor (relocated
-// here so the breakdown tables stay scannable), the entity's KPI numbers,
-// per-entity sparklines, and the cost-provenance note. With nothing selected
-// it falls back to a cost-provenance legend explaining the attribution model.
+// the selected client, server, or tool. It hosts the inline model editor
+// (relocated here so the breakdown tables stay scannable), the entity's KPI
+// numbers, per-entity sparklines, and the cost-provenance note. Tools have no
+// pricing model of their own (their cost inherits the client/server
+// attribution), so the tools scope shows the KPI numbers without the editor.
+// With nothing selected it falls back to a cost-provenance legend explaining
+// the attribution model.
 export function MetricsInspector({
   scope,
   row,
@@ -71,11 +74,16 @@ export function MetricsInspector({
       <div className="flex-shrink-0 flex items-center gap-2 px-4 py-3 border-b border-border-subtle">
         <div className="min-w-0">
           <div className="text-[10px] uppercase tracking-[0.3em] text-text-muted/60">
-            {scope === 'clients' ? 'client' : 'server'}
+            {scope === 'clients' ? 'client' : scope === 'tools' ? 'tool' : 'server'}
           </div>
           <div className="font-mono text-sm text-text-primary truncate" title={row.name}>
-            {row.name}
+            {row.tool ?? row.name}
           </div>
+          {scope === 'tools' && row.server && (
+            <div className="font-mono text-[10px] text-text-muted truncate" title={row.server}>
+              {row.server}
+            </div>
+          )}
         </div>
         <button
           onClick={onClose}
@@ -87,42 +95,48 @@ export function MetricsInspector({
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark p-4 space-y-4">
-        {/* Pricing model editor */}
-        <section className="space-y-1.5">
-          <h3 className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">Pricing model</h3>
-          <div title={MODEL_PRECEDENCE_HINT}>
-            {scope === 'clients' ? (
-              <ClientModelCell
-                client={row.name}
-                declaredModel={declaredModel}
-                effective={effective}
-                costAttribution={costAttribution}
-                onSaved={onClientSaved}
-                onOpenManager={onOpenManager}
-                pickerAlign="left"
-              />
-            ) : (
-              <ServerModelCell
-                server={row.name}
-                declaredModel={declaredModel}
-                defaultModel={defaultModel}
-                effective={effective}
-                onSaved={onServerSaved}
-                onOpenManager={onOpenManager}
-                pickerAlign="left"
-              />
+        {/* Pricing model editor — clients/servers only; a tool's cost inherits
+            the client/server attribution and has no model of its own. */}
+        {scope !== 'tools' && (
+          <section className="space-y-1.5">
+            <h3 className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">Pricing model</h3>
+            <div title={MODEL_PRECEDENCE_HINT}>
+              {scope === 'clients' ? (
+                <ClientModelCell
+                  client={row.name}
+                  declaredModel={declaredModel}
+                  effective={effective}
+                  costAttribution={costAttribution}
+                  onSaved={onClientSaved}
+                  onOpenManager={onOpenManager}
+                  pickerAlign="left"
+                />
+              ) : (
+                <ServerModelCell
+                  server={row.name}
+                  declaredModel={declaredModel}
+                  defaultModel={defaultModel}
+                  effective={effective}
+                  onSaved={onServerSaved}
+                  onOpenManager={onOpenManager}
+                  pickerAlign="left"
+                />
+              )}
+            </div>
+            {effective?.provenance === 'mixed' && (
+              <p className="text-[10px] leading-snug text-text-muted/70">{MIXED_PROVENANCE_NOTE}</p>
             )}
-          </div>
-          {effective?.provenance === 'mixed' && (
-            <p className="text-[10px] leading-snug text-text-muted/70">{MIXED_PROVENANCE_NOTE}</p>
-          )}
-          {effective?.provenance === 'none' && (
-            <p className="text-[10px] leading-snug text-text-muted/70">{UNPRICED_NOTE}</p>
-          )}
-        </section>
+            {effective?.provenance === 'none' && (
+              <p className="text-[10px] leading-snug text-text-muted/70">{UNPRICED_NOTE}</p>
+            )}
+          </section>
+        )}
 
         {/* KPI numbers */}
         <section className="grid grid-cols-2 gap-2">
+          {row.calls !== undefined && (
+            <InspectorStat label="Calls" value={formatCompactNumber(row.calls)} className="text-text-primary" />
+          )}
           <InspectorStat label="Input" value={formatCompactNumber(row.input)} className="text-secondary" />
           <InspectorStat label="Output" value={formatCompactNumber(row.output)} className="text-primary" />
           <InspectorStat label="Total" value={formatCompactNumber(row.total)} className="text-text-primary" />
@@ -132,6 +146,14 @@ export function MetricsInspector({
             className={row.cost === undefined ? 'text-text-muted' : 'text-emerald-400'}
           />
         </section>
+        {scope === 'tools' && row.cost === undefined && (
+          // Not ATTRIBUTION_HINT: its copy points at the Top Clients table,
+          // which the Tools scope does not render.
+          <p className="text-[10px] leading-snug text-text-muted/70">
+            No priced calls yet. Set a pricing model on a client or server (Clients/Servers scope), or a
+            gateway default, to enable estimates.
+          </p>
+        )}
 
         {/* Token sparkline */}
         {tokenSeries.length > 0 && (
@@ -183,15 +205,6 @@ export function MetricsInspector({
   );
 }
 
-function InspectorStat({ label, value, className }: { label: string; value: string; className?: string }) {
-  return (
-    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-2.5">
-      <span className="text-[9px] text-text-muted uppercase tracking-wider block mb-0.5">{label}</span>
-      <span className={cn('text-sm font-bold tabular-nums', className)}>{value}</span>
-    </div>
-  );
-}
-
 // Shown when nothing is selected — a cost-provenance legend rather than an
 // empty rail, carrying the same honesty copy the cards use.
 function InspectorOverview({ onOpenManager }: { onOpenManager: () => void }) {
@@ -202,7 +215,7 @@ function InspectorOverview({ onOpenManager }: { onOpenManager: () => void }) {
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark p-4 space-y-3 text-[11px] leading-relaxed text-text-muted">
         <p>
-          Select a client or server to inspect its tokens, estimated cost, and pricing model.
+          Select a client, server, or tool to inspect its tokens, estimated cost, and pricing model.
         </p>
         <p className="text-text-secondary">{ATTRIBUTION_HINT}.</p>
         <div className="space-y-1.5 pt-1">

--- a/web/src/components/metrics/metricsData.ts
+++ b/web/src/components/metrics/metricsData.ts
@@ -3,6 +3,7 @@
 // export both components and plain functions). The bottom glance tab, the
 // Metrics workspace, and the detached window all derive their numbers here so
 // cost/token math is defined exactly once.
+import { TOOL_NAME_DELIMITER } from '../../lib/constants';
 import type {
   CostUsage,
   EffectiveModel,
@@ -10,6 +11,7 @@ import type {
   TokenMetricsResponse,
   CostMetricsResponse,
   TokenUsage,
+  ToolUsageResponse,
 } from '../../types';
 
 export type SortDirection = 'asc' | 'desc';
@@ -19,13 +21,19 @@ export type SortDirection = 'asc' | 'desc';
 export type BreakdownSortColumn = 'name' | 'input' | 'output' | 'total' | 'cost';
 
 // A single row in a breakdown table. `cost` is optional: undefined means
-// pricing-unknown (rendered as an em-dash, never $0).
+// pricing-unknown (rendered as an em-dash, never $0). Tool rows carry the
+// server/tool split (names collide across servers, so `name` is the unique
+// server-prefixed key while the table renders the two parts) plus the call
+// count for the inspector.
 export interface BreakdownRow {
   name: string;
   input: number;
   output: number;
   total: number;
   cost?: number;
+  server?: string;
+  tool?: string;
+  calls?: number;
 }
 
 export function derivePerServerRows(
@@ -56,6 +64,29 @@ export function derivePerClientRows(
     total: tokenClients[name]?.total_tokens ?? 0,
     cost: costClients[name]?.total_usd,
   }));
+}
+
+// Rows for the Metrics "Tools" scope, one per (server, tool) with recorded
+// calls. Fed by GET /api/tools/usage rather than the status snapshot — the
+// tools pipeline is the single per-tool data source everywhere in the UI.
+export function derivePerToolRows(usage: ToolUsageResponse | null): BreakdownRow[] {
+  if (!usage?.servers) return [];
+  const rows: BreakdownRow[] = [];
+  for (const [server, tools] of Object.entries(usage.servers)) {
+    for (const [tool, stat] of Object.entries(tools)) {
+      rows.push({
+        name: `${server}${TOOL_NAME_DELIMITER}${tool}`,
+        server,
+        tool,
+        calls: stat.calls,
+        input: stat.inputTokens ?? 0,
+        output: stat.outputTokens ?? 0,
+        total: (stat.inputTokens ?? 0) + (stat.outputTokens ?? 0),
+        cost: stat.costUsd,
+      });
+    }
+  }
+  return rows;
 }
 
 export function sortBreakdownRows(

--- a/web/src/components/metrics/metricsShared.tsx
+++ b/web/src/components/metrics/metricsShared.tsx
@@ -311,6 +311,30 @@ export function SortableHeader({
   );
 }
 
+// ScrollableBreakdown bounds a long BreakdownTable (the per-tool list runs to
+// 100+ rows on a real stack) to an in-place scroll region with a sticky
+// header, shared by the Metrics workspace Tools scope and the detached
+// window's Per-Tool panel.
+export function ScrollableBreakdown({ children }: { children: ReactNode }) {
+  return (
+    <div className="max-h-[60vh] overflow-y-auto scrollbar-dark [&_thead_th]:sticky [&_thead_th]:top-0 [&_thead_th]:z-[1] [&_thead_th]:bg-surface">
+      {children}
+    </div>
+  );
+}
+
+// InspectorStat renders one labeled KPI number, shared by the Metrics
+// inspector and the Tools detail panel so per-entity numbers read the same
+// in both workspaces.
+export function InspectorStat({ label, value, className }: { label: string; value: string; className?: string }) {
+  return (
+    <div className="rounded-lg bg-surface-elevated/60 border border-border/30 p-2.5">
+      <span className="text-[9px] text-text-muted uppercase tracking-wider block mb-0.5">{label}</span>
+      <span className={cn('text-sm font-bold tabular-nums', className)}>{value}</span>
+    </div>
+  );
+}
+
 // BreakdownTable renders the shared client/server breakdown. Each host injects
 // a Model cell via `renderModel`, shows a Cost column when `showCost`, and may
 // make rows selectable (`onSelectRow` + `selectedName`) to drive a detail
@@ -360,13 +384,39 @@ export function BreakdownTable({
               key={row.name}
               aria-selected={onSelectRow ? selected : undefined}
               onClick={onSelectRow ? () => onSelectRow(row.name) : undefined}
+              // Selectable rows are keyboard-reachable in place (Enter/Space),
+              // complementing the workspace-level arrow-key navigation. Only
+              // keydowns on the row itself count: events bubbling out of nested
+              // interactive elements (the inline model editor) must keep their
+              // native behavior.
+              tabIndex={onSelectRow ? 0 : undefined}
+              onKeyDown={
+                onSelectRow
+                  ? (e) => {
+                      if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) {
+                        e.preventDefault();
+                        onSelectRow(row.name);
+                      }
+                    }
+                  : undefined
+              }
               className={cn(
                 'border-b border-border/20 last:border-0 transition-colors',
-                onSelectRow && 'cursor-pointer',
+                onSelectRow && 'cursor-pointer focus-visible:outline focus-visible:outline-1 focus-visible:outline-primary/60',
                 selected ? 'bg-primary/[0.07]' : 'hover:bg-surface-highlight/30',
               )}
             >
-              <td className="px-3 py-2 font-medium text-text-primary font-mono">{row.name}</td>
+              <td className="px-3 py-2 font-medium text-text-primary font-mono">
+                {row.server && row.tool ? (
+                  <>
+                    <span className="text-text-muted/70">{row.server}</span>
+                    <span className="text-text-muted/50" aria-hidden="true">{' › '}</span>
+                    {row.tool}
+                  </>
+                ) : (
+                  row.name
+                )}
+              </td>
               {renderModel && (
                 <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
                   {renderModel(row)}

--- a/web/src/components/workspaces/MetricsWorkspace.tsx
+++ b/web/src/components/workspaces/MetricsWorkspace.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { BarChart3, Boxes, Layers, Server, Users } from 'lucide-react';
+import { BarChart3, Boxes, Layers, Server, Users, Wrench } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { useUIStore } from '../../stores/useUIStore';
 import { useStackStore } from '../../stores/useStackStore';
 import { useWindowManager } from '../../hooks/useWindowManager';
 import { useListNav } from '../../hooks/useListNav';
+import { useToolUsage } from '../../hooks/useToolUsage';
 import { useMetricsSeries, type MetricsTimeRange } from '../../hooks/useMetricsSeries';
 import { WorkspaceShell } from '../layout/WorkspaceShell';
 import { PopoutButton } from '../ui/PopoutButton';
@@ -22,6 +23,7 @@ import {
   PanelHeader,
   BreakdownTable,
   ModelMixBars,
+  ScrollableBreakdown,
 } from '../metrics/metricsShared';
 import {
   aggregateModelMix,
@@ -29,6 +31,7 @@ import {
   buildCostChartData,
   derivePerServerRows,
   derivePerClientRows,
+  derivePerToolRows,
   deriveSessionKpis,
   hasMetricsData,
   sortBreakdownRows,
@@ -37,8 +40,8 @@ import {
   type SortDirection,
 } from '../metrics/metricsData';
 
-type Scope = 'overview' | 'clients' | 'servers' | 'models';
-const SCOPES: Scope[] = ['overview', 'clients', 'servers', 'models'];
+type Scope = 'overview' | 'clients' | 'servers' | 'tools' | 'models';
+const SCOPES: Scope[] = ['overview', 'clients', 'servers', 'tools', 'models'];
 
 function isScope(v: string | null): v is Scope {
   return v != null && (SCOPES as string[]).includes(v);
@@ -46,7 +49,7 @@ function isScope(v: string | null): v is Scope {
 
 // MetricsWorkspace is the first-class cost/token observability surface, sibling
 // to Topology, Library, Variables, and Tools. The left rail is a scope
-// navigator (overview / clients / servers / models); the center carries the
+// navigator (overview / clients / servers / tools / models); the center carries the
 // session KPI row, the trend charts, and the active scope's breakdown; the
 // right rail inspects the selected client or server (and hosts its inline
 // pricing-model editor). Scope and selection are URL-synced so reload and
@@ -75,6 +78,8 @@ export function MetricsWorkspace() {
   const [isPaused, setIsPaused] = useState(false);
   const [serverSort, setServerSort] = useState<{ col: BreakdownSortColumn; dir: SortDirection }>({ col: 'total', dir: 'desc' });
   const [clientSort, setClientSort] = useState<{ col: BreakdownSortColumn; dir: SortDirection }>({ col: 'cost', dir: 'desc' });
+  // Cost-descending default so the most expensive tools surface first.
+  const [toolSort, setToolSort] = useState<{ col: BreakdownSortColumn; dir: SortDirection }>({ col: 'cost', dir: 'desc' });
   // Polite announcement for range/refresh, read by screen readers.
   const [liveMsg, setLiveMsg] = useState('');
 
@@ -83,6 +88,11 @@ export function MetricsWorkspace() {
     paused: isPaused,
     perClient: true,
   });
+
+  // Per-tool usage powers the Tools scope (and its rail count badge), so the
+  // poll runs whenever the workspace is mounted — same 15s cadence Audit Mode
+  // uses, against the same single per-tool data source.
+  const { usage: toolUsageData, error: toolUsageError } = useToolUsage(true);
 
   // ---- URL state ----------------------------------------------------------
   const scope: Scope = isScope(searchParams.get('scope')) ? (searchParams.get('scope') as Scope) : 'overview';
@@ -141,23 +151,28 @@ export function MetricsWorkspace() {
     () => sortBreakdownRows(derivePerClientRows(tokenUsage, costUsage), clientSort.col, clientSort.dir),
     [tokenUsage, costUsage, clientSort],
   );
+  const toolRows = useMemo(
+    () => sortBreakdownRows(derivePerToolRows(toolUsageData), toolSort.col, toolSort.dir),
+    [toolUsageData, toolSort],
+  );
   const modelMix = useMemo(
     () => aggregateModelMix(effectiveServerModels, effectiveClientModels),
     [effectiveServerModels, effectiveClientModels],
   );
 
-  // Rows for the active selectable scope (clients/servers), used by the
+  // Rows for the active selectable scope (clients/servers/tools), used by the
   // inspector lookup and keyboard navigation.
   const activeRows: BreakdownRow[] = useMemo(
-    () => (scope === 'servers' ? serverRows : scope === 'clients' ? clientRows : []),
-    [scope, serverRows, clientRows],
+    () =>
+      scope === 'servers' ? serverRows : scope === 'clients' ? clientRows : scope === 'tools' ? toolRows : [],
+    [scope, serverRows, clientRows, toolRows],
   );
   const selectedRow = useMemo(
     () => activeRows.find((r) => r.name === selected) ?? null,
     [activeRows, selected],
   );
 
-  // Keyboard nav over the active breakdown (clients/servers only).
+  // Keyboard nav over the active breakdown (clients/servers/tools).
   const selectedIndex = useMemo(
     () => activeRows.findIndex((r) => r.name === selected),
     [activeRows, selected],
@@ -169,16 +184,18 @@ export function MetricsWorkspace() {
       const next = activeRows[i];
       if (next) setSelected(next.name);
     },
-    enabled: scope === 'clients' || scope === 'servers',
+    enabled: scope === 'clients' || scope === 'servers' || scope === 'tools',
   });
 
   const sortServers = (col: BreakdownSortColumn) =>
     setServerSort((s) => (s.col === col ? { col, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { col, dir: 'desc' }));
   const sortClients = (col: BreakdownSortColumn) =>
     setClientSort((s) => (s.col === col ? { col, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { col, dir: 'desc' }));
+  const sortTools = (col: BreakdownSortColumn) =>
+    setToolSort((s) => (s.col === col ? { col, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { col, dir: 'desc' }));
 
   // ---- Inspector wiring ---------------------------------------------------
-  const inspectorScope = scope === 'servers' ? 'servers' : 'clients';
+  const inspectorScope = scope === 'servers' ? 'servers' : scope === 'tools' ? 'tools' : 'clients';
   const inspectorTokenPoints =
     selectedRow && scope === 'servers' ? metricsData?.per_server?.[selectedRow.name] : undefined;
   const inspectorCostPoints =
@@ -187,17 +204,22 @@ export function MetricsWorkspace() {
       : selectedRow && scope === 'clients'
         ? costData?.per_client?.[selectedRow.name]
         : undefined;
+  // Tools have no pricing model of their own — their cost inherits the
+  // client/server attribution — so the model editor wiring stays scoped to
+  // clients/servers.
   const inspectorDeclared =
     scope === 'servers' ? declaredServerModels[selectedRow?.name ?? ''] : clientModels[selectedRow?.name ?? ''];
   const inspectorEffective =
     scope === 'servers'
       ? effectiveServerModels[selectedRow?.name ?? '']
-      : effectiveClientModels[selectedRow?.name ?? ''];
+      : scope === 'tools'
+        ? undefined
+        : effectiveClientModels[selectedRow?.name ?? ''];
 
   const inspector = (
     <MetricsInspector
       scope={inspectorScope}
-      row={scope === 'clients' || scope === 'servers' ? selectedRow : null}
+      row={scope === 'clients' || scope === 'servers' || scope === 'tools' ? selectedRow : null}
       effective={inspectorEffective}
       declaredModel={inspectorDeclared}
       defaultModel={defaultModel}
@@ -218,6 +240,7 @@ export function MetricsWorkspace() {
       onSelectScope={setScope}
       clientCount={clientRows.length}
       serverCount={serverRows.length}
+      toolCount={toolRows.length}
       modelCount={modelMix.length}
     />
   );
@@ -304,6 +327,31 @@ export function MetricsWorkspace() {
                   </PanelHeader>
                 )}
 
+                {scope === 'tools' && (
+                  <PanelHeader icon={Wrench} label="Per-Tool">
+                    {toolRows.length > 0 ? (
+                      <ScrollableBreakdown>
+                        <BreakdownTable
+                          rows={toolRows}
+                          nameLabel="Tool"
+                          sortColumn={toolSort.col}
+                          sortDirection={toolSort.dir}
+                          onSort={sortTools}
+                          showCost
+                          selectedName={selected}
+                          onSelectRow={setSelected}
+                        />
+                      </ScrollableBreakdown>
+                    ) : toolUsageError ? (
+                      // A failed fetch is not "no usage" — say the data source
+                      // is unavailable instead of implying calls went unrecorded.
+                      <EmptyScopeNote text={`Tool usage unavailable: ${toolUsageError}`} />
+                    ) : (
+                      <EmptyScopeNote text="No per-tool usage recorded yet. Tool rows appear after the first tool call; cost needs a pricing model." />
+                    )}
+                  </PanelHeader>
+                )}
+
                 {scope === 'clients' && (
                   <PanelHeader icon={Users} label="Top Clients">
                     {clientRows.length > 0 ? (
@@ -380,10 +428,11 @@ interface ScopeRailProps {
   onSelectScope: (s: Scope) => void;
   clientCount: number;
   serverCount: number;
+  toolCount: number;
   modelCount: number;
 }
 
-function ScopeRail({ compact, scope, onSelectScope, clientCount, serverCount, modelCount }: ScopeRailProps) {
+function ScopeRail({ compact, scope, onSelectScope, clientCount, serverCount, toolCount, modelCount }: ScopeRailProps) {
   return (
     <aside className="h-full flex flex-col bg-surface border-r border-border-subtle">
       <div className={cn('flex-shrink-0 px-3 border-b border-border-subtle/60', compact ? 'py-2' : 'py-3')}>
@@ -393,6 +442,7 @@ function ScopeRail({ compact, scope, onSelectScope, clientCount, serverCount, mo
         <ScopePill label="Overview" icon={BarChart3} active={scope === 'overview'} onClick={() => onSelectScope('overview')} />
         <ScopePill label="Clients" icon={Users} count={clientCount} active={scope === 'clients'} onClick={() => onSelectScope('clients')} />
         <ScopePill label="Servers" icon={Server} count={serverCount} active={scope === 'servers'} onClick={() => onSelectScope('servers')} />
+        <ScopePill label="Tools" icon={Wrench} count={toolCount} active={scope === 'tools'} onClick={() => onSelectScope('tools')} />
         <ScopePill label="Models" icon={Boxes} count={modelCount} active={scope === 'models'} onClick={() => onSelectScope('models')} />
       </div>
     </aside>

--- a/web/src/components/workspaces/ToolDetailPanel.tsx
+++ b/web/src/components/workspaces/ToolDetailPanel.tsx
@@ -1,12 +1,15 @@
 import { useRef, type ReactNode } from 'react';
 import { Wrench } from 'lucide-react';
 import { cn } from '../../lib/cn';
+import { formatCompactNumber, formatUSD } from '../../lib/format';
 import { CodeViewer } from '../ui/CodeViewer';
 import { ZoomControls } from '../ui/ZoomControls';
 import { InspectorHeader, PaneAnchor } from '../inspector';
+import { InspectorStat } from '../metrics/metricsShared';
 import { formatLastUsed, type AuditState } from '../../lib/toolAudit';
 import { useTextZoom } from '../../hooks/useTextZoom';
 import type { ToolRow } from '../../hooks/useToolsEditor';
+import type { ToolUsageStat } from '../../types';
 
 // Per-state styling for the audit row, mirroring the list's AUDIT_STYLES.
 const AUDIT_LABEL: Record<AuditState, { text: string; dot: string; label: string }> = {
@@ -25,6 +28,9 @@ interface ToolDetailPanelProps {
   enabled: boolean;
   auditMode: boolean;
   auditState: AuditState | null;
+  // The tool's observed usage (calls/tokens/cost), when any call has been
+  // recorded. Shown whenever present — not gated on Audit Mode.
+  usage?: ToolUsageStat;
   lastCalledAt?: string;
   onClose: () => void;
 }
@@ -40,6 +46,7 @@ export function ToolDetailPanel({
   enabled,
   auditMode,
   auditState,
+  usage,
   lastCalledAt,
   onClose,
 }: ToolDetailPanelProps) {
@@ -121,21 +128,40 @@ export function ToolDetailPanel({
               )}
             </Section>
 
-            {auditMode && auditState && (
+            {(usage || (auditMode && auditState)) && (
               <Section title="Usage">
-                <div
-                  className={cn(
-                    'flex items-center gap-1.5 text-[11px]',
-                    AUDIT_LABEL[auditState].text,
+                <div className="space-y-2">
+                  {auditMode && auditState && (
+                    <div
+                      className={cn(
+                        'flex items-center gap-1.5 text-[11px]',
+                        AUDIT_LABEL[auditState].text,
+                      )}
+                    >
+                      <span
+                        className={cn('inline-block w-1.5 h-1.5 rounded-full', AUDIT_LABEL[auditState].dot)}
+                        aria-hidden="true"
+                      />
+                      <span>{AUDIT_LABEL[auditState].label}</span>
+                      {auditState !== 'disabled' && (
+                        <span className="text-text-muted/70">· {formatLastUsed(lastCalledAt)}</span>
+                      )}
+                    </div>
                   )}
-                >
-                  <span
-                    className={cn('inline-block w-1.5 h-1.5 rounded-full', AUDIT_LABEL[auditState].dot)}
-                    aria-hidden="true"
-                  />
-                  <span>{AUDIT_LABEL[auditState].label}</span>
-                  {auditState !== 'disabled' && (
-                    <span className="text-text-muted/70">· {formatLastUsed(lastCalledAt)}</span>
+                  {usage && (
+                    <div className="grid grid-cols-2 gap-2">
+                      <InspectorStat label="Calls" value={formatCompactNumber(usage.calls)} className="text-text-primary" />
+                      <InspectorStat label="Last used" value={formatLastUsed(usage.lastCalledAt)} className="text-text-secondary" />
+                      <InspectorStat label="Input" value={formatCompactNumber(usage.inputTokens ?? 0)} className="text-secondary" />
+                      <InspectorStat label="Output" value={formatCompactNumber(usage.outputTokens ?? 0)} className="text-primary" />
+                      {/* Cost only when a pricing model priced the calls — the
+                          em-dash rule every cost surface follows. */}
+                      <InspectorStat
+                        label="Cost · est."
+                        value={usage.costUsd === undefined ? '—' : formatUSD(usage.costUsd)}
+                        className={usage.costUsd === undefined ? 'text-text-muted' : 'text-emerald-400'}
+                      />
+                    </div>
                   )}
                 </div>
               </Section>

--- a/web/src/components/workspaces/ToolsWorkspace.tsx
+++ b/web/src/components/workspaces/ToolsWorkspace.tsx
@@ -133,15 +133,22 @@ export function ToolsWorkspace() {
 
   // ---- Audit Mode ---------------------------------------------------------
   // An overlay that classifies each tool as used / configured-but-unused /
-  // disabled against a lookback window. Usage is fetched only while the mode
-  // is on (the hook idles otherwise) so the editor pays nothing when it's off.
+  // disabled against a lookback window.
   const [auditMode, setAuditMode] = useState(false);
   const [auditWindow, setAuditWindow] = useState<AuditWindow>(DEFAULT_AUDIT_WINDOW);
   // Fleet bulk-action panel (expose-all / hide-pattern across servers).
   const [fleetOpen, setFleetOpen] = useState(false);
   // Per-client access editor (which servers each client may reach).
   const [accessOpen, setAccessOpen] = useState(false);
-  const { usage, fetchedAt } = useToolUsage(auditMode);
+  // The tool whose detail is shown in the right rail. Distinct from the
+  // whitelist selection (the checkboxes) — this is the "active" tool. Picking a
+  // global-search result sets it so that tool is revealed on arrival. Declared
+  // here (above the usage hook) because usage polling is gated on it.
+  const [selectedTool, setSelectedTool] = useState<string | null>(null);
+  // Usage polls while something consumes it: Audit Mode's classification, or
+  // the detail panel's Usage section for the selected tool (shown outside
+  // Audit Mode too). Otherwise the hook idles so the editor pays nothing.
+  const { usage, fetchedAt } = useToolUsage(auditMode || selectedTool != null);
   const windowMs = auditWindowMs(auditWindow);
   const usageByServer = usage?.servers;
 
@@ -161,10 +168,6 @@ export function ToolsWorkspace() {
   // A pending target set while the active editor has unsaved edits. The switch
   // commits (URL change) only after the user discards.
   const [pendingServer, setPendingServer] = useState<string | null>(null);
-  // The tool whose detail is shown in the right rail. Distinct from the
-  // whitelist selection (the checkboxes) — this is the "active" tool. Picking a
-  // global-search result sets it so that tool is revealed on arrival.
-  const [selectedTool, setSelectedTool] = useState<string | null>(null);
 
   // Switch to a server (or reveal a tool on the active one). Unsaved edits on
   // the current server route through a confirm dialog before the switch
@@ -213,9 +216,8 @@ export function ToolsWorkspace() {
     return toolCatalog.find((t) => t.name === prefixed)?.inputSchema;
   }, [selectedTool, activeServerName, toolCatalog]);
   const selectedEnabled = selectedTool ? editor.selected.has(selectedTool) : false;
-  const selectedLastCalled = selectedTool
-    ? usageByServer?.[activeServerName]?.[selectedTool]?.lastCalledAt
-    : undefined;
+  const selectedUsage = selectedTool ? usageByServer?.[activeServerName]?.[selectedTool] : undefined;
+  const selectedLastCalled = selectedUsage?.lastCalledAt;
   const selectedAuditState = useMemo(() => {
     if (!auditMode || !selectedTool || fetchedAt == null) return null;
     return classifyTool(selectedEnabled, selectedLastCalled, windowMs, fetchedAt);
@@ -240,6 +242,7 @@ export function ToolsWorkspace() {
       enabled={selectedEnabled}
       auditMode={auditMode}
       auditState={selectedAuditState}
+      usage={selectedUsage}
       lastCalledAt={selectedLastCalled}
       onClose={() => setSelectedTool(null)}
     />

--- a/web/src/pages/DetachedMetricsPage.tsx
+++ b/web/src/pages/DetachedMetricsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { BarChart3, AlertCircle, Maximize2, Minimize2, Users, Server } from 'lucide-react';
+import { BarChart3, AlertCircle, Maximize2, Minimize2, Users, Server, Wrench } from 'lucide-react';
 import { IconButton } from '../components/ui/IconButton';
 import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
@@ -10,13 +10,15 @@ import { ClientModelCell } from '../components/pricing/ClientModelCell';
 import { ServerModelCell } from '../components/pricing/ServerModelCell';
 import { PricingManagerSlideOver } from '../components/pricing/PricingManagerSlideOver';
 import { useMetricsSeries, type MetricsTimeRange } from '../hooks/useMetricsSeries';
+import { useToolUsage } from '../hooks/useToolUsage';
 import { MetricsControls } from '../components/metrics/MetricsControls';
-import { MetricsKpiRow, TokenChart, CostChart, PanelHeader, BreakdownTable } from '../components/metrics/metricsShared';
+import { MetricsKpiRow, TokenChart, CostChart, PanelHeader, BreakdownTable, ScrollableBreakdown } from '../components/metrics/metricsShared';
 import {
   buildTokenChartData,
   buildCostChartData,
   derivePerServerRows,
   derivePerClientRows,
+  derivePerToolRows,
   deriveSessionKpis,
   hasMetricsData,
   sortBreakdownRows,
@@ -45,9 +47,15 @@ function DetachedMetricsPageContent() {
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [clientSortColumn, setClientSortColumn] = useState<BreakdownSortColumn>('cost');
   const [clientSortDirection, setClientSortDirection] = useState<SortDirection>('desc');
+  const [toolSortColumn, setToolSortColumn] = useState<BreakdownSortColumn>('cost');
+  const [toolSortDirection, setToolSortDirection] = useState<SortDirection>('desc');
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   useDetachedWindowSync('metrics');
+
+  // Per-tool usage for the Per-Tool panel — the same GET /api/tools/usage
+  // pipeline the Tools workspace and Metrics Tools scope consume.
+  const { usage: toolUsageData } = useToolUsage(true);
 
   const { metricsData, costData, isLoading, error, reload, clear } = useMetricsSeries({
     timeRange,
@@ -98,6 +106,14 @@ function DetachedMetricsPageContent() {
     }
   };
 
+  const handleToolSort = (column: BreakdownSortColumn) => {
+    if (toolSortColumn === column) setToolSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else {
+      setToolSortColumn(column);
+      setToolSortDirection('desc');
+    }
+  };
+
   // Optimistic local updates after a successful model save. The detached
   // window owns local state (not the main window's store); the next status
   // poll confirms from the backend, and the main window catches up on its own.
@@ -136,6 +152,7 @@ function DetachedMetricsPageContent() {
     clientSortColumn,
     clientSortDirection,
   );
+  const sortedTools = sortBreakdownRows(derivePerToolRows(toolUsageData), toolSortColumn, toolSortDirection);
   const chartData = buildTokenChartData(metricsData);
   const costChartData = buildCostChartData(costData);
   const costSeriesHasData = costChartData.some((d) => d['Cost (USD)'] > 0);
@@ -283,6 +300,21 @@ function DetachedMetricsPageContent() {
                     />
                   )}
                 />
+              </PanelHeader>
+            )}
+
+            {sortedTools.length > 0 && (
+              <PanelHeader icon={Wrench} label="Per-Tool">
+                <ScrollableBreakdown>
+                  <BreakdownTable
+                    rows={sortedTools}
+                    nameLabel="Tool"
+                    sortColumn={toolSortColumn}
+                    sortDirection={toolSortDirection}
+                    onSort={handleToolSort}
+                    showCost
+                  />
+                </ScrollableBreakdown>
               </PanelHeader>
             )}
           </div>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -314,6 +314,13 @@ export interface ToolUsageStat {
   // RFC3339; absent when the tool has a count but no recorded timestamp,
   // or (cross-referenced from the status list) has never been called.
   lastCalledAt?: string;
+  // Cumulative tokens of the tool's own calls; absent (zero) on responses
+  // from gateways predating per-tool cost attribution.
+  inputTokens?: number;
+  outputTokens?: number;
+  // Cumulative estimated cost of the tool's priced calls. Absent when no
+  // call was priced — the em-dash rule, never $0.
+  costUsd?: number;
 }
 
 // GET /api/tools/usage — per-(server, tool) call counts + last-called times,


### PR DESCRIPTION
## Description

Extends cost accounting from server/model/client granularity down to individual tools: per-tool tokens and estimated dollars in the API and web UI, and real weekly-dollar impact on `gridctl optimize` unused-tool findings (previously stubbed to zero).

## Type of Change

- [x] New feature

## Changes Made

- `ToolStat` gains input/output token and micro-USD cost counters, recorded at the observer's single attribution point (`RecordToolCallUsage` for calls+tokens in one bucket lookup, `RecordToolCost` on the priced path only); the legacy no-tool-name path is guarded so it never creates a phantom entry
- Per-tool tokens and cost persist through the metrics NDJSON flush/seed cycle (`omitempty`, max-wins restore); legacy files load cleanly with zero values, and `ClearCost` zeroes per-tool cost while keeping calls/tokens
- `GET /api/tools/usage` adds `inputTokens`, `outputTokens`, and `costUsd` (omitted when unpriced, never `$0`)
- `detectUnusedTools` prices findings via a per-tool schema context tax modeled on `unusedServerImpact` (measured per-tool schema tokens from the live tools/list, conservative fallback and cap); the shared observed-rate idiom is extracted to `observedPerTokenRate`
- Metrics workspace gains a fifth "Tools" scope: server-qualified rows (`server › tool`), cost-descending default sort, sticky-header scroll region, keyboard-navigable rows, inspector with per-tool KPIs (no pricing editor; tool cost inherits client/server attribution), and a distinct error state when the usage endpoint is unavailable
- Tools workspace detail panel shows calls, last-used, tokens, and estimated cost whenever traffic exists (no longer gated on Audit Mode); usage polling idles unless Audit Mode is on or a tool is selected
- Detached metrics window gains a matching Per-Tool panel
- Docs updated (`cost-observability.md` per-tool section, `api-reference.md` field docs) and CHANGELOG entry added

## Testing

- `go test -race ./pkg/metrics/... ./pkg/optimize/... ./pkg/telemetry/... ./internal/api/...` (new coverage: counters, empty-name guard, ClearCost semantics, restore max-wins, flush/seed round-trip incl. legacy lines, API cost fields, impact formula incl. fallback and cap)
- `make test` (full suite), `make test-frontend` (1108 tests incl. new Tools scope, detail panel, and optimize chip specs), `golangci-lint run`, `npm run lint`, `make build`

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #886