### PR TITLE
feat: add Logs and Traces workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to gridctl will be documented in this file.
 
 ### Features
 
+- Logs and Traces are now top-level workspaces (Cmd+7 / Cmd+8) alongside Stack, Library, Variables, Tools, Metrics, and Pins. The Logs workspace shows the aggregate stream from the gateway and every server with no node selection required: a source rail (all sources / gateway / per server) filters the same stream client-side, each line in the all-sources view is badged with its origin, and severity, search, and source state live in the URL (`?agent=`, `?level=`, `?q=`) so views are shareable. The Traces workspace carries the full trace list, waterfall, and span detail with URL-synced selection (`?trace=`). The two correlate: a log line with a trace ID pivots to its trace, and a trace's waterfall pivots to the logs for that trace. Detached popouts move to `/logs-window` and `/traces-window` (existing window handles keep working), workspace nav pills collapse to icons below 1360px so all eight fit, and the bottom-panel tabs are unchanged
+
 - Full-view client cards on the Stack canvas are now horizontal: the client icon sits on the left with the name, transport, and linked status stacked beside it in a wider, shorter card, replacing the centered column layout and its dead space above the icon. Compact cards are unchanged
 
 - Automated npm advisory fixes: a scheduled `NPM Audit Fix` workflow runs `npm audit fix` against `web/` weekly (and on demand via `workflow_dispatch`) and opens or updates a single reviewable PR when the lockfile changes, listing the advisories it addresses. Only semver-compatible updates are applied; the frontend CI job's `npm audit --audit-level=high` gate is unchanged, this keeps main passing it so fresh advisories stop failing unrelated PRs

--- a/web/src/__tests__/LogsWorkspace.test.tsx
+++ b/web/src/__tests__/LogsWorkspace.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { LogsWorkspace } from '../components/workspaces/LogsWorkspace';
+import { useStackStore } from '../stores/useStackStore';
+import { useUIStore, COMPACT_MODE_DEFAULTS } from '../stores/useUIStore';
+import type { LogEntry } from '../lib/api';
+import type { MCPServerStatus } from '../types';
+
+vi.mock('../hooks/useWindowManager', () => ({
+  useWindowManager: () => ({
+    openDetachedWindow: vi.fn(),
+    closeDetachedWindow: vi.fn(),
+    broadcastStateUpdate: vi.fn(),
+    broadcastSelectionChange: vi.fn(),
+  }),
+}));
+
+const gatewayEntry: LogEntry = {
+  level: 'INFO',
+  ts: '2026-07-23T10:00:00Z',
+  msg: 'gateway listening',
+  component: 'gateway',
+};
+
+const githubEntry: LogEntry = {
+  level: 'ERROR',
+  ts: '2026-07-23T10:00:01Z',
+  msg: 'tool call failed',
+  component: 'client',
+  trace_id: 'abc123def456',
+  attrs: { server: 'github' },
+};
+
+const zapierEntry: LogEntry = {
+  level: 'DEBUG',
+  ts: '2026-07-23T10:00:02Z',
+  msg: 'polling upstream',
+  component: 'client',
+  attrs: { server: 'zapier' },
+};
+
+vi.mock('../lib/api', async (importActual) => {
+  const actual = await importActual<typeof import('../lib/api')>();
+  return {
+    ...actual,
+    fetchGatewayLogs: vi.fn(),
+  };
+});
+
+import { fetchGatewayLogs } from '../lib/api';
+
+function server(name: string): MCPServerStatus {
+  return { name, transport: 'stdio', initialized: true, tools: [], healthy: true } as unknown as MCPServerStatus;
+}
+
+function renderAt(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/logs" element={<LogsWorkspace />} />
+        <Route path="/traces" element={<div data-testid="traces-probe" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(fetchGatewayLogs).mockResolvedValue([gatewayEntry, githubEntry, zapierEntry]);
+  useStackStore.setState({ mcpServers: [server('github'), server('zapier')] });
+  useUIStore.setState({ compactMode: { ...COMPACT_MODE_DEFAULTS }, logsDetached: false });
+});
+
+describe('LogsWorkspace', () => {
+  it('shows the aggregate stream from every source with no selection', async () => {
+    renderAt('/logs');
+    await waitFor(() => {
+      expect(screen.getByText('gateway listening')).toBeInTheDocument();
+    });
+    expect(screen.getByText('tool call failed')).toBeInTheDocument();
+    expect(screen.getByText('polling upstream')).toBeInTheDocument();
+    expect(vi.mocked(fetchGatewayLogs)).toHaveBeenCalled();
+  });
+
+  it('renders a source rail with all sources, gateway, and each server', async () => {
+    renderAt('/logs');
+    await waitFor(() => {
+      expect(screen.getByText('gateway listening')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /All sources/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Gateway/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /github/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /zapier/ })).toBeInTheDocument();
+  });
+
+  it('badges each line with its source in the all-sources view', async () => {
+    renderAt('/logs');
+    await waitFor(() => {
+      expect(screen.getByText('tool call failed')).toBeInTheDocument();
+    });
+    // Badge next to the entry, in addition to the rail pill.
+    const githubMentions = screen.getAllByText('github');
+    expect(githubMentions.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('filters to a single server from the ?agent= param', async () => {
+    renderAt('/logs?agent=github');
+    await waitFor(() => {
+      expect(screen.getByText('tool call failed')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('gateway listening')).not.toBeInTheDocument();
+    expect(screen.queryByText('polling upstream')).not.toBeInTheDocument();
+  });
+
+  it('filters levels from the ?level= param', async () => {
+    renderAt('/logs?level=error');
+    await waitFor(() => {
+      expect(screen.getByText('tool call failed')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('gateway listening')).not.toBeInTheDocument();
+  });
+
+  it('filters to a single trace from the ?trace= param', async () => {
+    renderAt('/logs?trace=abc123def456');
+    await waitFor(() => {
+      expect(screen.getByText('tool call failed')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('gateway listening')).not.toBeInTheDocument();
+    // Active-filter chip with the shortened id.
+    expect(screen.getByText(/trace: abc123de/)).toBeInTheDocument();
+  });
+
+  it('keeps every level disabled through the level=none sentinel', async () => {
+    renderAt('/logs?level=none');
+    await waitFor(() => {
+      expect(screen.getByText(/0 \/ 3 entries/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText('gateway listening')).not.toBeInTheDocument();
+    expect(screen.queryByText('tool call failed')).not.toBeInTheDocument();
+    expect(screen.getByText('No entries match your filters')).toBeInTheDocument();
+  });
+
+  it('pivots a log line with a trace id to the Traces workspace', async () => {
+    renderAt('/logs');
+    await waitFor(() => {
+      expect(screen.getByText('tool call failed')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'View trace abc123def456' }));
+    expect(screen.getByTestId('traces-probe')).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/TracesWorkspace.test.tsx
+++ b/web/src/__tests__/TracesWorkspace.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { TracesWorkspace } from '../components/workspaces/TracesWorkspace';
+import { useStackStore } from '../stores/useStackStore';
+import { useTracesStore } from '../stores/useTracesStore';
+import { useUIStore, COMPACT_MODE_DEFAULTS } from '../stores/useUIStore';
+import type { TraceDetail, TraceSummary } from '../lib/api';
+import type { MCPServerStatus } from '../types';
+
+vi.mock('../hooks/useWindowManager', () => ({
+  useWindowManager: () => ({
+    openDetachedWindow: vi.fn(),
+    closeDetachedWindow: vi.fn(),
+    broadcastStateUpdate: vi.fn(),
+    broadcastSelectionChange: vi.fn(),
+  }),
+}));
+
+const summary: TraceSummary = {
+  traceId: 'abc123def4567890',
+  rootSpanId: 's1',
+  operation: 'tools/call create_issue',
+  server: 'github',
+  startTime: '2026-07-23T10:00:00Z',
+  duration: 42,
+  spanCount: 1,
+  hasError: false,
+  status: 'ok',
+};
+
+const detail: TraceDetail = {
+  traceId: 'abc123def4567890',
+  spans: [
+    {
+      spanId: 's1',
+      name: 'github.create_issue',
+      startTime: '2026-07-23T10:00:00.000Z',
+      endTime: '2026-07-23T10:00:00.042Z',
+      duration: 42,
+      status: 'ok',
+      attributes: {},
+      events: [],
+    },
+  ],
+};
+
+vi.mock('../lib/api', async (importActual) => {
+  const actual = await importActual<typeof import('../lib/api')>();
+  return {
+    ...actual,
+    fetchTraces: vi.fn(),
+    fetchTraceDetail: vi.fn(),
+  };
+});
+
+import { fetchTraces, fetchTraceDetail } from '../lib/api';
+
+function server(name: string): MCPServerStatus {
+  return { name, transport: 'stdio', initialized: true, tools: [], healthy: true } as unknown as MCPServerStatus;
+}
+
+function renderAt(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/traces" element={<TracesWorkspace />} />
+        <Route path="/logs" element={<div data-testid="logs-probe" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(fetchTraces).mockResolvedValue({ traces: [summary], total: 1 });
+  vi.mocked(fetchTraceDetail).mockResolvedValue(detail);
+  useStackStore.setState({ mcpServers: [server('github')] });
+  useUIStore.setState({ compactMode: { ...COMPACT_MODE_DEFAULTS }, tracesDetached: false });
+  useTracesStore.setState({
+    traces: [],
+    total: 0,
+    isLoading: false,
+    error: null,
+    filters: { server: '', errorsOnly: false, minDuration: null, search: '' },
+    selectedTraceId: null,
+    traceDetail: null,
+    isLoadingDetail: false,
+    detailError: null,
+  });
+});
+
+describe('TracesWorkspace', () => {
+  it('shows the global trace list without any selection', async () => {
+    renderAt('/traces');
+    await waitFor(() => {
+      expect(screen.getByText('tools/call create_issue')).toBeInTheDocument();
+    });
+    expect(vi.mocked(fetchTraces)).toHaveBeenCalled();
+  });
+
+  it('resolves a ?trace= deep link into the selected waterfall', async () => {
+    renderAt('/traces?trace=abc123def4567890');
+    await waitFor(() => {
+      expect(vi.mocked(fetchTraceDetail)).toHaveBeenCalledWith('abc123def4567890');
+    });
+    await waitFor(() => {
+      expect(screen.getByText('github.create_issue')).toBeInTheDocument();
+    });
+  });
+
+  it('mirrors a row selection into the URL', async () => {
+    renderAt('/traces');
+    await waitFor(() => {
+      expect(screen.getByText('tools/call create_issue')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('tools/call create_issue'));
+    await waitFor(() => {
+      expect(useTracesStore.getState().selectedTraceId).toBe('abc123def4567890');
+    });
+  });
+
+  it('pivots from the trace detail to logs filtered by the trace id', async () => {
+    renderAt('/traces?trace=abc123def4567890');
+    await waitFor(() => {
+      expect(screen.getByText('github.create_issue')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /View logs/ }));
+    expect(screen.getByTestId('logs-probe')).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/logTypes.test.ts
+++ b/web/src/__tests__/logTypes.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GATEWAY_LOG_SOURCE,
+  filterParsedLogs,
+  logSourceOf,
+  parseLogEntry,
+  type ParsedLog,
+} from '../components/log/logTypes';
+
+function entry(over: Partial<ParsedLog>): ParsedLog {
+  return {
+    level: 'INFO',
+    timestamp: '2026-07-23T10:00:00Z',
+    message: 'hello',
+    raw: 'hello',
+    ...over,
+  };
+}
+
+describe('logSourceOf', () => {
+  it('reads the server attribute when present', () => {
+    expect(logSourceOf(entry({ attrs: { server: 'github' } }))).toBe('github');
+  });
+
+  it('falls back to the gateway source without a server attribute', () => {
+    expect(logSourceOf(entry({}))).toBe(GATEWAY_LOG_SOURCE);
+    expect(logSourceOf(entry({ attrs: { other: 'x' } }))).toBe(GATEWAY_LOG_SOURCE);
+    expect(logSourceOf(entry({ attrs: { server: '' } }))).toBe(GATEWAY_LOG_SOURCE);
+  });
+
+  it('classifies parsed structured entries by their server attr', () => {
+    const parsed = parseLogEntry({
+      level: 'ERROR',
+      ts: '2026-07-23T10:00:00Z',
+      msg: 'boom',
+      attrs: { server: 'zapier' },
+    });
+    expect(logSourceOf(parsed)).toBe('zapier');
+  });
+});
+
+describe('filterParsedLogs', () => {
+  const logs: ParsedLog[] = [
+    entry({ message: 'gateway up', component: 'gateway' }),
+    entry({ level: 'ERROR', message: 'call failed', attrs: { server: 'github' }, traceId: 'abc123' }),
+    entry({ level: 'DEBUG', message: 'poll tick', attrs: { server: 'zapier' } }),
+  ];
+
+  it('passes everything through with no filter', () => {
+    expect(filterParsedLogs(logs, {})).toHaveLength(3);
+  });
+
+  it('filters by source, treating gateway as entries without a server attr', () => {
+    expect(filterParsedLogs(logs, { source: 'github' }).map((l) => l.message)).toEqual(['call failed']);
+    expect(filterParsedLogs(logs, { source: GATEWAY_LOG_SOURCE }).map((l) => l.message)).toEqual(['gateway up']);
+    expect(filterParsedLogs(logs, { source: null })).toHaveLength(3);
+  });
+
+  it('filters by level set', () => {
+    expect(filterParsedLogs(logs, { levels: new Set(['ERROR']) }).map((l) => l.message)).toEqual([
+      'call failed',
+    ]);
+  });
+
+  it('filters by trace id', () => {
+    expect(filterParsedLogs(logs, { traceId: 'abc123' }).map((l) => l.message)).toEqual(['call failed']);
+    expect(filterParsedLogs(logs, { traceId: 'missing' })).toHaveLength(0);
+  });
+
+  it('matches search queries against message, component, source, and trace id', () => {
+    expect(filterParsedLogs(logs, { query: 'failed' })).toHaveLength(1);
+    expect(filterParsedLogs(logs, { query: 'zapier' }).map((l) => l.message)).toEqual(['poll tick']);
+    expect(filterParsedLogs(logs, { query: 'abc123' })).toHaveLength(1);
+    expect(filterParsedLogs(logs, { query: 'nope' })).toHaveLength(0);
+  });
+
+  it('composes filters', () => {
+    expect(
+      filterParsedLogs(logs, { source: 'zapier', levels: new Set(['DEBUG']), query: 'poll' }),
+    ).toHaveLength(1);
+    expect(
+      filterParsedLogs(logs, { source: 'zapier', levels: new Set(['ERROR']) }),
+    ).toHaveLength(0);
+  });
+});

--- a/web/src/components/log/LogFilterBar.tsx
+++ b/web/src/components/log/LogFilterBar.tsx
@@ -1,0 +1,88 @@
+import { Search } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { LevelFilter } from './LevelFilter';
+import { ZoomControls } from '../ui/ZoomControls';
+import type { LogLevel } from './logTypes';
+
+interface LogFilterBarProps {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  enabledLevels: Set<LogLevel>;
+  onToggleLevel: (level: LogLevel) => void;
+  fontSize: number;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onResetZoom: () => void;
+  isMin: boolean;
+  isMax: boolean;
+  isDefault: boolean;
+  filteredCount: number;
+  totalCount: number;
+  /** Extra chips (e.g. an active trace filter) rendered after the level filter. */
+  children?: React.ReactNode;
+}
+
+// Search + level + zoom row shared by the Logs workspace and the detached
+// logs window. Purely presentational; all state lives with the caller.
+export function LogFilterBar({
+  searchQuery,
+  onSearchChange,
+  enabledLevels,
+  onToggleLevel,
+  fontSize,
+  onZoomIn,
+  onZoomOut,
+  onResetZoom,
+  isMin,
+  isMax,
+  isDefault,
+  filteredCount,
+  totalCount,
+  children,
+}: LogFilterBarProps) {
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 border-b border-border/30 bg-surface-elevated/30 flex-shrink-0">
+      {/* Search input */}
+      <div className="relative flex-1 max-w-xs">
+        <Search
+          size={12}
+          className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-muted"
+        />
+        <input
+          type="text"
+          placeholder="Filter logs..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className={cn(
+            'w-full pl-7 pr-3 py-1.5 text-xs font-mono',
+            'bg-background/60 border border-border/50 rounded-md',
+            'text-text-primary placeholder:text-text-muted',
+            'focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20',
+            'transition-all duration-200'
+          )}
+        />
+      </div>
+
+      {/* Level filter */}
+      <LevelFilter enabledLevels={enabledLevels} onToggle={onToggleLevel} />
+
+      {children}
+
+      {/* Zoom controls */}
+      <ZoomControls
+        fontSize={fontSize}
+        onZoomIn={onZoomIn}
+        onZoomOut={onZoomOut}
+        onReset={onResetZoom}
+        isMin={isMin}
+        isMax={isMax}
+        isDefault={isDefault}
+      />
+
+      {/* Log count */}
+      <span className="text-[10px] text-text-muted font-mono ml-auto">
+        {filteredCount} / {totalCount} entries
+      </span>
+    </div>
+  );
+}

--- a/web/src/components/log/LogLine.tsx
+++ b/web/src/components/log/LogLine.tsx
@@ -1,17 +1,24 @@
-import { ChevronRight } from 'lucide-react';
+import { Activity, ChevronRight } from 'lucide-react';
 import { cn } from '../../lib/cn';
-import { LEVEL_STYLES, formatTimestamp, type ParsedLog } from './logTypes';
+import { GATEWAY_LOG_SOURCE, LEVEL_STYLES, formatTimestamp, type ParsedLog } from './logTypes';
 
 export function LogLine({
   log,
   isExpanded,
   onToggle,
+  source,
+  onTraceClick,
 }: {
   log: ParsedLog;
   isExpanded: boolean;
   onToggle: () => void;
+  /** When set, renders a source column (aggregate all-sources view). */
+  source?: string;
+  /** When set, trace IDs render as pivots into the trace view. */
+  onTraceClick?: (traceId: string) => void;
 }) {
   const styles = LEVEL_STYLES[log.level] || LEVEL_STYLES.DEBUG;
+  const showSource = source !== undefined;
 
   return (
     <div
@@ -25,7 +32,9 @@ export function LogLine({
       <div
         className={cn(
           'grid gap-2 px-3 py-1 log-text cursor-pointer',
-          'grid-cols-[8.5em_5.5em_7.5em_1fr_2em]',
+          showSource
+            ? 'grid-cols-[8.5em_5.5em_7em_7.5em_1fr_2em]'
+            : 'grid-cols-[8.5em_5.5em_7.5em_1fr_2em]',
         )}
         onClick={onToggle}
       >
@@ -46,6 +55,25 @@ export function LogLine({
           {log.level.slice(0, 4)}
         </span>
 
+        {/* Source (aggregate view only) */}
+        {showSource && (
+          <span
+            className={cn(
+              'inline-flex items-center gap-1 min-w-0 font-mono log-text',
+              source === GATEWAY_LOG_SOURCE ? 'text-primary/80' : 'text-violet-400/90'
+            )}
+            title={source}
+          >
+            <span
+              className={cn(
+                'w-1 h-1 rounded-full flex-shrink-0',
+                source === GATEWAY_LOG_SOURCE ? 'bg-primary' : 'bg-violet-400'
+              )}
+            />
+            <span className="truncate">{source}</span>
+          </span>
+        )}
+
         {/* Component */}
         <span className="text-secondary font-mono log-text truncate" title={log.component}>
           {log.component || '\u2014'}
@@ -62,8 +90,21 @@ export function LogLine({
           {log.message}
         </span>
 
-        {/* Expand indicator */}
-        <span className="flex items-center justify-center">
+        {/* Trace pivot + expand indicator */}
+        <span className="flex items-center justify-center gap-0.5">
+          {onTraceClick && log.traceId && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onTraceClick(log.traceId!);
+              }}
+              title={`View trace ${log.traceId}`}
+              aria-label={`View trace ${log.traceId}`}
+              className="p-0.5 rounded text-text-muted opacity-0 group-hover:opacity-100 hover:text-primary transition-all"
+            >
+              <Activity size={11} />
+            </button>
+          )}
           <ChevronRight
             size={12}
             className={cn(
@@ -88,7 +129,16 @@ export function LogLine({
             {log.traceId && (
               <div className="flex gap-2 mt-1 pt-1 border-t border-border/20">
                 <span className="text-text-muted">trace_id:</span>
-                <span className="text-secondary">{log.traceId}</span>
+                {onTraceClick ? (
+                  <button
+                    onClick={() => onTraceClick(log.traceId!)}
+                    className="text-secondary hover:text-primary hover:underline text-left"
+                  >
+                    {log.traceId}
+                  </button>
+                ) : (
+                  <span className="text-secondary">{log.traceId}</span>
+                )}
               </div>
             )}
             {log.attrs && (

--- a/web/src/components/log/LogStream.tsx
+++ b/web/src/components/log/LogStream.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState, type RefObject } from 'react';
+import { Terminal } from 'lucide-react';
+import { LogLine } from './LogLine';
+import { logSourceOf, type ParsedLog } from './logTypes';
+
+interface LogStreamProps {
+  /** Already-filtered entries to render. */
+  logs: ParsedLog[];
+  isLoading: boolean;
+  error: string | null;
+  /** True when a search/trace filter is hiding entries. */
+  hasActiveFilter?: boolean;
+  onClearFilter?: () => void;
+  /** Render the per-line source badge (aggregate all-sources view). */
+  showSource?: boolean;
+  onTraceClick?: (traceId: string) => void;
+  fontSize: number;
+  containerRef: RefObject<HTMLDivElement | null>;
+  /** Slot above the first entry (e.g. PersistedFromMarker). */
+  header?: React.ReactNode;
+  emptyText?: string;
+}
+
+// Scrollable log stream shared by the Logs workspace and the detached logs
+// window: owns follow/auto-scroll (pausing scroll position when the user
+// scrolls up), row expansion, and the loading/error/empty states.
+export function LogStream({
+  logs,
+  isLoading,
+  error,
+  hasActiveFilter,
+  onClearFilter,
+  showSource,
+  onTraceClick,
+  fontSize,
+  containerRef,
+  header,
+  emptyText = 'No logs yet',
+}: LogStreamProps) {
+  const [autoScroll, setAutoScroll] = useState(true);
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
+  // Follow: keep pinned to the newest entry until the user scrolls up.
+  useEffect(() => {
+    if (autoScroll && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [logs, autoScroll, containerRef]);
+
+  const handleScroll = () => {
+    if (!containerRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
+    setAutoScroll(scrollHeight - scrollTop - clientHeight < 50);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      onScroll={handleScroll}
+      className="flex-1 overflow-auto bg-background/80 scrollbar-dark min-h-0"
+      style={{ '--log-font-size': `${fontSize}px` } as React.CSSProperties}
+    >
+      {/* Loading state */}
+      {isLoading && logs.length === 0 && !error && (
+        <div className="flex items-center gap-2 p-4 text-text-muted text-xs">
+          <div className="w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+          Loading logs...
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && (
+        <div className="flex items-center gap-2 p-4 text-status-error text-xs">
+          <span className="w-2 h-2 rounded-full bg-status-error" />
+          Error: {error}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && !error && logs.length === 0 && (
+        <div className="flex flex-col items-center justify-center h-full text-text-muted text-xs gap-2">
+          <Terminal size={20} className="text-text-muted/30" />
+          <span>{hasActiveFilter ? 'No entries match your filters' : emptyText}</span>
+          {hasActiveFilter && onClearFilter && (
+            <button onClick={onClearFilter} className="text-primary hover:underline">
+              Clear filters
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Log entries */}
+      {!error && logs.length > 0 && (
+        <div className="divide-y divide-border/20">
+          {header}
+          {logs.map((log, i) => (
+            <LogLine
+              key={i}
+              log={log}
+              isExpanded={expandedIndex === i}
+              onToggle={() => setExpandedIndex(expandedIndex === i ? null : i)}
+              source={showSource ? logSourceOf(log) : undefined}
+              onTraceClick={onTraceClick}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/log/index.ts
+++ b/web/src/components/log/index.ts
@@ -1,11 +1,18 @@
 export { LogLine } from './LogLine';
 export { LogsTab } from './LogsTab';
 export { LevelFilter } from './LevelFilter';
+export { LogFilterBar } from './LogFilterBar';
+export { LogStream } from './LogStream';
 export {
   type LogLevel,
   type ParsedLog,
+  type LogFilter,
   LOG_LEVELS,
   LEVEL_STYLES,
+  GATEWAY_LOG_SOURCE,
   parseLogEntry,
   formatTimestamp,
+  logSourceOf,
+  normalizeLogSourceParam,
+  filterParsedLogs,
 } from './logTypes';

--- a/web/src/components/log/logTypes.ts
+++ b/web/src/components/log/logTypes.ts
@@ -146,6 +146,53 @@ export function parseLogEntry(input: string | LogEntry): ParsedLog {
   };
 }
 
+// Canonical source token for gateway-origin entries. Server-origin entries in
+// the aggregate /api/logs buffer carry attrs.server; gateway components do
+// not. URL state uses this token (`?agent=gateway`), never the display string.
+export const GATEWAY_LOG_SOURCE = 'gateway';
+
+export function logSourceOf(log: ParsedLog): string {
+  const server = log.attrs?.server;
+  return typeof server === 'string' && server !== '' ? server : GATEWAY_LOG_SOURCE;
+}
+
+// Normalizes the ?agent= URL param to a source token: absent/empty = all
+// sources (null). Legacy handles from the pre-workspace detached page carry
+// the display string "Gateway" — fold it into the canonical token instead of
+// filtering to nothing.
+export function normalizeLogSourceParam(param: string | null): string | null {
+  if (param === null || param === '') return null;
+  return param === 'Gateway' ? GATEWAY_LOG_SOURCE : param;
+}
+
+export interface LogFilter {
+  // null = all sources; GATEWAY_LOG_SOURCE = gateway-origin only; else server name.
+  source?: string | null;
+  levels?: Set<LogLevel>;
+  query?: string;
+  traceId?: string | null;
+}
+
+// Single shared predicate so the workspace and the detached window filter the
+// aggregate stream identically.
+export function filterParsedLogs(logs: ParsedLog[], filter: LogFilter): ParsedLog[] {
+  const query = filter.query?.toLowerCase() ?? '';
+  return logs.filter((log) => {
+    if (filter.source != null && logSourceOf(log) !== filter.source) return false;
+    if (filter.levels && !filter.levels.has(log.level)) return false;
+    if (filter.traceId && log.traceId !== filter.traceId) return false;
+    if (query) {
+      return (
+        log.message.toLowerCase().includes(query) ||
+        log.component?.toLowerCase().includes(query) ||
+        logSourceOf(log).toLowerCase().includes(query) ||
+        log.traceId?.toLowerCase().includes(query)
+      );
+    }
+    return true;
+  });
+}
+
 export function formatTimestamp(ts: string): string {
   if (!ts) return '';
   try {

--- a/web/src/components/shell/WorkspaceSwitcher.tsx
+++ b/web/src/components/shell/WorkspaceSwitcher.tsx
@@ -33,10 +33,15 @@ function WorkspacePill({ workspace }: WorkspacePillProps) {
       to={`/${workspace.id}`}
       role="tab"
       aria-selected={isActive}
+      aria-label={workspace.label}
+      title={workspace.label}
       data-workspace={workspace.id}
       onClick={handleClick}
       className={cn(
-        'inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors',
+        // Icon-only below 1360px: eight text pills plus the right-side action
+        // cluster collide on narrower windows, so labels collapse to icons
+        // (title + aria-label keep the pills identifiable).
+        'inline-flex items-center gap-1.5 px-2 min-[1360px]:px-3 py-1 rounded-full text-xs font-medium transition-colors',
         'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/60',
         isActive
           ? 'bg-primary/15 text-primary border border-primary/30'
@@ -44,7 +49,7 @@ function WorkspacePill({ workspace }: WorkspacePillProps) {
       )}
     >
       <Icon size={12} aria-hidden="true" />
-      {workspace.label}
+      <span className="hidden min-[1360px]:inline">{workspace.label}</span>
     </NavLink>
   );
 }

--- a/web/src/components/traces/TraceWaterfall.tsx
+++ b/web/src/components/traces/TraceWaterfall.tsx
@@ -7,6 +7,8 @@ import type { TraceDetail, Span } from '../../lib/api';
 interface TraceWaterfallProps {
   trace: TraceDetail;
   onClose?: () => void;
+  /** Extra header actions (e.g. the trace-to-logs pivot), left of close. */
+  actions?: React.ReactNode;
 }
 
 // Distinct colors for server-keyed spans (in order of preference)
@@ -85,7 +87,7 @@ function formatTotalDuration(ms: number): string {
   return `${(ms / 1000).toFixed(2)}s`;
 }
 
-export function TraceWaterfall({ trace, onClose }: TraceWaterfallProps) {
+export function TraceWaterfall({ trace, onClose, actions }: TraceWaterfallProps) {
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
 
   const { sorted, depthMap, traceStart, totalDuration, p95 } = useMemo(() => {
@@ -126,15 +128,18 @@ export function TraceWaterfall({ trace, onClose }: TraceWaterfallProps) {
             <AlertCircle size={11} className="text-status-error flex-shrink-0" />
           )}
         </div>
-        {onClose && (
-          <button
-            onClick={onClose}
-            className="p-1 rounded-md hover:bg-surface-highlight transition-colors flex-shrink-0 ml-2"
-            aria-label="Close waterfall"
-          >
-            <X size={12} className="text-text-muted" />
-          </button>
-        )}
+        <div className="flex items-center gap-1 flex-shrink-0 ml-2">
+          {actions}
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="p-1 rounded-md hover:bg-surface-highlight transition-colors flex-shrink-0"
+              aria-label="Close waterfall"
+            >
+              <X size={12} className="text-text-muted" />
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Body: waterfall + optional span detail */}

--- a/web/src/components/traces/TracesView.tsx
+++ b/web/src/components/traces/TracesView.tsx
@@ -1,0 +1,353 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { Activity, AlertCircle, RefreshCw, ScrollText, X, Filter } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { IconButton } from '../ui/IconButton';
+import { ZoomControls } from '../ui/ZoomControls';
+import { useTracesStore } from '../../stores/useTracesStore';
+import { useTextZoom } from '../../hooks/useTextZoom';
+import { TraceWaterfall } from './TraceWaterfall';
+import { PersistedFromMarker } from '../telemetry/PersistedFromMarker';
+import { POLLING } from '../../lib/constants';
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+interface TracesViewProps {
+  /** Load + poll only while true (workspace mounted, tab visible, ...). */
+  active: boolean;
+  /** Server names for the filter dropdown. */
+  servers: string[];
+  /** When set, the waterfall header gets a "View logs" pivot. */
+  onViewLogs?: (traceId: string) => void;
+  /** Extra toolbar actions (e.g. the popout button), rendered rightmost. */
+  toolbarExtra?: React.ReactNode;
+}
+
+// Shared traces surface — control bar, trace list, and waterfall — backed by
+// useTracesStore. Mounted by the Traces workspace and the detached window
+// (each browser window gets its own store instance, so detached state never
+// bleeds into the main shell).
+export function TracesView({ active, servers, onViewLogs, toolbarExtra }: TracesViewProps) {
+  const traces = useTracesStore((s) => s.traces);
+  const isLoading = useTracesStore((s) => s.isLoading);
+  const error = useTracesStore((s) => s.error);
+  const filters = useTracesStore((s) => s.filters);
+  const setFilters = useTracesStore((s) => s.setFilters);
+  const selectedTraceId = useTracesStore((s) => s.selectedTraceId);
+  const traceDetail = useTracesStore((s) => s.traceDetail);
+  const isLoadingDetail = useTracesStore((s) => s.isLoadingDetail);
+  const detailError = useTracesStore((s) => s.detailError);
+  const selectTrace = useTracesStore((s) => s.selectTrace);
+  const loadTraces = useTracesStore((s) => s.loadTraces);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const intervalRef = useRef<number | null>(null);
+
+  const { fontSize, zoomIn, zoomOut, resetZoom, isMin, isMax, isDefault } = useTextZoom({
+    storageKey: 'gridctl-traces-font-size',
+    defaultSize: 11,
+    minSize: 8,
+    maxSize: 20,
+    containerRef,
+  });
+
+  const load = useCallback(() => {
+    loadTraces();
+  }, [loadTraces]);
+
+  // Initial load + reload when activated or a server-side filter changes.
+  // filters.search is deliberately excluded: it only filters client-side, so
+  // reloading per keystroke would hammer the API and flash the skeleton.
+  useEffect(() => {
+    if (!active) return;
+    load();
+  }, [active, filters.server, filters.errorsOnly, filters.minDuration, load]);
+
+  // Auto-refresh while active
+  useEffect(() => {
+    if (!active) {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      return;
+    }
+    intervalRef.current = window.setInterval(load, POLLING.STATUS);
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [active, load]);
+
+  // Client-side search filter
+  const filteredTraces = useMemo(() => {
+    if (!filters.search) return traces;
+    const q = filters.search.toLowerCase();
+    return traces.filter(
+      (t) =>
+        t.traceId.toLowerCase().includes(q) ||
+        t.operation.toLowerCase().includes(q) ||
+        t.server.toLowerCase().includes(q)
+    );
+  }, [traces, filters.search]);
+
+  const hasFilters = filters.server || filters.errorsOnly || filters.minDuration != null || filters.search;
+  const clearFilters = () => setFilters({ server: '', errorsOnly: false, minDuration: null, search: '' });
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Control bar */}
+      <div className="flex items-center justify-between px-3 h-9 flex-shrink-0 border-b border-border/30 bg-surface-elevated/20 gap-2">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          {/* Search */}
+          <input
+            type="text"
+            placeholder="Search traces…"
+            value={filters.search}
+            onChange={(e) => setFilters({ search: e.target.value })}
+            className="h-6 px-2 text-[10px] bg-background/60 border border-border/40 rounded text-text-secondary placeholder:text-text-muted focus:outline-none focus:border-primary/50 w-36"
+          />
+
+          {/* Server filter */}
+          <select
+            value={filters.server}
+            onChange={(e) => setFilters({ server: e.target.value })}
+            className="h-6 px-1.5 text-[10px] bg-background/60 border border-border/40 rounded text-text-secondary focus:outline-none focus:border-primary/50 max-w-[120px]"
+          >
+            <option value="">All servers</option>
+            {servers.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+
+          {/* Errors toggle */}
+          <button
+            onClick={() => setFilters({ errorsOnly: !filters.errorsOnly })}
+            className={cn(
+              'h-6 px-2 text-[10px] font-medium rounded border transition-colors flex items-center gap-1',
+              filters.errorsOnly
+                ? 'bg-status-error/15 text-status-error border-status-error/30'
+                : 'bg-background/60 text-text-muted border-border/40 hover:text-text-secondary hover:border-border/60'
+            )}
+          >
+            <AlertCircle size={9} />
+            Errors
+          </button>
+
+          {/* Min duration */}
+          <div className="flex items-center gap-1">
+            <input
+              type="number"
+              placeholder="Min ms"
+              value={filters.minDuration ?? ''}
+              onChange={(e) =>
+                setFilters({ minDuration: e.target.value ? Number(e.target.value) : null })
+              }
+              className="h-6 px-2 text-[10px] bg-background/60 border border-border/40 rounded text-text-secondary placeholder:text-text-muted focus:outline-none focus:border-primary/50 w-16"
+              min={0}
+            />
+          </div>
+
+          {/* Clear filters */}
+          {hasFilters && (
+            <button
+              onClick={clearFilters}
+              className="h-6 px-1.5 text-[10px] text-text-muted hover:text-text-secondary transition-colors flex items-center gap-1 rounded hover:bg-surface-highlight/30"
+            >
+              <X size={9} />
+              Clear
+            </button>
+          )}
+
+          {/* Live indicator */}
+          <span className="flex items-center gap-1 text-[9px] text-status-running font-medium flex-shrink-0">
+            <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
+            Live
+          </span>
+        </div>
+
+        <div className="flex items-center gap-1 flex-shrink-0">
+          <ZoomControls
+            fontSize={fontSize}
+            onZoomIn={zoomIn}
+            onZoomOut={zoomOut}
+            onReset={resetZoom}
+            isMin={isMin}
+            isMax={isMax}
+            isDefault={isDefault}
+          />
+          <div className="w-px h-4 bg-border/50 mx-0.5" />
+          <IconButton
+            icon={RefreshCw}
+            onClick={load}
+            tooltip="Refresh"
+            size="sm"
+            variant="ghost"
+          />
+          {toolbarExtra && (
+            <>
+              <div className="w-px h-4 bg-border/50 mx-0.5" />
+              {toolbarExtra}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 min-h-0">
+        {/* Trace list */}
+        <div className={cn('flex flex-col min-h-0', selectedTraceId && traceDetail ? 'w-[40%] border-r border-border/30' : 'w-full')}>
+          {/* Loading skeleton */}
+          {isLoading && filteredTraces.length === 0 && (
+            <div className="p-3 space-y-2 animate-pulse">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-7 rounded bg-surface-elevated/60 border border-border/20" />
+              ))}
+            </div>
+          )}
+
+          {/* Error */}
+          {error && !isLoading && (
+            <div className="flex flex-col items-center justify-center flex-1 gap-2 text-xs">
+              <AlertCircle size={20} className="text-status-error" />
+              <span className="text-status-error">{error}</span>
+              <button onClick={load} className="text-primary hover:underline text-xs">Retry</button>
+            </div>
+          )}
+
+          {/* Empty state */}
+          {!isLoading && !error && filteredTraces.length === 0 && (
+            <div className="flex flex-col items-center justify-center flex-1 gap-2 text-text-muted">
+              <Activity size={24} className="text-text-muted/30" />
+              <span className="text-xs">No traces yet</span>
+              <span className="text-[10px] text-text-muted/60">
+                {hasFilters ? 'No traces match your filters' : 'Traces appear after tool calls'}
+              </span>
+              {hasFilters && (
+                <button
+                  onClick={clearFilters}
+                  className="text-[10px] text-primary hover:underline flex items-center gap-1"
+                >
+                  <Filter size={9} /> Clear filters
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Table */}
+          {filteredTraces.length > 0 && (
+            <div
+              ref={containerRef}
+              className="flex-1 overflow-y-auto scrollbar-dark min-h-0"
+              style={{ '--text-zoom-size': `${fontSize}px` } as React.CSSProperties}
+            >
+              {/* Provenance boundary — top-of-list marker when any server
+                  has traces persistence enabled with files on disk. */}
+              <PersistedFromMarker serverName={null} signal="traces" />
+              <table className="w-full">
+                <thead className="sticky top-0 z-10 bg-surface-elevated/95 backdrop-blur-sm">
+                  <tr className="border-b border-border/30">
+                    <th className="px-3 py-1.5 text-left text-[9px] font-medium text-text-muted uppercase tracking-wider">Time</th>
+                    <th className="px-3 py-1.5 text-left text-[9px] font-medium text-text-muted uppercase tracking-wider">Trace ID</th>
+                    <th className="px-3 py-1.5 text-left text-[9px] font-medium text-text-muted uppercase tracking-wider">Operation</th>
+                    <th className="px-3 py-1.5 text-left text-[9px] font-medium text-text-muted uppercase tracking-wider">Server</th>
+                    <th className="px-3 py-1.5 text-right text-[9px] font-medium text-text-muted uppercase tracking-wider">Duration</th>
+                    <th className="px-3 py-1.5 text-right text-[9px] font-medium text-text-muted uppercase tracking-wider">Spans</th>
+                    <th className="px-3 py-1.5 text-left text-[9px] font-medium text-text-muted uppercase tracking-wider">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredTraces.map((trace) => {
+                    const isSelected = selectedTraceId === trace.traceId;
+                    return (
+                      <tr
+                        key={trace.traceId}
+                        onClick={() => selectTrace(isSelected ? null : trace.traceId)}
+                        className={cn(
+                          'border-b border-border/15 cursor-pointer transition-colors',
+                          isSelected
+                            ? 'bg-primary/5 border-l-2 border-l-primary'
+                            : 'hover:bg-surface-highlight/20'
+                        )}
+                      >
+                        <td className="px-3 py-1.5 text-text-muted font-mono whitespace-nowrap text-zoom">{formatTime(trace.startTime)}</td>
+                        <td className="px-3 py-1.5 font-mono text-text-secondary text-zoom">{trace.traceId.slice(0, 8)}</td>
+                        <td className="px-3 py-1.5 text-text-primary truncate max-w-[160px] text-zoom">{trace.operation}</td>
+                        <td className="px-3 py-1.5 text-text-secondary font-mono text-zoom">{trace.server}</td>
+                        <td className="px-3 py-1.5 text-right text-text-secondary tabular-nums font-mono text-zoom">{formatDuration(trace.duration)}</td>
+                        <td className="px-3 py-1.5 text-right text-text-muted tabular-nums text-zoom">{trace.spanCount}</td>
+                        <td className="px-3 py-1.5">
+                          <span
+                            className={cn(
+                              'px-1.5 py-0.5 text-[9px] font-medium rounded-full border',
+                              trace.status === 'error'
+                                ? 'bg-status-error/10 text-status-error border-status-error/20'
+                                : 'bg-status-running/10 text-status-running border-status-running/20'
+                            )}
+                          >
+                            {trace.status}
+                          </span>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        {/* Waterfall panel */}
+        {selectedTraceId && (
+          <div className="flex-1 min-h-0 min-w-0">
+            {isLoadingDetail && !traceDetail && (
+              <div className="flex items-center justify-center h-full">
+                <div className="w-6 h-6 rounded-full border-2 border-primary/30 border-t-primary animate-spin" />
+              </div>
+            )}
+            {detailError && (
+              <div className="flex flex-col items-center justify-center h-full gap-2 text-xs">
+                <AlertCircle size={16} className="text-status-error" />
+                <span className="text-status-error">{detailError}</span>
+              </div>
+            )}
+            {traceDetail && (
+              <TraceWaterfall
+                trace={traceDetail}
+                onClose={() => selectTrace(null)}
+                actions={
+                  onViewLogs ? (
+                    <button
+                      onClick={() => onViewLogs(traceDetail.traceId)}
+                      title="View logs for this trace"
+                      className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-text-muted hover:text-primary hover:bg-surface-highlight transition-colors"
+                    >
+                      <ScrollText size={11} />
+                      View logs
+                    </button>
+                  ) : undefined
+                }
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/workspaces/LogsWorkspace.tsx
+++ b/web/src/components/workspaces/LogsWorkspace.tsx
@@ -1,0 +1,364 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Copy, Layers, Pause, Play, Radio, RefreshCw, Server, Trash2, X } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useUIStore } from '../../stores/useUIStore';
+import { useStackStore } from '../../stores/useStackStore';
+import { useWindowManager } from '../../hooks/useWindowManager';
+import { useLogFontSize } from '../../hooks/useLogFontSize';
+import { useLogStream } from '../../hooks/useLogStream';
+import { WorkspaceShell } from '../layout/WorkspaceShell';
+import { IconButton } from '../ui/IconButton';
+import { PopoutButton } from '../ui/PopoutButton';
+import { PersistedFromMarker } from '../telemetry/PersistedFromMarker';
+import { copyTextToClipboard } from '../../lib/clipboard';
+import {
+  GATEWAY_LOG_SOURCE,
+  LOG_LEVELS,
+  LogFilterBar,
+  LogStream,
+  filterParsedLogs,
+  logSourceOf,
+  normalizeLogSourceParam,
+  type LogLevel,
+} from '../log';
+
+const ALL_LEVELS: ReadonlySet<LogLevel> = new Set(LOG_LEVELS);
+
+// `none` is the every-level-disabled sentinel: an empty CSV would read back as
+// "param absent" and silently re-enable all levels on the round-trip.
+const NO_LEVELS_PARAM = 'none';
+
+function levelsFromParam(param: string | null): Set<LogLevel> {
+  if (!param) return new Set(ALL_LEVELS);
+  if (param === NO_LEVELS_PARAM) return new Set<LogLevel>();
+  const parsed = param
+    .split(',')
+    .map((l) => l.trim().toUpperCase())
+    .filter((l): l is LogLevel => (ALL_LEVELS as Set<string>).has(l));
+  return parsed.length > 0 ? new Set(parsed) : new Set(ALL_LEVELS);
+}
+
+// LogsWorkspace is the first-class log surface: the aggregate multi-server
+// stream from GET /api/logs with no selection prerequisite. The left rail
+// picks a source (all / gateway / per server) as a client-side filter over the
+// same stream — never a second fetch path. Source, level, search, and trace
+// filters are URL-synced (?agent=, ?level=, ?q=, ?trace=) so reload,
+// deep-links, and the node-to-logs and trace-to-logs pivots all land on the
+// exact view they name.
+export function LogsWorkspace() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const compact = useUIStore((s) => s.compactMode.logs);
+  const logsDetached = useUIStore((s) => s.logsDetached);
+  const { openDetachedWindow } = useWindowManager();
+  const mcpServers = useStackStore((s) => s.mcpServers);
+
+  const [isPaused, setIsPaused] = useState(false);
+  const { logs, isLoading, error, refresh, clear } = useLogStream({ active: true, paused: isPaused });
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { fontSize, zoomIn, zoomOut, resetZoom, isMin, isMax, isDefault } =
+    useLogFontSize(containerRef);
+
+  // ---- URL state ----------------------------------------------------------
+  const source = normalizeLogSourceParam(searchParams.get('agent'));
+  const searchQuery = searchParams.get('q') ?? '';
+  const traceFilter = searchParams.get('trace');
+  const enabledLevels = useMemo(() => levelsFromParam(searchParams.get('level')), [searchParams]);
+
+  const updateParams = useCallback(
+    (mutate: (p: URLSearchParams) => void) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          mutate(params);
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const setSource = useCallback(
+    (next: string | null) => {
+      updateParams((p) => {
+        if (next) p.set('agent', next);
+        else p.delete('agent');
+      });
+    },
+    [updateParams],
+  );
+
+  const setSearchQuery = useCallback(
+    (q: string) => {
+      updateParams((p) => {
+        if (q) p.set('q', q);
+        else p.delete('q');
+      });
+    },
+    [updateParams],
+  );
+
+  const toggleLevel = useCallback(
+    (level: LogLevel) => {
+      const next = new Set(enabledLevels);
+      if (next.has(level)) next.delete(level);
+      else next.add(level);
+      updateParams((p) => {
+        if (next.size === ALL_LEVELS.size) p.delete('level');
+        else if (next.size === 0) p.set('level', NO_LEVELS_PARAM);
+        else p.set('level', [...next].map((l) => l.toLowerCase()).join(','));
+      });
+    },
+    [enabledLevels, updateParams],
+  );
+
+  const clearTraceFilter = useCallback(() => {
+    updateParams((p) => p.delete('trace'));
+  }, [updateParams]);
+
+  const clearFilters = useCallback(() => {
+    updateParams((p) => {
+      p.delete('q');
+      p.delete('level');
+      p.delete('trace');
+    });
+  }, [updateParams]);
+
+  // ---- Derived data -------------------------------------------------------
+  const sourceCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const log of logs) {
+      const s = logSourceOf(log);
+      counts.set(s, (counts.get(s) ?? 0) + 1);
+    }
+    return counts;
+  }, [logs]);
+
+  const serverNames = useMemo(() => {
+    const names = new Set(mcpServers.map((s) => s.name));
+    // Sources present in the stream but not (or no longer) deployed still get
+    // a rail entry so their entries stay reachable.
+    for (const name of sourceCounts.keys()) {
+      if (name !== GATEWAY_LOG_SOURCE) names.add(name);
+    }
+    return [...names].sort();
+  }, [mcpServers, sourceCounts]);
+
+  const filteredLogs = useMemo(
+    () =>
+      filterParsedLogs(logs, {
+        source,
+        levels: enabledLevels,
+        query: searchQuery,
+        traceId: traceFilter,
+      }),
+    [logs, source, enabledLevels, searchQuery, traceFilter],
+  );
+
+  const hasActiveFilter =
+    searchQuery !== '' || traceFilter != null || enabledLevels.size !== ALL_LEVELS.size;
+
+  const handleCopy = () => copyTextToClipboard(filteredLogs.map((log) => log.raw).join('\n'));
+
+  const leftRail = (
+    <SourceRail
+      compact={compact}
+      source={source}
+      onSelectSource={setSource}
+      serverNames={serverNames}
+      totalCount={logs.length}
+      counts={sourceCounts}
+    />
+  );
+
+  return (
+    <div className="absolute inset-0 flex flex-col bg-background text-text-primary overflow-hidden">
+      <WorkspaceShell workspace="logs" defaultLeftPct={16} left={leftRail} minLeftPx={180}>
+        <main className="flex flex-col h-full overflow-hidden">
+          <header
+            className={cn(
+              'flex-shrink-0 bg-surface/30 backdrop-blur-sm border-b border-border-subtle flex items-center justify-between gap-3 px-6',
+              compact ? 'py-2' : 'py-3',
+            )}
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="font-sans text-text-muted/60 text-[10px] uppercase tracking-[0.4em]">logs</div>
+              <div className="font-mono text-[10px] text-text-muted truncate">
+                {source ?? 'all sources'}
+              </div>
+              {isPaused && (
+                <span className="text-[9px] px-1.5 py-0.5 bg-status-pending/15 text-status-pending rounded-full font-medium border border-status-pending/20">
+                  Paused
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-1">
+              <IconButton
+                icon={isPaused ? Play : Pause}
+                onClick={() => setIsPaused((p) => !p)}
+                tooltip={isPaused ? 'Resume' : 'Pause'}
+                size="sm"
+                variant="ghost"
+                className={isPaused ? 'text-status-running hover:text-status-running' : ''}
+              />
+              <IconButton icon={RefreshCw} onClick={refresh} tooltip="Refresh" size="sm" variant="ghost" />
+              <IconButton icon={Copy} onClick={handleCopy} tooltip="Copy Logs" size="sm" variant="ghost" />
+              <IconButton
+                icon={Trash2}
+                onClick={clear}
+                tooltip="Clear Logs"
+                size="sm"
+                variant="ghost"
+                className="hover:text-status-error"
+              />
+              <div className="w-px h-4 bg-border/50 mx-0.5" />
+              <PopoutButton
+                onClick={() =>
+                  openDetachedWindow('logs', source ? `agent=${encodeURIComponent(source)}` : undefined)
+                }
+                tooltip="Open in separate window"
+                disabled={logsDetached}
+              />
+            </div>
+          </header>
+
+          <LogFilterBar
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            enabledLevels={enabledLevels}
+            onToggleLevel={toggleLevel}
+            fontSize={fontSize}
+            onZoomIn={zoomIn}
+            onZoomOut={zoomOut}
+            onResetZoom={resetZoom}
+            isMin={isMin}
+            isMax={isMax}
+            isDefault={isDefault}
+            filteredCount={filteredLogs.length}
+            totalCount={logs.length}
+          >
+            {traceFilter && (
+              <button
+                onClick={clearTraceFilter}
+                title="Clear trace filter"
+                className="flex items-center gap-1 h-6 px-2 text-[10px] font-mono rounded border bg-primary/10 text-primary border-primary/30 hover:bg-primary/15 transition-colors"
+              >
+                trace: {traceFilter.slice(0, 8)}
+                <X size={9} />
+              </button>
+            )}
+          </LogFilterBar>
+
+          <LogStream
+            logs={filteredLogs}
+            isLoading={isLoading}
+            error={error}
+            hasActiveFilter={hasActiveFilter}
+            onClearFilter={clearFilters}
+            showSource={source == null}
+            onTraceClick={(traceId) => navigate(`/traces?trace=${encodeURIComponent(traceId)}`)}
+            fontSize={fontSize}
+            containerRef={containerRef}
+            header={
+              source != null && source !== GATEWAY_LOG_SOURCE ? (
+                <PersistedFromMarker serverName={source} signal="logs" />
+              ) : undefined
+            }
+            emptyText="No logs yet"
+          />
+        </main>
+      </WorkspaceShell>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Left rail — source navigator
+// ---------------------------------------------------------------------------
+
+interface SourceRailProps {
+  compact: boolean;
+  source: string | null;
+  onSelectSource: (source: string | null) => void;
+  serverNames: string[];
+  totalCount: number;
+  counts: Map<string, number>;
+}
+
+function SourceRail({ compact, source, onSelectSource, serverNames, totalCount, counts }: SourceRailProps) {
+  return (
+    <aside className="h-full flex flex-col bg-surface border-r border-border-subtle">
+      <div className={cn('flex-shrink-0 px-3 border-b border-border-subtle/60', compact ? 'py-2' : 'py-3')}>
+        <div className="text-[10px] font-medium text-text-muted/60 uppercase tracking-[0.3em]">sources</div>
+      </div>
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-dark px-2 py-2 space-y-0.5">
+        <SourcePill
+          label="All sources"
+          icon={Layers}
+          count={totalCount}
+          active={source == null}
+          onClick={() => onSelectSource(null)}
+        />
+        <SourcePill
+          label="Gateway"
+          icon={Radio}
+          count={counts.get(GATEWAY_LOG_SOURCE) ?? 0}
+          active={source === GATEWAY_LOG_SOURCE}
+          onClick={() => onSelectSource(GATEWAY_LOG_SOURCE)}
+        />
+        {serverNames.map((name) => (
+          <SourcePill
+            key={name}
+            label={name}
+            icon={Server}
+            count={counts.get(name) ?? 0}
+            active={source === name}
+            onClick={() => onSelectSource(name)}
+          />
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+function SourcePill({
+  label,
+  icon: Icon,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  icon: LucideIcon;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-current={active}
+      className={cn(
+        'group w-full flex items-center gap-2 px-3 py-1.5 rounded-md text-left transition-colors',
+        active ? 'bg-primary/10 text-primary' : 'text-text-secondary hover:bg-surface-highlight/50 hover:text-text-primary',
+      )}
+    >
+      <Icon size={13} className={active ? 'text-primary' : 'text-text-muted'} aria-hidden="true" />
+      <span className={cn('flex-1 min-w-0 text-xs font-medium truncate', active && 'text-primary')}>{label}</span>
+      <span
+        className={cn(
+          'flex-shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded tabular-nums',
+          active ? 'bg-primary/15 text-primary' : 'bg-surface-elevated text-text-muted',
+        )}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+export default LogsWorkspace;

--- a/web/src/components/workspaces/TracesWorkspace.tsx
+++ b/web/src/components/workspaces/TracesWorkspace.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { cn } from '../../lib/cn';
+import { useUIStore } from '../../stores/useUIStore';
+import { useStackStore } from '../../stores/useStackStore';
+import { useTracesStore } from '../../stores/useTracesStore';
+import { useWindowManager } from '../../hooks/useWindowManager';
+import { PopoutButton } from '../ui/PopoutButton';
+import { TracesView } from '../traces/TracesView';
+
+// TracesWorkspace is the first-class trace surface: the global trace list,
+// waterfall, and span detail from TracesView, with the selection and filters
+// URL-synced (?trace=, ?server=, ?errors=, ?q=) so deep links — including the
+// log-line trace pivot — restore the exact view. The trace detail pivots back
+// to /logs?trace=<id> for the reverse correlation.
+export function TracesWorkspace() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const compact = useUIStore((s) => s.compactMode.traces);
+  const tracesDetached = useUIStore((s) => s.tracesDetached);
+  const { openDetachedWindow } = useWindowManager();
+
+  const mcpServers = useStackStore((s) => s.mcpServers);
+  const servers = useMemo(() => mcpServers.map((s) => s.name).sort(), [mcpServers]);
+
+  const selectedTraceId = useTracesStore((s) => s.selectedTraceId);
+  const filters = useTracesStore((s) => s.filters);
+  const selectTrace = useTracesStore((s) => s.selectTrace);
+  const setFilters = useTracesStore((s) => s.setFilters);
+
+  // URL → store, once on mount: deep links win over whatever the store still
+  // holds from a previous visit.
+  const initialParams = useRef(searchParams);
+  useEffect(() => {
+    const p = initialParams.current;
+    const trace = p.get('trace');
+    const server = p.get('server');
+    const errors = p.get('errors');
+    const q = p.get('q');
+    if (server != null || errors != null || q != null) {
+      setFilters({
+        ...(server != null ? { server } : {}),
+        ...(errors != null ? { errorsOnly: errors === '1' } : {}),
+        ...(q != null ? { search: q } : {}),
+      });
+    }
+    if (trace && trace !== useTracesStore.getState().selectedTraceId) {
+      selectTrace(trace);
+    }
+  }, [setFilters, selectTrace]);
+
+  // Store → URL mirror. Reads live store state so the first pass after the
+  // mount sync above never rewrites the URL from stale render-time values.
+  useEffect(() => {
+    const s = useTracesStore.getState();
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev);
+        if (s.selectedTraceId) params.set('trace', s.selectedTraceId);
+        else params.delete('trace');
+        if (s.filters.server) params.set('server', s.filters.server);
+        else params.delete('server');
+        if (s.filters.errorsOnly) params.set('errors', '1');
+        else params.delete('errors');
+        if (s.filters.search) params.set('q', s.filters.search);
+        else params.delete('q');
+        return params;
+      },
+      { replace: true },
+    );
+  }, [selectedTraceId, filters, setSearchParams]);
+
+  return (
+    <div className="absolute inset-0 flex flex-col bg-background text-text-primary overflow-hidden">
+      <header
+        className={cn(
+          'flex-shrink-0 bg-surface/30 backdrop-blur-sm border-b border-border-subtle flex items-center gap-3 px-6',
+          compact ? 'py-2' : 'py-3',
+        )}
+      >
+        <div className="font-sans text-text-muted/60 text-[10px] uppercase tracking-[0.4em]">traces</div>
+        <div className="font-mono text-[10px] text-text-muted truncate">
+          {selectedTraceId ? selectedTraceId.slice(0, 16) : 'all tool calls'}
+        </div>
+      </header>
+      <div className="flex-1 min-h-0">
+        <TracesView
+          active
+          servers={servers}
+          onViewLogs={(traceId) => navigate(`/logs?trace=${encodeURIComponent(traceId)}`)}
+          toolbarExtra={
+            <PopoutButton
+              onClick={() => openDetachedWindow('traces')}
+              tooltip="Open in separate window"
+              disabled={tracesDetached}
+            />
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+export default TracesWorkspace;

--- a/web/src/hooks/useLogStream.ts
+++ b/web/src/hooks/useLogStream.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { parseLogEntry, type ParsedLog } from '../components/log/logTypes';
+import { fetchGatewayLogs } from '../lib/api';
+import { POLLING } from '../lib/constants';
+
+interface UseLogStreamOptions {
+  /** Fetch + poll only while true (workspace mounted, tab visible, ...). */
+  active: boolean;
+  /** Suspends polling without dropping the buffered entries. */
+  paused?: boolean;
+  lines?: number;
+}
+
+interface UseLogStreamResult {
+  logs: ParsedLog[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+  clear: () => void;
+}
+
+/**
+ * Shared aggregate log stream. Always reads GET /api/logs — the whole
+ * multi-server ring buffer — and leaves source/level/search filtering to the
+ * caller via `filterParsedLogs`. Per-server views are client-side filters over
+ * this stream, never a second fetch path (the per-server endpoint returns
+ * unstructured strings and would fork the rendering).
+ *
+ * `clear()` records a watermark instead of just emptying local state: the ring
+ * buffer is server-side, so a bare reset would repopulate on the next poll.
+ * Entries at or before the newest cleared timestamp stay hidden.
+ */
+export function useLogStream({ active, paused = false, lines = 500 }: UseLogStreamOptions): UseLogStreamResult {
+  const [logs, setLogs] = useState<ParsedLog[]>([]);
+  const [isLoading, setIsLoading] = useState(active);
+  const [error, setError] = useState<string | null>(null);
+  const clearedBeforeRef = useRef<number | null>(null);
+
+  const fetchLogs = useCallback(async () => {
+    try {
+      const entries = await fetchGatewayLogs(lines);
+      let parsed = (entries ?? []).map(parseLogEntry);
+      const clearedBefore = clearedBeforeRef.current;
+      if (clearedBefore != null) {
+        parsed = parsed.filter((log) => {
+          const ts = Date.parse(log.timestamp);
+          return Number.isNaN(ts) || ts > clearedBefore;
+        });
+      }
+      setLogs(parsed);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch logs');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [lines]);
+
+  // Fetch on activation, then poll while active and not paused.
+  useEffect(() => {
+    if (!active) return;
+    fetchLogs();
+    if (paused) return;
+    const interval = window.setInterval(fetchLogs, POLLING.LOGS);
+    return () => clearInterval(interval);
+  }, [active, paused, fetchLogs]);
+
+  const clear = useCallback(() => {
+    setLogs((prev) => {
+      const newest = prev.reduce((max, log) => {
+        const ts = Date.parse(log.timestamp);
+        return Number.isNaN(ts) ? max : Math.max(max, ts);
+      }, clearedBeforeRef.current ?? 0);
+      clearedBeforeRef.current = newest > 0 ? newest : Date.now();
+      return [];
+    });
+  }, []);
+
+  return { logs, isLoading, error, refresh: fetchLogs, clear };
+}

--- a/web/src/hooks/useWindowManager.ts
+++ b/web/src/hooks/useWindowManager.ts
@@ -11,13 +11,15 @@ const WINDOW_TITLES: Record<string, string> = {
   traces: 'Gridctl - Traces',
 };
 
-// Window types whose detached route differs from the default /<type>. Both
-// `registry` and `metrics` had their /<type> path claimed by an in-shell
-// workspace; the popout moves aside while the type key stays put, so no
-// call-site, broadcast channel, or stored detached state has to change.
+// Window types whose detached route differs from the default /<type>. Each of
+// these had its /<type> path claimed by an in-shell workspace; the popout
+// moves aside while the type key stays put, so no call-site, broadcast
+// channel, or stored detached state has to change.
 const WINDOW_PATHS: Record<string, string> = {
   registry: '/library-window',
   metrics: '/metrics-window',
+  logs: '/logs-window',
+  traces: '/traces-window',
 };
 
 type DetachableWindow = 'logs' | 'sidebar' | 'editor' | 'registry' | 'metrics' | 'traces';

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -1,0 +1,15 @@
+// Copies text via the async clipboard API, falling back to the legacy
+// textarea + execCommand path in contexts where the API is unavailable
+// (non-secure origins, detached windows on some platforms).
+export async function copyTextToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    document.body.appendChild(textArea);
+    textArea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textArea);
+  }
+}

--- a/web/src/pages/DetachedLogsPage.tsx
+++ b/web/src/pages/DetachedLogsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   Terminal,
@@ -10,48 +10,50 @@ import {
   RefreshCw,
   Maximize2,
   Minimize2,
-  Search,
   Radio,
+  Layers,
 } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { IconButton } from '../components/ui/IconButton';
-import { LogLine, LevelFilter, parseLogEntry, type LogLevel, type ParsedLog } from '../components/log';
-import { ZoomControls } from '../components/ui/ZoomControls';
-import { fetchServerLogs, fetchGatewayLogs, fetchStatus } from '../lib/api';
+import {
+  LogFilterBar,
+  LogStream,
+  GATEWAY_LOG_SOURCE,
+  LOG_LEVELS,
+  filterParsedLogs,
+  normalizeLogSourceParam,
+  type LogLevel,
+} from '../components/log';
+import { copyTextToClipboard } from '../lib/clipboard';
+import { fetchStatus } from '../lib/api';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
 import { useLogFontSize } from '../hooks/useLogFontSize';
+import { useLogStream } from '../hooks/useLogStream';
 import { POLLING } from '../lib/constants';
 import type { GatewayStatus } from '../types';
 import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 
 interface NodeOption {
   name: string;
-  type: 'gateway' | 'mcp-server' | 'resource';
+  type: 'mcp-server' | 'resource';
 }
 
 function DetachedLogsPageContent() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const initialAgent = searchParams.get('agent');
+  const source = normalizeLogSourceParam(searchParams.get('agent'));
 
-  const [logs, setLogs] = useState<ParsedLog[]>([]);
   const [isPaused, setIsPaused] = useState(false);
-  const [autoScroll, setAutoScroll] = useState(true);
-  const [isLoading, setIsLoading] = useState(initialAgent !== null);
-  const [error, setError] = useState<string | null>(null);
-  const [selectedAgent, setSelectedAgent] = useState<string | null>(initialAgent);
+  const { logs, isLoading, error, refresh, clear } = useLogStream({ active: true, paused: isPaused });
+
   const [nodes, setNodes] = useState<NodeOption[]>([]);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
   // Filter state
   const [searchQuery, setSearchQuery] = useState('');
-  const [enabledLevels, setEnabledLevels] = useState<Set<LogLevel>>(
-    new Set(['ERROR', 'WARN', 'INFO', 'DEBUG'])
-  );
-  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+  const [enabledLevels, setEnabledLevels] = useState<Set<LogLevel>>(new Set(LOG_LEVELS));
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const intervalRef = useRef<number | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Log font size with Ctrl+Scroll zoom
@@ -61,14 +63,12 @@ function DetachedLogsPageContent() {
   // Register with main window
   useDetachedWindowSync('logs');
 
-  // Fetch available nodes
+  // Fetch available nodes for the source picker
   useEffect(() => {
     const fetchNodes = async () => {
       try {
         const status: GatewayStatus = await fetchStatus();
         const nodeList: NodeOption[] = [
-          // Gateway option at the top
-          { name: 'Gateway', type: 'gateway' as const },
           ...(status['mcp-servers'] ?? []).map((s) => ({ name: s.name, type: 'mcp-server' as const })),
           ...(status.resources ?? []).map((r) => ({ name: r.name, type: 'resource' as const })),
         ];
@@ -96,104 +96,18 @@ function DetachedLogsPageContent() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  // Determine if selected is gateway
-  const isGateway = selectedAgent === 'Gateway';
+  const isGateway = source === GATEWAY_LOG_SOURCE;
+  const sourceLabel = source == null ? 'All sources' : isGateway ? 'Gateway' : source;
 
-  // Reset log state when the selected agent changes (state adjustment during
-  // render, so the reset commits together with the switch).
-  const [prevAgent, setPrevAgent] = useState(selectedAgent);
-  if (prevAgent !== selectedAgent) {
-    setPrevAgent(selectedAgent);
-    setLogs([]);
-    setError(null);
-    setExpandedIndex(null);
-    setSearchQuery('');
-    setIsLoading(selectedAgent !== null);
-  }
-
-  const fetchLogs = useCallback(async () => {
-    if (!selectedAgent) return;
-
-    try {
-      if (isGateway) {
-        const entries = await fetchGatewayLogs(500);
-        setLogs((entries ?? []).map(parseLogEntry));
-      } else {
-        const lines = await fetchServerLogs(selectedAgent, 500);
-        setLogs((lines ?? []).map(parseLogEntry));
-      }
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch logs');
-    } finally {
-      setIsLoading(false);
-    }
-  }, [selectedAgent, isGateway]);
-
-  // Fetch and mirror the selection into the URL on mount and agent change
-  useEffect(() => {
-    if (selectedAgent) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- async callback; state is set only after await, not synchronously
-      fetchLogs();
-      setSearchParams({ agent: selectedAgent });
-    } else {
-      setSearchParams({});
-    }
-  }, [selectedAgent, fetchLogs, setSearchParams]);
-
-  // Polling for logs
-  useEffect(() => {
-    if (!selectedAgent || isPaused) {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-      return;
-    }
-
-    intervalRef.current = window.setInterval(fetchLogs, POLLING.LOGS);
-
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    };
-  }, [selectedAgent, isPaused, fetchLogs]);
-
-  // Filter logs
-  const filteredLogs = useMemo(() => {
-    return (logs ?? []).filter((log) => {
-      // Level filter
-      if (!enabledLevels.has(log.level)) return false;
-
-      // Search filter
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase();
-        return (
-          log.message.toLowerCase().includes(query) ||
-          log.component?.toLowerCase().includes(query) ||
-          log.traceId?.toLowerCase().includes(query)
-        );
-      }
-
-      return true;
-    });
-  }, [logs, enabledLevels, searchQuery]);
-
-  // Auto-scroll to bottom
-  useEffect(() => {
-    if (autoScroll && containerRef.current) {
-      containerRef.current.scrollTop = containerRef.current.scrollHeight;
-    }
-  }, [filteredLogs, autoScroll]);
-
-  // Detect manual scroll
-  const handleScroll = () => {
-    if (!containerRef.current) return;
-    const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
-    setAutoScroll(scrollHeight - scrollTop - clientHeight < 50);
+  const handleSelectSource = (next: string | null) => {
+    setSearchParams(next ? { agent: next } : {});
+    setDropdownOpen(false);
   };
+
+  const filteredLogs = useMemo(
+    () => filterParsedLogs(logs, { source, levels: enabledLevels, query: searchQuery }),
+    [logs, source, enabledLevels, searchQuery],
+  );
 
   const toggleLevel = (level: LogLevel) => {
     setEnabledLevels((prev) => {
@@ -207,24 +121,7 @@ function DetachedLogsPageContent() {
     });
   };
 
-  const handleClearLogs = () => {
-    setLogs([]);
-    setExpandedIndex(null);
-  };
-
-  const handleCopyLogs = async () => {
-    const text = filteredLogs.map((log) => log.raw).join('\n');
-    try {
-      await navigator.clipboard.writeText(text);
-    } catch {
-      const textArea = document.createElement('textarea');
-      textArea.value = text;
-      document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textArea);
-    }
-  };
+  const handleCopyLogs = () => copyTextToClipboard(filteredLogs.map((log) => log.raw).join('\n'));
 
   const toggleFullscreen = async () => {
     if (!document.fullscreenElement) {
@@ -246,10 +143,7 @@ function DetachedLogsPageContent() {
     return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
   }, []);
 
-  const handleSelectAgent = (name: string) => {
-    setSelectedAgent(name);
-    setDropdownOpen(false);
-  };
+  const hasActiveFilter = searchQuery !== '' || enabledLevels.size !== LOG_LEVELS.length;
 
   return (
     <div className="h-screen w-screen bg-background flex flex-col overflow-hidden">
@@ -269,16 +163,22 @@ function DetachedLogsPageContent() {
         <div className="flex items-center gap-3">
           <div className={cn(
             'p-1.5 rounded-lg border',
-            isGateway ? 'bg-primary/10 border-primary/20' : 'bg-tertiary/10 border-tertiary/20'
+            source == null
+              ? 'bg-surface-elevated/60 border-border/50'
+              : isGateway
+                ? 'bg-primary/10 border-primary/20'
+                : 'bg-tertiary/10 border-tertiary/20'
           )}>
-            {isGateway ? (
+            {source == null ? (
+              <Layers size={14} className="text-text-secondary" />
+            ) : isGateway ? (
               <Radio size={14} className="text-primary" />
             ) : (
               <Terminal size={14} className="text-tertiary" />
             )}
           </div>
 
-          {/* Agent selector dropdown */}
+          {/* Source selector dropdown */}
           <div className="relative" ref={dropdownRef}>
             <button
               onClick={() => setDropdownOpen(!dropdownOpen)}
@@ -289,9 +189,7 @@ function DetachedLogsPageContent() {
                 dropdownOpen && 'bg-surface-highlight border-text-muted/30'
               )}
             >
-              <span className={cn(selectedAgent ? 'text-text-primary' : 'text-text-muted')}>
-                {selectedAgent ?? 'Select node...'}
-              </span>
+              <span className="text-text-primary">{sourceLabel}</span>
               <ChevronDown
                 size={14}
                 className={cn(
@@ -303,39 +201,35 @@ function DetachedLogsPageContent() {
 
             {dropdownOpen && (
               <div className="absolute top-full left-0 mt-1 w-64 py-1 bg-surface-elevated/95 backdrop-blur-xl border border-border/50 rounded-lg shadow-lg z-50 animate-fade-in-scale">
-                {(nodes ?? []).length === 0 ? (
-                  <div className="px-3 py-2 text-xs text-text-muted">No nodes available</div>
-                ) : (
-                  (nodes ?? []).map((node) => (
-                    <button
-                      key={node.name}
-                      onClick={() => handleSelectAgent(node.name)}
-                      className={cn(
-                        'w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors',
-                        'hover:bg-surface-highlight',
-                        selectedAgent === node.name && 'bg-primary/10 text-primary'
-                      )}
-                    >
-                      <span
-                        className={cn(
-                          'w-1.5 h-1.5 rounded-full',
-                          node.type === 'gateway' && 'bg-primary',
-                          node.type === 'mcp-server' && 'bg-violet-400',
-                          node.type === 'resource' && 'bg-secondary'
-                        )}
-                      />
-                      <span className="truncate">{node.name}</span>
-                      <span className="ml-auto text-[10px] text-text-muted uppercase">
-                        {node.type === 'mcp-server' ? 'server' : node.type}
-                      </span>
-                    </button>
-                  ))
-                )}
+                <SourceOption
+                  label="All sources"
+                  dotClass="bg-text-muted"
+                  tag="all"
+                  selected={source == null}
+                  onSelect={() => handleSelectSource(null)}
+                />
+                <SourceOption
+                  label="Gateway"
+                  dotClass="bg-primary"
+                  tag="gateway"
+                  selected={isGateway}
+                  onSelect={() => handleSelectSource(GATEWAY_LOG_SOURCE)}
+                />
+                {(nodes ?? []).map((node) => (
+                  <SourceOption
+                    key={node.name}
+                    label={node.name}
+                    dotClass={node.type === 'mcp-server' ? 'bg-violet-400' : 'bg-secondary'}
+                    tag={node.type === 'mcp-server' ? 'server' : node.type}
+                    selected={source === node.name}
+                    onSelect={() => handleSelectSource(node.name)}
+                  />
+                ))}
               </div>
             )}
           </div>
 
-          {isGateway && selectedAgent && (
+          {isGateway && (
             <span className="text-[10px] px-1.5 py-0.5 bg-primary/10 text-primary rounded font-medium border border-primary/20">
               Structured
             </span>
@@ -350,11 +244,10 @@ function DetachedLogsPageContent() {
         <div className="flex items-center gap-1">
           <IconButton
             icon={RefreshCw}
-            onClick={fetchLogs}
+            onClick={refresh}
             tooltip="Refresh"
             size="sm"
             variant="ghost"
-            disabled={!selectedAgent}
           />
           <IconButton
             icon={isPaused ? Play : Pause}
@@ -363,7 +256,6 @@ function DetachedLogsPageContent() {
             size="sm"
             variant="ghost"
             className={isPaused ? 'text-status-running hover:text-status-running' : ''}
-            disabled={!selectedAgent}
           />
           <IconButton
             icon={Copy}
@@ -371,16 +263,15 @@ function DetachedLogsPageContent() {
             tooltip="Copy Logs"
             size="sm"
             variant="ghost"
-            disabled={!selectedAgent || (logs ?? []).length === 0}
+            disabled={filteredLogs.length === 0}
           />
           <IconButton
             icon={Trash2}
-            onClick={handleClearLogs}
+            onClick={clear}
             tooltip="Clear Logs"
             size="sm"
             variant="ghost"
             className="hover:text-status-error"
-            disabled={!selectedAgent}
           />
           <div className="w-px h-4 bg-border/50 mx-1" />
           <IconButton
@@ -394,108 +285,37 @@ function DetachedLogsPageContent() {
       </header>
 
       {/* Filter bar */}
-      {selectedAgent && (
-        <div className="flex items-center gap-2 px-4 py-2 border-b border-border/30 bg-surface-elevated/30 flex-shrink-0">
-          {/* Search input */}
-          <div className="relative flex-1 max-w-xs">
-            <Search
-              size={12}
-              className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-muted"
-            />
-            <input
-              type="text"
-              placeholder="Filter logs..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className={cn(
-                'w-full pl-7 pr-3 py-1.5 text-xs font-mono',
-                'bg-background/60 border border-border/50 rounded-md',
-                'text-text-primary placeholder:text-text-muted',
-                'focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20',
-                'transition-all duration-200'
-              )}
-            />
-          </div>
-
-          {/* Level filter */}
-          <LevelFilter enabledLevels={enabledLevels} onToggle={toggleLevel} />
-
-          {/* Zoom controls */}
-          <ZoomControls
-            fontSize={fontSize}
-            onZoomIn={zoomIn}
-            onZoomOut={zoomOut}
-            onReset={resetZoom}
-            isMin={isMin}
-            isMax={isMax}
-            isDefault={isDefault}
-          />
-
-          {/* Log count */}
-          <span className="text-[10px] text-text-muted font-mono ml-auto">
-            {filteredLogs.length} / {(logs ?? []).length} entries
-          </span>
-        </div>
-      )}
+      <LogFilterBar
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        enabledLevels={enabledLevels}
+        onToggleLevel={toggleLevel}
+        fontSize={fontSize}
+        onZoomIn={zoomIn}
+        onZoomOut={zoomOut}
+        onResetZoom={resetZoom}
+        isMin={isMin}
+        isMax={isMax}
+        isDefault={isDefault}
+        filteredCount={filteredLogs.length}
+        totalCount={logs.length}
+      />
 
       {/* Log content */}
-      <main
-        ref={containerRef}
-        onScroll={handleScroll}
-        className="flex-1 overflow-auto bg-background scrollbar-dark min-h-0"
-        style={{ '--log-font-size': `${fontSize}px` } as React.CSSProperties}
-      >
-        {!selectedAgent && (
-          <div className="h-full flex flex-col items-center justify-center text-text-muted gap-3 animate-fade-in-scale">
-            <div className="p-4 rounded-xl bg-surface-elevated/50 border border-border/30">
-              <Terminal size={32} className="text-text-muted/50" />
-            </div>
-            <span className="text-sm">Select a node to view logs</span>
-          </div>
-        )}
-
-        {selectedAgent && isLoading && (
-          <div className="flex items-center gap-2 p-4 text-text-muted text-xs animate-fade-in-up">
-            <div className="w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-            Loading logs...
-          </div>
-        )}
-
-        {selectedAgent && error && (
-          <div className="flex items-center gap-2 p-4 text-status-error text-xs animate-fade-in-up">
-            <span className="w-2 h-2 rounded-full bg-status-error animate-pulse" />
-            Error: {error}
-          </div>
-        )}
-
-        {selectedAgent && !isLoading && !error && (filteredLogs?.length ?? 0) === 0 && (
-          <div className="flex flex-col items-center justify-center h-full text-text-muted text-xs gap-2 animate-fade-in-up">
-            <Terminal size={20} className="text-text-muted/30" />
-            <span>No logs available</span>
-            {searchQuery && (
-              <button
-                onClick={() => setSearchQuery('')}
-                className="text-primary hover:underline"
-              >
-                Clear filter
-              </button>
-            )}
-          </div>
-        )}
-
-        {selectedAgent && !isLoading && !error && (filteredLogs?.length ?? 0) > 0 && (
-          <div className="divide-y divide-border/20">
-            {(filteredLogs ?? []).map((log, i) => (
-              <LogLine
-                key={i}
-                log={log}
-                isExpanded={expandedIndex === i}
-                onToggle={() => setExpandedIndex(expandedIndex === i ? null : i)}
-              />
-            ))}
-          </div>
-        )}
-      </main>
+      <LogStream
+        logs={filteredLogs}
+        isLoading={isLoading}
+        error={error}
+        hasActiveFilter={hasActiveFilter}
+        onClearFilter={() => {
+          setSearchQuery('');
+          setEnabledLevels(new Set(LOG_LEVELS));
+        }}
+        showSource={source == null}
+        fontSize={fontSize}
+        containerRef={containerRef}
+        emptyText="No logs available"
+      />
 
       {/* Footer status bar */}
       <footer className="h-6 flex-shrink-0 bg-surface/90 backdrop-blur-xl border-t border-border/50 flex items-center justify-between px-4 text-[10px] text-text-muted">
@@ -508,6 +328,35 @@ function DetachedLogsPageContent() {
         </span>
       </footer>
     </div>
+  );
+}
+
+function SourceOption({
+  label,
+  dotClass,
+  tag,
+  selected,
+  onSelect,
+}: {
+  label: string;
+  dotClass: string;
+  tag: string;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      className={cn(
+        'w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors',
+        'hover:bg-surface-highlight',
+        selected && 'bg-primary/10 text-primary'
+      )}
+    >
+      <span className={cn('w-1.5 h-1.5 rounded-full', dotClass)} />
+      <span className="truncate">{label}</span>
+      <span className="ml-auto text-[10px] text-text-muted uppercase">{tag}</span>
+    </button>
   );
 }
 

--- a/web/src/pages/DetachedTracesPage.tsx
+++ b/web/src/pages/DetachedTracesPage.tsx
@@ -1,122 +1,27 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
-import {
-  Activity,
-  AlertCircle,
-  Maximize2,
-  Minimize2,
-  RefreshCw,
-  X,
-  Filter,
-} from 'lucide-react';
-import { cn } from '../lib/cn';
+import { useEffect, useState } from 'react';
+import { Activity, Maximize2, Minimize2 } from 'lucide-react';
 import { IconButton } from '../components/ui/IconButton';
-import { ZoomControls } from '../components/ui/ZoomControls';
 import { useDetachedWindowSync } from '../hooks/useBroadcastChannel';
-import { useTextZoom } from '../hooks/useTextZoom';
-import { fetchTraces, fetchTraceDetail, fetchMCPServers } from '../lib/api';
-import type { TraceSummary, TraceDetail } from '../lib/api';
-import { TraceWaterfall } from '../components/traces/TraceWaterfall';
-import { POLLING } from '../lib/constants';
+import { fetchMCPServers } from '../lib/api';
+import { TracesView } from '../components/traces/TracesView';
 import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 
-function formatTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleTimeString([], {
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    });
-  } catch {
-    return iso;
-  }
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  return `${(ms / 1000).toFixed(2)}s`;
-}
-
+// Frameless traces popout. The trace surface itself is the shared TracesView;
+// this page only adds the window chrome (title bar, fullscreen, footer). The
+// detached window runs its own store instance, so nothing here bleeds into
+// the main shell's traces state.
 function DetachedTracesPageContent() {
-  const [traces, setTraces] = useState<TraceSummary[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
-  const [traceDetail, setTraceDetail] = useState<TraceDetail | null>(null);
-  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
-  const [serverFilter, setServerFilter] = useState('');
   const [servers, setServers] = useState<string[]>([]);
-  const [errorsOnly, setErrorsOnly] = useState(false);
-  const [search, setSearch] = useState('');
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const tableRef = useRef<HTMLDivElement>(null);
 
   useDetachedWindowSync('traces');
 
-  const { fontSize, zoomIn, zoomOut, resetZoom, isMin, isMax, isDefault } = useTextZoom({
-    storageKey: 'gridctl-traces-font-size',
-    defaultSize: 11,
-    minSize: 8,
-    maxSize: 20,
-    containerRef: tableRef,
-  });
-
-  const load = useCallback(async () => {
-    try {
-      const result = await fetchTraces({
-        server: serverFilter || undefined,
-        errors: errorsOnly || undefined,
-        limit: 100,
-      });
-      setTraces(result.traces);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch traces');
-    } finally {
-      setIsLoading(false);
-    }
-  }, [serverFilter, errorsOnly]);
-
-  // Flag loading when the filters change (state adjustment during render, so
-  // the spinner commits together with the filter switch).
-  const filterKey = `${serverFilter}|${errorsOnly}`;
-  const [prevFilterKey, setPrevFilterKey] = useState(filterKey);
-  if (prevFilterKey !== filterKey) {
-    setPrevFilterKey(filterKey);
-    setIsLoading(true);
-  }
-
-  // Initial load and reload on filter change
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- async callback; state is set only after await, not synchronously
-    load();
-  }, [load]);
-
-  // Auto-refresh
-  useEffect(() => {
-    const interval = window.setInterval(load, POLLING.STATUS);
-    return () => clearInterval(interval);
-  }, [load]);
-
-  // Load deployed server names for the filter dropdown
+  // Load deployed server names for the filter dropdown. The detached window
+  // has no stack-store poller, so fetch directly.
   useEffect(() => {
     fetchMCPServers()
       .then((list) => setServers(list.map((s) => s.name).sort()))
       .catch(() => {});
-  }, []);
-
-  const selectTrace = useCallback(async (traceId: string | null) => {
-    setSelectedTraceId(traceId);
-    setTraceDetail(null);
-    if (!traceId) return;
-    setIsLoadingDetail(true);
-    try {
-      const detail = await fetchTraceDetail(traceId);
-      setTraceDetail(detail);
-    } catch {
-      // ignore
-    } finally {
-      setIsLoadingDetail(false);
-    }
   }, []);
 
   const toggleFullscreen = async () => {
@@ -134,17 +39,6 @@ function DetachedTracesPageContent() {
     document.addEventListener('fullscreenchange', handler);
     return () => document.removeEventListener('fullscreenchange', handler);
   }, []);
-
-  const filteredTraces = search
-    ? traces.filter(
-        (t) =>
-          t.traceId.toLowerCase().includes(search.toLowerCase()) ||
-          t.operation.toLowerCase().includes(search.toLowerCase()) ||
-          t.server.toLowerCase().includes(search.toLowerCase())
-      )
-    : traces;
-
-  const hasFilters = serverFilter || errorsOnly || search;
 
   return (
     <div className="h-screen w-screen bg-background flex flex-col overflow-hidden">
@@ -165,31 +59,9 @@ function DetachedTracesPageContent() {
             <Activity size={14} className="text-primary" />
           </div>
           <span className="text-sm font-semibold text-text-primary">Traces</span>
-          <span className="flex items-center gap-1 text-[9px] text-status-running font-medium">
-            <span className="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
-            Live
-          </span>
         </div>
 
         <div className="flex items-center gap-2">
-          <ZoomControls
-            fontSize={fontSize}
-            onZoomIn={zoomIn}
-            onZoomOut={zoomOut}
-            onReset={resetZoom}
-            isMin={isMin}
-            isMax={isMax}
-            isDefault={isDefault}
-          />
-          <div className="w-px h-4 bg-border/50" />
-          <IconButton
-            icon={RefreshCw}
-            onClick={() => { setIsLoading(true); load(); }}
-            tooltip="Refresh"
-            size="sm"
-            variant="ghost"
-          />
-          <div className="w-px h-4 bg-border/50" />
           <IconButton
             icon={isFullscreen ? Minimize2 : Maximize2}
             onClick={toggleFullscreen}
@@ -200,162 +72,14 @@ function DetachedTracesPageContent() {
         </div>
       </header>
 
-      {/* Filters bar */}
-      <div className="h-10 flex-shrink-0 bg-surface-elevated/20 border-b border-border/30 flex items-center gap-2 px-4">
-        <input
-          type="text"
-          placeholder="Search traces…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="h-6 px-2 text-[10px] bg-background/60 border border-border/40 rounded text-text-secondary placeholder:text-text-muted focus:outline-none focus:border-primary/50 w-48"
-        />
-        <select
-          value={serverFilter}
-          onChange={(e) => setServerFilter(e.target.value)}
-          className="h-6 px-1.5 text-[10px] bg-background/60 border border-border/40 rounded text-text-secondary focus:outline-none focus:border-primary/50"
-        >
-          <option value="">All servers</option>
-          {servers.map((s) => (
-            <option key={s} value={s}>{s}</option>
-          ))}
-        </select>
-        <button
-          onClick={() => setErrorsOnly(!errorsOnly)}
-          className={cn(
-            'h-6 px-2 text-[10px] font-medium rounded border transition-colors flex items-center gap-1',
-            errorsOnly
-              ? 'bg-status-error/15 text-status-error border-status-error/30'
-              : 'bg-background/60 text-text-muted border-border/40 hover:text-text-secondary'
-          )}
-        >
-          <AlertCircle size={9} />
-          Errors only
-        </button>
-        {hasFilters && (
-          <button
-            onClick={() => { setServerFilter(''); setErrorsOnly(false); setSearch(''); }}
-            className="h-6 px-1.5 text-[10px] text-text-muted hover:text-text-secondary flex items-center gap-1 rounded hover:bg-surface-highlight/30 transition-colors"
-          >
-            <X size={9} />
-            Clear
-          </button>
-        )}
-      </div>
-
-      {/* Content */}
-      <main className="flex flex-1 min-h-0">
-        {/* Trace list */}
-        <div className={cn('flex flex-col min-h-0 border-r border-border/30', traceDetail ? 'w-[35%]' : 'w-full')}>
-          {isLoading && filteredTraces.length === 0 && (
-            <div className="p-4 space-y-2 animate-pulse">
-              {[1, 2, 3, 4, 5].map((i) => (
-                <div key={i} className="h-8 rounded bg-surface-elevated/60 border border-border/20" />
-              ))}
-            </div>
-          )}
-
-          {error && !isLoading && (
-            <div className="flex flex-col items-center justify-center flex-1 gap-3">
-              <AlertCircle size={24} className="text-status-error" />
-              <span className="text-xs text-status-error">{error}</span>
-              <button onClick={load} className="text-xs text-primary hover:underline">Retry</button>
-            </div>
-          )}
-
-          {!isLoading && !error && filteredTraces.length === 0 && (
-            <div className="flex flex-col items-center justify-center flex-1 gap-2 text-text-muted">
-              <Activity size={32} className="text-text-muted/30" />
-              <span className="text-sm">No traces yet</span>
-              <span className="text-xs text-text-muted/60">
-                {hasFilters ? 'No traces match your filters' : 'Traces appear after tool calls'}
-              </span>
-              {hasFilters && (
-                <button
-                  onClick={() => { setServerFilter(''); setErrorsOnly(false); setSearch(''); }}
-                  className="text-xs text-primary hover:underline flex items-center gap-1"
-                >
-                  <Filter size={10} /> Clear filters
-                </button>
-              )}
-            </div>
-          )}
-
-          {filteredTraces.length > 0 && (
-            <div
-              ref={tableRef}
-              className="flex-1 overflow-y-auto scrollbar-dark min-h-0"
-              style={{ '--text-zoom-size': `${fontSize}px` } as React.CSSProperties}
-            >
-              <table className="w-full">
-                <thead className="sticky top-0 bg-surface/95 backdrop-blur-sm">
-                  <tr className="border-b border-border/30">
-                    <th className="px-4 py-2 text-left text-[9px] font-medium text-text-muted uppercase tracking-wider">Time</th>
-                    <th className="px-4 py-2 text-left text-[9px] font-medium text-text-muted uppercase tracking-wider">Trace ID</th>
-                    <th className="px-4 py-2 text-left text-[9px] font-medium text-text-muted uppercase tracking-wider">Operation</th>
-                    <th className="px-4 py-2 text-left text-[9px] font-medium text-text-muted uppercase tracking-wider">Server</th>
-                    <th className="px-4 py-2 text-right text-[9px] font-medium text-text-muted uppercase tracking-wider">Duration</th>
-                    <th className="px-4 py-2 text-left text-[9px] font-medium text-text-muted uppercase tracking-wider">Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredTraces.map((trace) => {
-                    const isSelected = selectedTraceId === trace.traceId;
-                    return (
-                      <tr
-                        key={trace.traceId}
-                        onClick={() => selectTrace(isSelected ? null : trace.traceId)}
-                        className={cn(
-                          'border-b border-border/15 cursor-pointer transition-colors',
-                          isSelected ? 'bg-primary/5 border-l-2 border-l-primary' : 'hover:bg-surface-highlight/20'
-                        )}
-                      >
-                        <td className="px-4 py-2 text-text-muted font-mono whitespace-nowrap text-zoom">{formatTime(trace.startTime)}</td>
-                        <td className="px-4 py-2 font-mono text-text-secondary text-zoom">{trace.traceId.slice(0, 8)}</td>
-                        <td className="px-4 py-2 text-text-primary truncate max-w-[200px] text-zoom">{trace.operation}</td>
-                        <td className="px-4 py-2 text-text-secondary font-mono text-zoom">{trace.server}</td>
-                        <td className="px-4 py-2 text-right text-text-secondary tabular-nums font-mono text-zoom">{formatDuration(trace.duration)}</td>
-                        <td className="px-4 py-2">
-                          <span
-                            className={cn(
-                              'px-1.5 py-0.5 text-[9px] font-medium rounded-full border',
-                              trace.status === 'error'
-                                ? 'bg-status-error/10 text-status-error border-status-error/20'
-                                : 'bg-status-running/10 text-status-running border-status-running/20'
-                            )}
-                          >
-                            {trace.status}
-                          </span>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
-
-        {/* Waterfall panel */}
-        {selectedTraceId && (
-          <div className="flex-1 min-h-0 min-w-0">
-            {isLoadingDetail && !traceDetail && (
-              <div className="flex items-center justify-center h-full">
-                <div className="w-8 h-8 rounded-full border-2 border-primary/30 border-t-primary animate-spin" />
-              </div>
-            )}
-            {traceDetail && (
-              <TraceWaterfall
-                trace={traceDetail}
-                onClose={() => selectTrace(null)}
-              />
-            )}
-          </div>
-        )}
+      {/* Content — shared trace surface (filters, list, waterfall) */}
+      <main className="flex-1 min-h-0">
+        <TracesView active servers={servers} />
       </main>
 
       {/* Footer */}
       <footer className="h-6 flex-shrink-0 bg-surface/90 backdrop-blur-xl border-t border-border/50 flex items-center justify-between px-4 text-[10px] text-text-muted">
-        <span>{traces.length > 0 ? `${traces.length} trace${traces.length !== 1 ? 's' : ''}` : 'No data'}</span>
+        <span>Traces</span>
         <span className="flex items-center gap-1">
           <span className="w-1.5 h-1.5 rounded-full bg-text-muted animate-pulse" />
           Detached Window

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -18,6 +18,8 @@ const VaultWorkspace = lazy(() => import('./components/workspaces/VaultWorkspace
 const ToolsWorkspace = lazy(() => import('./components/workspaces/ToolsWorkspace'));
 const MetricsWorkspace = lazy(() => import('./components/workspaces/MetricsWorkspace'));
 const PinsWorkspace = lazy(() => import('./components/workspaces/PinsWorkspace'));
+const LogsWorkspace = lazy(() => import('./components/workspaces/LogsWorkspace'));
+const TracesWorkspace = lazy(() => import('./components/workspaces/TracesWorkspace'));
 
 export function AppRoutes() {
   // Single mount point for theme application + cross-window sync; covers the
@@ -88,6 +90,22 @@ export function AppRoutes() {
             </Suspense>
           }
         />
+        <Route
+          path="/logs"
+          element={
+            <Suspense fallback={<WorkspaceLoadingShell />}>
+              <LogsWorkspace />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/traces"
+          element={
+            <Suspense fallback={<WorkspaceLoadingShell />}>
+              <TracesWorkspace />
+            </Suspense>
+          }
+        />
       </Route>
 
       {/* Root redirect — chooses a workspace based on stack + storage. */}
@@ -104,17 +122,17 @@ export function AppRoutes() {
       <Route path="/agent" element={<Navigate to="/library" replace />} />
 
       {/* Detached windows stay frameless — outside AppShell on purpose. */}
-      <Route path="/logs" element={<DetachedLogsPage />} />
       <Route path="/sidebar" element={<DetachedSidebarPage />} />
       <Route path="/editor" element={<DetachedEditorPage />} />
       <Route path="/library-window" element={<DetachedRegistryPage />} />
       {/* /registry → /library-window: silent redirect for bookmarks and
           existing detached window handles. */}
       <Route path="/registry" element={<Navigate to="/library-window" replace />} />
-      {/* /metrics is now the in-shell Metrics workspace; the detached popout
-          renders at /metrics-window (window type key stays `metrics`). */}
+      {/* /metrics, /logs, and /traces are in-shell workspaces; each detached
+          popout renders at /<type>-window (window type keys stay put). */}
       <Route path="/metrics-window" element={<DetachedMetricsPage />} />
-      <Route path="/traces" element={<DetachedTracesPage />} />
+      <Route path="/logs-window" element={<DetachedLogsPage />} />
+      <Route path="/traces-window" element={<DetachedTracesPage />} />
 
       {/* Catch-all: any unmatched URL (typo, stale bookmark, removed route)
           redirects to the root, where RootRedirect resolves the landing

--- a/web/src/stores/useUIStore.ts
+++ b/web/src/stores/useUIStore.ts
@@ -36,6 +36,8 @@ export const COMPACT_MODE_DEFAULTS: CompactModeMap = {
   tools: false,
   metrics: false,
   pins: false,
+  logs: false,
+  traces: false,
 };
 
 export interface CompactModeSlice {

--- a/web/src/types/workspace.ts
+++ b/web/src/types/workspace.ts
@@ -1,9 +1,9 @@
 import type { LucideIcon } from 'lucide-react';
-import { BarChart3, Layers, Library, Lock, Pin, Wrench } from 'lucide-react';
+import { Activity, BarChart3, Layers, Library, Lock, Pin, ScrollText, Wrench } from 'lucide-react';
 
 // Top-level workspaces in the unified shell. Routed at /stack, /library,
-// /vault, /tools, /metrics, and /pins inside AppShell.
-export type Workspace = 'stack' | 'library' | 'vault' | 'tools' | 'metrics' | 'pins';
+// /vault, /tools, /metrics, /pins, /logs, and /traces inside AppShell.
+export type Workspace = 'stack' | 'library' | 'vault' | 'tools' | 'metrics' | 'pins' | 'logs' | 'traces';
 
 export interface WorkspaceConfig {
   id: Workspace;
@@ -23,6 +23,8 @@ export const WORKSPACE_CONFIG: readonly WorkspaceConfig[] = [
   { id: 'tools',    label: 'Tools',     icon: Wrench,    shortcutKey: '4' },
   { id: 'metrics',  label: 'Metrics',   icon: BarChart3, shortcutKey: '5' },
   { id: 'pins',     label: 'Pins',      icon: Pin,       shortcutKey: '6' },
+  { id: 'logs',     label: 'Logs',      icon: ScrollText, shortcutKey: '7' },
+  { id: 'traces',   label: 'Traces',    icon: Activity,   shortcutKey: '8' },
 ] as const;
 
 // Derived for back-compat with existing call-sites in useUIStore, AppShell,


### PR DESCRIPTION
## Description

Adds Logs and Traces as top-level workspaces (Cmd+7 / Cmd+8), the additive half of #943. The Logs workspace shows the aggregate stream from the gateway and every server with no canvas selection required; the Traces workspace carries the full trace list, waterfall, and span detail. The bottom panel is untouched in this PR; its removal follows in the subtractive phase.

## Type of Change

- [x] New feature

## Changes Made

- New `/logs` workspace: aggregate stream via `GET /api/logs` only (per-server views are client-side filters, never a second fetch path), source rail (all / gateway / per server), per-line source badges in the all-sources view, severity/search/trace filters URL-synced (`?agent=`, `?level=`, `?q=`, `?trace=`), follow/pause with scroll-position preservation, text zoom, copy, clear, popout
- New `/traces` workspace: existing global trace surface with URL-synced selection and filters (`?trace=`, `?server=`, `?errors=`, `?q=`)
- Cross-links: log lines carrying a trace ID pivot to `/traces?trace=<id>`; the waterfall header pivots back to `/logs?trace=<id>`
- Shared cores extracted (`useLogStream`, `LogFilterBar`, `LogStream`, `TracesView`) so each workspace and its detached popout share one implementation; detached pages rebuilt on them
- Popout routes migrate to `/logs-window` and `/traces-window` (same pattern as `/metrics-window`; window-type keys and broadcast channels unchanged, existing handles keep working); legacy `?agent=Gateway` links normalize to the canonical `gateway` token
- Workspace nav pills collapse to icons below 1360px so all eight fit without clipping the header action cluster
- Disabling every severity level round-trips through a `level=none` sentinel instead of silently resetting to all levels
- Trace search no longer refetches from the server per keystroke (client-side filter only)

## Testing

- `make test-frontend`: 1258 tests across 125 files pass, including new suites for both workspaces and the log source helpers
- `cd web && npm run lint`: zero errors
- `make build` embeds the UI and compiles cleanly

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed
- [x] Changelog entry under [Unreleased]

Part of #943