### PR TITLE
fix: import skills with nested metadata and surface parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to gridctl will be documented in this file.
 ### Bug Fixes
 
 
+- Import skills whose SKILL.md `metadata` contains nested values (the openclaw/ClawHub publishing convention): non-string metadata values are now coerced to strings instead of failing the parse. SKILL.md files that genuinely cannot be parsed are surfaced by path and error across the CLI, import warnings, and the UI wizard instead of the misleading "no SKILL.md files found in repository"
 - Surface pin drift detail before approval: `GET /api/pins/{server}/diff` endpoint, `gridctl pins diff` subcommand with JSON output and 0/1/2 exit codes, and a first-class Pins workspace where the Approve action sits beside the rendered per-tool diff (non-printable characters escaped). Approvals can be bound to the reviewed snapshot via `expected_server_hash` / `pins approve --expect`, rejecting definitions that change after review
 
 ## [0.1.0-beta.14] - 2026-07-16

--- a/internal/api/skills.go
+++ b/internal/api/skills.go
@@ -710,11 +710,17 @@ func (s *Server) handleSkillSourcePreview(w http.ResponseWriter, r *http.Request
 		previews = []SkillPreview{}
 	}
 
+	malformed := result.Malformed
+	if malformed == nil {
+		malformed = []skills.MalformedSkill{}
+	}
+
 	writeJSON(w, map[string]any{
 		"repo":      repo,
 		"ref":       ref,
 		"commitSha": result.CommitSHA,
 		"skills":    previews,
+		"malformed": malformed,
 	})
 }
 

--- a/internal/api/skills_test.go
+++ b/internal/api/skills_test.go
@@ -4,9 +4,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/gridctl/gridctl/pkg/mcp"
 	"github.com/gridctl/gridctl/pkg/registry"
@@ -448,5 +454,89 @@ func TestStoreDir(t *testing.T) {
 
 	if store.Dir() != dir {
 		t.Errorf("expected Dir() = %q, got %q", dir, store.Dir())
+	}
+}
+
+// initPreviewTestRepo creates a local git repo with one valid and one
+// malformed SKILL.md for exercising the source-preview handler.
+func initPreviewTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+
+	files := map[string]string{
+		"skills/good/SKILL.md":   "---\nname: good-skill\ndescription: valid\n---\n\nBody.\n",
+		"skills/broken/SKILL.md": "---\nname: [unclosed\ndescription: broken\n---\n\nBody.\n",
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	for path, content := range files {
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if _, err := wt.Add(path); err != nil {
+			t.Fatalf("add: %v", err)
+		}
+	}
+	if _, err := wt.Commit("initial", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com"},
+	}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	return dir
+}
+
+// TestHandleSkills_SourcePreview_ReportsMalformed pins the wire contract of
+// the preview response: valid skills under "skills", parse failures under
+// "malformed" with "path" and "error" keys (the wizard depends on all three).
+func TestHandleSkills_SourcePreview_ReportsMalformed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	srv, _ := setupRegistryTestServer(t)
+	repoDir := initPreviewTestRepo(t)
+
+	body := strings.NewReader(`{"repo": ` + strconv.Quote(repoDir) + `}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/skills/sources/test-source/preview", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Skills []struct {
+			Name string `json:"name"`
+		} `json:"skills"`
+		Malformed []struct {
+			Path  string `json:"path"`
+			Error string `json:"error"`
+		} `json:"malformed"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if len(resp.Skills) != 1 || resp.Skills[0].Name != "good-skill" {
+		t.Fatalf("expected one good-skill preview, got %+v", resp.Skills)
+	}
+	if len(resp.Malformed) != 1 {
+		t.Fatalf("expected one malformed entry, got %+v", resp.Malformed)
+	}
+	if resp.Malformed[0].Path != filepath.Join("skills", "broken", "SKILL.md") {
+		t.Errorf("malformed path = %q", resp.Malformed[0].Path)
+	}
+	if !strings.Contains(resp.Malformed[0].Error, "parsing frontmatter") {
+		t.Errorf("malformed error = %q, want frontmatter parse error", resp.Malformed[0].Error)
 	}
 }

--- a/pkg/registry/frontmatter.go
+++ b/pkg/registry/frontmatter.go
@@ -2,11 +2,61 @@ package registry
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+// UnmarshalYAML decodes metadata leniently. Values that are not strings
+// (nested mappings, sequences, booleans, numbers) are coerced to their
+// string form instead of failing the whole SKILL.md parse. Non-mapping
+// metadata (e.g. a bare string) is ignored rather than treated as an error.
+// The mapping node is walked by hand so one bad entry (or a duplicate key,
+// which yaml.v3's map decoding rejects) cannot discard the valid keys.
+func (m *SkillMetadata) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return nil
+	}
+	out := make(SkillMetadata, len(value.Content)/2)
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		keyNode, valNode := value.Content[i], value.Content[i+1]
+		if keyNode.Kind != yaml.ScalarNode {
+			continue
+		}
+		out[keyNode.Value] = metadataNodeString(valNode)
+	}
+	*m = out
+	return nil
+}
+
+// metadataNodeString renders a YAML value node as a string. Scalars keep
+// their literal form as written (so "1.20", dates, and hex stay verbatim);
+// mappings and sequences become compact JSON.
+func metadataNodeString(n *yaml.Node) string {
+	switch n.Kind {
+	case yaml.ScalarNode:
+		if n.Tag == "!!null" {
+			return ""
+		}
+		return n.Value
+	case yaml.AliasNode:
+		if n.Alias != nil {
+			return metadataNodeString(n.Alias)
+		}
+		return ""
+	default:
+		var v any
+		if err := n.Decode(&v); err != nil {
+			return ""
+		}
+		if b, err := json.Marshal(v); err == nil {
+			return string(b)
+		}
+		return fmt.Sprintf("%v", v)
+	}
+}
 
 // ParseSkillMD parses a SKILL.md file into an AgentSkill.
 // The file format is YAML frontmatter between --- delimiters followed by a markdown body.

--- a/pkg/registry/frontmatter_test.go
+++ b/pkg/registry/frontmatter_test.go
@@ -291,3 +291,201 @@ func TestRenderSkillMD_EmptyBody(t *testing.T) {
 		t.Errorf("output should end with '---\\n', got %q", output[max(0, len(output)-10):])
 	}
 }
+
+// TestParseSkillMD_NestedMetadata is a regression test for skill imports
+// failing on the openclaw/ClawHub convention of nesting objects under
+// metadata. Non-string values must coerce to strings, not fail the parse.
+func TestParseSkillMD_NestedMetadata(t *testing.T) {
+	input := `---
+name: golang-code-style
+description: Golang code style conventions.
+license: MIT
+metadata:
+  author: samber
+  version: "1.2.2"
+  openclaw:
+    emoji: "X"
+    homepage: https://example.com/repo
+    requires:
+      bins:
+        - go
+    install: []
+---
+
+# Body
+`
+
+	skill, err := ParseSkillMD([]byte(input))
+	if err != nil {
+		t.Fatalf("ParseSkillMD() error = %v", err)
+	}
+	if skill.Name != "golang-code-style" {
+		t.Errorf("Name = %q, want %q", skill.Name, "golang-code-style")
+	}
+	if skill.Description == "" {
+		t.Error("Description should be populated")
+	}
+	if skill.Metadata["author"] != "samber" {
+		t.Errorf("Metadata[author] = %q, want %q", skill.Metadata["author"], "samber")
+	}
+	if skill.Metadata["version"] != "1.2.2" {
+		t.Errorf("Metadata[version] = %q, want %q", skill.Metadata["version"], "1.2.2")
+	}
+	if skill.Metadata["openclaw"] == "" {
+		t.Error("Metadata[openclaw] should be a non-empty string")
+	}
+	if !strings.Contains(skill.Metadata["openclaw"], "homepage") {
+		t.Errorf("Metadata[openclaw] should carry the nested content, got %q", skill.Metadata["openclaw"])
+	}
+}
+
+func TestParseSkillMD_MetadataScalarCoercion(t *testing.T) {
+	input := `---
+name: scalar-meta
+description: Metadata with non-string scalars
+metadata:
+  enabled: true
+  count: 42
+  tags: [a, b]
+---
+
+Body.
+`
+
+	skill, err := ParseSkillMD([]byte(input))
+	if err != nil {
+		t.Fatalf("ParseSkillMD() error = %v", err)
+	}
+	if skill.Metadata["enabled"] != "true" {
+		t.Errorf("Metadata[enabled] = %q, want %q", skill.Metadata["enabled"], "true")
+	}
+	if skill.Metadata["count"] != "42" {
+		t.Errorf("Metadata[count] = %q, want %q", skill.Metadata["count"], "42")
+	}
+	if skill.Metadata["tags"] != `["a","b"]` {
+		t.Errorf("Metadata[tags] = %q, want %q", skill.Metadata["tags"], `["a","b"]`)
+	}
+}
+
+func TestParseSkillMD_MetadataNonMapping(t *testing.T) {
+	input := `---
+name: bare-meta
+description: Metadata as a bare string
+metadata: just-a-string
+---
+
+Body.
+`
+
+	skill, err := ParseSkillMD([]byte(input))
+	if err != nil {
+		t.Fatalf("ParseSkillMD() error = %v", err)
+	}
+	if len(skill.Metadata) != 0 {
+		t.Errorf("Metadata should be empty for non-mapping input, got %v", skill.Metadata)
+	}
+}
+
+// TestRenderSkillMD_NestedMetadataRoundTrip verifies that a skill parsed
+// from nested metadata renders to valid string-to-string YAML that parses
+// back without error.
+func TestRenderSkillMD_NestedMetadataRoundTrip(t *testing.T) {
+	input := `---
+name: round-trip
+description: Nested metadata round trip
+metadata:
+  author: samber
+  openclaw:
+    emoji: "X"
+    requires:
+      bins:
+        - go
+---
+
+Body.
+`
+
+	skill, err := ParseSkillMD([]byte(input))
+	if err != nil {
+		t.Fatalf("ParseSkillMD() error = %v", err)
+	}
+
+	rendered, err := RenderSkillMD(skill)
+	if err != nil {
+		t.Fatalf("RenderSkillMD() error = %v", err)
+	}
+
+	reparsed, err := ParseSkillMD(rendered)
+	if err != nil {
+		t.Fatalf("ParseSkillMD(rendered) error = %v", err)
+	}
+	if reparsed.Metadata["author"] != "samber" {
+		t.Errorf("reparsed Metadata[author] = %q, want %q", reparsed.Metadata["author"], "samber")
+	}
+	if reparsed.Metadata["openclaw"] != skill.Metadata["openclaw"] {
+		t.Errorf("reparsed Metadata[openclaw] = %q, want %q", reparsed.Metadata["openclaw"], skill.Metadata["openclaw"])
+	}
+}
+
+// TestParseSkillMD_MetadataDuplicateKey verifies that a duplicate metadata
+// key (which yaml.v3 map decoding rejects) does not silently discard the
+// rest of the mapping. Last occurrence wins.
+func TestParseSkillMD_MetadataDuplicateKey(t *testing.T) {
+	input := `---
+name: dup-meta
+description: Duplicate metadata key
+metadata:
+  author: first
+  author: second
+  version: "1.0"
+---
+
+Body.
+`
+
+	skill, err := ParseSkillMD([]byte(input))
+	if err != nil {
+		t.Fatalf("ParseSkillMD() error = %v", err)
+	}
+	if skill.Metadata["author"] != "second" {
+		t.Errorf("Metadata[author] = %q, want %q (last occurrence wins)", skill.Metadata["author"], "second")
+	}
+	if skill.Metadata["version"] != "1.0" {
+		t.Errorf("Metadata[version] = %q, want %q (valid keys must survive)", skill.Metadata["version"], "1.0")
+	}
+}
+
+// TestParseSkillMD_MetadataLiteralScalars verifies that scalar metadata
+// values keep the literal form they were written in, rather than being
+// round-tripped through Go types (1.20 must not become "1.2", dates must
+// not become quoted timestamps, hex must not be decimalized).
+func TestParseSkillMD_MetadataLiteralScalars(t *testing.T) {
+	input := `---
+name: literal-meta
+description: Literal scalar preservation
+metadata:
+  ver: 1.20
+  date: 2024-01-05
+  hexish: 0x10
+  empty:
+---
+
+Body.
+`
+
+	skill, err := ParseSkillMD([]byte(input))
+	if err != nil {
+		t.Fatalf("ParseSkillMD() error = %v", err)
+	}
+	want := map[string]string{
+		"ver":    "1.20",
+		"date":   "2024-01-05",
+		"hexish": "0x10",
+		"empty":  "",
+	}
+	for k, w := range want {
+		if got := skill.Metadata[k]; got != w {
+			t.Errorf("Metadata[%s] = %q, want %q", k, got, w)
+		}
+	}
+}

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -14,16 +14,22 @@ const (
 	StateDisabled ItemState = "disabled"
 )
 
+// SkillMetadata holds the frontmatter metadata mapping. The agentskills.io
+// spec defines it as string-to-string, but ecosystems like openclaw/ClawHub
+// publish nested values there, so decoding is lenient: non-string values are
+// coerced to strings (see UnmarshalYAML in frontmatter.go).
+type SkillMetadata map[string]string
+
 // AgentSkill represents an Agent Skills standard SKILL.md file.
 // See https://agentskills.io/specification for the full spec.
 type AgentSkill struct {
 	// --- Frontmatter fields (from YAML between --- delimiters) ---
-	Name          string            `yaml:"name" json:"name"`
-	Description   string            `yaml:"description" json:"description"`
-	License       string            `yaml:"license,omitempty" json:"license,omitempty"`
-	Compatibility string            `yaml:"compatibility,omitempty" json:"compatibility,omitempty"`
-	Metadata      map[string]string `yaml:"metadata,omitempty" json:"metadata,omitempty"`
-	AllowedTools  string            `yaml:"allowed-tools,omitempty" json:"allowedTools,omitempty"`
+	Name          string        `yaml:"name" json:"name"`
+	Description   string        `yaml:"description" json:"description"`
+	License       string        `yaml:"license,omitempty" json:"license,omitempty"`
+	Compatibility string        `yaml:"compatibility,omitempty" json:"compatibility,omitempty"`
+	Metadata      SkillMetadata `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	AllowedTools  string        `yaml:"allowed-tools,omitempty" json:"allowedTools,omitempty"`
 	// AcceptanceCriteria documents expected skill behavior as human-readable
 	// Given/When/Then scenarios. Gridctl extension; not part of agentskills.io spec.
 	// See https://agentskills.io/specification

--- a/pkg/skills/importer.go
+++ b/pkg/skills/importer.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -160,12 +161,23 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 	}
 
 	if len(result.Skills) == 0 {
+		if len(result.Malformed) > 0 {
+			return nil, fmt.Errorf("no importable skills found: %s", summarizeMalformed(result.Malformed))
+		}
 		return nil, fmt.Errorf("no SKILL.md files found in repository")
 	}
 
 	imp.logger.Info("discovered skills", "count", len(result.Skills))
 
 	importResult := &ImportResult{}
+	// Surface parse failures on fresh imports only. Update re-imports with
+	// PreserveState, and warning about a permanently broken sibling SKILL.md
+	// on every sync would just train users to ignore warnings.
+	if !opts.PreserveState {
+		for _, m := range result.Malformed {
+			importResult.Warnings = append(importResult.Warnings, fmt.Sprintf("%s: failed to parse: %s", m.Path, m.Err))
+		}
+	}
 
 	// Build selection set for O(1) lookup (empty = import all)
 	selectedSet := make(map[string]bool, len(opts.Selected))
@@ -319,6 +331,23 @@ func (imp *Importer) Import(opts ImportOptions) (*ImportResult, error) {
 	}
 
 	return importResult, nil
+}
+
+// summarizeMalformed renders malformed SKILL.md entries for the zero-skills
+// error, capped so a repository full of bad files stays readable.
+func summarizeMalformed(malformed []MalformedSkill) string {
+	const maxShown = 3
+	shown := malformed
+	suffix := ""
+	if len(malformed) > maxShown {
+		shown = malformed[:maxShown]
+		suffix = "; ..."
+	}
+	parts := make([]string, len(shown))
+	for i, m := range shown {
+		parts[i] = fmt.Sprintf("%s: %s", m.Path, m.Err)
+	}
+	return fmt.Sprintf("%d SKILL.md file(s) failed to parse (%s%s)", len(malformed), strings.Join(parts, "; "), suffix)
 }
 
 // Remove removes an imported skill and cleans up origin and lock entries.

--- a/pkg/skills/importer_test.go
+++ b/pkg/skills/importer_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -437,4 +438,116 @@ func TestContentHashFile(t *testing.T) {
 	hash3, err := ContentHashFile(path3)
 	require.NoError(t, err)
 	assert.NotEqual(t, hash1, hash3)
+}
+
+// initRepoWithSkillContent creates a local git repo whose SKILL.md has the
+// given raw content (valid or intentionally malformed).
+func initRepoWithSkillContent(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	for path, content := range files {
+		full := filepath.Join(dir, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+		_, err = wt.Add(path)
+		require.NoError(t, err)
+	}
+	_, err = wt.Commit("initial", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com"},
+	})
+	require.NoError(t, err)
+	return dir
+}
+
+// TestImporter_Import_AllMalformedNamesFiles verifies that when every
+// SKILL.md fails to parse, the error names the failing file instead of
+// claiming no SKILL.md files exist.
+func TestImporter_Import_AllMalformedNamesFiles(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	repoDir := initRepoWithSkillContent(t, map[string]string{
+		"skills/broken/SKILL.md": "---\nname: [unclosed\ndescription: broken\n---\n\nBody.\n",
+	})
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Trust: true})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "no SKILL.md files found")
+	assert.Contains(t, err.Error(), "failed to parse")
+	assert.Contains(t, err.Error(), filepath.Join("skills", "broken", "SKILL.md"))
+}
+
+// TestImporter_Import_MixedMalformedWarns verifies that valid skills import
+// while unparseable ones surface as warnings.
+func TestImporter_Import_MixedMalformedWarns(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	repoDir := initRepoWithSkillContent(t, map[string]string{
+		"skills/good/SKILL.md":   "---\nname: good-skill\ndescription: valid\n---\n\nBody.\n",
+		"skills/broken/SKILL.md": "---\nname: [unclosed\ndescription: broken\n---\n\nBody.\n",
+	})
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	result, err := imp.Import(ImportOptions{Repo: repoDir, Trust: true})
+	require.NoError(t, err)
+
+	require.Len(t, result.Imported, 1)
+	assert.Equal(t, "good-skill", result.Imported[0].Name)
+
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, filepath.Join("skills", "broken", "SKILL.md")) && strings.Contains(w, "failed to parse") {
+			found = true
+		}
+	}
+	assert.True(t, found, "warnings should name the malformed file, got %v", result.Warnings)
+}
+
+// TestImporter_Import_NestedMetadata verifies end-to-end import of a skill
+// whose metadata nests objects (openclaw/ClawHub convention).
+func TestImporter_Import_NestedMetadata(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	repoDir := initRepoWithSkillContent(t, map[string]string{
+		"skills/nested/SKILL.md": `---
+name: nested-meta
+description: Skill with nested metadata
+metadata:
+  author: samber
+  version: "1.2.2"
+  openclaw:
+    emoji: "X"
+    requires:
+      bins:
+        - go
+---
+
+Body.
+`,
+	})
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	result, err := imp.Import(ImportOptions{Repo: repoDir, Trust: true})
+	require.NoError(t, err)
+	require.Len(t, result.Imported, 1)
+
+	sk, err := store.GetSkill("nested-meta")
+	require.NoError(t, err)
+	assert.Equal(t, "samber", sk.Metadata["author"])
+	assert.Equal(t, "1.2.2", sk.Metadata["version"])
+	assert.NotEmpty(t, sk.Metadata["openclaw"])
 }

--- a/pkg/skills/reconcile.go
+++ b/pkg/skills/reconcile.go
@@ -89,6 +89,10 @@ func (imp *Importer) Diff(ctx context.Context, skillName string) (*DiffResult, e
 		discovered = &result.Skills[0]
 	}
 	if discovered == nil {
+		if len(result.Malformed) > 0 {
+			m := result.Malformed[0]
+			return nil, fmt.Errorf("upstream SKILL.md failed to parse: %s: %s", m.Path, m.Err)
+		}
 		return nil, fmt.Errorf("skill %q not found at upstream path %q", skillName, origin.Path)
 	}
 

--- a/pkg/skills/reconcile_test.go
+++ b/pkg/skills/reconcile_test.go
@@ -2,6 +2,9 @@ package skills
 
 import (
 	"context"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -238,4 +241,35 @@ func TestImporter_Diff_NoOrigin(t *testing.T) {
 
 	_, err := imp.Diff(context.Background(), "local-only")
 	assert.Error(t, err, "a skill without an origin cannot be diffed")
+}
+
+// TestImporterDiff_UpstreamMalformedSurfacesParseError verifies that when
+// the upstream SKILL.md no longer parses, Diff reports the parse failure
+// instead of the misleading "not found at upstream path".
+func TestImporterDiff_UpstreamMalformedSurfacesParseError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+	repoDir, repo := initSkillRepo(t, "# Test\n\nv1.\n")
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	_, err := imp.Import(ImportOptions{Repo: repoDir, Ref: "master", Trust: true})
+	require.NoError(t, err)
+
+	// Upstream pushes a SKILL.md with broken frontmatter.
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "SKILL.md"),
+		[]byte("---\nname: [unclosed\ndescription: broken\n---\n\nBody.\n"), 0644))
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("SKILL.md")
+	require.NoError(t, err)
+	_, err = wt.Commit("break frontmatter", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com"},
+	})
+	require.NoError(t, err)
+
+	_, err = imp.Diff(context.Background(), "test-skill")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "not found at upstream path")
+	assert.Contains(t, err.Error(), "failed to parse")
 }

--- a/pkg/skills/remote.go
+++ b/pkg/skills/remote.go
@@ -22,6 +22,15 @@ type CloneResult struct {
 	RepoPath  string
 	CommitSHA string
 	Skills    []DiscoveredSkill
+	Malformed []MalformedSkill
+}
+
+// MalformedSkill records a SKILL.md that could not be read or parsed (or a
+// directory that could not be walked), so callers can surface the failure
+// instead of silently dropping it.
+type MalformedSkill struct {
+	Path string `json:"path"` // Relative path from repo root
+	Err  string `json:"error"`
 }
 
 // DiscoveredSkill represents a SKILL.md found in a cloned repo.
@@ -63,15 +72,19 @@ func CloneAndDiscover(repo, ref, subPath string, auth AuthConfig, logger *slog.L
 		}
 	}
 
-	skills, err := discoverSkills(searchDir, repoPath)
+	skills, malformed, err := discoverSkills(searchDir, repoPath)
 	if err != nil {
 		return nil, fmt.Errorf("discovering skills: %w", err)
+	}
+	for _, m := range malformed {
+		logger.Warn("skipping malformed SKILL.md", "path", m.Path, "error", m.Err)
 	}
 
 	return &CloneResult{
 		RepoPath:  repoPath,
 		CommitSHA: commitSHA,
 		Skills:    skills,
+		Malformed: malformed,
 	}, nil
 }
 
@@ -227,11 +240,23 @@ func updateExisting(repoPath, url, ref string, auth AuthConfig, logger *slog.Log
 	return repoPath, nil
 }
 
-func discoverSkills(searchDir, repoRoot string) ([]DiscoveredSkill, error) {
+func discoverSkills(searchDir, repoRoot string) ([]DiscoveredSkill, []MalformedSkill, error) {
 	var skills []DiscoveredSkill
+	var malformed []MalformedSkill
+
+	recordMalformed := func(path string, cause error) {
+		relPath, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			relPath = path
+		}
+		malformed = append(malformed, MalformedSkill{Path: relPath, Err: cause.Error()})
+	}
 
 	err := filepath.WalkDir(searchDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			// An unreadable directory hides any SKILL.md beneath it;
+			// record the failure so it isn't silently skipped.
+			recordMalformed(path, err)
 			return nil
 		}
 		if d.IsDir() || d.Name() != "SKILL.md" {
@@ -240,11 +265,13 @@ func discoverSkills(searchDir, repoRoot string) ([]DiscoveredSkill, error) {
 
 		data, err := os.ReadFile(path)
 		if err != nil {
+			recordMalformed(path, err)
 			return nil
 		}
 
 		sk, err := registry.ParseSkillMD(data)
 		if err != nil {
+			recordMalformed(path, err)
 			return nil
 		}
 
@@ -266,7 +293,7 @@ func discoverSkills(searchDir, repoRoot string) ([]DiscoveredSkill, error) {
 		return nil
 	})
 
-	return skills, err
+	return skills, malformed, err
 }
 
 func contentHash(data []byte) string {

--- a/pkg/skills/remote_test.go
+++ b/pkg/skills/remote_test.go
@@ -1,0 +1,79 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeSkillFile(t *testing.T, root, dir, content string) {
+	t.Helper()
+	skillDir := filepath.Join(root, dir)
+	require.NoError(t, os.MkdirAll(skillDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0644))
+}
+
+// TestDiscoverSkillsReportsMalformed verifies that unparseable SKILL.md
+// files are reported instead of silently dropped. Regression test for the
+// bug where a repo full of parse failures surfaced as "no SKILL.md files
+// found in repository".
+func TestDiscoverSkillsReportsMalformed(t *testing.T) {
+	root := t.TempDir()
+
+	writeSkillFile(t, root, "skills/good", `---
+name: good-skill
+description: A valid skill
+---
+
+Body.
+`)
+	writeSkillFile(t, root, "skills/broken", `---
+name: [unclosed
+description: broken yaml
+---
+
+Body.
+`)
+
+	discovered, malformed, err := discoverSkills(root, root)
+	require.NoError(t, err)
+
+	require.Len(t, discovered, 1)
+	assert.Equal(t, "good-skill", discovered[0].Name)
+
+	require.Len(t, malformed, 1)
+	assert.Equal(t, filepath.Join("skills", "broken", "SKILL.md"), malformed[0].Path)
+	assert.Contains(t, malformed[0].Err, "parsing frontmatter")
+}
+
+// TestDiscoverSkillsNestedMetadata verifies discovery tolerates the
+// openclaw/ClawHub convention of nesting objects under metadata.
+func TestDiscoverSkillsNestedMetadata(t *testing.T) {
+	root := t.TempDir()
+
+	writeSkillFile(t, root, "skills/openclaw-style", `---
+name: openclaw-style
+description: Skill with nested metadata
+metadata:
+  author: samber
+  openclaw:
+    emoji: "X"
+    requires:
+      bins:
+        - go
+---
+
+Body.
+`)
+
+	discovered, malformed, err := discoverSkills(root, root)
+	require.NoError(t, err)
+	assert.Empty(t, malformed)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, "openclaw-style", discovered[0].Name)
+	assert.Equal(t, "samber", discovered[0].Skill.Metadata["author"])
+	assert.NotEmpty(t, discovered[0].Skill.Metadata["openclaw"])
+}

--- a/web/src/__tests__/AddSourceStep.test.tsx
+++ b/web/src/__tests__/AddSourceStep.test.tsx
@@ -21,8 +21,10 @@ vi.mock('../components/ui/Toast', () => ({
 }));
 
 import { previewSkillSource, HTTPError } from '../lib/api';
+import { showToast } from '../components/ui/Toast';
 
 const mockPreview = vi.mocked(previewSkillSource);
+const mockToast = vi.mocked(showToast);
 
 describe('AddSourceStep — auth card', () => {
   beforeEach(() => {
@@ -156,5 +158,89 @@ describe('AddSourceStep — auth card', () => {
     await waitFor(() => expect(mockPreview).toHaveBeenCalledTimes(1));
     const [, params] = mockPreview.mock.calls[0];
     expect(params?.auth).toBeUndefined();
+  });
+});
+
+describe('AddSourceStep — malformed SKILL.md reporting', () => {
+  beforeEach(() => {
+    mockPreview.mockReset();
+    mockToast.mockReset();
+  });
+
+  const scan = (url = 'https://github.com/acme/skills') => {
+    fireEvent.change(screen.getByPlaceholderText(/https:\/\/github/i), {
+      target: { value: url },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /scan for skills/i }));
+  };
+
+  it('names the parse failure when all SKILL.md files are malformed', async () => {
+    mockPreview.mockResolvedValueOnce({
+      repo: 'https://github.com/acme/skills',
+      ref: '',
+      commitSha: 'abc',
+      skills: [],
+      malformed: [{ path: 'skills/broken/SKILL.md', error: 'parsing frontmatter: bad yaml' }],
+    });
+    const onPreview = vi.fn();
+
+    render(<AddSourceStep onPreviewLoaded={onPreview} />);
+    scan();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/1 SKILL\.md file found but none could be parsed/i),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/skills\/broken\/SKILL\.md/)).toBeInTheDocument();
+    expect(onPreview).not.toHaveBeenCalled();
+  });
+
+  it('keeps the plain message when the repository has no SKILL.md at all', async () => {
+    mockPreview.mockResolvedValueOnce({
+      repo: 'https://github.com/acme/skills',
+      ref: '',
+      commitSha: 'abc',
+      skills: [],
+      malformed: [],
+    });
+
+    render(<AddSourceStep onPreviewLoaded={vi.fn()} />);
+    scan();
+
+    await waitFor(() => {
+      expect(screen.getByText(/no SKILL\.md files found in this repository/i)).toBeInTheDocument();
+    });
+  });
+
+  it('warns via toast but proceeds when a mixed repo has some malformed files', async () => {
+    mockPreview.mockResolvedValueOnce({
+      repo: 'https://github.com/acme/skills',
+      ref: '',
+      commitSha: 'abc',
+      skills: [
+        {
+          name: 'good',
+          description: '',
+          body: '',
+          valid: true,
+          errors: [],
+          warnings: [],
+          findings: [],
+          exists: false,
+        },
+      ],
+      malformed: [{ path: 'skills/broken/SKILL.md', error: 'parsing frontmatter: bad yaml' }],
+    });
+    const onPreview = vi.fn();
+
+    render(<AddSourceStep onPreviewLoaded={onPreview} />);
+    scan();
+
+    await waitFor(() => expect(onPreview).toHaveBeenCalledTimes(1));
+    expect(mockToast).toHaveBeenCalledWith(
+      'warning',
+      expect.stringContaining('skills/broken/SKILL.md'),
+    );
   });
 });

--- a/web/src/components/registry/SkillEditor.tsx
+++ b/web/src/components/registry/SkillEditor.tsx
@@ -85,7 +85,9 @@ function buildSkillMDContent(fields: {
   if (fields.metadata && Object.keys(fields.metadata).length > 0) {
     lines.push('metadata:');
     for (const [k, v] of Object.entries(fields.metadata)) {
-      if (k) lines.push(`  ${k}: "${v}"`);
+      // Escape for a YAML double-quoted scalar; imported values may carry
+      // embedded quotes (e.g. nested metadata coerced to JSON strings).
+      if (k) lines.push(`  ${k}: "${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`);
     }
   }
   if (fields.acceptanceCriteria && fields.acceptanceCriteria.length > 0) {

--- a/web/src/components/wizard/steps/AddSourceStep.tsx
+++ b/web/src/components/wizard/steps/AddSourceStep.tsx
@@ -137,9 +137,24 @@ export function AddSourceStep({ onPreviewLoaded }: AddSourceStepProps) {
         auth,
       });
 
+      const malformed = result.malformed ?? [];
+
       if (result.skills.length === 0) {
-        setError('No SKILL.md files found in this repository');
+        if (malformed.length > 0) {
+          setError(
+            `${malformed.length} SKILL.md file${malformed.length === 1 ? '' : 's'} found but none could be parsed (${malformed[0].path}: ${malformed[0].error})`,
+          );
+        } else {
+          setError('No SKILL.md files found in this repository');
+        }
         return;
+      }
+
+      if (malformed.length > 0) {
+        showToast(
+          'warning',
+          `${malformed.length} SKILL.md file${malformed.length === 1 ? '' : 's'} could not be parsed and ${malformed.length === 1 ? 'is' : 'are'} not shown (${malformed[0].path})`,
+        );
       }
 
       onPreviewLoaded(result.skills, trimmedUrl, ref, path, auth);

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -624,11 +624,18 @@ export interface SkillPreview {
   exists: boolean;
 }
 
+/** A SKILL.md that was found in the repository but could not be parsed. */
+export interface MalformedSkillFile {
+  path: string;
+  error: string;
+}
+
 export interface SkillPreviewResponse {
   repo: string;
   ref: string;
   commitSha: string;
   skills: SkillPreview[];
+  malformed?: MalformedSkillFile[];
 }
 
 export interface ImportedSkillResult {


### PR DESCRIPTION
## Description

Importing skills from repositories that nest objects under the SKILL.md `metadata` field (the openclaw/ClawHub publishing convention, e.g. samber/cc-skills-golang) failed for every skill, and the resulting error claimed no SKILL.md files existed. This PR makes metadata decoding lenient and surfaces per-file parse failures everywhere the misleading message could appear.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Decode `metadata` by walking the YAML mapping node: scalar values keep their literal form ("1.20", dates, hex stay verbatim), nested mappings and sequences become compact JSON strings, and a duplicate key no longer discards the valid keys. The Go field stays `map[string]string`, so the JSON wire shape, frontend types, and fingerprints are unchanged, and `RenderSkillMD` output remains spec-conformant string-to-string
- `discoverSkills` records unreadable or unparseable SKILL.md files (including WalkDir errors) in `CloneResult.Malformed` and logs each at warn level instead of dropping them silently
- `Importer.Import` names the failing files when discovery yields zero skills ("no importable skills found: N SKILL.md file(s) failed to parse (...)") and appends per-file warnings on fresh imports when only some fail; warnings are suppressed on `PreserveState` re-syncs to avoid repeating noise on every update
- `Importer.Diff` reports the upstream parse failure instead of "skill not found at upstream path" when the upstream SKILL.md is malformed
- The source-preview API returns a `malformed` array; the wizard shows a specific error when nothing parses and a warning toast when a mixed repo has some unparseable files
- SkillEditor's frontmatter builder escapes backslashes and double quotes in metadata values, so coerced JSON strings no longer produce invalid YAML during live validation

## Testing

- `go test ./...`, `golangci-lint run` (0 issues), `cd web && npm run lint && npm test` (1,137 passed)
- New regression tests: lenient metadata parsing (nested, duplicate-key, literal scalars, non-mapping, render round-trip), malformed discovery, all-malformed and mixed-repo imports, malformed upstream diff, the preview handler wire contract, and the wizard's malformed reporting
- Verified end to end: `gridctl skill add https://github.com/samber/cc-skills-golang` previously failed with "no SKILL.md files found in repository"; it now imports 45 of the repo's 46 skills (the 46th is correctly held for `--trust` by the security scan) with metadata intact

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #899