### PR TITLE
refactor: drop version string from header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ All notable changes to gridctl will be documented in this file.
 
 ### Refactoring
 
+- Removed the gateway version string from the header, where it sat beside the wordmark competing with the brand mark and the workspace switcher for the app's most valuable real estate. It already appeared on the gateway node in the Stack canvas and in the gateway inspector sidebar, and those are the accurate homes for it: the version is a property of the gateway reported over `/api/status`, so beside the wordmark it read as the version of the web UI itself. This is the third header removal in the same direction, after the gateway-name chip, connection state, and server counts moved to the status bar. Nothing changes when the gateway is unreachable, since the header string was already conditional on gateway info being present; while connected, the version is now reached by way of the Stack workspace or `gridctl version`
+
 - Removed the header Variables panel, a second, weaker rendering of the same vault that could be opened while already standing on the Variables workspace. It never received the usage index, so it showed no consumer counts anywhere, and its delete confirmation omitted the consumer count and bulk-injection warning the workspace shows, making it the less safe of two delete paths for identical data. The header gear that opened it is gone entirely, since the workspace switcher sits in the same header and Variables has been a first-class tab since the bottom-panel removal; the creation wizard's Secret tile now navigates to the workspace instead of opening the panel
 
 

--- a/web/src/__tests__/GatewayNode.test.tsx
+++ b/web/src/__tests__/GatewayNode.test.tsx
@@ -31,6 +31,14 @@ function renderNode(data: GatewayNodeData = baseData) {
 }
 
 describe('GatewayNode', () => {
+  // The node is the primary surface for the gateway's identity now that the
+  // header no longer carries the version.
+  it('renders the gateway name and version', () => {
+    renderNode();
+    expect(screen.getByText('acme-stack')).toBeInTheDocument();
+    expect(screen.getByText('v9.9.9')).toBeInTheDocument();
+  });
+
   it('renders Code Mode as read-only status, not an action', () => {
     renderNode();
     const codeMode = screen.getByText('Code Mode').closest('[role="status"]');

--- a/web/src/__tests__/Header.test.tsx
+++ b/web/src/__tests__/Header.test.tsx
@@ -37,10 +37,14 @@ describe('Header', () => {
     expect(screen.queryByText(/active/i)).not.toBeInTheDocument();
   });
 
-  it('drops the gateway-name chip but keeps the version beside the logo', () => {
+  // The gateway name and version are both properties of the gateway, surfaced
+  // on the canvas node and inspector sidebar. Neither belongs in the header.
+  // gatewayInfo is populated in beforeEach, so these assertions prove the
+  // header omits values that are available to it rather than an empty store.
+  it('drops the gateway-name chip and the version beside the logo', () => {
     renderHeader();
     expect(screen.queryByText('acme-stack')).not.toBeInTheDocument();
-    expect(screen.getByText('v9.9.9')).toBeInTheDocument();
+    expect(screen.queryByText('v9.9.9')).not.toBeInTheDocument();
   });
 
   it('keeps the persistence quick-toggle while connected', () => {

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -24,7 +24,6 @@ interface HeaderProps {
 
 export function Header({ onRefresh, isRefreshing }: HeaderProps) {
   const navigate = useNavigate();
-  const gatewayInfo = useStackStore((s) => s.gatewayInfo);
   const connectionStatus = useStackStore((s) => s.connectionStatus);
 
   const toggleCommandPalette = useUIStore((s) => s.toggleCommandPalette);
@@ -107,18 +106,14 @@ export function Header({ onRefresh, isRefreshing }: HeaderProps) {
       {/* Subtle gradient line at top */}
       <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-primary/30 to-transparent" />
 
-      {/* Left: Logo & Version + Workspace Switcher */}
+      {/* Left: Logo + Workspace Switcher. The gateway version is deliberately
+          absent here. It is a property of the gateway reported over
+          /api/status, not of the UI shell, so it belongs with the gateway's
+          other properties on the canvas node and inspector sidebar rather than
+          beside the wordmark. */}
       <div className="flex items-center gap-4">
-        <div className="flex items-center gap-3">
-          {/* Brand Logo — inline so "ctl" follows the theme (readable on light) */}
-          <LogoWordmark className="h-10 w-auto block" />
-          {/* Version */}
-          {gatewayInfo?.version && (
-            <span className="text-xs font-mono text-text-muted tracking-wide">
-              {gatewayInfo.version}
-            </span>
-          )}
-        </div>
+        {/* Brand Logo — inline so "ctl" follows the theme (readable on light) */}
+        <LogoWordmark className="h-10 w-auto block" />
         <WorkspaceSwitcher />
       </div>
 


### PR DESCRIPTION
## Description

Removes the gateway version string from the header, where it sat beside the wordmark duplicating what the gateway node and inspector sidebar already show. The version is a property of the gateway reported over `/api/status`, so beside the wordmark it read as the version of the web UI itself; on the gateway surfaces it sits among the gateway's other properties, which is what it actually is.

This is the third header removal in the same direction, after the gateway-name chip, connection state, and server counts moved to the status bar.

## Type of Change

- [x] Refactor (no functional change to gateway behavior)

## Changes Made

- Removed the version block from `Header.tsx`, along with the `gatewayInfo` store selector it was the sole consumer of and the wrapper element left holding only the logo.
- Inverted the header test that asserted the version was present. The `gatewayInfo` fixture stays populated so the negative assertion proves the header omits a value available to it, rather than an empty store.
- Added the missing assertion that the gateway node renders its name and version. The node is the primary version surface now and had no test covering it, despite setting `version` in its fixture.
- Changelog entry under `[Unreleased]`.

`gatewayInfo.version` is untouched in the store and still feeds `GatewayNode` and `GatewaySidebar`. No backend, API, or schema changes; `gridctl version` is unaffected.

## Testing

`npm test` (1651 tests, 142 files) and `npm run lint` (zero errors) pass. Verified against a real build on a scratch port in both light and dark themes: the version is absent from the header on Stack and Library, still present on the gateway node, and the left cluster resolves to exactly two children (logo and workspace switcher) with no leftover wrapper.

Note this is not a regression when the gateway is unreachable. The header string was already conditional on gateway info being present, so it was already absent in that state. While connected, the version is reached via the Stack workspace or `gridctl version`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #1001
