### PR TITLE
Release v0.1.0-beta.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to gridctl will be documented in this file.
 
-## [Unreleased]
+## [0.1.0-beta.15] - 2026-07-28
 
 
 ### Features

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -7,7 +7,7 @@ Gridctl is pre-1.0 software. This page tracks the stability tier of each feature
 - **Stable** - production-ready. Backward-compatible changes only within the `0.x` line; breaking changes ride a clearly-labeled release.
 - **Experimental** - usable but the API, CLI surface, or output shape may change without notice. Pin a version if you build automation on top of it.
 
-Current as of **v0.1.0-beta.14** plus unreleased work on `main` (see [CHANGELOG.md](../CHANGELOG.md) for release-by-release detail).
+Current as of **v0.1.0-beta.15** (see [CHANGELOG.md](../CHANGELOG.md) for release-by-release detail).
 
 ## Feature stability
 


### PR DESCRIPTION
## Release v0.1.0-beta.15

Promotes the `[Unreleased]` changelog section to a dated release heading and bumps the project-status version marker. 73 commits since `v0.1.0-beta.14`, no breaking changes.

Headline surfaces in this release: native OAuth brokering for remote servers, the MCP server catalog (`search` / `add`), client config import, tool groups with per-group endpoints, budget caps and rate limits, poisoning-aware schema pins with a review flow, declarative client linking, skill projection into native client directories, and four new workspaces (Metrics, Pins, Logs, Traces).

## Changes

- `CHANGELOG.md`: `## [Unreleased]` → `## [0.1.0-beta.15] - 2026-07-28`
- `docs/project-status.md`: version marker bumped to v0.1.0-beta.15

## Pre-release checks

| Check | Result |
|---|---|
| `golangci-lint run --timeout 3m` | 0 issues |
| `go test -race ./...` | pass, 35 packages, no data races |
| `go build ./cmd/gridctl/` | pass |
| `npm ci && npm run build` (web) | pass |

## Note on changelog generation

The changelog was **not** regenerated with `git-cliff`. Regeneration rewrites the file from commit subjects, which would have replaced 128 lines of hand-authored release notes in `[Unreleased]` with terse one-liners and discarded the per-PR detail Article XV exists to capture. The section was promoted to a dated heading instead, preserving its content byte-for-byte (verified by whitespace-stripped comparison against the pre-release file).

Worth deciding separately: `cliff.toml` remains configured for full-file regeneration, so the same data loss is one `git-cliff -o CHANGELOG.md` away for the next release.

## Checklist

- [x] All checks passed (lint, test, build, web build)
- [x] Changelog updated
- [ ] PR reviewed and approved
- [ ] After merge, run `/release-gridctl --tag` to create the release tag