### PR TITLE
fix: land fetched commits in cached clone worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to gridctl will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- `gridctl skill add` and `gridctl skill update` now actually install upstream changes. The per-repo clone cache under `~/.gridctl/cache/repos/` was fetched on every run but the fetched commits never reached the checked-out worktree, so unpinned sources reported "already up to date" forever while branch-pinned sources reported "update available" on every run and reinstalled the same stale content. Updates now land the worktree on the freshly fetched remote-tracking tip for every ref shape (unpinned default branch, branch names, tags, and semver constraints, whose new matching tags were previously never detected), falling back to a fresh shallow clone when the fetched objects are incomplete. Cache mutations are serialized per repository, and offline behavior is unchanged: a failed fetch still degrades to the cached content with a warning. No manual cache clearing is needed after upgrading; the first `skill update` installs correctly. One exception: a skill whose upstream version was reviewed and skipped as locally-edited during a web sync recorded that version as seen, so it needs one `gridctl skill update --force <name>` to install it (#1010)
+
 ## [0.1.0-beta.15] - 2026-07-28
 
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -595,6 +595,18 @@ Static heuristics are one layer. Published benchmarks put signature-only detecti
 
 ---
 
+## Skills
+
+### Where imported skill sources are cached
+
+`gridctl skill add` clones each source repo into `~/.gridctl/cache/repos/<hash>/`, where `<hash>` is derived from the repo URL. The cache holds only clones; everything user-facing lives elsewhere (installed skills in `~/.gridctl/registry/skills/`, tracking in `~/.gridctl/skills.lock.yaml`). Deleting the cache directory is always safe: the next `skill add`, `skill update`, or `gridctl apply` that needs a repo re-clones it. The same cache is shared with git-sourced MCP server image builds, so a wholesale delete costs one re-clone per git source on the next apply.
+
+### `skill update` does not pick up an upstream change
+
+`skill update` fetches the source and installs whatever the pinned ref (or the default branch, for unpinned sources) now points at. Sources pinned to a version tag or full commit SHA are deliberately skipped by a bulk `gridctl skill update`; update them explicitly by name, or re-pin. A skill with local edits (drift) is also skipped so your changes are not overwritten; resolve the drift or pass `--force` to discard local edits and reinstall upstream (a backup of the edited `SKILL.md` is kept beside the skill). If a drifted skill was previously skipped during a web UI sync, its reviewed upstream version was recorded as seen, so a plain update reports up to date; `gridctl skill update --force <name>` installs it. When the network is unreachable, updates degrade to the cached content with a warning rather than failing.
+
+---
+
 ## General
 
 ### Getting help

--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -11,8 +11,10 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 )
@@ -29,7 +31,12 @@ type CloneOptions struct {
 // FetchOptions configures a Fetch call.
 type FetchOptions struct {
 	AllTags bool
-	Auth    transport.AuthMethod
+	// AllBranches fetches every remote branch with an explicit refspec,
+	// overriding the refspec stored at clone time. A single-branch clone's
+	// remote config only covers its own branch, so without this a later
+	// fetch cannot see branches (or a default branch) added upstream.
+	AllBranches bool
+	Auth        transport.AuthMethod
 }
 
 // Clone performs a plain git clone into destPath. When Ref is set it first
@@ -78,6 +85,9 @@ func Fetch(repoPath string, opts FetchOptions, logger *slog.Logger) error {
 	if opts.AllTags {
 		fetchOpts.Tags = gogit.AllTags
 	}
+	if opts.AllBranches {
+		fetchOpts.RefSpecs = []config.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}
+	}
 	if err := r.Fetch(fetchOpts); err != nil && err != gogit.NoErrAlreadyUpToDate {
 		return err
 	}
@@ -125,19 +135,134 @@ func Checkout(repo *gogit.Repository, ref string) error {
 	return fmt.Errorf("unable to checkout ref %q", ref)
 }
 
-// ResolveRef returns the commit hash for ref by consulting, in order:
-// tag, remote branch (origin), local branch.
-func ResolveRef(repo *gogit.Repository, ref string) (string, error) {
+// DefaultBranch returns the short name of the remote's default branch. It
+// consults, in order: the origin/HEAD symbolic ref (when the clone recorded
+// one), the local HEAD's branch when a matching remote-tracking ref exists,
+// and finally the remote-tracking branches themselves (a sole branch wins;
+// otherwise "main" then "master"). It works from a detached HEAD, which is
+// the resting state of a cache worktree after SyncWorktree.
+func DefaultBranch(repo *gogit.Repository) (string, error) {
+	if ref, err := repo.Reference("refs/remotes/origin/HEAD", false); err == nil && ref.Type() == plumbing.SymbolicReference {
+		return strings.TrimPrefix(ref.Target().Short(), "origin/"), nil
+	}
+
+	if head, err := repo.Reference(plumbing.HEAD, false); err == nil && head.Type() == plumbing.SymbolicReference {
+		name := head.Target().Short()
+		if _, err := repo.Reference(plumbing.NewRemoteReferenceName("origin", name), true); err == nil {
+			return name, nil
+		}
+	}
+
+	refs, err := repo.References()
+	if err != nil {
+		return "", fmt.Errorf("listing references: %w", err)
+	}
+	var branches []string
+	_ = refs.ForEach(func(r *plumbing.Reference) error {
+		name := string(r.Name())
+		if strings.HasPrefix(name, "refs/remotes/origin/") && name != "refs/remotes/origin/HEAD" {
+			branches = append(branches, strings.TrimPrefix(name, "refs/remotes/origin/"))
+		}
+		return nil
+	})
+	if len(branches) == 1 {
+		return branches[0], nil
+	}
+	for _, candidate := range []string{"main", "master"} {
+		for _, b := range branches {
+			if b == candidate {
+				return candidate, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("unable to determine default branch")
+}
+
+// ResolveRemoteRef resolves ref to a commit hash, preferring freshly fetched
+// remote-tracking state over possibly-stale local refs: tag, remote branch
+// (origin), local branch, raw commit hash. An empty ref resolves the remote
+// default branch. Annotated tags are peeled to their target commit so the
+// result is always checkout-able and comparable against HEAD commits.
+func ResolveRemoteRef(repo *gogit.Repository, ref string) (string, error) {
+	sha, _, err := resolveRemote(repo, ref)
+	return sha, err
+}
+
+// resolveRemote is ResolveRemoteRef plus the branch name the resolution went
+// through ("" for tags and raw hashes), so SyncWorktree can re-attach HEAD.
+func resolveRemote(repo *gogit.Repository, ref string) (sha, branch string, err error) {
+	if ref == "" {
+		b, err := DefaultBranch(repo)
+		if err != nil {
+			return "", "", err
+		}
+		r, err := repo.Reference(plumbing.NewRemoteReferenceName("origin", b), true)
+		if err != nil {
+			return "", "", fmt.Errorf("resolving origin/%s: %w", b, err)
+		}
+		return r.Hash().String(), b, nil
+	}
 	if t, err := repo.Tag(ref); err == nil {
-		return t.Hash().String(), nil
+		return peelToCommit(repo, t.Hash()).String(), "", nil
 	}
 	if r, err := repo.Reference(plumbing.NewRemoteReferenceName("origin", ref), true); err == nil {
-		return r.Hash().String(), nil
+		return r.Hash().String(), ref, nil
 	}
 	if b, err := repo.Reference(plumbing.NewBranchReferenceName(ref), true); err == nil {
-		return b.Hash().String(), nil
+		return b.Hash().String(), ref, nil
 	}
-	return "", fmt.Errorf("unable to resolve ref %q", ref)
+	if h := plumbing.NewHash(ref); !h.IsZero() && len(ref) == 40 {
+		if _, err := repo.CommitObject(h); err == nil {
+			return h.String(), "", nil
+		}
+	}
+	return "", "", fmt.Errorf("unable to resolve ref %q", ref)
+}
+
+// peelToCommit dereferences an annotated tag object to its target commit;
+// lightweight tag and commit hashes pass through unchanged.
+func peelToCommit(repo *gogit.Repository, h plumbing.Hash) plumbing.Hash {
+	if tag, err := repo.TagObject(h); err == nil {
+		return tag.Target
+	}
+	return h
+}
+
+// SyncWorktree lands the worktree on the commit ResolveRemoteRef finds for
+// ref and returns its hash. Unlike Checkout, it never resolves through a
+// stale local branch: after a Fetch, this is what actually surfaces new
+// upstream commits in the worktree. Branch targets fast-forward the local
+// branch and keep HEAD attached (the equivalent of `git checkout -B <branch>
+// <sha>`) so default-branch resolution keeps working on later syncs; tag and
+// raw-hash targets leave HEAD detached. Repeated syncs are idempotent.
+func SyncWorktree(repo *gogit.Repository, ref string) (string, error) {
+	sha, branch, err := resolveRemote(repo, ref)
+	if err != nil {
+		return "", err
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("getting worktree: %w", err)
+	}
+
+	if branch != "" {
+		branchRef := plumbing.NewBranchReferenceName(branch)
+		if err := repo.Storer.SetReference(plumbing.NewHashReference(branchRef, plumbing.NewHash(sha))); err != nil {
+			return "", fmt.Errorf("updating branch %s: %w", branch, err)
+		}
+		if err := wt.Checkout(&gogit.CheckoutOptions{Branch: branchRef, Force: true}); err != nil {
+			return "", fmt.Errorf("checking out %s at %s: %w", branch, sha, err)
+		}
+		return sha, nil
+	}
+
+	if err := wt.Checkout(&gogit.CheckoutOptions{
+		Hash:  plumbing.NewHash(sha),
+		Force: true,
+	}); err != nil {
+		return "", fmt.Errorf("checking out %s: %w", sha, err)
+	}
+	return sha, nil
 }
 
 // Open is a thin wrapper around gogit.PlainOpen. It lets callers avoid

--- a/pkg/git/clone_test.go
+++ b/pkg/git/clone_test.go
@@ -219,7 +219,7 @@ func TestCheckout_InvalidRef(t *testing.T) {
 	}
 }
 
-func TestResolveRef_Tag(t *testing.T) {
+func TestResolveRemoteRef_Tag(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping git test in short mode")
 	}
@@ -233,16 +233,16 @@ func TestResolveRef_Tag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	sha, err := ResolveRef(repo, "v1.0.0")
+	sha, err := ResolveRemoteRef(repo, "v1.0.0")
 	if err != nil {
-		t.Fatalf("ResolveRef: %v", err)
+		t.Fatalf("ResolveRemoteRef: %v", err)
 	}
 	if sha == "" {
 		t.Fatal("empty sha")
 	}
 }
 
-func TestResolveRef_Unknown(t *testing.T) {
+func TestResolveRemoteRef_Unknown(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping git test in short mode")
 	}
@@ -256,7 +256,7 @@ func TestResolveRef_Unknown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if _, err := ResolveRef(repo, "does-not-exist"); err == nil {
+	if _, err := ResolveRemoteRef(repo, "does-not-exist"); err == nil {
 		t.Fatal("expected error for unknown ref")
 	}
 }

--- a/pkg/git/sync_test.go
+++ b/pkg/git/sync_test.go
@@ -1,0 +1,264 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// initWorkRepo creates a non-bare repo with one commit on master and an
+// annotated tag v1.0.0, and returns its path. Unlike initBareRepo it stays
+// writable, so tests can push follow-up commits into it via commitFile.
+func initWorkRepo(t *testing.T) string {
+	t.Helper()
+
+	workDir := t.TempDir()
+	repo, err := gogit.PlainInit(workDir, false)
+	if err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("# Test repo"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if _, err := wt.Add("README.md"); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	sig := &object.Signature{Name: "test", Email: "test@test.com"}
+	commitHash, err := wt.Commit("initial commit", &gogit.CommitOptions{Author: sig})
+	if err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	if _, err := repo.CreateTag("v1.0.0", commitHash, &gogit.CreateTagOptions{
+		Tagger:  sig,
+		Message: "v1.0.0",
+	}); err != nil {
+		t.Fatalf("create tag: %v", err)
+	}
+	return workDir
+}
+
+// commitFile writes a file into the repo at repoPath and commits it,
+// returning the new commit hash.
+func commitFile(t *testing.T, repoPath, name, content, msg string) string {
+	t.Helper()
+
+	repo, err := gogit.PlainOpen(repoPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, name), []byte(content), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if _, err := wt.Add(name); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	hash, err := wt.Commit(msg, &gogit.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com"},
+	})
+	if err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	return hash.String()
+}
+
+// makeStaleClone clones srcPath and manufactures the post-fetch stale state
+// the bug lives in: the remote-tracking branch points at a fresh commit while
+// the local branch (and worktree) remain on the old one. The fresh commit is
+// created inside the clone so its objects are present locally, keeping the
+// test independent of fetch object-transfer behavior.
+func makeStaleClone(t *testing.T, srcPath, destPath string) (repo *gogit.Repository, staleSHA, freshSHA string) {
+	t.Helper()
+
+	repo, err := Clone(destPath, CloneOptions{URL: srcPath}, testLogger())
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	staleSHA = head.Hash().String()
+
+	freshSHA = commitFile(t, destPath, "README.md", "# Updated", "second commit")
+
+	// origin/master advances to the fresh commit (what a fetch does)...
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(
+		plumbing.NewRemoteReferenceName("origin", "master"), plumbing.NewHash(freshSHA))); err != nil {
+		t.Fatalf("set origin/master: %v", err)
+	}
+	// ...while the local branch and worktree stay on the old one (what a
+	// fetch does NOT touch).
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(
+		plumbing.NewBranchReferenceName("master"), plumbing.NewHash(staleSHA))); err != nil {
+		t.Fatalf("reset local master: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if err := wt.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName("master"), Force: true,
+	}); err != nil {
+		t.Fatalf("checkout stale master: %v", err)
+	}
+	return repo, staleSHA, freshSHA
+}
+
+// TestSyncWorktree_AdvancesStaleLocalBranch is the pkg/git regression test
+// for the stale-clone bug: checking out by branch name lands on the stale
+// local branch, while SyncWorktree must land on the remote-tracking tip.
+func TestSyncWorktree_AdvancesStaleLocalBranch(t *testing.T) {
+	srcPath := initWorkRepo(t)
+	destPath := filepath.Join(t.TempDir(), "clone")
+	repo, staleSHA, freshSHA := makeStaleClone(t, srcPath, destPath)
+
+	gotSHA, err := SyncWorktree(repo, "master")
+	if err != nil {
+		t.Fatalf("sync worktree: %v", err)
+	}
+	if gotSHA != freshSHA {
+		t.Errorf("synced to %s, want %s (stale was %s)", gotSHA, freshSHA, staleSHA)
+	}
+
+	data, err := os.ReadFile(filepath.Join(destPath, "README.md"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if !strings.Contains(string(data), "Updated") {
+		t.Errorf("worktree not advanced, README.md = %q", string(data))
+	}
+}
+
+// TestSyncWorktree_DefaultBranchIdempotent covers the unpinned (ref == "")
+// case, including a second sync from the detached-HEAD state the first one
+// leaves behind.
+func TestSyncWorktree_DefaultBranchIdempotent(t *testing.T) {
+	srcPath := initWorkRepo(t)
+	destPath := filepath.Join(t.TempDir(), "clone")
+	repo, _, freshSHA := makeStaleClone(t, srcPath, destPath)
+
+	first, err := SyncWorktree(repo, "")
+	if err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if first != freshSHA {
+		t.Errorf("first sync landed on %s, want %s", first, freshSHA)
+	}
+
+	// A branch sync re-attaches HEAD; a repeat sync must resolve the default
+	// branch again and be a no-op.
+	second, err := SyncWorktree(repo, "")
+	if err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if second != first {
+		t.Errorf("second sync landed on %s, want %s", second, first)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	if head.Name().Short() != "master" {
+		t.Errorf("HEAD = %s, want re-attached to master", head.Name())
+	}
+}
+
+// TestDefaultBranch_DetachedHead confirms default-branch resolution survives
+// a genuinely detached HEAD (the resting state after a tag or raw-hash sync)
+// by falling back to remote-tracking branch enumeration.
+func TestDefaultBranch_DetachedHead(t *testing.T) {
+	srcPath := initWorkRepo(t)
+	destPath := filepath.Join(t.TempDir(), "clone")
+
+	repo, err := Clone(destPath, CloneOptions{URL: srcPath}, testLogger())
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if err := wt.Checkout(&gogit.CheckoutOptions{Hash: head.Hash(), Force: true}); err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+
+	branch, err := DefaultBranch(repo)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	if branch != "master" {
+		t.Errorf("default branch = %q, want master", branch)
+	}
+}
+
+// TestResolveRemoteRef_AnnotatedTagPeels asserts an annotated tag resolves to
+// its target commit, not the tag object, so the result compares cleanly
+// against HEAD commits and checks out by hash.
+func TestResolveRemoteRef_AnnotatedTagPeels(t *testing.T) {
+	srcPath := initWorkRepo(t) // carries annotated tag v1.0.0 on the initial commit
+	destPath := filepath.Join(t.TempDir(), "clone")
+
+	repo, err := Clone(destPath, CloneOptions{URL: srcPath, AllTags: true}, testLogger())
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+
+	sha, err := ResolveRemoteRef(repo, "v1.0.0")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if sha != head.Hash().String() {
+		t.Errorf("resolved %s, want peeled commit %s", sha, head.Hash().String())
+	}
+
+	if _, err := SyncWorktree(repo, "v1.0.0"); err != nil {
+		t.Errorf("sync to annotated tag: %v", err)
+	}
+}
+
+// TestResolveRemoteRef_RawSHA covers the hash fallback used when reconcile
+// passes a resolved commit hash as the ref.
+func TestResolveRemoteRef_RawSHA(t *testing.T) {
+	srcPath := initWorkRepo(t)
+	destPath := filepath.Join(t.TempDir(), "clone")
+
+	repo, err := Clone(destPath, CloneOptions{URL: srcPath}, testLogger())
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+
+	sha, err := ResolveRemoteRef(repo, head.Hash().String())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if sha != head.Hash().String() {
+		t.Errorf("resolved %s, want %s", sha, head.Hash().String())
+	}
+}

--- a/pkg/skills/importer_test.go
+++ b/pkg/skills/importer_test.go
@@ -270,6 +270,188 @@ func TestImporter_Update_PreservesState(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, registry.StateDisabled, sk.State,
 		"disabled skill should remain disabled after sync")
+	assert.Contains(t, sk.Body, "Second version.",
+		"update must install the new upstream content, not re-render the cached worktree")
+}
+
+// TestImporter_Update_UnpinnedInstallsFresh is the regression test for the
+// stale clone cache bug: an unpinned source (Ref == "", the default `gridctl
+// skill add <repo>` shape) must detect an upstream commit and install its
+// content, not report "already up to date" against the frozen first-import
+// worktree.
+func TestImporter_Update_UnpinnedInstallsFresh(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+	repoDir, repo := initSkillRepo(t, "# Test\n\nFirst version.\n")
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	result, err := imp.Import(ImportOptions{Repo: repoDir, Trust: true})
+	require.NoError(t, err)
+	require.Len(t, result.Imported, 1)
+
+	commitChange(t, repo, repoDir, "# Test\n\nSecond version.\n")
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	updateResult, err := imp.Update("test-skill", false, false, false)
+	require.NoError(t, err)
+	require.Len(t, updateResult.Imported, 1, "expected a re-import after upstream change, got warnings: %v", updateResult.Warnings)
+
+	data, err := os.ReadFile(filepath.Join(regDir, "skills", "test-skill", "SKILL.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "Second version.", "on-disk registry copy must carry the new upstream content")
+
+	origin, err := ReadOrigin(filepath.Join(regDir, "skills", "test-skill"))
+	require.NoError(t, err)
+	assert.Equal(t, head.Hash().String(), origin.CommitSHA, "origin must record the new upstream commit")
+
+	// A repeat update is a clean no-op, not a perpetual "update available".
+	repeat, err := imp.Update("test-skill", false, false, false)
+	require.NoError(t, err)
+	assert.Empty(t, repeat.Imported)
+	require.NotEmpty(t, repeat.Warnings)
+	assert.Contains(t, repeat.Warnings[0], "already up to date")
+}
+
+// TestImporter_Update_PinnedBranchInstallsFresh covers the branch-pinned
+// profile of the same bug: update detected the change but re-installed the
+// stale worktree, looping on "update available" forever.
+func TestImporter_Update_PinnedBranchInstallsFresh(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+	repoDir, repo := initSkillRepo(t, "# Test\n\nFirst version.\n")
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	result, err := imp.Import(ImportOptions{Repo: repoDir, Ref: "master", Trust: true})
+	require.NoError(t, err)
+	require.Len(t, result.Imported, 1)
+
+	commitChange(t, repo, repoDir, "# Test\n\nSecond version.\n")
+
+	updateResult, err := imp.Update("test-skill", false, false, false)
+	require.NoError(t, err)
+	require.Len(t, updateResult.Imported, 1)
+
+	data, err := os.ReadFile(filepath.Join(regDir, "skills", "test-skill", "SKILL.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "Second version.")
+
+	repeat, err := imp.Update("test-skill", false, false, false)
+	require.NoError(t, err)
+	assert.Empty(t, repeat.Imported, "second update must not loop on a phantom change")
+	require.NotEmpty(t, repeat.Warnings)
+	assert.Contains(t, repeat.Warnings[0], "already up to date")
+}
+
+// TestImporter_Import_DiscoversNewUpstreamSkill verifies that re-running an
+// import against an already-cached repo sees skills added upstream after the
+// first import.
+func TestImporter_Import_DiscoversNewUpstreamSkill(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+
+	repoDir := initRepoWithSkillContent(t, map[string]string{
+		"skills/one/SKILL.md": "---\nname: one-skill\ndescription: first\n---\n\nBody.\n",
+	})
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	result, err := imp.Import(ImportOptions{Repo: repoDir, Path: "skills", Trust: true})
+	require.NoError(t, err)
+	require.Len(t, result.Imported, 1)
+
+	// A second skill lands upstream after the first import.
+	srcRepo, err := git.PlainOpen(repoDir)
+	require.NoError(t, err)
+	newFile := filepath.Join(repoDir, "skills", "two", "SKILL.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(newFile), 0755))
+	require.NoError(t, os.WriteFile(newFile, []byte("---\nname: two-skill\ndescription: second\n---\n\nBody.\n"), 0644))
+	wt, err := srcRepo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("skills/two/SKILL.md")
+	require.NoError(t, err)
+	_, err = wt.Commit("add second skill", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com"},
+	})
+	require.NoError(t, err)
+
+	result, err = imp.Import(ImportOptions{Repo: repoDir, Path: "skills", Trust: true})
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(result.Imported))
+	for _, s := range result.Imported {
+		names = append(names, s.Name)
+	}
+	assert.Contains(t, names, "two-skill", "re-import must discover skills added upstream, got %v (warnings: %v)", names, result.Warnings)
+}
+
+// TestFetchAndCompare_SemverConstraintDetectsNewTag covers the detection gap
+// for semver-constraint refs: a new matching tag upstream must report as a
+// change even though the constraint itself is not a resolvable git ref.
+func TestFetchAndCompare_SemverConstraintDetectsNewTag(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, regDir := setupTestRegistry(t)
+	lockPath := filepath.Join(regDir, "skills.lock.yaml")
+	repoDir, repo := initSkillRepo(t, "# Test\n\nFirst version.\n")
+
+	head, err := repo.Head()
+	require.NoError(t, err)
+	_, err = repo.CreateTag("v1.0.0", head.Hash(), nil)
+	require.NoError(t, err)
+
+	imp := NewImporter(store, regDir, lockPath, slog.Default())
+	result, err := imp.Import(ImportOptions{Repo: repoDir, Ref: "^1.0.0", Trust: true})
+	require.NoError(t, err)
+	require.Len(t, result.Imported, 1)
+
+	origin, err := ReadOrigin(filepath.Join(regDir, "skills", "test-skill"))
+	require.NoError(t, err)
+
+	commitChange(t, repo, repoDir, "# Test\n\nSecond version.\n")
+	head2, err := repo.Head()
+	require.NoError(t, err)
+	_, err = repo.CreateTag("v1.1.0", head2.Hash(), nil)
+	require.NoError(t, err)
+
+	newSHA, changed, err := FetchAndCompare(repoDir, "^1.0.0", origin.CommitSHA, AuthConfig{}, slog.Default())
+	require.NoError(t, err)
+	assert.True(t, changed, "new matching tag must be detected as a change")
+	assert.Equal(t, head2.Hash().String(), newSHA)
+}
+
+// TestCloneAndDiscover_ConcurrentSameRepo exercises the per-repo lock: two
+// concurrent operations against one cached clone must serialize rather than
+// race on the shared worktree. Run with -race to make this meaningful.
+func TestCloneAndDiscover_ConcurrentSameRepo(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	repoDir, repo := initSkillRepo(t, "# Test\n\nFirst version.\n")
+
+	// Seed the cache, then push an upstream change so concurrent calls
+	// exercise the mutation path, not just reads.
+	_, err := CloneAndDiscover(repoDir, "", "", AuthConfig{}, slog.Default())
+	require.NoError(t, err)
+	commitChange(t, repo, repoDir, "# Test\n\nSecond version.\n")
+
+	var wg sync.WaitGroup
+	errs := make([]error, 4)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = CloneAndDiscover(repoDir, "", "", AuthConfig{}, slog.Default())
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		assert.NoError(t, err, "concurrent CloneAndDiscover #%d", i)
+	}
 }
 
 // TestImporter_Import_NoPreserveStateResetsState confirms that the default

--- a/pkg/skills/remote.go
+++ b/pkg/skills/remote.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
 
@@ -16,6 +17,20 @@ import (
 	gitpkg "github.com/gridctl/gridctl/pkg/git"
 	"github.com/gridctl/gridctl/pkg/registry"
 )
+
+// repoLocks serializes fetch/checkout mutations per cached clone. The
+// daemon's background update checker, the web UI's sync fan-out, and CLI
+// commands can all touch the same cache directory, and go-git makes no
+// concurrency guarantees for a shared on-disk repository.
+var repoLocks sync.Map // map[string]*sync.Mutex
+
+// lockRepoPath locks the mutex for repoPath and returns its unlock func.
+func lockRepoPath(repoPath string) func() {
+	m, _ := repoLocks.LoadOrStore(repoPath, &sync.Mutex{})
+	mu := m.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
 
 // CloneResult contains the result of a clone + discovery operation.
 type CloneResult struct {
@@ -100,12 +115,15 @@ func FetchAndCompare(repo, ref, currentSHA string, auth AuthConfig, logger *slog
 		return "", true, nil
 	}
 
+	unlock := lockRepoPath(repoPath)
+	defer unlock()
+
 	authMethod, err := authMethodFor(auth, repo)
 	if err != nil {
 		return currentSHA, false, gitpkg.RedactError(err)
 	}
 
-	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{Auth: authMethod}, logger); err != nil {
+	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{AllTags: true, AllBranches: true, Auth: authMethod}, logger); err != nil {
 		logger.Warn("fetch failed", "error", gitpkg.RedactError(err))
 		return currentSHA, false, nil
 	}
@@ -115,20 +133,31 @@ func FetchAndCompare(repo, ref, currentSHA string, auth AuthConfig, logger *slog
 		return currentSHA, false, nil
 	}
 
-	if ref != "" {
-		newSHA, err := gitpkg.ResolveRef(r, ref)
-		if err != nil {
-			return currentSHA, false, nil
-		}
-		return newSHA, newSHA != currentSHA, nil
-	}
-
-	head, err := r.Head()
+	// Resolve against remote-tracking state, never the local HEAD: a fetch
+	// updates only refs/remotes/origin/*, so local refs (and the worktree)
+	// still describe the previous sync and would mask upstream changes.
+	target, err := semverTarget(repoPath, ref)
 	if err != nil {
 		return currentSHA, false, nil
 	}
-	newSHA := head.Hash().String()
+	newSHA, err := gitpkg.ResolveRemoteRef(r, target)
+	if err != nil {
+		return currentSHA, false, nil
+	}
 	return newSHA, newSHA != currentSHA, nil
+}
+
+// semverTarget resolves a semver-constraint ref to its best matching tag in
+// the cached repo; any other ref passes through unchanged.
+func semverTarget(repoPath, ref string) (string, error) {
+	if !IsSemVerConstraint(ref) {
+		return ref, nil
+	}
+	tags, err := gitpkg.ListTags(repoPath)
+	if err != nil {
+		return "", fmt.Errorf("listing tags: %w", err)
+	}
+	return ResolveSemVerConstraint(ref, tags)
 }
 
 // ListRemoteTags returns all tags from a cached repository.
@@ -146,11 +175,20 @@ func cloneShallow(url, ref string, auth AuthConfig, logger *slog.Logger) (string
 		return "", fmt.Errorf("getting cache path: %w", err)
 	}
 
+	unlock := lockRepoPath(repoPath)
+	defer unlock()
+
 	// If repo exists, fetch updates instead
 	if _, err := os.Stat(repoPath); err == nil {
 		return updateExisting(repoPath, url, ref, auth, logger)
 	}
 
+	return cloneFresh(repoPath, url, ref, auth, logger)
+}
+
+// cloneFresh clones url into repoPath and lands the worktree on ref.
+// Callers must hold the repoPath lock.
+func cloneFresh(repoPath, url, ref string, auth AuthConfig, logger *slog.Logger) (string, error) {
 	authMethod, err := authMethodFor(auth, url)
 	if err != nil {
 		return "", err
@@ -210,31 +248,33 @@ func updateExisting(repoPath, url, ref string, auth AuthConfig, logger *slog.Log
 		return "", err
 	}
 
-	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{AllTags: true, Auth: authMethod}, logger); err != nil {
+	if err := gitpkg.Fetch(repoPath, gitpkg.FetchOptions{AllTags: true, AllBranches: true, Auth: authMethod}, logger); err != nil {
+		// Offline or unreachable remote: serve the cached content rather
+		// than failing. The worktree cannot have anything newer to land.
 		logger.Warn("fetch failed, using cached", "error", gitpkg.RedactError(err))
+		return repoPath, nil
 	}
 
-	if ref != "" {
-		if IsSemVerConstraint(ref) {
-			tags, err := gitpkg.ListTags(repoPath)
-			if err != nil {
-				logger.Warn("failed to list tags, using cached", "error", err)
-				return repoPath, nil
-			}
-			resolvedTag, err := ResolveSemVerConstraint(ref, tags)
-			if err != nil {
-				logger.Warn("failed to resolve constraint, using cached", "constraint", ref, "error", err)
-				return repoPath, nil
-			}
-			if err := gitpkg.Checkout(r, resolvedTag); err != nil {
-				logger.Warn("failed to checkout tag, using cached", "tag", resolvedTag, "error", err)
-				return repoPath, nil
-			}
-		} else {
-			if err := gitpkg.Checkout(r, ref); err != nil {
-				logger.Warn("failed to checkout ref, using cached", "ref", ref, "error", err)
-			}
+	// Land the worktree on what the fetch brought in. A fetch updates only
+	// remote-tracking refs; without this step the worktree (and therefore
+	// discovery) stays frozen at the first-import commit forever, for every
+	// ref shape including the unpinned default branch.
+	target, err := semverTarget(repoPath, ref)
+	if err != nil {
+		logger.Warn("failed to resolve constraint, using cached", "constraint", ref, "error", err)
+		return repoPath, nil
+	}
+	if _, err := gitpkg.SyncWorktree(r, target); err != nil {
+		// go-git can advance remote-tracking refs without transferring the
+		// backing objects (observed with local-path remotes), leaving the
+		// resolved commit un-checkoutable. The fetch above succeeded, so the
+		// remote is reachable: a fresh clone is the reliable recovery and
+		// costs one shallow clone only when upstream actually changed.
+		logger.Warn("worktree sync failed, re-cloning", "ref", target, "error", gitpkg.RedactError(err))
+		if rmErr := os.RemoveAll(repoPath); rmErr != nil {
+			return "", fmt.Errorf("removing stale cache for re-clone: %w", rmErr)
 		}
+		return cloneFresh(repoPath, url, ref, auth, logger)
 	}
 
 	return repoPath, nil


### PR DESCRIPTION
## Description

`gridctl skill add` and `gridctl skill update` fetched the per-repo clone cache on every run but never landed the fetched commits in the checked-out worktree, so upstream changes were never installed: unpinned sources reported "already up to date" forever, and branch-pinned sources reported "update available" on every run while reinstalling stale content.

## Type of Change

- [x] Bug fix

## Changes Made

- `pkg/git`: new `SyncWorktree`/`ResolveRemoteRef`/`DefaultBranch` helpers that resolve refs against freshly fetched remote-tracking state (remote-first precedence, annotated tags peeled, empty ref resolves the remote default branch) and land the worktree on the result, fast-forwarding local branches and keeping HEAD attached; `Fetch` gains an `AllBranches` refspec option; `ResolveRef` is subsumed and removed
- `pkg/skills`: `updateExisting` now syncs the worktree after every fetch for all ref shapes, falling back to a fresh shallow clone when fetched objects are incomplete (go-git can advance refs without transferring objects); `FetchAndCompare` resolves remote-tracking state instead of stale local HEAD and detects new tags matching semver constraints; cache mutations serialize per repo path
- Offline behavior preserved: a failed fetch degrades to cached content with a warning
- Docs: troubleshooting section on the skills clone cache; changelog entry

## Testing

- New regression tests: unpinned and branch-pinned updates install fresh content and stop looping, re-import discovers upstream-added skills, semver constraint detects a new matching tag, concurrent operations on one cache dir race-cleanly, plus `pkg/git` unit tests for stale-branch advancement, default-branch resolution from detached HEAD, tag peeling, and idempotent re-sync
- `go test ./...`, `go test -race ./pkg/git/ ./pkg/skills/`, and `golangci-lint run` all pass

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #1010