### PR TITLE
chore: add roadmap board config

### DIFF
--- a/.github/roadmap.yml
+++ b/.github/roadmap.yml
@@ -1,0 +1,2 @@
+owner: gridctl
+project: 2


### PR DESCRIPTION
## Description

Pins the roadmap board coordinates so board-management tooling resolves the Gridctl Roadmap project without prompting.

## Type of Change

- [x] Chore

## Changes Made

- Add .github/roadmap.yml with owner and project number

## Testing

Tooling that reads .github/roadmap.yml resolves org gridctl, project 2; the file has no runtime effect on gridctl itself.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed