### PR TITLE
chore: group react packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,12 @@ updates:
       rjsf:
         patterns:
           - "@rjsf/*"
+      # react-dom pins its peer react to the exact same version, so a solo
+      # bump of either one fails npm ci with an unresolvable peer conflict
+      # (see the react-dom 19.2.8 bump). Group them so they move in lockstep.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"


### PR DESCRIPTION
## Description

Group react, react-dom, and their type packages in Dependabot's npm config so they bump together. react-dom pins its peer react to the exact same version, so a solo bump of either fails `npm ci` with an unresolvable ERESOLVE peer conflict, which is what broke the frontend check on #971 (react-dom 19.2.8 against react 19.2.7).

## Type of Change

- [x] Chore (CI/config change, no functional impact)

## Changes Made

- Add a `react` group (`react`, `react-dom`, `@types/react`, `@types/react-dom`) to the npm ecosystem in `.github/dependabot.yml`, beside the existing `rjsf` group

## Testing

Config-only; validated against the Dependabot v2 schema. Future react bumps arrive as a single grouped PR.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed