### PR TITLE
fix: treat empty client config file as empty JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to gridctl will be documented in this file.
 ### Bug Fixes
 
 
+- `gridctl link`, `gridctl unlink`, and link status no longer fail with a JSON parse error when a client's config file exists but is empty or whitespace-only (Antigravity 2.0 creates its `mcp_config.json` as a zero-byte file on install); an empty file is now treated the same as a missing one
+
 - Grok Build is now a supported global context sync target writing a managed block to `~/.grok/AGENTS.md`; it was previously misreported as having no documented global instruction file
 
 - Import skills whose SKILL.md `metadata` contains nested values (the openclaw/ClawHub publishing convention): non-string metadata values are now coerced to strings instead of failing the parse. SKILL.md files that genuinely cannot be parsed are surfaced by path and error across the CLI, import warnings, and the UI wizard instead of the misleading "no SKILL.md files found in repository"

--- a/pkg/provisioner/json.go
+++ b/pkg/provisioner/json.go
@@ -24,6 +24,12 @@ func readJSONFile(path string) (map[string]any, bool, error) {
 
 // parseJSON parses JSON or JSONC bytes into a map.
 func parseJSON(raw []byte) (map[string]any, bool, error) {
+	// Some clients (Antigravity 2.0) pre-create their config as an empty file;
+	// treat it the same as a missing one.
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return map[string]any{}, false, nil
+	}
+
 	// Try hujson to detect and handle comments/trailing commas
 	ast, err := hujson.Parse(raw)
 	if err != nil {

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -270,6 +270,62 @@ func TestLink_MalformedJSON_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestLink_EmptyConfigFile_TreatsAsEmpty(t *testing.T) {
+	p, configPath := testMCPServersProvisioner(t, "config.json", false)
+	opts := defaultLinkOpts()
+
+	// Some clients (Antigravity 2.0) create the config as a zero-byte file.
+	if err := os.WriteFile(configPath, []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Link(configPath, opts); err != nil {
+		t.Fatal(err)
+	}
+
+	data := readTestJSON(t, configPath)
+	servers := data["mcpServers"].(map[string]any)
+	entry := servers["gridctl"].(map[string]any)
+	if entry["serverUrl"] != "http://localhost:8180/sse" {
+		t.Errorf("unexpected entry: %v", entry)
+	}
+}
+
+func TestLink_WhitespaceOnlyConfigFile_TreatsAsEmpty(t *testing.T) {
+	p, configPath := testMCPServersProvisioner(t, "config.json", false)
+	opts := defaultLinkOpts()
+
+	if err := os.WriteFile(configPath, []byte("\n  \n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Link(configPath, opts); err != nil {
+		t.Fatal(err)
+	}
+
+	data := readTestJSON(t, configPath)
+	servers := data["mcpServers"].(map[string]any)
+	if _, ok := servers["gridctl"]; !ok {
+		t.Error("expected gridctl entry after linking whitespace-only config")
+	}
+}
+
+func TestIsLinked_EmptyConfigFile_ReturnsFalse(t *testing.T) {
+	p, configPath := testMCPServersProvisioner(t, "config.json", false)
+
+	if err := os.WriteFile(configPath, []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	linked, err := p.IsLinked(configPath, "gridctl")
+	if err != nil {
+		t.Fatalf("IsLinked returned error: %v", err)
+	}
+	if linked {
+		t.Error("expected not linked for empty config file")
+	}
+}
+
 func TestLink_JSONC_WithComments(t *testing.T) {
 	p, configPath := testMCPServersProvisioner(t, "config.json", false)
 	opts := defaultLinkOpts()


### PR DESCRIPTION
## Description

`gridctl link` failed with `parsing JSON: hujson: ... unexpected EOF` when a client's MCP config file exists but is empty. Antigravity 2.0 creates `~/.gemini/config/mcp_config.json` as a zero-byte file on install, so linking Antigravity was broken out of the box; the same defect hit link, unlink, and link status for every JSON-based client with an empty config, and broke `gridctl link --all` if any one detected client had one.

## Type of Change

- [x] Bug fix

## Changes Made

- `parseJSON` in `pkg/provisioner/json.go` now returns an empty config object for empty or whitespace-only input, so an empty file behaves the same as a missing one across all JSON provisioner read paths
- Regression tests: link against a zero-byte file, link against a whitespace-only file, and `IsLinked` on an empty file returning false without error
- Changelog entry under `[Unreleased]`

## Testing

- `go test ./...` passes; `golangci-lint run` clean
- New tests fail before the fix with the exact reported error and pass after
- Verified on a machine with a fresh Antigravity 2.0 install: `gridctl link antigravity --dry-run` previously exited 1, now renders the config diff

Closes #929