### PR TITLE
fix: refit stack canvas after tool fan-out toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to gridctl will be documented in this file.
 ### Bug Fixes
 
 
+- The Stack canvas now refits the viewport after expanding or collapsing a server's tool fan-out with no client selected, so the revealed tool nodes stay in view at the maximum zoom that fits instead of clipping past the right edge at higher zoom levels. Layout recomputes refit too: the reset-layout button and the compact/full card toggle re-frame the graph instead of leaving the resized layout spilling out of view. Status polls and node drags still never move the viewport. Access Lens now frames the whole graph (every server is grantable, so all must be visible) and refits when tools are expanded or collapsed mid-edit, while grant/revoke toggles still hold the canvas still
+
 - `gridctl link`, `gridctl unlink`, and link status no longer fail with a JSON parse error when a client's config file exists but is empty or whitespace-only (Antigravity 2.0 creates its `mcp_config.json` as a zero-byte file on install); an empty file is now treated the same as a missing one
 
 - Grok Build is now a supported global context sync target writing a managed block to `~/.grok/AGENTS.md`; it was previously misreported as having no documented global instruction file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to gridctl will be documented in this file.
 
 ### Features
 
+- Full-view client cards on the Stack canvas are now horizontal: the client icon sits on the left with the name, transport, and linked status stacked beside it in a wider, shorter card, replacing the centered column layout and its dead space above the icon. Compact cards are unchanged
+
 - Automated npm advisory fixes: a scheduled `NPM Audit Fix` workflow runs `npm audit fix` against `web/` weekly (and on demand via `workflow_dispatch`) and opens or updates a single reviewable PR when the lockfile changes, listing the advisories it addresses. Only semver-compatible updates are applied; the frontend CI job's `npm audit --audit-level=high` gate is unchanged, this keeps main passing it so fresh advisories stop failing unrelated PRs
 
 - Tool groups in the web UI: the Tools workspace gains a Groups panel (header button, shown only when a `groups:` block exists) listing each group with its member count, description, copyable endpoint URL, and a link-command hint; selecting a group shows the exposed surface per member tool — the renamed name with its canonical origin, the rewritten description beside the downstream original so operators see exactly what a group client's model sees, and annotation chips for declared hints. Tool rows in the workspace carry compact group badges for members. `GET /api/groups` additionally returns a `members` array with each exposed tool's post-rewrite name, description, merged annotations, and origin. Stacks without groups are visually unchanged

--- a/web/src/__tests__/CanvasRefit.test.tsx
+++ b/web/src/__tests__/CanvasRefit.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+// The fitView spy must be hoisted so the module mock below can close over it.
+const { fitView } = vi.hoisted(() => ({ fitView: vi.fn() }));
+
+// Mock React Flow for every consumer in Canvas's module graph: CanvasBase
+// (ReactFlow, Background, BackgroundVariant), Canvas (useReactFlow,
+// useViewport, Panel), the node components (Handle, Position), the store
+// (applyNodeChanges, applyEdgeChanges), and edge building (MarkerType).
+vi.mock('@xyflow/react', () => ({
+  ReactFlow: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="react-flow">{children}</div>
+  ),
+  Background: () => null,
+  BackgroundVariant: { Dots: 'dots', Lines: 'lines', Cross: 'cross' },
+  Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Handle: () => null,
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+  MarkerType: { Arrow: 'arrow', ArrowClosed: 'arrowclosed' },
+  useReactFlow: () => ({ fitView, zoomIn: vi.fn(), zoomOut: vi.fn() }),
+  useViewport: () => ({ zoom: 1 }),
+  applyNodeChanges: (_changes: unknown, nodes: unknown) => nodes,
+  applyEdgeChanges: (_changes: unknown, edges: unknown) => edges,
+}));
+
+import { Canvas } from '../components/graph/Canvas';
+import { useStackStore } from '../stores/useStackStore';
+import { useAccessLensStore } from '../stores/useAccessLensStore';
+import type { GatewayStatus, MCPServerStatus } from '../types';
+
+function makeServer(name: string, toolCount: number): MCPServerStatus {
+  return {
+    name,
+    transport: 'http',
+    initialized: true,
+    toolCount,
+    tools: Array.from({ length: toolCount }, (_, i) => `${name}-tool-${i}`),
+  };
+}
+
+function status(servers: MCPServerStatus[]): GatewayStatus {
+  return {
+    gateway: { name: 'gw', version: '0.0.0' },
+    'mcp-servers': servers,
+  };
+}
+
+function fittedIds(callIndex = -1): string[] {
+  const calls = fitView.mock.calls;
+  const call = calls.at(callIndex);
+  const opts = call?.[0] as { nodes?: { id: string }[] } | undefined;
+  return (opts?.nodes ?? []).map((n) => n.id);
+}
+
+describe('Canvas auto-refit on tool fan-out', () => {
+  beforeEach(() => {
+    fitView.mockClear();
+    useStackStore.setState({
+      expandedServers: new Set(),
+      selectedNodeId: null,
+      draggedPositions: new Map(),
+    });
+    useStackStore.getState().setGatewayStatus(status([makeServer('github', 3)]));
+  });
+
+  it('refits with the fan-out node ids when a server expands with nothing selected', () => {
+    render(<Canvas />);
+    fitView.mockClear();
+
+    act(() => {
+      useStackStore.getState().toggleServerExpanded('mcp-github');
+    });
+
+    expect(fitView).toHaveBeenCalled();
+    const toolIds = useStackStore
+      .getState()
+      .nodes.filter((n) => (n.data as { type?: string }).type === 'tool')
+      .map((n) => n.id);
+    expect(toolIds.length).toBe(3);
+    const ids = fittedIds();
+    for (const toolId of toolIds) {
+      expect(ids).toContain(toolId);
+    }
+  });
+
+  it('does not refit on a polling refresh with an unchanged node set', () => {
+    render(<Canvas />);
+    act(() => {
+      useStackStore.getState().toggleServerExpanded('mcp-github');
+    });
+    fitView.mockClear();
+
+    act(() => {
+      useStackStore.getState().setGatewayStatus(status([makeServer('github', 3)]));
+    });
+
+    expect(fitView).not.toHaveBeenCalled();
+  });
+
+  it('refits after resetLayout even though the node id set is unchanged', () => {
+    render(<Canvas />);
+    fitView.mockClear();
+
+    // The reset button and the compact-cards toggle both recompute every
+    // position through resetLayout without adding or removing nodes.
+    act(() => {
+      useStackStore.getState().resetLayout();
+    });
+
+    expect(fitView).toHaveBeenCalled();
+  });
+
+  it('refits on expansion during Access Lens editing, but not on scope toggles', () => {
+    useStackStore.setState({ selectedNodeId: 'client-claude' });
+    useAccessLensStore.setState({ enabled: true, clientSlug: 'claude' });
+    try {
+      render(<Canvas />);
+      fitView.mockClear();
+
+      // A draft grant/revoke changes highlighting only; the canvas holds still.
+      act(() => {
+        useAccessLensStore.getState().toggleServer('github');
+      });
+      expect(fitView).not.toHaveBeenCalled();
+
+      // Expanding a server changes the node set; the fan-out must come into frame.
+      act(() => {
+        useStackStore.getState().toggleServerExpanded('mcp-github');
+      });
+      expect(fitView).toHaveBeenCalled();
+    } finally {
+      useAccessLensStore.setState({ enabled: false, clientSlug: null });
+    }
+  });
+
+  it('refits without the tool ids after collapsing', () => {
+    render(<Canvas />);
+    act(() => {
+      useStackStore.getState().toggleServerExpanded('mcp-github');
+    });
+    fitView.mockClear();
+
+    act(() => {
+      useStackStore.getState().toggleServerExpanded('mcp-github');
+    });
+
+    expect(fitView).toHaveBeenCalled();
+    const ids = fittedIds();
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids.some((id) => id.includes('tool'))).toBe(false);
+  });
+});

--- a/web/src/components/graph/Canvas.tsx
+++ b/web/src/components/graph/Canvas.tsx
@@ -98,30 +98,36 @@ export function Canvas() {
   // override re-lights the canvas live against unsaved edits.
   const highlightState = usePathHighlight(nodes, edges, selectedNodeId, scopeOverride);
 
-  // Auto-fit the view to a focused client's reachable subgraph. The fit key
-  // captures the highlighted node set, so the view re-fits whenever that set
-  // changes - including expanding a reachable server while the client stays
-  // focused, which brings the newly-fanned-out tools into frame.
+  // Auto-fit the view whenever the visible layout changes. With a client
+  // focused the fit key is its highlighted reachable subgraph; otherwise it is
+  // every node id, so expanding or collapsing a server's tool fan-out (or
+  // servers appearing on hot reload) re-frames the whole graph at max zoom.
+  // The layout epoch folds in resetLayout (reset button, compact-cards
+  // toggle), which recomputes every position without changing the id set.
+  // Keying on epoch plus sorted ids keeps the canvas still during status
+  // polls and node drags, which change neither.
   //
-  // Suppressed while actively editing in Access Lens: the draft scope narrows
-  // the reachable set on every tool/server toggle, and auto-refitting then would
-  // yank the canvas out from under the operator (and recenter the servers behind
-  // the slide-over panel). Selecting the client already framed it; hold still.
+  // Access Lens uses the whole-graph key even though a client is selected:
+  // the operator can grant servers outside the current reach, so every server
+  // must be in frame, and scope toggles only change highlighting, never node
+  // ids, so draft edits still hold the canvas still while expand/collapse
+  // re-frames. The sidebar is a grid column, so fitView fits the narrowed
+  // canvas area on its own.
+  const layoutEpoch = useStackStore((s) => s.layoutEpoch);
   const selectedNode = nodes.find((n) => n.id === selectedNodeId);
   const isClientSelected =
     (selectedNode?.data as { type?: string } | undefined)?.type === 'client';
-  const fitKey =
+  const fitIds =
     isClientSelected && !lensActive
       ? [...highlightState.highlightedNodeIds].sort().join(',')
-      : '';
+      : (nodes ?? []).map((n) => n.id).sort().join(',');
+  const fitKey = fitIds ? `${layoutEpoch}:${fitIds}` : '';
   useEffect(() => {
     if (!fitKey) return;
-    const ids = fitKey.split(',').map((id) => ({ id }));
-    // Defer one frame so React Flow has mounted/measured any new tool nodes.
-    const raf = requestAnimationFrame(() => {
-      fitView({ nodes: ids, padding: 0.25, duration: 400, maxZoom: 1.5 });
-    });
-    return () => cancelAnimationFrame(raf);
+    const ids = fitKey.slice(fitKey.indexOf(':') + 1).split(',').map((id) => ({ id }));
+    // fitView queues internally until new nodes are measured (React Flow 12.5+),
+    // so no frame deferral is needed before fitting freshly-mounted tool nodes.
+    fitView({ nodes: ids, padding: 0.25, duration: 400, maxZoom: 1.5 });
   }, [fitKey, fitView]);
 
   // Evolvable grid - main lines at 100px, sub-grid dots at 20px fade in at >0.8x

--- a/web/src/components/graph/ClientNode.tsx
+++ b/web/src/components/graph/ClientNode.tsx
@@ -57,39 +57,37 @@ const ClientNode = memo(({ data, selected }: ClientNodeProps) => {
   return (
     <div
       className={cn(
-        'w-40 rounded-xl relative',
+        'w-52 rounded-xl relative',
         'backdrop-blur-xl border transition-all duration-200 ease-out',
         'bg-gradient-to-b from-surface/95 via-surface/90 to-surface/80',
         'shadow-bevel',
-        'flex flex-col items-center justify-center text-center p-3 gap-1',
+        'flex items-center gap-3 px-3',
         selected && 'border-text-secondary ring-2 ring-white/15',
         !selected && 'border-border hover:shadow-node-hover hover:border-text-secondary/40'
       )}
-      style={{ height: 120 }}
+      style={{ height: LAYOUT.CLIENT_HEIGHT }}
     >
       {/* Top accent */}
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
 
       {/* Icon */}
-      <div className="p-2 rounded-lg border bg-white/[0.04] border-white/10">
+      <div className="p-2 rounded-lg border bg-white/[0.04] border-white/10 flex-shrink-0">
         <Icon size={20} className="text-text-primary" />
       </div>
 
-      {/* Name */}
-      <span className="font-semibold text-xs text-text-primary truncate max-w-[130px] px-1">
-        {data.name}
-      </span>
-
-      {/* Transport badge */}
-      <span className="text-[9px] text-text-muted font-mono uppercase tracking-wider">
-        {data.transport}
-      </span>
-
-      {/* Status */}
-      <span className="inline-flex items-center gap-1.5 text-[10px] px-1.5 py-0.5 rounded font-medium border bg-status-running/10 border-status-running/25 text-status-running">
-        <StatusDot status={data.status} />
-        Linked
-      </span>
+      {/* Name, transport, and status stack beside the icon */}
+      <div className="flex flex-col items-start gap-0.5 min-w-0">
+        <span className="font-semibold text-xs text-text-primary truncate max-w-full">
+          {data.name}
+        </span>
+        <span className="text-[9px] text-text-muted font-mono uppercase tracking-wider">
+          {data.transport}
+        </span>
+        <span className="mt-0.5 inline-flex items-center gap-1.5 text-[10px] px-1.5 py-0.5 rounded font-medium border bg-status-running/10 border-status-running/25 text-status-running">
+          <StatusDot status={data.status} />
+          Linked
+        </span>
+      </div>
 
       {/* Source handle (connects to gateway on the right) */}
       <Handle

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -7,8 +7,9 @@ export const LAYOUT = {
   NODE_WIDTH: 256,
   NODE_HEIGHT: 140,
   NODE_HEIGHT_COMPACT: 48,    // Compact mode: header only
-  CLIENT_WIDTH: 160,   // Linked client node width
-  CLIENT_HEIGHT: 120,  // Linked client node height
+  CLIENT_WIDTH: 160,   // Linked client node width (compact mode)
+  CLIENT_WIDTH_FULL: 208,  // Full-card client width (horizontal icon + text)
+  CLIENT_HEIGHT: 84,   // Full-card client height
   CLIENT_HEIGHT_COMPACT: 48,  // Client compact mode height
   TOOL_WIDTH: 200,     // Tool fan-out pill width
   TOOL_HEIGHT: 34,     // Tool fan-out pill height

--- a/web/src/lib/graph/utils.ts
+++ b/web/src/lib/graph/utils.ts
@@ -21,7 +21,7 @@ export function getNodeDimensions(node: Node, compact = false): { width: number;
       };
     case 'client':
       return {
-        width: LAYOUT.CLIENT_WIDTH,
+        width: compact ? LAYOUT.CLIENT_WIDTH : LAYOUT.CLIENT_WIDTH_FULL,
         height: compact ? LAYOUT.CLIENT_HEIGHT_COMPACT : LAYOUT.CLIENT_HEIGHT,
       };
     case 'skill':

--- a/web/src/stores/useStackStore.ts
+++ b/web/src/stores/useStackStore.ts
@@ -89,6 +89,10 @@ interface StackState {
   // canvas. Independent per server and preserved across polling refreshes so
   // an expanded server stays expanded when the graph data refetches.
   expandedServers: Set<string>;
+  // Bumped whenever resetLayout recomputes positions from scratch (reset
+  // button, compact-cards toggle) so the canvas can refit even though the
+  // node id set is unchanged.
+  layoutEpoch: number;
   connectionStatus: ConnectionStatus;
   lastUpdated: Date | null;
   isLoading: boolean;
@@ -152,6 +156,7 @@ export const useStackStore = create<StackState>()(
     autoscaleLastSeen: {},
     selectedNodeId: null,
     expandedServers: new Set<string>(),
+    layoutEpoch: 0,
     connectionStatus: 'disconnected',
     lastUpdated: null,
     isLoading: true,
@@ -367,7 +372,12 @@ export const useStackStore = create<StackState>()(
       const fanned = appendToolFanout(nodes, edges, get().expandedServers, {
         compact: isCompact,
       });
-      set({ nodes: fanned.nodes, edges: fanned.edges, draggedPositions: new Map() });
+      set({
+        nodes: fanned.nodes,
+        edges: fanned.edges,
+        draggedPositions: new Map(),
+        layoutEpoch: get().layoutEpoch + 1,
+      });
     },
 
     onNodesChange: (changes) => {


### PR DESCRIPTION
## Description

The Stack canvas auto-refit was gated on a client being selected, so most node-set and layout changes never re-framed the viewport. Also makes the full-view client card horizontal to remove the dead space above the icon.

## Type of Change

- [x] Bug fix
- [x] UI change

## Changes Made

- Key the auto-refit effect on the sorted visible-node-id set: expanding or collapsing a server's tool fan-out (and servers appearing on hot reload) now re-frames the graph at the maximum zoom that fits, while status polls and node drags, which never change ids, hold still
- Add a `layoutEpoch` to the stack store, bumped by `resetLayout` and folded into the fit key, so the reset-layout button and the compact/full card toggle refit even though the id set is unchanged
- Access Lens now uses the whole-graph key: entering a scope edit frames every server (all are grantable), expand/collapse mid-edit refits, and grant/revoke toggles still hold the canvas still since they only change highlighting
- Drop the `requestAnimationFrame` wrapper around `fitView`; React Flow 12.5+ queues fitView until new nodes are measured
- Full-view client cards are now horizontal (icon left, name/transport/status stacked beside it, 208x84) replacing the centered 160x120 column; compact cards unchanged. Kept as separate commits so the layout change is independently revertable

## Testing

- New `CanvasRefit.test.tsx` covers: refit with fan-out ids on expand with nothing selected, no refit on a same-id-set poll refresh, refit after `resetLayout` with an unchanged id set, lens-mode refit on expansion but not on scope toggles, and refit without tool ids after collapse
- `cd web && npm test`: 121 files, 1225 tests passing; `npm run lint` at zero errors
- Verified against a live daemon: expansion at zoom 1.2 previously left all fan-out nodes clipped past the right edge with an unchanged viewport transform; each reported scenario (expand, compact/full toggle, lens editing) now re-frames

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #937