### PR TITLE
fix: surface pin drift detail before approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to gridctl will be documented in this file.
 
+## [Unreleased]
+
+
+### Bug Fixes
+
+
+- Surface pin drift detail before approval: `GET /api/pins/{server}/diff` endpoint, `gridctl pins diff` subcommand with JSON output and 0/1/2 exit codes, and a first-class Pins workspace where the Approve action sits beside the rendered per-tool diff (non-printable characters escaped). Approvals can be bound to the reviewed snapshot via `expected_server_hash` / `pins approve --expect`, rejecting definitions that change after review
+
 ## [0.1.0-beta.14] - 2026-07-16
 
 

--- a/cmd/gridctl/pins.go
+++ b/cmd/gridctl/pins.go
@@ -7,8 +7,10 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/gridctl/gridctl/pkg/output"
 	"github.com/gridctl/gridctl/pkg/pins"
@@ -33,13 +35,16 @@ const (
 const pinsJSONSchemaVersion = 1
 
 var (
-	pinsStack        string
-	pinsExitCode     bool
-	pinsListFormat   string
-	pinsListJSON     *bool
-	pinsListPlain    *bool
-	pinsVerifyFormat string
-	pinsVerifyJSON   *bool
+	pinsStack         string
+	pinsExitCode      bool
+	pinsListFormat    string
+	pinsListJSON      *bool
+	pinsListPlain     *bool
+	pinsVerifyFormat  string
+	pinsVerifyJSON    *bool
+	pinsDiffFormat    string
+	pinsDiffJSON      *bool
+	pinsApproveExpect string
 )
 
 var pinsCmd = &cobra.Command{
@@ -102,13 +107,67 @@ Exit codes:
 	},
 }
 
+var pinsDiffCmd = &cobra.Command{
+	Use:   "diff [server]",
+	Short: "Show what changed for drifted servers",
+	Long: `Show the per-tool delta between pinned and live tool definitions.
+
+Without an argument, recomputes the diff for every pinned server against its
+live definitions and reports the servers with changes; servers that cannot be
+diffed (e.g. removed from the stack) are skipped with a warning. With a server
+name, diffs that one server regardless of status. Requires a running stack,
+since the live definitions come from the gateway.
+
+Default output is a per-tool before/after view with control characters
+escaped (poisoned descriptions hide instructions in invisible characters);
+use '--format json' for a machine-readable document. The JSON includes each
+server's live_server_hash for 'pins approve --expect'.
+
+Exit codes:
+  0  no drift
+  1  drift detected
+  2  infrastructure error (no running stack, unknown server, API failure,
+     or servers skipped with warnings)`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := resolveFormat(pinsDiffFormat, cmd.Flags().Changed("format"), *pinsDiffJSON)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(pinsExitInfrastructure)
+		}
+		server := ""
+		if len(args) == 1 {
+			server = args[0]
+		}
+		st, err := resolveRunningStack()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(pinsExitInfrastructure)
+		}
+		doc, warnings, err := buildPinsDiffDoc(st, server)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(pinsExitInfrastructure)
+		}
+		if exit := pinsDiffExit(os.Stdout, os.Stderr, doc, warnings, format); exit != pinsExitOK {
+			os.Exit(exit)
+		}
+		return nil
+	},
+}
+
 var pinsApproveCmd = &cobra.Command{
 	Use:   "approve <server>",
 	Short: "Approve schema changes for a server",
-	Long:  "Re-pin the current tool definitions for a server, clearing drift status.",
-	Args:  cobra.ExactArgs(1),
+	Long: `Re-pin the current tool definitions for a server, clearing drift status.
+
+Pass --expect with the live_server_hash from 'pins diff --format json' to
+bind the approval to the reviewed definitions: if the server's tools change
+again between review and approval, the approve is rejected instead of
+silently pinning definitions nobody saw.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runPinsApprove(args[0])
+		return runPinsApprove(args[0], pinsApproveExpect)
 	},
 }
 
@@ -136,8 +195,14 @@ func init() {
 	pinsVerifyCmd.Flags().BoolVar(&pinsExitCode, "exit-code", false, "Exit with code 1 if drift is detected (for CI)")
 	_ = pinsVerifyCmd.Flags().MarkDeprecated("exit-code", "drift now exits 1 by default")
 
+	pinsDiffCmd.Flags().StringVar(&pinsDiffFormat, "format", "", "Output format: 'json' for machine-readable output (default: text)")
+	pinsDiffJSON = addJSONAlias(pinsDiffCmd)
+
+	pinsApproveCmd.Flags().StringVar(&pinsApproveExpect, "expect", "", "Reviewed live_server_hash from 'pins diff'; approval is rejected if the live definitions no longer match")
+
 	pinsCmd.AddCommand(pinsListCmd)
 	pinsCmd.AddCommand(pinsVerifyCmd)
+	pinsCmd.AddCommand(pinsDiffCmd)
 	pinsCmd.AddCommand(pinsApproveCmd)
 	pinsCmd.AddCommand(pinsResetCmd)
 }
@@ -345,7 +410,244 @@ func pinsVerifyExit(stdout, stderr io.Writer, stackName string, servers map[stri
 	return pinsExitOK
 }
 
-func runPinsApprove(server string) error {
+// pinsToolDiff is one modified tool in the diff document, mirroring the
+// GET /api/pins/{server}/diff wire shape.
+type pinsToolDiff struct {
+	Name           string `json:"name"`
+	OldHash        string `json:"old_hash"`
+	NewHash        string `json:"new_hash"`
+	OldDescription string `json:"old_description"`
+	NewDescription string `json:"new_description"`
+}
+
+// pinsDiffServer is one server's delta in the diff document. LiveServerHash
+// fingerprints the live definitions; pass it to 'pins approve --expect' to
+// bind the approval to this reviewed snapshot.
+type pinsDiffServer struct {
+	Name           string         `json:"name"`
+	Status         string         `json:"status"`
+	LiveServerHash string         `json:"live_server_hash"`
+	ModifiedTools  []pinsToolDiff `json:"modified_tools"`
+	NewTools       []string       `json:"new_tools"`
+	RemovedTools   []string       `json:"removed_tools"`
+}
+
+// pinsDiffDoc is the machine-readable document emitted by `pins diff --format json`.
+type pinsDiffDoc struct {
+	SchemaVersion int              `json:"schema_version"`
+	Stack         string           `json:"stack"`
+	HasDrift      bool             `json:"has_drift"`
+	Servers       []pinsDiffServer `json:"servers"`
+}
+
+// apiErrorMessage extracts the "error" field from a writeJSONError body,
+// falling back to the raw body so the daemon's actual reason is never hidden.
+func apiErrorMessage(body []byte, fallback string) string {
+	var wire struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &wire); err == nil && wire.Error != "" {
+		return wire.Error
+	}
+	if len(body) > 0 {
+		return string(body)
+	}
+	return fallback
+}
+
+// fetchPinsDiff retrieves one server's diff from the running gateway.
+func fetchPinsDiff(st *state.DaemonState, server string) (*pinsDiffServer, error) {
+	url := fmt.Sprintf("http://localhost:%d/api/pins/%s/diff", st.Port, server)
+	client := &http.Client{Timeout: pinsAPITimeout}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("calling pins API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	// 404 covers two distinct cases the daemon distinguishes in its message:
+	// no pins for the server, or pins exist but the server is not in the
+	// gateway (removed from the stack). Surface the daemon's reason verbatim.
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%s (for a server removed from the stack, run 'gridctl pins reset %s')",
+			apiErrorMessage(body, "no pins found for server "+server), server)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("diff failed: %s", string(body))
+	}
+
+	var wire struct {
+		Server         string         `json:"server"`
+		Status         string         `json:"status"`
+		LiveServerHash string         `json:"live_server_hash"`
+		ModifiedTools  []pinsToolDiff `json:"modified_tools"`
+		NewTools       []string       `json:"new_tools"`
+		RemovedTools   []string       `json:"removed_tools"`
+	}
+	if err := json.Unmarshal(body, &wire); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+	return &pinsDiffServer{
+		Name:           wire.Server,
+		Status:         wire.Status,
+		LiveServerHash: wire.LiveServerHash,
+		ModifiedTools:  wire.ModifiedTools,
+		NewTools:       wire.NewTools,
+		RemovedTools:   wire.RemovedTools,
+	}, nil
+}
+
+// hasChanges reports whether a server's diff carries any delta.
+func (sv *pinsDiffServer) hasChanges() bool {
+	return len(sv.ModifiedTools)+len(sv.NewTools)+len(sv.RemovedTools) > 0
+}
+
+// buildPinsDiffDoc assembles the diff report from the running gateway. With a
+// named server it diffs that one server regardless of status. Without, it
+// recomputes against live tools for every pinned server (the persisted status
+// can be stale) and reports the ones with changes; servers that fail to diff
+// are skipped with a warning rather than aborting the whole report.
+func buildPinsDiffDoc(st *state.DaemonState, server string) (pinsDiffDoc, []string, error) {
+	doc := pinsDiffDoc{
+		SchemaVersion: pinsJSONSchemaVersion,
+		Stack:         st.StackName,
+		Servers:       []pinsDiffServer{},
+	}
+
+	if server != "" {
+		sv, err := fetchPinsDiff(st, server)
+		if err != nil {
+			return doc, nil, err
+		}
+		doc.Servers = append(doc.Servers, *sv)
+		doc.HasDrift = len(sv.ModifiedTools) > 0
+		return doc, nil, nil
+	}
+
+	_, servers, err := loadPinsForCLI()
+	if err != nil {
+		return doc, nil, err
+	}
+
+	var warnings []string
+	for _, name := range sortedMapKeys(servers) {
+		sv, err := fetchPinsDiff(st, name)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("skipping %s: %v", name, err))
+			continue
+		}
+		if !sv.hasChanges() {
+			continue
+		}
+		doc.Servers = append(doc.Servers, *sv)
+		if len(sv.ModifiedTools) > 0 {
+			doc.HasDrift = true
+		}
+	}
+	return doc, warnings, nil
+}
+
+// pinsDiffExit renders the diff report and returns the process exit code:
+// 0 no drift, 1 drift detected, 2 infrastructure error (including servers
+// that could not be diffed, so CI never mistakes a partial report for clean).
+// Drift outranks warnings: it is the actionable signal.
+func pinsDiffExit(stdout, stderr io.Writer, doc pinsDiffDoc, warnings []string, format string) int {
+	for _, wmsg := range warnings {
+		fmt.Fprintln(stderr, "warning: "+wmsg)
+	}
+	if strings.EqualFold(format, "json") {
+		if err := output.EncodeJSON(stdout, doc); err != nil {
+			fmt.Fprintln(stderr, err)
+			return pinsExitInfrastructure
+		}
+	} else {
+		renderPinsDiffText(stdout, doc)
+	}
+	if doc.HasDrift {
+		return pinsExitDrift
+	}
+	if len(warnings) > 0 {
+		return pinsExitInfrastructure
+	}
+	return pinsExitOK
+}
+
+// renderPinsDiffText prints the human per-tool before/after view.
+func renderPinsDiffText(w io.Writer, doc pinsDiffDoc) {
+	if len(doc.Servers) == 0 {
+		fmt.Fprintln(w, "No drift detected.")
+		return
+	}
+	for i, sv := range doc.Servers {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "%s (%s)\n", sv.Name, sv.Status)
+		if len(sv.ModifiedTools)+len(sv.NewTools)+len(sv.RemovedTools) == 0 {
+			fmt.Fprintln(w, "  ✓ no changes")
+			continue
+		}
+		for _, d := range sv.ModifiedTools {
+			fmt.Fprintf(w, "  ~ %s\n", escapeNonPrintable(d.Name))
+			fmt.Fprintf(w, "      old %s  %s\n", shortPinHash(d.OldHash), escapeNonPrintable(d.OldDescription))
+			fmt.Fprintf(w, "      new %s  %s\n", shortPinHash(d.NewHash), escapeNonPrintable(d.NewDescription))
+		}
+		for _, name := range sv.NewTools {
+			fmt.Fprintf(w, "  + %s (new tool, pinned on approve)\n", escapeNonPrintable(name))
+		}
+		for _, name := range sv.RemovedTools {
+			fmt.Fprintf(w, "  - %s (removed from server)\n", escapeNonPrintable(name))
+		}
+	}
+}
+
+// shortPinHash abbreviates a pin hash for display, keeping any scheme prefix
+// (e.g. "h2:") and the first 12 hex characters.
+func shortPinHash(h string) string {
+	prefix := ""
+	if idx := strings.IndexByte(h, ':'); idx >= 0 {
+		prefix, h = h[:idx+1], h[idx+1:]
+	}
+	if len(h) > 12 {
+		h = h[:12]
+	}
+	return prefix + h
+}
+
+// escapeNonPrintable renders control and other non-printable runes as visible
+// escape sequences such as \n or U+202E. Tool descriptions are instructions to
+// the model, and poisoned ones hide payloads in exactly this channel, so the
+// reviewer must see every character.
+// Backslash is escaped too, so literal escape-looking text in a description
+// cannot spoof the rendering of a real hidden character.
+func escapeNonPrintable(s string) string {
+	if !strings.ContainsFunc(s, func(r rune) bool { return r == '\\' || !unicode.IsPrint(r) }) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r == '\\' {
+			b.WriteString(`\\`)
+			continue
+		}
+		if unicode.IsPrint(r) {
+			b.WriteRune(r)
+			continue
+		}
+		q := strconv.QuoteRune(r)
+		b.WriteString(q[1 : len(q)-1])
+	}
+	return b.String()
+}
+
+func runPinsApprove(server, expectHash string) error {
 	st, err := resolveRunningStack()
 	if err != nil {
 		return err
@@ -354,7 +656,16 @@ func runPinsApprove(server string) error {
 	url := fmt.Sprintf("http://localhost:%d/api/pins/%s/approve", st.Port, server)
 	client := &http.Client{Timeout: pinsAPITimeout}
 
-	resp, err := client.Post(url, "application/json", nil)
+	var reqBody io.Reader
+	if expectHash != "" {
+		payload, err := json.Marshal(map[string]string{"expected_server_hash": expectHash})
+		if err != nil {
+			return fmt.Errorf("encoding request: %w", err)
+		}
+		reqBody = strings.NewReader(string(payload))
+	}
+
+	resp, err := client.Post(url, "application/json", reqBody)
 	if err != nil {
 		return fmt.Errorf("calling pins API: %w", err)
 	}
@@ -366,7 +677,12 @@ func runPinsApprove(server string) error {
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("no pins found for server %q. Deploy the stack first", server)
+		return fmt.Errorf("%s (for a server removed from the stack, run 'gridctl pins reset %s')",
+			apiErrorMessage(body, "no pins found for server "+server), server)
+	}
+	if resp.StatusCode == http.StatusConflict {
+		return fmt.Errorf("%s (run 'gridctl pins diff %s' to review the current definitions)",
+			apiErrorMessage(body, "tool definitions changed since review"), server)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("approve failed: %s", string(body))

--- a/cmd/gridctl/pins_test.go
+++ b/cmd/gridctl/pins_test.go
@@ -211,3 +211,141 @@ func TestPinsVerifyExit_EmptyStoreJSONEmitsDocument(t *testing.T) {
 		t.Errorf("empty store must report has_drift=false, got %v", decoded["has_drift"])
 	}
 }
+
+func testDiffDoc(hasDrift bool) pinsDiffDoc {
+	sv := pinsDiffServer{
+		Name:          "myserver",
+		Status:        pins.VerifyStatusVerified,
+		ModifiedTools: []pinsToolDiff{},
+		NewTools:      []string{},
+		RemovedTools:  []string{},
+	}
+	if hasDrift {
+		sv.Status = pins.VerifyStatusDrift
+		sv.ModifiedTools = []pinsToolDiff{{
+			Name:           "poisoned",
+			OldHash:        "h2:947cd68fbf83c18ca75435e6730174418b91fd0e",
+			NewHash:        "h2:267032e068c7ee40310b8cea8e12f1248a974166",
+			OldDescription: "original description",
+			NewDescription: "new\u202edescription\nwith hidden characters",
+		}}
+		sv.NewTools = []string{"added"}
+		sv.RemovedTools = []string{"retired"}
+	}
+	return pinsDiffDoc{
+		SchemaVersion: pinsJSONSchemaVersion,
+		Stack:         "mystack",
+		HasDrift:      hasDrift,
+		Servers:       []pinsDiffServer{sv},
+	}
+}
+
+func TestPinsDiffExit_Codes(t *testing.T) {
+	cases := []struct {
+		name     string
+		doc      pinsDiffDoc
+		warnings []string
+		format   string
+		want     int
+	}{
+		{"clean text", testDiffDoc(false), nil, "", pinsExitOK},
+		{"clean json", testDiffDoc(false), nil, "json", pinsExitOK},
+		{"drift text", testDiffDoc(true), nil, "", pinsExitDrift},
+		{"drift json", testDiffDoc(true), nil, "json", pinsExitDrift},
+		// Skipped servers must not read as clean: warnings raise exit 2.
+		{"clean with warnings", testDiffDoc(false), []string{"skipping gone: not in gateway"}, "", pinsExitInfrastructure},
+		// Drift outranks warnings; it is the actionable signal.
+		{"drift with warnings", testDiffDoc(true), []string{"skipping gone: not in gateway"}, "", pinsExitDrift},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			got := pinsDiffExit(&stdout, &stderr, tc.doc, tc.warnings, tc.format)
+			if got != tc.want {
+				t.Errorf("exit code: expected %d, got %d (stdout=%q stderr=%q)", tc.want, got, stdout.String(), stderr.String())
+			}
+			if len(tc.warnings) > 0 && !strings.Contains(stderr.String(), "warning: skipping gone") {
+				t.Errorf("warnings not printed to stderr, got %q", stderr.String())
+			}
+			if tc.format == "json" {
+				var decoded map[string]any
+				if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+					t.Errorf("json mode stdout is not valid JSON: %v", err)
+				}
+				if hasDrift, ok := decoded["has_drift"].(bool); !ok || hasDrift != tc.doc.HasDrift {
+					t.Errorf("has_drift = %v, want %v", decoded["has_drift"], tc.doc.HasDrift)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderPinsDiffText_EscapesAndShortensHashes(t *testing.T) {
+	var buf bytes.Buffer
+	renderPinsDiffText(&buf, testDiffDoc(true))
+	out := buf.String()
+
+	if !strings.Contains(out, "myserver (drift)") {
+		t.Errorf("missing server header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "old h2:947cd68fbf83") || !strings.Contains(out, "new h2:267032e068c7") {
+		t.Errorf("expected shortened old/new hashes, got:\n%s", out)
+	}
+	// The RTL-override and newline in the poisoned description must render as
+	// visible escapes, never as the raw control characters.
+	if strings.ContainsAny(out, "\u202e") {
+		t.Error("raw U+202E leaked into text output")
+	}
+	if !strings.Contains(out, `new\u202edescription\nwith hidden characters`) {
+		t.Errorf("expected escaped description, got:\n%s", out)
+	}
+	if !strings.Contains(out, "+ added") || !strings.Contains(out, "- retired") {
+		t.Errorf("expected new/removed tool lines, got:\n%s", out)
+	}
+}
+
+func TestRenderPinsDiffText_CleanAndEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	renderPinsDiffText(&buf, testDiffDoc(false))
+	if !strings.Contains(buf.String(), "no changes") {
+		t.Errorf("expected 'no changes' for a clean server, got:\n%s", buf.String())
+	}
+
+	buf.Reset()
+	renderPinsDiffText(&buf, pinsDiffDoc{Servers: []pinsDiffServer{}})
+	if !strings.Contains(buf.String(), "No drift detected.") {
+		t.Errorf("expected empty-doc message, got:\n%s", buf.String())
+	}
+}
+
+func TestEscapeNonPrintable(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain text stays", "plain text stays"},
+		{"tab\there", `tab\there`},
+		{"line\nbreak", `line\nbreak`},
+		{"rtl\u202eoverride", `rtl\u202eoverride`},
+		{"zero\u200bwidth", `zero\u200bwidth`},
+		{"bell\x07", `bell\a`},
+		{"back\\slash", `back\\slash`},
+		{"isolate\u2066wrap\u2069", `isolate\u2066wrap\u2069`},
+	}
+	for _, tc := range cases {
+		if got := escapeNonPrintable(tc.in); got != tc.want {
+			t.Errorf("escapeNonPrintable(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestShortPinHash(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"h2:947cd68fbf83c18ca75435e6730174418b91fd0e", "h2:947cd68fbf83"},
+		{"947cd68fbf83c18ca75435e6730174418b91fd0e", "947cd68fbf83"},
+		{"h2:short", "h2:short"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := shortPinHash(tc.in); got != tc.want {
+			t.Errorf("shortPinHash(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -380,6 +380,7 @@ func (s *Server) Handler() http.Handler {
 	// Pins endpoints
 	mux.HandleFunc("GET /api/pins", s.handleListPins)
 	mux.HandleFunc("GET /api/pins/{server}", s.handleGetServerPins)
+	mux.HandleFunc("GET /api/pins/{server}/diff", s.handlePinsDiff)
 	mux.HandleFunc("POST /api/pins/{server}/approve", s.handleApprovePins)
 	mux.HandleFunc("DELETE /api/pins/{server}", s.handleResetPins)
 

--- a/internal/api/pins.go
+++ b/internal/api/pins.go
@@ -1,8 +1,63 @@
 package api
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
+
+	"github.com/gridctl/gridctl/pkg/pins"
 )
+
+// pinsToolDiff is the wire form of pins.ToolDiff.
+type pinsToolDiff struct {
+	Name           string `json:"name"`
+	OldHash        string `json:"old_hash"`
+	NewHash        string `json:"new_hash"`
+	OldDescription string `json:"old_description"`
+	NewDescription string `json:"new_description"`
+}
+
+// pinsDiffResponse is the document returned by GET /api/pins/{server}/diff.
+// Slices are always non-nil so consumers see [] rather than null.
+// LiveServerHash is the fingerprint Approve would store for the live tools;
+// pass it back as expected_server_hash on approve to bind the approval to
+// this reviewed snapshot.
+type pinsDiffResponse struct {
+	Server         string         `json:"server"`
+	Status         string         `json:"status"`
+	LiveServerHash string         `json:"live_server_hash"`
+	ModifiedTools  []pinsToolDiff `json:"modified_tools"`
+	NewTools       []string       `json:"new_tools"`
+	RemovedTools   []string       `json:"removed_tools"`
+}
+
+func buildPinsDiffResponse(vr *pins.VerifyResult, liveServerHash string) pinsDiffResponse {
+	resp := pinsDiffResponse{
+		Server:         vr.ServerName,
+		Status:         vr.Status,
+		LiveServerHash: liveServerHash,
+		ModifiedTools:  make([]pinsToolDiff, 0, len(vr.ModifiedTools)),
+		NewTools:       vr.NewTools,
+		RemovedTools:   vr.RemovedTools,
+	}
+	if resp.NewTools == nil {
+		resp.NewTools = []string{}
+	}
+	if resp.RemovedTools == nil {
+		resp.RemovedTools = []string{}
+	}
+	for _, d := range vr.ModifiedTools {
+		resp.ModifiedTools = append(resp.ModifiedTools, pinsToolDiff{
+			Name:           d.Name,
+			OldHash:        d.OldHash,
+			NewHash:        d.NewHash,
+			OldDescription: d.OldDescription,
+			NewDescription: d.NewDescription,
+		})
+	}
+	return resp
+}
 
 // handleListPins returns all servers' pin records.
 // GET /api/pins
@@ -37,14 +92,73 @@ func (s *Server) handleGetServerPins(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, sp)
 }
 
+// handlePinsDiff compares a server's pinned tool definitions against its live
+// tools and returns the per-tool delta (modified, new, removed). The diff is
+// recomputed on demand via the read-only Verify path; nothing is persisted, so
+// viewing a diff never mutates pin state.
+// GET /api/pins/{server}/diff
+func (s *Server) handlePinsDiff(w http.ResponseWriter, r *http.Request) {
+	if s.pinStore == nil {
+		writeJSONError(w, "Pin store not available", http.StatusServiceUnavailable)
+		return
+	}
+	serverName := r.PathValue("server")
+
+	// A server with no pins has nothing to diff against; mirror the
+	// get-server semantics rather than returning an empty diff.
+	if _, ok := s.pinStore.GetServer(serverName); !ok {
+		writeJSONError(w, "No pins found for server: "+serverName, http.StatusNotFound)
+		return
+	}
+
+	client := s.gateway.Router().GetClient(serverName)
+	if client == nil {
+		writeJSONError(w, "Server not found in gateway: "+serverName, http.StatusNotFound)
+		return
+	}
+
+	tools := client.Tools()
+	vr, err := s.pinStore.Verify(serverName, tools)
+	if err != nil {
+		writeJSONError(w, "Failed to compute diff: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	liveHash, err := pins.HashTools(tools)
+	if err != nil {
+		writeJSONError(w, "Failed to fingerprint live tools: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, buildPinsDiffResponse(vr, liveHash))
+}
+
 // handleApprovePins re-pins the current tool definitions for a server, clearing drift.
 // POST /api/pins/{server}/approve
+//
+// The optional JSON body {"expected_server_hash": "..."} binds the approval
+// to a reviewed diff: when present, the live tools must still hash to that
+// fingerprint (as returned by the diff endpoint's live_server_hash) or the
+// approval is rejected with 409, so definitions that changed after review
+// can never be pinned unseen. An empty body preserves the unconditional
+// approve for existing callers.
 func (s *Server) handleApprovePins(w http.ResponseWriter, r *http.Request) {
 	if s.pinStore == nil {
 		writeJSONError(w, "Pin store not available", http.StatusServiceUnavailable)
 		return
 	}
 	serverName := r.PathValue("server")
+
+	var body struct {
+		ExpectedServerHash string `json:"expected_server_hash"`
+	}
+	if r.Body != nil {
+		// A missing or empty body is fine; only a malformed one is an error.
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+			writeJSONError(w, "Invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
 
 	// Verify the server has existing pins before approving.
 	if _, ok := s.pinStore.GetServer(serverName); !ok {
@@ -59,6 +173,20 @@ func (s *Server) handleApprovePins(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tools := client.Tools()
+
+	if body.ExpectedServerHash != "" {
+		liveHash, err := pins.HashTools(tools)
+		if err != nil {
+			writeJSONError(w, "Failed to fingerprint live tools: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if liveHash != body.ExpectedServerHash {
+			writeJSONError(w,
+				"Tool definitions changed since the reviewed diff; fetch the diff again and re-review",
+				http.StatusConflict)
+			return
+		}
+	}
 
 	if err := s.pinStore.Approve(serverName, tools); err != nil {
 		writeJSONError(w, "Failed to approve pins: "+err.Error(), http.StatusInternalServerError)

--- a/internal/api/pins_test.go
+++ b/internal/api/pins_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gridctl/gridctl/pkg/mcp"
@@ -154,6 +155,215 @@ func TestHandlePins_Approve_ServerNotInGateway(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandlePinsDiff_NoStore(t *testing.T) {
+	server := &Server{gateway: mcp.NewGateway()}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/pins/myserver/diff", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestHandlePinsDiff_PinsNotFound(t *testing.T) {
+	server, _ := setupPinsServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/pins/unknown-server/diff", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandlePinsDiff_ServerNotInGateway(t *testing.T) {
+	server, ps := setupPinsServer(t)
+
+	tools := []mcp.Tool{{Name: "tool1", Description: "does something"}}
+	if _, err := ps.VerifyOrPin("myserver", tools); err != nil {
+		t.Fatalf("VerifyOrPin: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/pins/myserver/diff", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandlePinsDiff_Clean(t *testing.T) {
+	server, ps := setupPinsServer(t)
+
+	tools := []mcp.Tool{{Name: "tool1", Description: "does something"}}
+	if _, err := ps.VerifyOrPin("myserver", tools); err != nil {
+		t.Fatalf("VerifyOrPin: %v", err)
+	}
+	server.gateway.Router().AddClient(newMockAgentClient("myserver", tools))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/pins/myserver/diff", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var result pinsDiffResponse
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Status != pins.VerifyStatusVerified {
+		t.Errorf("status = %q, want %q", result.Status, pins.VerifyStatusVerified)
+	}
+	// Empty deltas must serialize as [] rather than null.
+	if result.ModifiedTools == nil || result.NewTools == nil || result.RemovedTools == nil {
+		t.Error("expected empty slices, got nil")
+	}
+	if len(result.ModifiedTools)+len(result.NewTools)+len(result.RemovedTools) != 0 {
+		t.Errorf("expected empty diff, got %+v", result)
+	}
+}
+
+func TestHandlePinsDiff_Drift(t *testing.T) {
+	server, ps := setupPinsServer(t)
+
+	pinned := []mcp.Tool{
+		{Name: "stable", Description: "unchanged"},
+		{Name: "poisoned", Description: "original description"},
+		{Name: "retired", Description: "will disappear"},
+	}
+	if _, err := ps.VerifyOrPin("myserver", pinned); err != nil {
+		t.Fatalf("VerifyOrPin: %v", err)
+	}
+
+	live := []mcp.Tool{
+		{Name: "stable", Description: "unchanged"},
+		{Name: "poisoned", Description: "new sneaky description"},
+		{Name: "added", Description: "brand new"},
+	}
+	server.gateway.Router().AddClient(newMockAgentClient("myserver", live))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/pins/myserver/diff", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var result pinsDiffResponse
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Server != "myserver" {
+		t.Errorf("server = %q, want %q", result.Server, "myserver")
+	}
+	if result.Status != pins.VerifyStatusDrift {
+		t.Errorf("status = %q, want %q", result.Status, pins.VerifyStatusDrift)
+	}
+	if len(result.ModifiedTools) != 1 {
+		t.Fatalf("modified_tools = %d, want 1", len(result.ModifiedTools))
+	}
+	mod := result.ModifiedTools[0]
+	if mod.Name != "poisoned" {
+		t.Errorf("modified tool = %q, want %q", mod.Name, "poisoned")
+	}
+	if mod.OldDescription != "original description" || mod.NewDescription != "new sneaky description" {
+		t.Errorf("descriptions = %q -> %q, want original -> new", mod.OldDescription, mod.NewDescription)
+	}
+	if mod.OldHash == "" || mod.NewHash == "" || mod.OldHash == mod.NewHash {
+		t.Errorf("hashes = %q -> %q, want distinct non-empty", mod.OldHash, mod.NewHash)
+	}
+	if len(result.NewTools) != 1 || result.NewTools[0] != "added" {
+		t.Errorf("new_tools = %v, want [added]", result.NewTools)
+	}
+	if len(result.RemovedTools) != 1 || result.RemovedTools[0] != "retired" {
+		t.Errorf("removed_tools = %v, want [retired]", result.RemovedTools)
+	}
+	if result.LiveServerHash == "" {
+		t.Error("live_server_hash missing; approve cannot be bound to the reviewed diff without it")
+	}
+
+	// Viewing a diff must not mutate pin state: still drift-free on disk
+	// until approved, and a subsequent approve clears it.
+	if sp, ok := ps.GetServer("myserver"); !ok || len(sp.Tools) != 3 {
+		t.Error("diff mutated stored pins")
+	}
+	if err := ps.Approve("myserver", live); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if sp, _ := ps.GetServer("myserver"); sp.Status != pins.StatusPinned {
+		t.Errorf("status after approve = %q, want %q", sp.Status, pins.StatusPinned)
+	}
+}
+
+func TestHandlePins_Approve_ExpectedHash(t *testing.T) {
+	server, ps := setupPinsServer(t)
+
+	pinned := []mcp.Tool{{Name: "echo", Description: "original"}}
+	if _, err := ps.VerifyOrPin("myserver", pinned); err != nil {
+		t.Fatalf("VerifyOrPin: %v", err)
+	}
+	live := []mcp.Tool{{Name: "echo", Description: "changed"}}
+	server.gateway.Router().AddClient(newMockAgentClient("myserver", live))
+
+	// Fetch the diff to get the reviewed fingerprint.
+	req := httptest.NewRequest(http.MethodGet, "/api/pins/myserver/diff", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+	var diff pinsDiffResponse
+	if err := json.NewDecoder(w.Body).Decode(&diff); err != nil {
+		t.Fatalf("decode diff: %v", err)
+	}
+
+	// A stale fingerprint (definitions changed after review) must be rejected.
+	stale := strings.NewReader(`{"expected_server_hash":"h2:not-what-was-reviewed"}`)
+	req = httptest.NewRequest(http.MethodPost, "/api/pins/myserver/approve", stale)
+	w = httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("stale hash: status = %d, want %d", w.Code, http.StatusConflict)
+	}
+	if sp, _ := ps.GetServer("myserver"); sp.Tools["echo"].Description != "original" {
+		t.Error("stale-hash approve must not re-pin")
+	}
+
+	// The reviewed fingerprint still matches the live tools: approve succeeds.
+	fresh := strings.NewReader(`{"expected_server_hash":"` + diff.LiveServerHash + `"}`)
+	req = httptest.NewRequest(http.MethodPost, "/api/pins/myserver/approve", fresh)
+	w = httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("matching hash: status = %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+	if sp, _ := ps.GetServer("myserver"); sp.Tools["echo"].Description != "changed" {
+		t.Error("approve with matching hash should re-pin the live definitions")
+	}
+}
+
+func TestHandlePins_Approve_NoBodyStaysUnconditional(t *testing.T) {
+	server, ps := setupPinsServer(t)
+
+	pinned := []mcp.Tool{{Name: "echo", Description: "original"}}
+	if _, err := ps.VerifyOrPin("myserver", pinned); err != nil {
+		t.Fatalf("VerifyOrPin: %v", err)
+	}
+	server.gateway.Router().AddClient(newMockAgentClient("myserver", []mcp.Tool{{Name: "echo", Description: "changed"}}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/pins/myserver/approve", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (empty body preserves the legacy contract)", w.Code, http.StatusOK)
 	}
 }
 

--- a/pkg/pins/store.go
+++ b/pkg/pins/store.go
@@ -209,6 +209,24 @@ func (ps *PinStore) withFileLock(fn func() (*VerifyResult, error)) (*VerifyResul
 	return result, err
 }
 
+// HashTools computes the server-level fingerprint that Approve would store
+// for the given tools. It lets callers bind an approval to a reviewed
+// snapshot: capture the fingerprint when rendering a diff, then compare it
+// against the live one at approve time and reject on mismatch, closing the
+// window where a server swaps in unreviewed definitions between review and
+// approval.
+func HashTools(tools []mcp.Tool) (string, error) {
+	hashes := make([]string, 0, len(tools))
+	for _, t := range sortedTools(tools) {
+		h, err := hashTool(t)
+		if err != nil {
+			return "", fmt.Errorf("pins: hashing tool %q: %w", t.Name, err)
+		}
+		hashes = append(hashes, h)
+	}
+	return hashStrings(hashes), nil
+}
+
 // pinServer hashes all provided tools and stores them as a fresh pin record.
 // Caller must hold ps.mu.Lock().
 func (ps *PinStore) pinServer(serverName string, tools []mcp.Tool) (*VerifyResult, error) {

--- a/web/src/__tests__/PinsPanel.test.tsx
+++ b/web/src/__tests__/PinsPanel.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { PinsPanel } from '../components/pins/PinsPanel';
+import { usePinsStore } from '../stores/usePinsStore';
+import * as api from '../lib/api';
+import type { ServerPins } from '../lib/api';
+
+vi.mock('../components/ui/Toast', () => ({ showToast: vi.fn() }));
+
+function serverPins(status: ServerPins['status']): ServerPins {
+  return {
+    server_hash: 'h2:abc',
+    pinned_at: '2026-07-01T00:00:00Z',
+    last_verified_at: '2026-07-15T00:00:00Z',
+    tool_count: 3,
+    status,
+    tools: {},
+  };
+}
+
+// Surfaces the current location in the DOM so navigation from row clicks is
+// observable without reassigning module state from inside a component.
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="location">{`${loc.pathname}${loc.search}`}</div>;
+}
+
+function renderPanel() {
+  return render(
+    <MemoryRouter initialEntries={['/topology']}>
+      <LocationProbe />
+      <Routes>
+        <Route path="*" element={<PinsPanel />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  usePinsStore.setState({
+    pins: {
+      github: serverPins('pinned'),
+      zapier: serverPins('drift'),
+    },
+  });
+});
+
+afterEach(() => {
+  usePinsStore.setState({ pins: null });
+  vi.restoreAllMocks();
+});
+
+describe('PinsPanel', () => {
+  it('navigates to the Pins workspace when a row is clicked', () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByText('zapier'));
+    expect(screen.getByTestId('location')).toHaveTextContent('/pins?server=zapier');
+  });
+
+  it('exposes a keyboard-accessible affordance for the row drill-down', () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: /open github in pins workspace/i }));
+    expect(screen.getByTestId('location')).toHaveTextContent('/pins?server=github');
+  });
+
+  it('approves without navigating when the Approve button is clicked', async () => {
+    const approve = vi.spyOn(api, 'approveServerPins').mockResolvedValue(undefined);
+    vi.spyOn(api, 'fetchServerPins').mockResolvedValue({
+      github: serverPins('pinned'),
+      zapier: serverPins('pinned'),
+    });
+
+    renderPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: /^approve$/i }));
+
+    await waitFor(() => expect(approve).toHaveBeenCalledWith('zapier'));
+    expect(screen.getByTestId('location')).toHaveTextContent('/topology');
+  });
+
+  it('shows no Approve button for pinned servers', () => {
+    usePinsStore.setState({ pins: { github: serverPins('pinned') } });
+    renderPanel();
+
+    expect(screen.queryByRole('button', { name: /^approve$/i })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/PinsWorkspace.test.tsx
+++ b/web/src/__tests__/PinsWorkspace.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { PinsWorkspace } from '../components/workspaces/PinsWorkspace';
+import { usePinsStore } from '../stores/usePinsStore';
+import * as api from '../lib/api';
+import type { PinsDiff, ServerPins } from '../lib/api';
+
+vi.mock('../components/ui/Toast', () => ({ showToast: vi.fn() }));
+
+function serverPins(status: ServerPins['status'], tools: ServerPins['tools'] = {}): ServerPins {
+  return {
+    server_hash: 'h2:abc',
+    pinned_at: '2026-07-01T00:00:00Z',
+    last_verified_at: '2026-07-15T00:00:00Z',
+    tool_count: Object.keys(tools).length,
+    status,
+    tools,
+  };
+}
+
+const zapierDiff: PinsDiff = {
+  server: 'zapier',
+  status: 'drift',
+  live_server_hash: 'h2:reviewed-live-fingerprint',
+  modified_tools: [
+    {
+      name: 'poisoned_tool',
+      old_hash: 'h2:947cd68fbf83c18ca75435e6730174418b91fd0e',
+      new_hash: 'h2:267032e068c7ee40310b8cea8e12f1248a974166',
+      old_description: 'original description',
+      new_description: 'changed description',
+    },
+  ],
+  new_tools: ['brand_new_tool'],
+  removed_tools: ['retired_tool'],
+};
+
+function renderWorkspace(initialEntry = '/pins') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <PinsWorkspace />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  usePinsStore.setState({
+    pins: {
+      github: serverPins('pinned', {
+        create_issue: {
+          hash: 'h2:aaaa11112222333344445555',
+          name: 'create_issue',
+          description: 'Create an issue',
+          pinned_at: '2026-07-01T00:00:00Z',
+        },
+      }),
+      zapier: serverPins('drift'),
+    },
+  });
+  vi.spyOn(api, 'fetchPinsDiff').mockResolvedValue(zapierDiff);
+});
+
+afterEach(() => {
+  usePinsStore.setState({ pins: null });
+  vi.restoreAllMocks();
+});
+
+describe('PinsWorkspace', () => {
+  it('selects the drifted server first and renders its diff', async () => {
+    renderWorkspace();
+
+    // Drift sorts first, so zapier is the default selection and its diff loads.
+    await waitFor(() => expect(api.fetchPinsDiff).toHaveBeenCalledWith('zapier'));
+
+    expect(await screen.findByText('poisoned_tool')).toBeInTheDocument();
+    expect(screen.getByText(/original description/)).toBeInTheDocument();
+    expect(screen.getByText(/changed description/)).toBeInTheDocument();
+    expect(screen.getByText(/h2:947cd68fbf83/)).toBeInTheDocument();
+    expect(screen.getByText(/h2:267032e068c7/)).toBeInTheDocument();
+    expect(screen.getByText('brand_new_tool')).toBeInTheDocument();
+    expect(screen.getByText('retired_tool')).toBeInTheDocument();
+  });
+
+  it('co-locates Approve with the rendered diff and approves the reviewed server', async () => {
+    const approve = vi.spyOn(api, 'approveServerPins').mockResolvedValue(undefined);
+    vi.spyOn(api, 'fetchServerPins').mockResolvedValue({
+      github: serverPins('pinned'),
+      zapier: serverPins('pinned'),
+    });
+
+    renderWorkspace();
+
+    // Approve is disabled until the diff has rendered — no blind approval.
+    const approveButton = await screen.findByRole('button', { name: /approve/i });
+    await screen.findByText('poisoned_tool');
+
+    const driftSection = screen.getByRole('region', { name: /schema drift for zapier/i });
+    expect(driftSection).toContainElement(approveButton);
+    expect(approveButton).toHaveTextContent(/3 changes/);
+
+    fireEvent.click(approveButton);
+    // The approval is bound to the reviewed diff's fingerprint so definitions
+    // that change after review are rejected server-side.
+    await waitFor(() =>
+      expect(approve).toHaveBeenCalledWith('zapier', 'h2:reviewed-live-fingerprint'),
+    );
+  });
+
+  it('honors ?server= selection and shows pinned tool records', async () => {
+    renderWorkspace('/pins?server=github');
+
+    expect(await screen.findByText('create_issue')).toBeInTheDocument();
+    expect(screen.getByText(/h2:aaaa11112222/)).toBeInTheDocument();
+    // A pinned server has no drift section.
+    expect(screen.queryByText(/schema drift/i)).not.toBeInTheDocument();
+  });
+
+  it('renders hidden characters in descriptions as visible escapes', async () => {
+    vi.spyOn(api, 'fetchPinsDiff').mockResolvedValue({
+      ...zapierDiff,
+      modified_tools: [
+        {
+          ...zapierDiff.modified_tools[0],
+          new_description: 'visible‮hidden payload',
+        },
+      ],
+      new_tools: [],
+      removed_tools: [],
+    });
+
+    renderWorkspace();
+
+    expect(await screen.findByText(/visible\\u202ehidden payload/)).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/nonPrintable.test.ts
+++ b/web/src/__tests__/nonPrintable.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { escapeNonPrintable, shortPinHash } from '../lib/nonPrintable';
+
+describe('escapeNonPrintable', () => {
+  it('leaves printable text untouched', () => {
+    expect(escapeNonPrintable('plain text stays, even with punctuation!')).toBe(
+      'plain text stays, even with punctuation!',
+    );
+  });
+
+  it('escapes common control characters with their named forms', () => {
+    expect(escapeNonPrintable('line\nbreak\tand\rreturn')).toBe(
+      'line\\nbreak\\tand\\rreturn',
+    );
+  });
+
+  it('escapes bidi overrides and zero-width characters as unicode escapes', () => {
+    expect(escapeNonPrintable('rtl‮override')).toBe('rtl\\u202eoverride');
+    expect(escapeNonPrintable('zero​width')).toBe('zero\\u200bwidth');
+    expect(escapeNonPrintable('bom﻿here')).toBe('bom\\ufeffhere');
+  });
+
+  it('escapes backslash so escape-looking text cannot spoof real escapes', () => {
+    expect(escapeNonPrintable('back\\slash')).toBe('back\\\\slash');
+    expect(escapeNonPrintable('fake \\u202e text')).toBe('fake \\\\u202e text');
+  });
+
+  it('escapes bidi isolates, ALM, and astral tag characters', () => {
+    expect(escapeNonPrintable('a\u2066b\u2069c')).toBe('a\\u2066b\\u2069c');
+    expect(escapeNonPrintable('x\u061cy')).toBe('x\\u061cy');
+    expect(escapeNonPrintable('tag\u{e0041}char')).toBe('tag\\u{e0041}char');
+  });
+
+  it('escapes C0 controls', () => {
+    expect(escapeNonPrintable('bell')).toBe('bell\\u0007');
+  });
+});
+
+describe('shortPinHash', () => {
+  it('keeps the scheme prefix and truncates to 12 hex chars', () => {
+    expect(shortPinHash('h2:947cd68fbf83c18ca75435e6730174418b91fd0e')).toBe('h2:947cd68fbf83');
+  });
+
+  it('handles legacy unprefixed hashes', () => {
+    expect(shortPinHash('947cd68fbf83c18ca75435e6730174418b91fd0e')).toBe('947cd68fbf83');
+  });
+
+  it('passes short values through', () => {
+    expect(shortPinHash('h2:short')).toBe('h2:short');
+    expect(shortPinHash('')).toBe('');
+  });
+});

--- a/web/src/components/pins/PinDriftBadge.tsx
+++ b/web/src/components/pins/PinDriftBadge.tsx
@@ -1,11 +1,12 @@
+import { useNavigate } from 'react-router-dom';
 import { Lock, LockOpen } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { usePinsStore, useDriftedServers } from '../../stores/usePinsStore';
-import { useUIStore } from '../../stores/useUIStore';
 
 export function PinDriftBadge() {
   const pins = usePinsStore((s) => s.pins);
   const driftedServers = useDriftedServers();
+  const navigate = useNavigate();
 
   if (pins === null) return null;
   if (Object.keys(pins).length === 0) return null;
@@ -22,8 +23,9 @@ export function PinDriftBadge() {
     ? 'bg-status-pending shadow-[0_0_6px_var(--color-status-pending-glow)]'
     : 'bg-status-running shadow-[0_0_6px_var(--color-status-running-glow)]';
 
+  // The Pins workspace shows the drift diff; drifted servers sort first there.
   const handleClick = () => {
-    useUIStore.getState().setBottomPanelTab('pins');
+    navigate('/pins');
   };
 
   return (

--- a/web/src/components/pins/PinsPanel.tsx
+++ b/web/src/components/pins/PinsPanel.tsx
@@ -1,24 +1,16 @@
 import { useState } from 'react';
-import { Lock, LockOpen, CheckCircle2, Clock, RefreshCw } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Lock, LockOpen, CheckCircle2, ChevronRight, Clock, RefreshCw } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { usePinsStore } from '../../stores/usePinsStore';
 import { approveServerPins, fetchServerPins } from '../../lib/api';
+import { pinStatusMeta } from './pinStatus';
 import { showToast } from '../ui/Toast';
 import { formatRelativeTime } from '../../lib/time';
 
-function statusLabel(status: string): { label: string; colorClass: string } {
-  switch (status) {
-    case 'drift':
-      return { label: 'Drift', colorClass: 'text-status-pending' };
-    case 'approved_pending_redeploy':
-      return { label: 'Approved', colorClass: 'text-status-running' };
-    default:
-      return { label: 'Pinned', colorClass: 'text-status-running' };
-  }
-}
-
 export function PinsPanel() {
   const pins = usePinsStore((s) => s.pins);
+  const navigate = useNavigate();
   const [approvingServers, setApprovingServers] = useState<Set<string>>(new Set());
 
   const handleApprove = async (serverName: string) => {
@@ -73,16 +65,23 @@ export function PinsPanel() {
         </thead>
         <tbody>
           {entries.map(([name, sp]) => {
-            const { label, colorClass } = statusLabel(sp.status);
+            const { label, colorClass } = pinStatusMeta(sp.status);
             const isApproving = approvingServers.has(name);
             const lastVerified = sp.last_verified_at
               ? formatRelativeTime(new Date(sp.last_verified_at))
               : '—';
 
+            const openWorkspace = () => navigate(`/pins?server=${encodeURIComponent(name)}`);
             return (
               <tr
                 key={name}
-                className="border-b border-border/20 hover:bg-surface-highlight/20 transition-colors"
+                onClick={() => {
+                  // A mouseup that ends a text-selection drag must not
+                  // navigate away from the text just selected.
+                  if (window.getSelection()?.toString()) return;
+                  openWorkspace();
+                }}
+                className="border-b border-border/20 hover:bg-surface-highlight/20 transition-colors cursor-pointer"
               >
                 <td className="px-4 py-2.5 font-mono text-text-primary">{name}</td>
                 <td className="px-4 py-2.5">
@@ -103,9 +102,14 @@ export function PinsPanel() {
                   </span>
                 </td>
                 <td className="px-4 py-2.5 text-right">
+                  <div className="flex items-center justify-end gap-2">
                   {sp.status === 'drift' && (
                     <button
-                      onClick={() => handleApprove(name)}
+                      onClick={(e) => {
+                        // Approving must not also trigger the row's navigation.
+                        e.stopPropagation();
+                        handleApprove(name);
+                      }}
                       disabled={isApproving}
                       className={cn(
                         'flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium transition-all duration-200 ml-auto',
@@ -127,6 +131,19 @@ export function PinsPanel() {
                       )}
                     </button>
                   )}
+                  {/* The row's onClick is a mouse convenience; this button is
+                      the accessible affordance (keyboard focus + SR name). */}
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      openWorkspace();
+                    }}
+                    aria-label={`Open ${name} in Pins workspace`}
+                    className="p-0.5 rounded text-text-muted/40 hover:text-text-primary hover:bg-surface-highlight transition-colors flex-shrink-0"
+                  >
+                    <ChevronRight size={13} aria-hidden="true" />
+                  </button>
+                  </div>
                 </td>
               </tr>
             );

--- a/web/src/components/pins/pinStatus.ts
+++ b/web/src/components/pins/pinStatus.ts
@@ -1,0 +1,17 @@
+import type { ServerPins } from '../../lib/api';
+
+// Shared status display metadata for pin surfaces (bottom-panel tab,
+// workspace rail, and detail header), keyed to the status color tokens.
+export function pinStatusMeta(status: ServerPins['status']): {
+  label: string;
+  colorClass: string;
+} {
+  switch (status) {
+    case 'drift':
+      return { label: 'Drift', colorClass: 'text-status-pending' };
+    case 'approved_pending_redeploy':
+      return { label: 'Approved', colorClass: 'text-status-running' };
+    default:
+      return { label: 'Pinned', colorClass: 'text-status-running' };
+  }
+}

--- a/web/src/components/workspaces/PinsWorkspace.tsx
+++ b/web/src/components/workspaces/PinsWorkspace.tsx
@@ -1,0 +1,521 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  CheckCircle2,
+  Clock,
+  Loader2,
+  Lock,
+  LockOpen,
+  Minus,
+  Pin,
+  Plus,
+  RefreshCw,
+} from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { usePinsStore } from '../../stores/usePinsStore';
+import {
+  approveServerPins,
+  fetchPinsDiff,
+  fetchServerPins,
+  type PinsDiff,
+  type ServerPins,
+} from '../../lib/api';
+import { escapeNonPrintable, shortPinHash } from '../../lib/nonPrintable';
+import { formatRelativeTime } from '../../lib/time';
+import { useListNav } from '../../hooks/useListNav';
+import { useUIStore } from '../../stores/useUIStore';
+import { WorkspaceShell } from '../layout/WorkspaceShell';
+import { pinStatusMeta } from '../pins/pinStatus';
+import { showToast } from '../ui/Toast';
+
+// PinsWorkspace is the schema-pinning surface, sibling to Topology, Library,
+// Variables, Tools, and Metrics. The left rail lists pinned servers (drifted
+// first); the center pane shows the selected server's drift diff (when any)
+// with the Approve action beside it, followed by its pinned tool records.
+// The diff is fetched from GET /api/pins/{server}/diff, which recomputes the
+// delta against live tools and never mutates pin state - approval is the only
+// mutating action, and it always sits next to the rendered diff.
+export function PinsWorkspace() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const compact = useUIStore((s) => s.compactMode.pins);
+  const pins = usePinsStore((s) => s.pins);
+
+  // Drifted servers first, then alphabetical, for a stable rail order that
+  // surfaces what needs attention.
+  const entries = useMemo(() => {
+    if (!pins) return [];
+    return Object.entries(pins).sort(([aName, a], [bName, b]) => {
+      const aDrift = a.status === 'drift' ? 0 : 1;
+      const bDrift = b.status === 'drift' ? 0 : 1;
+      if (aDrift !== bDrift) return aDrift - bDrift;
+      return aName.localeCompare(bName);
+    });
+  }, [pins]);
+
+  const serverParam = searchParams.get('server') ?? '';
+  const activeServerName = useMemo(() => {
+    if (entries.some(([name]) => name === serverParam)) return serverParam;
+    return entries[0]?.[0] ?? '';
+  }, [entries, serverParam]);
+
+  const activePins = useMemo(
+    () => entries.find(([name]) => name === activeServerName)?.[1] ?? null,
+    [entries, activeServerName],
+  );
+
+  const applyServer = useCallback(
+    (name: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('server', name);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const selectedIndex = entries.findIndex(([name]) => name === activeServerName);
+  useListNav({
+    itemCount: entries.length,
+    selectedIndex: selectedIndex < 0 ? 0 : selectedIndex,
+    setSelectedIndex: (i) => {
+      const name = entries[i]?.[0];
+      if (name) applyServer(name);
+    },
+  });
+
+  // null means the first /api/pins poll has not landed yet; the endpoint
+  // returns an empty object (not an error) when pinning is disabled.
+  if (pins === null) {
+    return (
+      <PinsEmptyState
+        icon={<Loader2 size={24} className="text-primary/70 animate-spin" />}
+        title="Loading pins…"
+        body="Fetching pin state from the gateway."
+      />
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <PinsEmptyState
+        icon={<Pin size={24} className="text-primary/70" />}
+        title="No servers pinned yet"
+        body="Servers are pinned automatically on first verify after deploy. If schema pinning is disabled in your stack, nothing will appear here."
+      />
+    );
+  }
+
+  return (
+    <div className="absolute inset-0 flex flex-col bg-background text-text-primary overflow-hidden">
+      <WorkspaceShell
+        workspace="pins"
+        defaultLeftPct={20}
+        left={
+          <ServerRail
+            compact={compact}
+            entries={entries}
+            activeServerName={activeServerName}
+            onSelect={applyServer}
+          />
+        }
+        minLeftPx={220}
+      >
+        <main className="flex flex-col h-full overflow-hidden">
+          <header
+            className={cn(
+              'flex-shrink-0 bg-surface/30 backdrop-blur-sm border-b border-border-subtle px-6 flex items-center gap-3',
+              compact ? 'py-2' : 'py-3',
+            )}
+          >
+            <div className="font-sans text-text-muted/60 text-[10px] uppercase tracking-[0.4em]">
+              pins
+            </div>
+            <div className="font-mono text-[10px] text-text-muted">
+              {entries.length} {entries.length === 1 ? 'server' : 'servers'} pinned
+            </div>
+          </header>
+
+          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark">
+            {activePins && (
+              <ServerDetail key={activeServerName} name={activeServerName} pins={activePins} />
+            )}
+          </div>
+        </main>
+      </WorkspaceShell>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Left rail
+// ---------------------------------------------------------------------------
+
+interface ServerRailProps {
+  compact: boolean;
+  entries: Array<[string, ServerPins]>;
+  activeServerName: string;
+  onSelect: (name: string) => void;
+}
+
+function ServerRail({ compact, entries, activeServerName, onSelect }: ServerRailProps) {
+  return (
+    <aside className="h-full flex flex-col bg-surface border-r border-border-subtle">
+      <div
+        className={cn(
+          'flex-shrink-0 px-3 border-b border-border-subtle/60',
+          compact ? 'py-2' : 'py-3',
+        )}
+      >
+        <div className="text-[10px] font-medium text-text-muted/60 uppercase tracking-[0.3em]">
+          servers
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark px-2 py-2 space-y-0.5">
+        {entries.map(([name, sp]) => {
+          const active = name === activeServerName;
+          const { label, colorClass } = pinStatusMeta(sp.status);
+          return (
+            <button
+              key={name}
+              onClick={() => onSelect(name)}
+              aria-current={active}
+              className={cn(
+                'w-full flex items-center gap-2 px-3 py-1.5 rounded-md text-left transition-colors',
+                active
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-text-secondary hover:bg-surface-highlight/50 hover:text-text-primary',
+              )}
+            >
+              <span className={cn('flex-shrink-0', colorClass)}>
+                {sp.status === 'drift' ? <LockOpen size={11} /> : <Lock size={11} />}
+              </span>
+              <span
+                className={cn('flex-1 min-w-0 text-xs font-mono truncate', active && 'text-primary')}
+              >
+                {name}
+              </span>
+              <span
+                className={cn(
+                  'flex-shrink-0 text-[10px] px-1.5 py-0.5 rounded',
+                  sp.status === 'drift'
+                    ? 'bg-status-pending/15 text-status-pending'
+                    : 'bg-surface-elevated text-text-muted',
+                )}
+              >
+                {label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Server detail - drift diff (when drifted) + pinned tool records
+// ---------------------------------------------------------------------------
+
+function ServerDetail({ name, pins: sp }: { name: string; pins: ServerPins }) {
+  const { label, colorClass } = pinStatusMeta(sp.status);
+  const toolRecords = useMemo(
+    () => Object.values(sp.tools ?? {}).sort((a, b) => a.name.localeCompare(b.name)),
+    [sp.tools],
+  );
+
+  return (
+    <div className="px-6 py-4 max-w-3xl space-y-4">
+      <div className="flex items-center gap-3">
+        <h2 className="text-sm font-mono text-text-primary">{name}</h2>
+        <span className={cn('flex items-center gap-1.5 text-xs', colorClass)}>
+          {sp.status === 'drift' ? <LockOpen size={11} /> : <Lock size={11} />}
+          {label}
+        </span>
+        <span className="flex items-center gap-1 text-[11px] text-text-muted ml-auto">
+          <Clock size={10} className="text-text-muted/60" />
+          {sp.last_verified_at
+            ? `verified ${formatRelativeTime(new Date(sp.last_verified_at))}`
+            : 'never verified'}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-4 text-[11px] text-text-muted">
+        <span>
+          <span className="text-text-secondary font-medium">{sp.tool_count}</span> tools pinned
+        </span>
+        {sp.pinned_at && <span>first pinned {formatRelativeTime(new Date(sp.pinned_at))}</span>}
+      </div>
+
+      {sp.status === 'drift' && <DriftSection serverName={name} />}
+
+      <section className="space-y-2">
+        <h3 className="text-[10px] uppercase tracking-[0.18em] text-text-muted/70">
+          Pinned tool records
+        </h3>
+        <div className="rounded-lg border border-border/40 bg-background/60 overflow-hidden">
+          <table className="w-full text-xs border-collapse">
+            <thead>
+              <tr className="border-b border-border/30">
+                <th className="text-left px-3 py-2 text-text-muted font-medium">Tool</th>
+                <th className="text-left px-3 py-2 text-text-muted font-medium">Hash</th>
+                <th className="text-left px-3 py-2 text-text-muted font-medium">Pinned</th>
+              </tr>
+            </thead>
+            <tbody>
+              {toolRecords.map((rec) => (
+                <tr key={rec.name} className="border-b border-border/20 last:border-b-0">
+                  <td className="px-3 py-2 align-top">
+                    <div className="font-mono text-text-primary">{escapeNonPrintable(rec.name)}</div>
+                    {rec.description && (
+                      <div className="text-[10px] text-text-muted mt-0.5 whitespace-pre-wrap break-words">
+                        {escapeNonPrintable(rec.description)}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 align-top font-mono text-text-muted whitespace-nowrap">
+                    {shortPinHash(rec.hash)}
+                  </td>
+                  <td className="px-3 py-2 align-top text-text-muted whitespace-nowrap">
+                    {rec.pinned_at ? formatRelativeTime(new Date(rec.pinned_at)) : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Drift diff + informed approve
+// ---------------------------------------------------------------------------
+
+function DriftSection({ serverName }: { serverName: string }) {
+  const [diff, setDiff] = useState<PinsDiff | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isApproving, setIsApproving] = useState(false);
+  // Bumped by Retry and by a failed approve so the effect refetches.
+  const [attempt, setAttempt] = useState(0);
+
+  // No reset needed on server change: ServerDetail is keyed by server name,
+  // so this section remounts (with null state) whenever the selection moves.
+  // Retry resets state in its click handler before bumping `attempt`.
+  useEffect(() => {
+    let cancelled = false;
+    fetchPinsDiff(serverName)
+      .then((d) => {
+        if (!cancelled) setDiff(d);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load diff');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [serverName, attempt]);
+
+  const reloadDiff = () => {
+    setDiff(null);
+    setError(null);
+    setAttempt((n) => n + 1);
+  };
+
+  const handleApprove = async () => {
+    if (!diff) return;
+    setIsApproving(true);
+    try {
+      // Bind the approval to the reviewed snapshot: the gateway rejects with
+      // 409 if the live definitions no longer hash to what was rendered here.
+      await approveServerPins(serverName, diff.live_server_hash);
+      const updated = await fetchServerPins();
+      usePinsStore.getState().setPins(updated);
+      showToast('success', `Pins approved for ${serverName}`);
+    } catch (err) {
+      showToast('error', `Failed to approve: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      // The definitions may have changed again since review; reload the diff
+      // so the user re-reviews the current state instead of a stale one.
+      reloadDiff();
+    } finally {
+      setIsApproving(false);
+    }
+  };
+
+  const changeCount =
+    (diff?.modified_tools.length ?? 0) +
+    (diff?.new_tools.length ?? 0) +
+    (diff?.removed_tools.length ?? 0);
+
+  return (
+    <section
+      className="rounded-lg border border-status-pending/30 bg-status-pending/[0.04] px-4 py-3 space-y-3"
+      aria-label={`Schema drift for ${serverName}`}
+    >
+      <div className="flex items-center gap-2">
+        <LockOpen size={12} className="text-status-pending flex-shrink-0" />
+        <h3 className="text-xs font-medium text-status-pending">Schema drift</h3>
+        <span className="text-[10px] text-text-muted">
+          {diff ? `${changeCount} ${changeCount === 1 ? 'change' : 'changes'}` : ''}
+        </span>
+        <button
+          onClick={handleApprove}
+          disabled={isApproving || diff === null}
+          title={
+            diff === null
+              ? 'Review the changes below before approving'
+              : 'Re-pin the live definitions shown below'
+          }
+          className={cn(
+            'ml-auto flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium transition-all duration-200',
+            isApproving || diff === null
+              ? 'text-text-muted bg-surface-highlight/30 cursor-not-allowed'
+              : 'text-status-running bg-status-running/10 border border-status-running/20 hover:bg-status-running/20',
+          )}
+        >
+          {isApproving ? (
+            <>
+              <RefreshCw size={10} className="animate-spin" />
+              Approving…
+            </>
+          ) : (
+            <>
+              <CheckCircle2 size={10} />
+              Approve {diff ? `${changeCount} ${changeCount === 1 ? 'change' : 'changes'}` : ''}
+            </>
+          )}
+        </button>
+      </div>
+
+      {error && (
+        <div role="alert" className="flex items-center gap-2 text-[11px] text-status-error">
+          <span className="min-w-0">{error}</span>
+          <button
+            onClick={reloadDiff}
+            className="flex-shrink-0 inline-flex items-center gap-1 rounded-md border border-border/40 bg-background/40 px-2 py-0.5 text-[10px] text-text-secondary hover:text-text-primary hover:border-border transition-colors"
+          >
+            <RefreshCw size={10} />
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!diff && !error && (
+        <p className="flex items-center gap-2 text-[11px] text-text-muted">
+          <Loader2 size={11} className="animate-spin" />
+          Comparing pinned definitions against live tools…
+        </p>
+      )}
+
+      {diff && (
+        <div className="space-y-3">
+          {diff.modified_tools.map((d) => (
+            <div
+              key={d.name}
+              className="rounded-md border border-border/40 bg-background/60 px-3 py-2 space-y-1.5"
+            >
+              <div className="text-xs font-mono text-text-primary">{escapeNonPrintable(d.name)}</div>
+              <DiffRow kind="old" hash={d.old_hash} description={d.old_description} />
+              <DiffRow kind="new" hash={d.new_hash} description={d.new_description} />
+            </div>
+          ))}
+
+          {diff.new_tools.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-text-muted">
+              <Plus size={11} className="text-status-running" />
+              <span>New tools (pinned on approve):</span>
+              {diff.new_tools.map((n) => (
+                <span key={n} className="font-mono text-text-secondary">
+                  {escapeNonPrintable(n)}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {diff.removed_tools.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-text-muted">
+              <Minus size={11} className="text-status-error" />
+              <span>Removed from server:</span>
+              {diff.removed_tools.map((n) => (
+                <span key={n} className="font-mono text-text-secondary">
+                  {escapeNonPrintable(n)}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {changeCount === 0 && (
+            <p className="text-[11px] text-text-muted">
+              The live definitions match the pins again; approving will simply re-verify.
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// One side of a before/after pair. Descriptions render as plain text with
+// control characters escaped - they can carry prompt-injection payloads and
+// must never be interpreted as markup.
+function DiffRow({
+  kind,
+  hash,
+  description,
+}: {
+  kind: 'old' | 'new';
+  hash: string;
+  description: string;
+}) {
+  return (
+    <div className="flex items-start gap-2 text-[11px]">
+      <span
+        className={cn(
+          'flex-shrink-0 w-8 font-mono uppercase',
+          kind === 'old' ? 'text-status-error/80' : 'text-status-running/80',
+        )}
+      >
+        {kind}
+      </span>
+      <span className="flex-shrink-0 font-mono text-text-muted">{shortPinHash(hash)}</span>
+      <span className="min-w-0 text-text-secondary whitespace-pre-wrap break-words">
+        {description ? escapeNonPrintable(description) : <em className="text-text-muted/60">no description</em>}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty states
+// ---------------------------------------------------------------------------
+
+function PinsEmptyState({
+  icon,
+  title,
+  body,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-background px-6 py-12">
+      <div className="max-w-md w-full text-center space-y-4">
+        <div className="mx-auto w-14 h-14 rounded-2xl bg-primary/10 border border-primary/20 flex items-center justify-center">
+          {icon}
+        </div>
+        <div className="space-y-1.5">
+          <h2 className="text-base font-semibold text-text-primary">{title}</h2>
+          <p className="text-xs text-text-muted leading-relaxed">{body}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default PinsWorkspace;

--- a/web/src/hooks/useGlobalCommands.tsx
+++ b/web/src/hooks/useGlobalCommands.tsx
@@ -21,6 +21,7 @@ import {
   Plus,
   PanelBottom,
   Compass,
+  Pin,
   Sun,
   Moon,
   Monitor,
@@ -116,6 +117,15 @@ export function useGlobalCommands({ onRefresh }: GlobalCommandsOptions = {}) {
         icon: <BarChart2 size={14} />,
         keywords: ['metrics', 'stats', 'tokens', 'usage', 'cost', 'charts', 'dashboard', 'open'],
         onSelect: () => navigate('/metrics'),
+      },
+      {
+        id: 'navigate:workspace-pins',
+        label: 'Go to Pins',
+        section: 'global',
+        icon: <Pin size={14} />,
+        shortcut: ['⌘', '6'],
+        keywords: ['pins', 'workspace', 'drift', 'schema', 'tofu', 'approve', 'go'],
+        onSelect: () => navigate('/pins'),
       },
       {
         id: 'navigate:spec',

--- a/web/src/hooks/usePolling.ts
+++ b/web/src/hooks/usePolling.ts
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useStackStore } from '../stores/useStackStore';
 import { useAuthStore } from '../stores/useAuthStore';
 import { useRegistryStore } from '../stores/useRegistryStore';
 import { usePinsStore } from '../stores/usePinsStore';
-import { useUIStore } from '../stores/useUIStore';
 import { useTelemetryStore } from '../stores/useTelemetryStore';
 import { fetchStatus, fetchTools, fetchToolCatalog, fetchClients, fetchRegistryStatus, fetchRegistrySkills, fetchSkillSources, fetchServerPins, fetchStackSpec, getTelemetryInventory, AuthError } from '../lib/api';
 import { showToast } from '../components/ui/Toast';
@@ -13,6 +13,7 @@ let _prevDriftCount = 0;
 
 export function usePolling() {
   const intervalRef = useRef<number | null>(null);
+  const navigate = useNavigate();
 
   const setGatewayStatus = useStackStore((s) => s.setGatewayStatus);
   const setClients = useStackStore((s) => s.setClients);
@@ -60,7 +61,9 @@ export function usePolling() {
         const driftedCount = Object.values(pins).filter((sp) => sp.status === 'drift').length;
         if (driftedCount > 0 && _prevDriftCount === 0) {
           showToast('warning', `Schema drift detected on ${driftedCount} server${driftedCount > 1 ? 's' : ''}`, {
-            action: { label: 'View', onClick: () => useUIStore.getState().setBottomPanelTab('pins') },
+            // Land on the Pins workspace, where the per-tool diff and the
+            // Approve action live; drifted servers sort first there.
+            action: { label: 'View', onClick: () => navigate('/pins') },
             duration: 6000,
           });
         }
@@ -139,7 +142,7 @@ export function usePolling() {
         setConnectionStatus('error');
       }
     }
-  }, [setGatewayStatus, setClients, setTools, setToolCatalog, setError, setConnectionStatus, setAuthRequired, setLoading, refreshNodesAndEdges]);
+  }, [setGatewayStatus, setClients, setTools, setToolCatalog, setError, setConnectionStatus, setAuthRequired, setLoading, refreshNodesAndEdges, navigate]);
 
   useEffect(() => {
     // Don't poll while auth prompt is showing

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1561,17 +1561,63 @@ export async function fetchServerPins(): Promise<Record<string, ServerPins>> {
   return fetchJSON<Record<string, ServerPins>>('/api/pins');
 }
 
+export interface PinsToolDiff {
+  name: string;
+  old_hash: string;
+  new_hash: string;
+  old_description: string;
+  new_description: string;
+}
+
+export interface PinsDiff {
+  server: string;
+  status: string;
+  // Fingerprint of the live definitions this diff was computed from; pass to
+  // approveServerPins to bind the approval to the reviewed snapshot.
+  live_server_hash: string;
+  modified_tools: PinsToolDiff[];
+  new_tools: string[];
+  removed_tools: string[];
+}
+
 /**
- * Approve current tool definitions for a server, clearing drift
+ * Fetch the per-tool delta between pinned and live tool definitions.
+ * Computed on demand server-side; never mutates pin state.
+ * GET /api/pins/{server}/diff
+ */
+export async function fetchPinsDiff(serverName: string): Promise<PinsDiff> {
+  return fetchJSON<PinsDiff>(`/api/pins/${encodeURIComponent(serverName)}/diff`);
+}
+
+/**
+ * Approve current tool definitions for a server, clearing drift.
+ * When expectedServerHash (from PinsDiff.live_server_hash) is provided, the
+ * gateway rejects the approval with 409 if the live definitions changed after
+ * the diff was reviewed, so nothing unreviewed can be pinned.
  * POST /api/pins/{server}/approve
  */
-export async function approveServerPins(serverName: string): Promise<void> {
+export async function approveServerPins(
+  serverName: string,
+  expectedServerHash?: string,
+): Promise<void> {
   const response = await fetch(`${API_BASE}/api/pins/${encodeURIComponent(serverName)}/approve`, {
     method: 'POST',
     headers: buildHeaders(),
+    ...(expectedServerHash
+      ? { body: JSON.stringify({ expected_server_hash: expectedServerHash }) }
+      : {}),
   });
   if (response.status === 401) throw new AuthError('Authentication required');
-  if (!response.ok) throw new Error(`API error: ${response.status} ${response.statusText}`);
+  if (!response.ok) {
+    let message = `API error: ${response.status} ${response.statusText}`;
+    try {
+      const body = (await response.json()) as { error?: string };
+      if (body?.error) message = body.error;
+    } catch {
+      // Non-JSON error body; keep the status-line message.
+    }
+    throw new Error(message);
+  }
 }
 
 // === JSON-RPC Helper (for MCP protocol calls) ===

--- a/web/src/lib/nonPrintable.ts
+++ b/web/src/lib/nonPrintable.ts
@@ -1,0 +1,41 @@
+// Tool descriptions are instructions to the model, and poisoned ones hide
+// payloads in control, zero-width, and bidi-override characters. Anything a
+// reviewer is asked to approve must render every character visibly.
+
+// Backslash (so real escapes cannot be spoofed by literal escape-looking
+// text), C0/C1 controls, soft hyphen, ALM, zero-width and bidi controls
+// (including the U+2066-U+2069 isolates), line/paragraph separators, word
+// joiners, BOM, and astral Unicode tag characters (an ASCII-smuggling
+// channel). Deliberately excludes plain spaces and printable text.
+// eslint-disable-next-line no-control-regex
+const NON_PRINTABLE = /[\\\u0000-\u001f\u007f-\u009f\u00ad\u061c\u200b-\u200f\u2028-\u202e\u2060-\u2064\u2066-\u206f\ufeff\u{e0000}-\u{e007f}]/gu;
+
+const NAMED: Record<string, string> = {
+  '\\': '\\\\',
+  '\n': '\\n',
+  '\r': '\\r',
+  '\t': '\\t',
+};
+
+/**
+ * Replaces non-printable characters with visible escape sequences (\\n,
+ * \\u202e, ...) so hidden instructions cannot survive review unseen.
+ */
+export function escapeNonPrintable(s: string): string {
+  return s.replace(NON_PRINTABLE, (ch) => {
+    const named = NAMED[ch];
+    if (named) return named;
+    const cp = ch.codePointAt(0)!;
+    return cp > 0xffff
+      ? `\\u{${cp.toString(16)}}`
+      : `\\u${cp.toString(16).padStart(4, '0')}`;
+  });
+}
+
+/** Abbreviates a pin hash for display, keeping any scheme prefix (h2:). */
+export function shortPinHash(hash: string): string {
+  const idx = hash.indexOf(':');
+  const prefix = idx >= 0 ? hash.slice(0, idx + 1) : '';
+  const rest = idx >= 0 ? hash.slice(idx + 1) : hash;
+  return prefix + (rest.length > 12 ? rest.slice(0, 12) : rest);
+}

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -17,6 +17,7 @@ const LibraryWorkspace = lazy(() => import('./components/workspaces/LibraryWorks
 const VaultWorkspace = lazy(() => import('./components/workspaces/VaultWorkspace'));
 const ToolsWorkspace = lazy(() => import('./components/workspaces/ToolsWorkspace'));
 const MetricsWorkspace = lazy(() => import('./components/workspaces/MetricsWorkspace'));
+const PinsWorkspace = lazy(() => import('./components/workspaces/PinsWorkspace'));
 
 export function AppRoutes() {
   // Single mount point for theme application + cross-window sync; covers the
@@ -76,6 +77,14 @@ export function AppRoutes() {
           element={
             <Suspense fallback={<WorkspaceLoadingShell />}>
               <MetricsWorkspace />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/pins"
+          element={
+            <Suspense fallback={<WorkspaceLoadingShell />}>
+              <PinsWorkspace />
             </Suspense>
           }
         />

--- a/web/src/stores/useUIStore.ts
+++ b/web/src/stores/useUIStore.ts
@@ -35,6 +35,7 @@ export const COMPACT_MODE_DEFAULTS: CompactModeMap = {
   vault: false,
   tools: false,
   metrics: false,
+  pins: false,
 };
 
 export interface CompactModeSlice {

--- a/web/src/types/workspace.ts
+++ b/web/src/types/workspace.ts
@@ -1,9 +1,9 @@
 import type { LucideIcon } from 'lucide-react';
-import { BarChart3, Library, Lock, Network, Wrench } from 'lucide-react';
+import { BarChart3, Library, Lock, Network, Pin, Wrench } from 'lucide-react';
 
 // Top-level workspaces in the unified shell. Routed at /topology, /library,
-// /vault, /tools, and /metrics inside AppShell.
-export type Workspace = 'topology' | 'library' | 'vault' | 'tools' | 'metrics';
+// /vault, /tools, /metrics, and /pins inside AppShell.
+export type Workspace = 'topology' | 'library' | 'vault' | 'tools' | 'metrics' | 'pins';
 
 export interface WorkspaceConfig {
   id: Workspace;
@@ -22,6 +22,7 @@ export const WORKSPACE_CONFIG: readonly WorkspaceConfig[] = [
   { id: 'vault',    label: 'Variables', icon: Lock,     shortcutKey: '3' },
   { id: 'tools',    label: 'Tools',     icon: Wrench,    shortcutKey: '4' },
   { id: 'metrics',  label: 'Metrics',   icon: BarChart3, shortcutKey: '5' },
+  { id: 'pins',     label: 'Pins',      icon: Pin,       shortcutKey: '6' },
 ] as const;
 
 // Derived for back-compat with existing call-sites in useUIStore, AppShell,


### PR DESCRIPTION
## Description

Schema drift could only be approved blind: the Pins panel flagged drift but nothing in the product showed what changed, even though the pins engine computes the full per-tool diff and discards it after logging. This PR makes the delta reviewable everywhere and binds approvals to the reviewed snapshot.

## Type of Change

- [x] Bug fix (security UX gap: uninformed re-trust of drifted MCP tool definitions)

## Changes Made

- `GET /api/pins/{server}/diff`: recomputes the per-tool delta (modified, new, removed, with old/new hashes and descriptions) via the read-only `Verify` path; nothing new persisted, pin-file format unchanged
- Bound approvals: the diff carries a `live_server_hash` fingerprint, and `POST /api/pins/{server}/approve` accepts an optional `expected_server_hash`, rejecting with 409 if the live definitions changed after review. An empty body preserves the legacy unconditional approve
- `gridctl pins diff [server]` with `--format json` and 0/1/2 exit codes; no-arg mode recomputes against live tools for every pinned server and skips unreachable ones with warnings (warnings exit 2 so CI never mistakes a partial report for clean); `pins approve --expect <hash>` for bound approval
- Pins promoted to a sixth top-level workspace (`/pins`, Cmd+6, command palette entry): master-detail with drifted servers first, per-tool diff with description before/after, and Approve co-located with the rendered diff
- Bottom-panel Pins rows, the statusbar drift badge, and the drift toast now all land on the workspace; the bottom tab remains as a glance surface with a keyboard-accessible drill-down
- Non-printable characters (controls, zero-width, bidi overrides and isolates, Unicode tag characters, plus backslash to prevent escape spoofing) render as visible escapes in both CLI and UI, since poisoned descriptions hide instructions in exactly that channel

## Testing

- `make test`, `golangci-lint run` (0 issues), `cd web && npm run lint` (0 errors), `npm test` (1134 passing, 20 new)
- Verified end-to-end against a scratch stack with a mock MCP server: induced a rug pull via a poisoned description with a hidden zero-width character, confirmed drift detection, diff rendering with visible escapes in CLI and workspace, 409 on stale-hash approve, and successful bound approve

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #897