### PR TITLE
fix: restart stopped container-backed MCP servers on apply

### DIFF
--- a/pkg/runtime/orchestrator.go
+++ b/pkg/runtime/orchestrator.go
@@ -142,7 +142,6 @@ func (o *Orchestrator) SetCredentialResolver(r CredentialResolver) {
 	o.credentialResolver = r
 }
 
-
 // RuntimeInfo returns the detected runtime info, or nil if not set.
 func (o *Orchestrator) RuntimeInfo() *RuntimeInfo {
 	return o.runtimeInfo
@@ -350,6 +349,13 @@ func nReplicaPlaceholders(n int) []MCPServerReplica {
 func (o *Orchestrator) startMCPServer(ctx context.Context, stack *config.Stack, server *config.MCPServer, opts UpOptions, hostPort, replicaID, totalReplicas int) (*MCPServerResult, error) {
 	runtimeName := ReplicaContainerName(stack.Name, server.Name, replicaID, totalReplicas)
 
+	// Name drives both container name and DNS alias; for multi-replica
+	// servers we suffix it so replicas don't collide.
+	workloadName := server.Name
+	if totalReplicas > 1 {
+		workloadName = fmt.Sprintf("%s-replica-%d", server.Name, replicaID)
+	}
+
 	// Check if container already exists
 	exists, workloadID, err := o.runtime.Exists(ctx, runtimeName)
 	if err != nil {
@@ -358,6 +364,19 @@ func (o *Orchestrator) startMCPServer(ctx context.Context, stack *config.Stack, 
 
 	if exists {
 		o.logger.Info("MCP server already exists, starting", "name", server.Name, "replica", replicaID)
+
+		status, err := o.runtime.Status(ctx, workloadID)
+		if err != nil {
+			return nil, err
+		}
+		if status.State != WorkloadStateRunning {
+			// A previous shutdown left this container stopped; restart it
+			// rather than handing a dead container to the MCP client.
+			if _, err := o.runtime.Start(ctx, WorkloadConfig{Name: workloadName, Stack: stack.Name}); err != nil {
+				return nil, err
+			}
+		}
+
 		// Get actual host port
 		actualHostPort, _ := o.runtime.GetHostPort(ctx, workloadID, server.Port)
 		return &MCPServerResult{
@@ -415,13 +434,8 @@ func (o *Orchestrator) startMCPServer(ctx context.Context, stack *config.Stack, 
 		networkName = server.Network
 	}
 
-	// Create workload config. Name drives both container name and DNS alias;
-	// for multi-replica servers we suffix it so replicas don't collide. Labels
-	// still carry the logical server name so Down/List filters by stack work.
-	workloadName := server.Name
-	if totalReplicas > 1 {
-		workloadName = fmt.Sprintf("%s-replica-%d", server.Name, replicaID)
-	}
+	// Create workload config. Labels still carry the logical server name so
+	// Down/List filters by stack work.
 	cfg := WorkloadConfig{
 		Name:        workloadName,
 		Stack:       stack.Name,

--- a/pkg/runtime/orchestrator_restart_test.go
+++ b/pkg/runtime/orchestrator_restart_test.go
@@ -1,0 +1,68 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"go.uber.org/mock/gomock"
+)
+
+// TestOrchestrator_Up_MCPServer_RestartsStoppedContainer reproduces the bug
+// where `apply` silently handed a stopped container to the MCP client
+// builder instead of restarting it first: startMCPServer's "exists" branch
+// returned early on Exists() alone, without ever checking run state or
+// calling Start, so a container left Exited by a previous shutdown was
+// never brought back up. The gateway then hung on the stdio initialize
+// handshake against a process that wasn't running.
+func TestOrchestrator_Up_MCPServer_RestartsStoppedContainer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRT := NewMockWorkloadRuntime(ctrl)
+	mockBuilder := &MockBuilder{}
+
+	mockRT.EXPECT().Ping(gomock.Any()).Return(nil).AnyTimes()
+	mockRT.EXPECT().Close().Return(nil).AnyTimes()
+	mockRT.EXPECT().EnsureNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	existingID := WorkloadID("existing-github-container")
+	mockRT.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(true, existingID, nil).AnyTimes()
+
+	// The container exists but is stopped, matching `docker ps -a` showing
+	// "Exited (0)" after a previous gridctl shutdown.
+	mockRT.EXPECT().Status(gomock.Any(), existingID).Return(&WorkloadStatus{
+		ID:    existingID,
+		State: WorkloadStateStopped,
+	}, nil).Times(1)
+
+	mockRT.EXPECT().Start(gomock.Any(), gomock.Any()).Return(&WorkloadStatus{
+		ID:    existingID,
+		State: WorkloadStateRunning,
+	}, nil).Times(1)
+
+	mockRT.EXPECT().GetHostPort(gomock.Any(), existingID, gomock.Any()).Return(0, nil).AnyTimes()
+
+	orch := NewOrchestrator(mockRT, mockBuilder)
+	orch.SetLogger(testLogger())
+
+	topo := &config.Stack{
+		Version: "1",
+		Name:    "test-restart",
+		Network: config.Network{Name: "test-net", Driver: "bridge"},
+		MCPServers: []config.MCPServer{
+			{
+				Name:      "github",
+				Image:     "ghcr.io/github/github-mcp-server:latest",
+				Transport: "stdio",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	result, err := orch.Up(ctx, topo, UpOptions{BasePort: 9000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.MCPServers) != 1 {
+		t.Fatalf("expected 1 MCP server, got %d", len(result.MCPServers))
+	}
+}


### PR DESCRIPTION
## Summary
- `startMCPServer` checked only `Exists()` (presence) and returned immediately when a container by that name was already present, never checking run state or calling `Start`. A container left `Exited` by a prior shutdown was handed to the MCP client unchanged, which then hung on the stdio initialize handshake until the transport timeout.
- Mirrors the `Status()` + `Start()` restart that `startResource` already does correctly for the `resources:` block.

Fixes #1007

## Test plan
- [x] Added `TestOrchestrator_Up_MCPServer_RestartsStoppedContainer` (`pkg/runtime/orchestrator_restart_test.go`); confirmed it fails against the pre-fix code (missing `Status`/`Start` calls) and passes after the fix.
- [x] `go build ./...`
- [x] `go test ./pkg/runtime/... ./pkg/controller/...` — all green, no regressions.