### PR TITLE
fix: make gateway serverInfo name configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ All notable changes to gridctl will be documented in this file.
 ### Bug Fixes
 
 
+- The gateway's announced MCP identity is now configurable: an optional `gateway.name` field in stack.yaml overrides the `serverInfo.name` reported in the initialize response (default unchanged: `gridctl-gateway`), and group endpoints announce a group-suffixed identity (`<name>/<group>`). The response also carries the MCP `title` field for clients that prefer it. Clients such as VS Code / GitHub Copilot display the server-reported name rather than the entry key in their own config file, so multiple linked gridctl endpoints were previously indistinguishable in their tool lists
+
 - The Stack canvas now refits the viewport after expanding or collapsing a server's tool fan-out with no client selected, so the revealed tool nodes stay in view at the maximum zoom that fits instead of clipping past the right edge at higher zoom levels. Layout recomputes refit too: the reset-layout button and the compact/full card toggle re-frame the graph instead of leaving the resized layout spilling out of view. Status polls and node drags still never move the viewport. Access Lens now frames the whole graph (every server is grantable, so all must be visible) and refits when tools are expanded or collapsed mid-edit, while grant/revoke toggles still hold the canvas still
 
 - `gridctl link`, `gridctl unlink`, and link status no longer fail with a JSON parse error when a client's config file exists but is empty or whitespace-only (Antigravity 2.0 creates its `mcp_config.json` as a zero-byte file on install); an empty file is now treated the same as a missing one

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -68,6 +68,7 @@ gateway:
 | `default_model` | string | No | - | Model ID used to price tool calls for servers without their own `model` field (e.g. `"claude-opus-4-7"`). Enables cost observability; figures are estimates from the embedded LiteLLM rates, not billing truth. Empty disables cost attribution for servers without a per-server `model` |
 | `output_format` | string | No | `"json"` | Default output format for tool call results: `"json"`, `"toon"`, `"csv"`, or `"text"`. Per-server `output_format` overrides this value |
 | `maxToolResultBytes` | int | No | `65536` | Maximum size of a tool result in bytes before truncation. Results over the limit are truncated with a suffix noting the original size. `0` uses the default (64 KB) |
+| `name` | string | No | `"gridctl-gateway"` | Identity announced to MCP clients in the initialize response (`serverInfo.name`). Some clients (VS Code / GitHub Copilot) display this instead of the entry key in their own config, so give distinct gateways distinct names. Group endpoints announce `<name>/<group>`. Requires a restart to propagate |
 | `security` | object | No | - | Security settings (see [Security](#security)) |
 | `tokenizer` | string | No | `"embedded"` | Token counting mode: `"embedded"` (cl100k_base approximation) or `"api"` (exact counts via Anthropic `count_tokens` endpoint) |
 | `tokenizer_api_key` | string | No | - | Anthropic API key for `tokenizer: api`. Falls back to `ANTHROPIC_API_KEY` env var. Supports `${VAR}` and `${var:KEY}` references |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -275,6 +275,28 @@ Tool calls fail with `connection lost` after working initially.
    gridctl reload
    ```
 
+### Client shows "gridctl-gateway" instead of my config entry name
+
+**Symptoms:**
+
+The tool list in VS Code / GitHub Copilot labels a gridctl connection `gridctl-gateway` even though the entry in the client's config file has a different name (for example `gridctl-local`). With several gridctl entries linked, all of them show the same label.
+
+**Causes:**
+
+The entry key written by `gridctl link --name` / `--group` is a client-local alias and never reaches the gateway. Some clients instead display the identity the gateway reports in its MCP `initialize` response (`serverInfo.name`), which defaults to `gridctl-gateway` for every gridctl endpoint.
+
+**Resolution:**
+
+1. Set a distinct announced name per gateway in `stack.yaml`:
+   ```yaml
+   gateway:
+     name: acme-stack
+   ```
+
+2. Group endpoints (`/groups/<name>/mcp`) automatically announce a suffixed identity such as `acme-stack/<group>`, so linked groups are distinguishable without configuration.
+
+3. Restart the stack (`gridctl apply`); connected clients pick up the new name on their next initialize.
+
 ---
 
 ## Hot Reload

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -576,6 +576,32 @@ gateway:
 	}
 }
 
+func TestLoadStack_GatewayName(t *testing.T) {
+	content := `
+version: "1"
+name: name-test
+mcp-servers:
+  - name: server1
+    image: alpine:latest
+    port: 3000
+gateway:
+  name: acme-stack
+`
+	path := writeTempFile(t, content)
+
+	stack, err := LoadStack(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stack.Gateway == nil {
+		t.Fatal("expected gateway config")
+	}
+	if stack.Gateway.Name != "acme-stack" {
+		t.Errorf("expected gateway name 'acme-stack', got '%s'", stack.Gateway.Name)
+	}
+}
+
 func TestLoadStack_AuthConfigEnvExpansion(t *testing.T) {
 	t.Setenv("TEST_AUTH_TOKEN", "expanded-token")
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -293,6 +293,13 @@ type TracingConfig struct {
 
 // GatewayConfig holds optional gateway-level configuration.
 type GatewayConfig struct {
+	// Name overrides the identity the gateway announces to MCP clients in the
+	// initialize response (serverInfo.name). Some clients (VS Code / GitHub
+	// Copilot) display this value rather than the entry key from their own
+	// config file, so distinct gateways need distinct names to be told apart.
+	// Empty keeps the default "gridctl-gateway".
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+
 	// AllowedOrigins lists origins for CORS.
 	// When not set, defaults to ["*"] (allow all) for backward compatibility.
 	// Set explicit origins to restrict cross-origin access.

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -224,6 +224,9 @@ func (b *GatewayBuilder) Build(verbose bool) (*GatewayInstance, error) {
 	inst.Gateway = mcp.NewGateway()
 	inst.Gateway.SetDockerClient(b.rt.DockerClient())
 	inst.Gateway.SetVersion(b.version)
+	if b.stack.Gateway != nil {
+		inst.Gateway.SetName(b.stack.Gateway.Name)
+	}
 
 	// Phase 1a: Enable code mode if configured
 	codeModeEnabled := b.config.CodeMode

--- a/pkg/mcp/gateway.go
+++ b/pkg/mcp/gateway.go
@@ -242,6 +242,17 @@ func (g *Gateway) SetVersion(version string) {
 	g.serverInfo.Version = version
 }
 
+// SetName overrides the announced serverInfo name. Empty input is a no-op so
+// an unset stack field can never blank the identity.
+func (g *Gateway) SetName(name string) {
+	if name == "" {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.serverInfo.Name = name
+}
+
 // SetCodeMode enables code mode with the given timeout.
 // When code mode is active, tools/list returns meta-tools instead of individual tools.
 func (g *Gateway) SetCodeMode(timeout time.Duration) {
@@ -1560,9 +1571,18 @@ func (g *Gateway) HandleInitialize(params InitializeParams, accessID, group stri
 		}
 	}
 
+	// Group endpoints announce a group-suffixed identity so several linked
+	// endpoints of the same gateway are distinguishable in clients that
+	// display the server-reported name instead of their own config key.
+	info := g.ServerInfo()
+	if group != "" {
+		info.Name = info.Name + "/" + group
+	}
+	info.Title = info.Name
+
 	return &InitializeResult{
 		ProtocolVersion: protocolVersion,
-		ServerInfo:      g.ServerInfo(),
+		ServerInfo:      info,
 		Capabilities:    caps,
 		Instructions:    g.buildInstructions(),
 	}, session, nil

--- a/pkg/mcp/gateway_test.go
+++ b/pkg/mcp/gateway_test.go
@@ -50,6 +50,56 @@ func TestGateway_SetVersion(t *testing.T) {
 	}
 }
 
+func TestGateway_SetName(t *testing.T) {
+	g := NewGateway()
+	g.SetName("acme-stack")
+
+	if got := g.ServerInfo().Name; got != "acme-stack" {
+		t.Errorf("expected server name 'acme-stack', got '%s'", got)
+	}
+
+	// Empty input must not blank the identity.
+	g.SetName("")
+	if got := g.ServerInfo().Name; got != "acme-stack" {
+		t.Errorf("expected empty SetName to be a no-op, got '%s'", got)
+	}
+}
+
+func TestGateway_HandleInitialize_ServerIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		setName  string
+		group    string
+		wantName string
+	}{
+		{"default", "", "", "gridctl-gateway"},
+		{"configured name", "acme-stack", "", "acme-stack"},
+		{"group suffixes default", "", "local", "gridctl-gateway/local"},
+		{"group suffixes configured name", "acme-stack", "remote", "acme-stack/remote"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGateway()
+			g.SetName(tt.setName)
+			params := InitializeParams{
+				ProtocolVersion: MCPProtocolVersion,
+				ClientInfo:      ClientInfo{Name: "test-client", Version: "1.0"},
+			}
+
+			result, _, err := g.HandleInitialize(params, "", tt.group)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.ServerInfo.Name != tt.wantName {
+				t.Errorf("expected server name '%s', got '%s'", tt.wantName, result.ServerInfo.Name)
+			}
+			if result.ServerInfo.Title != tt.wantName {
+				t.Errorf("expected title '%s', got '%s'", tt.wantName, result.ServerInfo.Title)
+			}
+		})
+	}
+}
+
 func TestGateway_HandleInitialize(t *testing.T) {
 	g := NewGateway()
 	params := InitializeParams{

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -322,7 +322,10 @@ const MaxRequestBodySize = 1 * 1024 * 1024
 
 // ServerInfo contains information about the MCP server.
 type ServerInfo struct {
-	Name    string `json:"name"`
+	Name string `json:"name"`
+	// Title is the human-friendly display name from the 2025-06-18 MCP
+	// revision; clients that understand it prefer it over Name.
+	Title   string `json:"title,omitempty"`
 	Version string `json:"version"`
 }
 


### PR DESCRIPTION
## Description

Adds an optional `gateway.name` stack.yaml field that overrides the `serverInfo.name` the gateway announces in the MCP initialize response. Clients such as VS Code / GitHub Copilot display this server-reported name rather than the entry key in their own config, so multiple linked gridctl endpoints were indistinguishable in their tool lists.

## Type of Change

- [x] Bug fix

## Changes Made

- Optional `name` field on `GatewayConfig`; empty keeps the `gridctl-gateway` default (back-compat, Article IX)
- `Gateway.SetName()` seam, wired from the stack config in the controller build path
- Group endpoints announce a group-suffixed identity (`<name>/<group>`) so linked groups are distinguishable without configuration
- `ServerInfo` gains the MCP-spec `title` field, populated with the resolved name
- Docs: `gateway.name` in the config schema table plus a troubleshooting entry explaining the config-key vs `serverInfo.name` distinction
- Regression tests: identity default/override/group-suffix table in `pkg/mcp`, `SetName` empty no-op, `gateway.name` loader parsing

## Testing

- `go test ./...` passes; `golangci-lint run` clean
- New table-driven test `TestGateway_HandleInitialize_ServerIdentity` covers default, configured, and group-suffixed identities; existing default-name assertions pass unmodified

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #939