### PR TITLE
fix: support Grok Build in global context sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to gridctl will be documented in this file.
 ### Bug Fixes
 
 
+- Grok Build is now a supported global context sync target writing a managed block to `~/.grok/AGENTS.md`; it was previously misreported as having no documented global instruction file
+
 - Import skills whose SKILL.md `metadata` contains nested values (the openclaw/ClawHub publishing convention): non-string metadata values are now coerced to strings instead of failing the parse. SKILL.md files that genuinely cannot be parsed are surfaced by path and error across the CLI, import warnings, and the UI wizard instead of the misleading "no SKILL.md files found in repository"
 - Surface pin drift detail before approval: `GET /api/pins/{server}/diff` endpoint, `gridctl pins diff` subcommand with JSON output and 0/1/2 exit codes, and a first-class Pins workspace where the Approve action sits beside the rendered per-tool diff (non-printable characters escaped). Approvals can be bound to the reviewed snapshot via `expected_server_hash` / `pins approve --expect`, rejecting definitions that change after review
 

--- a/docs/global-context.md
+++ b/docs/global-context.md
@@ -30,9 +30,9 @@ Each client receives the canonical content through the safest mechanism it suppo
 |---|---|---|
 | Dedicated file | Claude Code (`~/.claude/rules/gridctl.md`), Roo Code, Continue, VS Code Copilot | gridctl owns a whole file inside a rules directory the client reads. Zero merge risk. |
 | Import shim | Gemini CLI (`~/.gemini/GEMINI.md`), Goose (`~/.config/goose/.goosehints`) | One `@`-import line referencing the canonical file is inserted; the rest of the file is never reordered or rewritten. Canonical edits flow through the reference without re-syncing. |
-| Managed block | OpenCode, Zed, Cline, Antigravity, Windsurf | The full file is written when absent; when user content exists, a `<!-- BEGIN GRIDCTL MANAGED -->` … `<!-- END GRIDCTL MANAGED -->` block is inserted and only that block is ever rewritten. Windsurf's `global_rules.md` has a 6,000-character limit; oversized content is refused with a count. |
+| Managed block | OpenCode, Zed, Cline, Grok Build (`~/.grok/AGENTS.md`), Antigravity, Windsurf | The full file is written when absent; when user content exists, a `<!-- BEGIN GRIDCTL MANAGED -->` … `<!-- END GRIDCTL MANAGED -->` block is inserted and only that block is ever rewritten. Windsurf's `global_rules.md` has a 6,000-character limit; oversized content is refused with a count. |
 
-Not syncable, reported honestly in `ctx status` instead of worked around: Claude Desktop (instructions live in the app UI), Cursor (global User Rules are app-internal storage), AnythingLLM (UI/API only), and Grok Build (no documented global file). Antigravity's global path rests on unofficial documentation and is flagged experimental.
+Not syncable, reported honestly in `ctx status` instead of worked around: Claude Desktop (instructions live in the app UI), Cursor (global User Rules are app-internal storage), and AnythingLLM (UI/API only). Antigravity's global path rests on unofficial documentation and is flagged experimental.
 
 Every write is preceded by a timestamped backup (`<file>.gridctl-backup-<ts>`, three retained) and performed atomically. Managed content carries a header naming the source and the edit command, so a reader landing in the file knows where changes belong.
 

--- a/pkg/contexts/contexts_test.go
+++ b/pkg/contexts/contexts_test.go
@@ -886,7 +886,7 @@ func TestStatusesIncludeUnsupportedClients(t *testing.T) {
 	for _, cs := range statuses {
 		bySlug[cs.Slug] = cs
 	}
-	for _, slug := range []string{"claude", "cursor", "anythingllm", "grok"} {
+	for _, slug := range []string{"claude", "cursor", "anythingllm"} {
 		cs, ok := bySlug[slug]
 		if !ok {
 			t.Errorf("%s missing from statuses", slug)
@@ -895,5 +895,33 @@ func TestStatusesIncludeUnsupportedClients(t *testing.T) {
 		if cs.State != StateUnsupported || cs.Detail == "" {
 			t.Errorf("%s: state=%q detail=%q", slug, cs.State, cs.Detail)
 		}
+	}
+}
+
+// TestGrokIsSupportedBlockTarget is a regression test: Grok Build was once
+// listed unsupported ("no documented global instruction file"), but Grok
+// reads global rules from ~/.grok/AGENTS.md (documented in its bundled user
+// guide and verified with `grok inspect`).
+func TestGrokIsSupportedBlockTarget(t *testing.T) {
+	tgt, ok := FindTarget("grok")
+	if !ok {
+		t.Fatal("grok must be a supported target")
+	}
+	if tgt.Strategy != StrategyBlock {
+		t.Errorf("Strategy = %q, want %q", tgt.Strategy, StrategyBlock)
+	}
+	for _, goos := range []string{"darwin", "linux", "windows"} {
+		if tgt.Paths[goos] != "~/.grok/AGENTS.md" {
+			t.Errorf("Paths[%s] = %q, want %q", goos, tgt.Paths[goos], "~/.grok/AGENTS.md")
+		}
+	}
+	if tgt.MaxChars != 0 {
+		t.Errorf("MaxChars = %d, want 0 (Grok documents no cap)", tgt.MaxChars)
+	}
+	if tgt.Experimental {
+		t.Error("grok must not be experimental; path comes from first-party docs")
+	}
+	if _, stillUnsupported := findUnsupported("grok"); stillUnsupported {
+		t.Error("grok must no longer be listed unsupported")
 	}
 }

--- a/pkg/contexts/targets.go
+++ b/pkg/contexts/targets.go
@@ -120,6 +120,13 @@ func Targets() []Target {
 			DetectDirs: []string{"~/Documents/Cline", "~/.agents"},
 		},
 		{
+			Slug:       "grok",
+			Name:       "Grok Build",
+			Strategy:   StrategyBlock,
+			Paths:      allOS("~/.grok/AGENTS.md"),
+			DetectDirs: []string{"~/.grok"},
+		},
+		{
 			Slug:     "antigravity",
 			Name:     "Antigravity",
 			Strategy: StrategyBlock,
@@ -168,7 +175,6 @@ func Unsupported() []UnsupportedClient {
 		{Slug: "claude", Name: "Claude Desktop", Reason: "instructions live in the app UI; no global context file"},
 		{Slug: "cursor", Name: "Cursor", Reason: "global User Rules are stored in app-internal storage; no supported file path"},
 		{Slug: "anythingllm", Name: "AnythingLLM", Reason: "workspace system prompt is UI/API only; no context file"},
-		{Slug: "grok", Name: "Grok Build", Reason: "no documented global instruction file"},
 	}
 }
 


### PR DESCRIPTION
## Description

Global context sync classified Grok Build as unsupported ("no documented global instruction file"), so `ctx sync` refused to write a Grok target and both `ctx status` and the UI displayed a false capability statement. Grok Build 0.2.101 documents global rules discovery at `~/.grok/` (its bundled user guide lists `AGENTS.md` among the recognized filenames), and `grok inspect` confirms `~/.grok/AGENTS.md` loads as a global project instruction.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Moved Grok Build from `Unsupported()` to `Targets()` in `pkg/contexts/targets.go`: managed-block strategy on `~/.grok/AGENTS.md` (all platforms), detect dir `~/.grok`, no character cap (Grok documents none), not experimental (first-party docs). Same pattern as OpenCode, Zed, and Cline; no Grok-specific write logic
- Regression test `TestGrokIsSupportedBlockTarget`; updated `TestStatusesIncludeUnsupportedClients`, which had encoded the stale classification
- `docs/global-context.md`: Grok Build moved from the not-syncable sentence to the managed-block row
- Changelog entry

The CLI, sync engine, and web UI all derive from the targets table, so no other code changes are needed.

## Testing

- `go test ./...` passes; `golangci-lint run` reports 0 issues
- Verified end to end on a machine with Grok Build 0.2.101: `ctx status` lists grok as a detected block target, `ctx sync grok` creates `~/.grok/AGENTS.md` with the managed block, and `grok inspect` then lists that file as a loaded global instruction

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #901