### PR TITLE
chore: migrate tooling from make to Taskfile

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,6 @@
 
 ## Checklist
 
-- [ ] Tests pass (`make test`)
+- [ ] Tests pass (`task test`)
 - [ ] Commits follow conventional format (`type: subject`)
 - [ ] No secrets or credentials committed

--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -51,8 +51,13 @@ jobs:
           go install golang.org/x/vuln/cmd/govulncheck@latest
           bash scripts/govulncheck.sh
 
+      - name: Set up Task
+        uses: go-task/setup-task@v2
+        with:
+          version: 3.x
+
       - name: Build Go binary
-        run: make build-go
+        run: task build:go
 
       - name: Validate example stacks
         run: |

--- a/.github/workflows/install-smoke.yaml
+++ b/.github/workflows/install-smoke.yaml
@@ -68,6 +68,11 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Set up Task
+        uses: go-task/setup-task@v2
+        with:
+          version: 3.x
+
       - name: Build PR binary and smoke `gridctl upgrade --check`
         # The released binary referenced by install.sh predates this PR and
         # does not contain the `upgrade` subcommand, so we exercise the
@@ -78,7 +83,7 @@ jobs:
         env:
           TAG: ${{ steps.latest.outputs.tag }}
         run: |
-          make build-go
+          task build:go
           ./gridctl upgrade --check --version "$TAG"
 
       - name: Uninstall removes the binary

--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -2,7 +2,7 @@ name: Update Pricing Snapshot
 
 # Keeps the embedded LiteLLM pricing snapshot
 # (pkg/pricing/data/model_prices.json) current without a maintainer remembering
-# to run `make update-pricing`. Weekly, this fetches the upstream table, runs it
+# to run `task pricing:update`. Weekly, this fetches the upstream table, runs it
 # through the validation gate (scripts/validate-pricing.sh), and — only when the
 # table actually changed — opens or updates a single reviewable PR. The binary
 # still embeds only the committed file; nothing here touches the build.
@@ -26,13 +26,18 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Set up Task
+        uses: go-task/setup-task@v2
+        with:
+          version: 3.x
+
       # Fetches upstream, validates the candidate (JSON / non-empty / model
       # floor / shrink guard), and replaces the committed file only on success.
       # A malformed or truncated upstream response fails the job loudly rather
       # than committing bad data; a network failure leaves the file untouched.
-      # jq, curl, and make are preinstalled on ubuntu-latest.
+      # jq and curl are preinstalled on ubuntu-latest; task is installed above.
       - name: Refresh pricing snapshot (validated)
-        run: make update-pricing
+        run: task pricing:update
 
       # peter-evans/create-pull-request is a no-op when the working tree is
       # clean (table unchanged), and reuses the same branch/PR on re-runs so the
@@ -59,7 +64,7 @@ jobs:
             (`pkg/pricing/data/model_prices.json`).
 
             The upstream table was fetched and passed the validation gate
-            (`make update-pricing` → `scripts/validate-pricing.sh`: valid JSON,
+            (`task pricing:update` → `scripts/validate-pricing.sh`: valid JSON,
             non-empty, model-count floor, and shrink guard). The diff below is
             the price-table delta.
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Build artifacts
 cmd/gridctl/web/
+.task/
 
 # Web dependencies and build
 node_modules/
@@ -57,7 +58,7 @@ web/coverage/
 tmp/
 temp/
 
-# Pricing refresh temp file (make update-pricing writes here before atomic mv)
+# Pricing refresh temp file (task pricing:update writes here before atomic mv)
 pkg/pricing/data/.model_prices.*
 
 # Mock server binaries and PID files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,22 +8,23 @@ Gridctl is an MCP (Model Context Protocol) gateway with a built-in skills regist
 
 ## Build and run
 
-The Makefile is the entry point for everything. Common targets:
+Task (https://taskfile.dev) is the entry point for everything; tasks live in `Taskfile.yml`. Run `task --list` for the full catalog and `task --summary <name>` for per-task notes. Install with `brew install go-task/tap/go-task` (or `npm install -g @go-task/cli`, or `go install github.com/go-task/task/v3/cmd/task@latest`). A transitional Makefile shim forwards the old `make <target>` names. Common tasks:
 
-| Target | Notes |
+| Task | Notes |
 |---|---|
-| `make build` | Builds the web frontend (`web/dist` → `cmd/gridctl/web/dist`), then builds the Go binary with `-tags embed_web` so the UI is embedded. Produces `./gridctl` in the repo root. |
-| `make build-go` | Backend only. Skips the embed tag if `cmd/gridctl/web/dist` is absent (UI 404s in that case). |
-| `make build-web` | Frontend only (`cd web && npm run build`). |
-| `make dev` | Runs the Vite dev server (`web/`) against a separately-running backend. |
-| `make test` | `go test -v ./...` (unit tests only). |
-| `make test-integration` | `go test -v -tags=integration ./tests/integration/...`. Requires Docker (or Podman). These tests hit real container runtimes per Article IV of `CONSTITUTION.md`; mocks are disallowed in `tests/integration/`. |
-| `make test-frontend` | `cd web && npm test` (Vitest). |
-| `make generate` | Regenerates `go.uber.org/mock` mocks under `pkg/mcp/` and `pkg/runtime/`. Required after touching the interfaces they're generated from. |
-| `make update-pricing` | Refreshes the embedded LiteLLM pricing snapshot at `pkg/pricing/data/model_prices.json` (weekly cadence). |
-| `make mock-servers [PORT=9001]` | Builds and runs the example mock MCP servers in `examples/_mock-servers/` (HTTP on PORT, SSE on PORT+1). Pair with `make clean-mock-servers`. |
+| `task build` | Builds the web frontend (`web/dist` → `cmd/gridctl/web/dist`), then builds the Go binary with `-tags embed_web` so the UI is embedded. Produces `./gridctl` in the repo root. |
+| `task build:go` | Backend only. Skips the embed tag if `cmd/gridctl/web/dist` is absent (UI 404s in that case). |
+| `task build:web` | Frontend only (`cd web && npm run build`). |
+| `task dev` | Runs the Vite dev server (`web/`) against a separately-running backend. |
+| `task test` | `go test -race ./...` (unit tests only, same race detector CI runs). |
+| `task test:integration` | `go test -tags=integration -race -timeout 5m ./tests/integration/...`. Requires Docker (or Podman). These tests hit real container runtimes per Article IV of `CONSTITUTION.md`; mocks are disallowed in `tests/integration/`. |
+| `task test:frontend` | `cd web && npm test` (Vitest). |
+| `task lint` | `golangci-lint run` plus `npm run lint` in `web/` (both CI-gated). |
+| `task generate` | Regenerates `go.uber.org/mock` mocks under `pkg/mcp/` and `pkg/runtime/`. Required after touching the interfaces they're generated from. |
+| `task pricing:update` | Refreshes the embedded LiteLLM pricing snapshot at `pkg/pricing/data/model_prices.json` (weekly cadence). |
+| `task mock:servers` | Builds and runs the example mock MCP servers in `examples/_mock-servers/` (HTTP on PORT, SSE on PORT+1; `PORT=9001` default). Pair with `task mock:clean`. |
 
-Always test local changes with `make build` followed by `./gridctl …`. The `gridctl` binary on `$PATH` is typically a brew-installed release and will not reflect your changes.
+Always test local changes with `task build` followed by `./gridctl …`. The `gridctl` binary on `$PATH` is typically a brew-installed release and will not reflect your changes.
 
 `gridctl serve` and `gridctl apply` daemonize by default. If you need a process you can ctrl-C (or that a test script can kill), pass `-f` / `--foreground`.
 
@@ -88,7 +89,7 @@ tests/integration/  Real-runtime suites (build tag `integration`). Cover gateway
                     replicas, transports (incl. Podman), code-mode cost, private git auth, optimize heuristics.
 examples/           Example stack YAMLs grouped by surface (getting-started, transports, openapi, registry, secrets-vault,
                     code-mode, platforms, tracing, access-control, autoscale, declarative-link, gateways, portable-stack).
-                    examples/_mock-servers/ is the source for `make mock-servers`.
+                    examples/_mock-servers/ is the source for `task mock:servers`.
 docs/               User-facing documentation (cli-reference, config-schema, api-reference, skills, tools-workspace,
                     global-context, scaling, cost-observability, installation, project-status, troubleshooting).
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to gridctl will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- The project task runner is now Task (https://taskfile.dev): `task build`, `task test`, `task lint`, and friends replace the Makefile targets, with namespaced names for grouped work (`build:web`, `test:integration`, `pricing:update`, `mock:servers`). Run `task --list` for the catalog. A transitional Makefile shim keeps every old `make <target>` name working while muscle memory catches up. `task test` and `task test:integration` now run with the race detector to match CI, `task lint` covers both golangci-lint and the frontend lint, a failed frontend build now fails `task build:web` instead of silently staging stale assets, and the `gridctl validate` hint for unknown pricing models points at `task pricing:update` (#1014)
+
 ### Bug Fixes
 
 - Skill import no longer strips frontmatter keys it does not model. The registry parser decoded SKILL.md frontmatter into a fixed set of fields and re-emitted only those, so client extensions like `argument-hint`, `disable-model-invocation`, `hooks`, and `model` silently vanished from every imported copy, from re-syncs, from renames, and from web editor saves. Unknown keys are now captured into an `extra` field, preserved verbatim through parse, render, the JSON API, and the editor's save path (values exact; ordering may normalize), and never interpreted by gridctl. Registries written before the fix heal on their next `gridctl skill update`, which re-imports the upstream file with the keys intact (#1009)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md). We expect all 
 - **Node.js** 20 or later
 - **Docker** (for running containers and integration tests)
 - **Git** with commit signing configured
+- **Task** (`brew install go-task/tap/go-task`, `npm install -g @go-task/cli`, or another [install method](https://taskfile.dev/docs/installation))
 
 ### Development Setup
 
@@ -27,13 +28,13 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md). We expect all 
 2. **Install dependencies:**
 
    ```bash
-   make deps
+   task deps
    ```
 
 3. **Build the project:**
 
    ```bash
-   make build
+   task build
    ```
 
 4. **Verify the build:**
@@ -45,25 +46,30 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md). We expect all 
 5. **Run tests:**
 
    ```bash
-   make test
+   task test
    ```
 
 ### Build Commands
 
+Tasks live in `Taskfile.yml`; `task --list` shows the full catalog. The most common:
+
 | Command | Description |
 |---------|-------------|
-| `make build` | Build frontend and backend |
-| `make build-web` | Build React frontend only |
-| `make build-go` | Build Go binary only |
-| `make dev` | Run Vite dev server for frontend development |
-| `make test` | Run unit tests |
-| `make test-coverage` | Run tests with coverage report |
-| `make test-frontend` | Run frontend tests (Vitest) |
-| `make test-integration` | Run integration tests (requires Docker) |
-| `make generate` | Regenerate mocks under `pkg/mcp/` and `pkg/runtime/` |
-| `make clean` | Remove build artifacts |
+| `task build` | Build frontend and backend |
+| `task build:web` | Build React frontend only |
+| `task build:go` | Build Go binary only |
+| `task dev` | Run Vite dev server for frontend development |
+| `task test` | Run unit tests (race detector on, matching CI) |
+| `task test:coverage` | Run tests with coverage report |
+| `task test:frontend` | Run frontend tests (Vitest) |
+| `task test:integration` | Run integration tests (requires Docker) |
+| `task lint` | Lint backend (golangci-lint) and frontend (ESLint) |
+| `task generate` | Regenerate mocks under `pkg/mcp/` and `pkg/runtime/` |
+| `task clean` | Remove build artifacts |
 
-> The `gridctl` binary on your `$PATH` is typically a released build. Test local changes with `make build` followed by `./gridctl …`.
+> The `gridctl` binary on your `$PATH` is typically a released build. Test local changes with `task build` followed by `./gridctl …`.
+>
+> A transitional Makefile shim forwards the old `make <target>` names to their `task` equivalents.
 
 ## 🔧 Making Changes
 
@@ -106,8 +112,8 @@ Example: `feature/add-ssh-transport` or `fix/container-timeout`
 Run tests before submitting:
 
 ```bash
-make test                  # Unit tests
-make test-integration      # Integration tests (requires Docker)
+task test                  # Unit tests
+task test:integration      # Integration tests (requires Docker)
 ```
 
 ## 📋 Commit Guidelines

--- a/Makefile
+++ b/Makefile
@@ -1,178 +1,83 @@
-.PHONY: all build build-web build-go dev clean help test test-coverage test-integration test-frontend mock-servers clean-mock-servers generate update-pricing validate-pricing
+# Transitional shim: gridctl now uses Task (https://taskfile.dev) as its task
+# runner. Tasks live in Taskfile.yml; run `task --list` for the catalog. This
+# shim forwards the old make targets to their task equivalents so existing
+# muscle memory and older instructions keep working. It will be removed after
+# a two-release sunset.
+#
+# Install task:
+#   brew install go-task/tap/go-task
+#   npm install -g @go-task/cli
+#   go install github.com/go-task/task/v3/cmd/task@latest
 
-# Version from git tags (fallback to dev)
-VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
-DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
+.PHONY: all build build-web build-go dev clean deps run test test-coverage test-frontend test-integration lint mock-servers clean-mock-servers generate update-pricing validate-pricing help
 
-# Default target
-all: build
+# $(1) is the task name; command-line variable overrides (PORT=, FILE=) pass
+# through via MAKEOVERRIDES, both as Task variables and as environment (make
+# exported overrides into recipe environments, so e.g. `make build-go
+# GOOS=linux` keeps working). Values containing spaces are not supported by
+# the shim; call task directly for those.
+define forward
+	@command -v task >/dev/null 2>&1 || { \
+		echo "This project now uses Task (https://taskfile.dev)."; \
+		echo "Install it with: brew install go-task/tap/go-task"; \
+		exit 1; }
+	@echo "make is deprecated here; forwarding to: task $(1)"
+	@env $(MAKEOVERRIDES) task $(1) $(MAKEOVERRIDES)
+endef
 
-# Build everything
-build: build-web build-go
+all:
+	$(call forward,build)
 
-# Build the React frontend
+build:
+	$(call forward,build)
+
 build-web:
-	@if [ -f web/tsconfig.json ]; then \
-		echo "Building web frontend..."; \
-		(cd web && npm run build); \
-		echo "Copying dist to cmd/gridctl/web/dist..."; \
-		rm -rf cmd/gridctl/web; \
-		mkdir -p cmd/gridctl/web; \
-		cp -r web/dist cmd/gridctl/web/; \
-	else \
-		echo "Skipping web build (source files not present)"; \
-	fi
+	$(call forward,build:web)
 
-# Build the Go binary
 build-go:
-	@echo "Building Go binary ($(VERSION))..."
-	@if [ -d cmd/gridctl/web/dist ]; then \
-		echo "Including embedded web assets..."; \
-		go build -tags embed_web -ldflags "$(LDFLAGS)" -o gridctl ./cmd/gridctl; \
-	else \
-		echo "Building without web assets (run make build-web first to include UI)..."; \
-		go build -ldflags "$(LDFLAGS)" -o gridctl ./cmd/gridctl; \
-	fi
+	$(call forward,build:go)
 
-# Development mode - run Vite dev server
 dev:
-	cd web && npm run dev
+	$(call forward,dev)
 
-# Clean build artifacts
 clean:
-	@echo "Cleaning build artifacts..."
-	rm -rf gridctl
-	rm -rf cmd/gridctl/web
-	rm -rf web/dist
-	rm -rf web/node_modules
+	$(call forward,clean)
 
-# Install dependencies
 deps:
-	@echo "Installing dependencies..."
-	cd web && npm install
-	go mod tidy
+	$(call forward,deps)
 
-# Run the built binary
-run: build
-	./gridctl
+run:
+	$(call forward,run)
 
-# Run tests
 test:
-	@echo "Running tests..."
-	go test -v ./...
+	$(call forward,test)
 
-# Run tests with coverage
 test-coverage:
-	@echo "Running tests with coverage..."
-	go test -coverprofile=coverage.out ./...
-	go tool cover -html=coverage.out -o coverage.html
-	@echo "Coverage report generated: coverage.html"
+	$(call forward,test:coverage)
 
-# Run frontend tests
 test-frontend:
-	@echo "Running frontend tests..."
-	cd web && npm test
+	$(call forward,test:frontend)
 
-# Run integration tests (requires Docker)
 test-integration:
-	@echo "Running integration tests..."
-	go test -v -tags=integration ./tests/integration/...
+	$(call forward,test:integration)
 
-# Build and run mock MCP servers for examples
-# Usage: make mock-servers [PORT=9001]
-PORT ?= 9001
+lint:
+	$(call forward,lint)
+
 mock-servers:
-	@echo "Building and starting mock MCP servers..."
-	@command -v go >/dev/null 2>&1 || { echo "Error: Go is not installed. Please install Go first: https://go.dev/dl/"; exit 1; }
-	@echo "Building mock-stdio-server..."
-	@(cd examples/_mock-servers/local-stdio-server && go build -o mock-stdio-server .)
-	@echo "Building mock-mcp-server..."
-	@(cd examples/_mock-servers/mock-mcp-server && go build -o mock-mcp-server .)
-	@echo "Starting mock-mcp-server on port $(PORT) (HTTP mode)..."
-	@examples/_mock-servers/mock-mcp-server/mock-mcp-server -port $(PORT) > /dev/null 2>&1 & echo $$! > examples/_mock-servers/mock-mcp-server/.pid-http
-	@echo "Starting mock-mcp-server on port $$(( $(PORT) + 1 )) (SSE mode)..."
-	@examples/_mock-servers/mock-mcp-server/mock-mcp-server -port $$(( $(PORT) + 1 )) -sse > /dev/null 2>&1 & echo $$! > examples/_mock-servers/mock-mcp-server/.pid-sse
-	@echo ""
-	@echo "Mock servers running:"
-	@echo "  mock-stdio-server: built at examples/_mock-servers/local-stdio-server/mock-stdio-server"
-	@echo "  mock-mcp-server:   HTTP on localhost:$(PORT), SSE on localhost:$$(( $(PORT) + 1 ))"
-	@echo ""
-	@echo "Run 'make clean-mock-servers' to stop and remove them."
+	$(call forward,mock:servers)
 
-# Stop and remove mock MCP servers
 clean-mock-servers:
-	@echo "Stopping mock MCP servers..."
-	@if [ -f examples/_mock-servers/mock-mcp-server/.pid-http ]; then \
-		kill $$(cat examples/_mock-servers/mock-mcp-server/.pid-http) 2>/dev/null || true; \
-		rm -f examples/_mock-servers/mock-mcp-server/.pid-http; \
-	fi
-	@if [ -f examples/_mock-servers/mock-mcp-server/.pid-sse ]; then \
-		kill $$(cat examples/_mock-servers/mock-mcp-server/.pid-sse) 2>/dev/null || true; \
-		rm -f examples/_mock-servers/mock-mcp-server/.pid-sse; \
-	fi
-	@echo "Removing mock server binaries..."
-	@rm -f examples/_mock-servers/local-stdio-server/mock-stdio-server
-	@rm -f examples/_mock-servers/mock-mcp-server/mock-mcp-server
-	@echo "Mock servers cleaned up."
+	$(call forward,mock:clean)
 
-# Refresh embedded LiteLLM pricing data. Recommended weekly cadence — the
-# upstream file changes whenever providers adjust per-token rates or add
-# new models. The download is non-fatal: if the fetch fails the existing
-# embedded snapshot is preserved.
-PRICING_URL := https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
-PRICING_DEST := pkg/pricing/data/model_prices.json
-update-pricing:
-	@echo "Refreshing pricing data from $(PRICING_URL)..."
-	@tmp=$$(mktemp $(dir $(PRICING_DEST)).model_prices.XXXXXX); \
-	if curl -sSL --fail --max-time 30 -o $$tmp $(PRICING_URL); then \
-		if scripts/validate-pricing.sh $$tmp $(PRICING_DEST); then \
-			mv $$tmp $(PRICING_DEST); \
-			echo "Updated $(PRICING_DEST) ($$(wc -c < $(PRICING_DEST)) bytes)."; \
-		else \
-			rm -f $$tmp; \
-			echo "ERROR: pricing validation failed; keeping existing $(PRICING_DEST)." >&2; \
-			exit 1; \
-		fi; \
-	else \
-		rm -f $$tmp; \
-		echo "WARN: pricing refresh failed; keeping existing $(PRICING_DEST)."; \
-	fi
-
-# Validate a pricing snapshot without fetching. Defaults to the committed file;
-# point it at any candidate with FILE=/path/to/table.json to test the gate (it is
-# always compared against the committed snapshot's entry count). Exits non-zero on
-# malformed, empty, or substantially-shrunken input. Shared by update-pricing and
-# the scheduled refresh workflow.
-validate-pricing:
-	@scripts/validate-pricing.sh "$${FILE:-$(PRICING_DEST)}" "$(PRICING_DEST)"
-
-# Generate mocks (requires mockgen: go install go.uber.org/mock/mockgen@latest)
 generate:
-	@echo "Generating mocks..."
-	go generate ./pkg/mcp/... ./pkg/runtime/...
-	@echo "Done."
+	$(call forward,generate)
 
-# Help
+update-pricing:
+	$(call forward,pricing:update)
+
+validate-pricing:
+	$(call forward,pricing:validate)
+
 help:
-	@echo "Gridctl Makefile"
-	@echo ""
-	@echo "Usage:"
-	@echo "  make build      - Build frontend and backend"
-	@echo "  make build-web  - Build React frontend only"
-	@echo "  make build-go   - Build Go binary only"
-	@echo "  make dev        - Run Vite dev server"
-	@echo "  make clean      - Remove build artifacts"
-	@echo "  make deps       - Install all dependencies"
-	@echo "  make run        - Build and run the binary"
-	@echo "  make test       - Run all tests"
-	@echo "  make test-coverage - Run tests with coverage report"
-	@echo "  make test-frontend - Run frontend tests"
-	@echo "  make test-integration - Run integration tests (requires Docker)"
-	@echo "  make generate   - Regenerate mock files (requires mockgen)"
-	@echo "  make update-pricing - Refresh embedded LiteLLM pricing data (weekly)"
-	@echo "  make validate-pricing [FILE=...] - Validate a pricing snapshot (gate for update-pricing)"
-	@echo "  make mock-servers [PORT=9001] - Build and run mock MCP servers for examples"
-	@echo "  make clean-mock-servers - Stop and remove mock MCP servers"
-	@echo "  make help       - Show this help message"
+	$(call forward,--list)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,190 @@
+version: '3'
+
+# gridctl task runner. Run `task --list` for the catalog, `task --summary <name>`
+# for the long-form notes on a task. Old `make <target>` names forward here via
+# the transitional Makefile shim.
+
+set: [errexit, pipefail]
+
+vars:
+  VERSION:
+    sh: git describe --tags --always --dirty 2>/dev/null || echo "dev"
+  COMMIT:
+    sh: git rev-parse --short HEAD 2>/dev/null || echo "none"
+  DATE:
+    sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
+  LDFLAGS: -X main.version={{.VERSION}} -X main.commit={{.COMMIT}} -X main.date={{.DATE}}
+  PRICING_URL: https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
+  PRICING_DIR: pkg/pricing/data
+  PRICING_DEST: pkg/pricing/data/model_prices.json
+
+tasks:
+  default:
+    desc: Build frontend and backend (same as build)
+    cmds:
+      - task: build
+
+  build:
+    desc: Build frontend and backend
+    cmds:
+      - task: build:web
+      - task: build:go
+
+  build:web:
+    desc: Build the React frontend and stage it for embedding
+    summary: |
+      Builds web/ with Vite and copies web/dist into cmd/gridctl/web/dist,
+      where the embed_web build tag picks it up. A checkout without frontend
+      source (no web/tsconfig.json) skips the build instead of failing.
+    cmds:
+      - |
+        if [ ! -f web/tsconfig.json ]; then
+          echo "Skipping web build (source files not present)"
+          exit 0
+        fi
+        echo "Building web frontend..."
+        (cd web && npm run build)
+        echo "Copying dist to cmd/gridctl/web/dist..."
+        rm -rf cmd/gridctl/web
+        mkdir -p cmd/gridctl/web
+        cp -r web/dist cmd/gridctl/web/
+
+  build:go:
+    desc: Build the Go binary only
+    summary: |
+      Embeds the web UI (-tags embed_web) when cmd/gridctl/web/dist exists;
+      otherwise builds without it and the UI 404s. Run `task build:web` first
+      to include the UI. Version metadata comes from git describe.
+    cmds:
+      - |
+        echo "Building Go binary ({{.VERSION}})..."
+        if [ -d cmd/gridctl/web/dist ]; then
+          echo "Including embedded web assets..."
+          go build -tags embed_web -ldflags "{{.LDFLAGS}}" -o gridctl ./cmd/gridctl
+        else
+          echo "Building without web assets (run 'task build:web' first to include UI)..."
+          go build -ldflags "{{.LDFLAGS}}" -o gridctl ./cmd/gridctl
+        fi
+
+  dev:
+    desc: Run the Vite dev server against a separately running backend
+    cmds:
+      - cd web && npm run dev
+
+  clean:
+    desc: Remove build artifacts
+    cmds:
+      - rm -rf gridctl
+      - rm -rf cmd/gridctl/web
+      - rm -rf web/dist
+      - rm -rf web/node_modules
+
+  deps:
+    desc: Install frontend and backend dependencies
+    cmds:
+      - cd web && npm install
+      - go mod tidy
+
+  run:
+    desc: Build and run the binary
+    cmds:
+      - task: build
+      - ./gridctl
+
+  test:
+    desc: Run unit tests with the race detector (matches CI)
+    cmds:
+      - go test -race ./...
+
+  test:coverage:
+    desc: Run unit tests with a coverage report
+    cmds:
+      - go test -race -coverprofile=coverage.out ./...
+      - go tool cover -html=coverage.out -o coverage.html
+      - echo "Coverage report generated coverage.html"
+
+  test:frontend:
+    desc: Run frontend tests (Vitest)
+    cmds:
+      - cd web && npm test
+
+  test:integration:
+    desc: Run integration tests (requires Docker or Podman, matches CI flags)
+    cmds:
+      - go test -tags=integration -race -timeout 5m ./tests/integration/...
+
+  lint:
+    desc: Lint backend and frontend
+    cmds:
+      - task: lint:go
+      - task: lint:web
+
+  lint:go:
+    desc: Lint Go code (golangci-lint, gosec enabled)
+    cmds:
+      - golangci-lint run
+
+  lint:web:
+    desc: Lint the frontend (zero-error baseline, enforced by CI)
+    cmds:
+      - cd web && npm run lint
+
+  generate:
+    desc: Regenerate mocks under pkg/mcp/ and pkg/runtime/ (requires mockgen)
+    cmds:
+      - go generate ./pkg/mcp/... ./pkg/runtime/...
+
+  pricing:update:
+    desc: Refresh the embedded LiteLLM pricing snapshot (weekly cadence)
+    summary: |
+      Fetches the upstream LiteLLM pricing table, validates it with
+      scripts/validate-pricing.sh, and replaces {{.PRICING_DEST}} only on
+      success. A fetch failure warns and keeps the existing snapshot (exit 0);
+      a validation failure keeps the snapshot and exits 1.
+    cmds:
+      - |
+        echo "Refreshing pricing data from {{.PRICING_URL}}..."
+        tmp=$(mktemp {{.PRICING_DIR}}/.model_prices.XXXXXX)
+        if curl -sSL --fail --max-time 30 -o "$tmp" {{.PRICING_URL}}; then
+          if scripts/validate-pricing.sh "$tmp" {{.PRICING_DEST}}; then
+            mv "$tmp" {{.PRICING_DEST}}
+            echo "Updated {{.PRICING_DEST}} ($(wc -c < {{.PRICING_DEST}}) bytes)."
+          else
+            rm -f "$tmp"
+            echo "ERROR: pricing validation failed; keeping existing {{.PRICING_DEST}}." >&2
+            exit 1
+          fi
+        else
+          rm -f "$tmp"
+          echo "WARN: pricing refresh failed; keeping existing {{.PRICING_DEST}}."
+        fi
+
+  pricing:validate:
+    desc: Validate a pricing snapshot (FILE=... to test a candidate)
+    summary: |
+      Runs scripts/validate-pricing.sh against the committed snapshot by
+      default; point it at any candidate with `task pricing:validate
+      FILE=/path/to/table.json`. The candidate is always compared against the
+      committed snapshot's entry count. Exits non-zero on malformed, empty, or
+      substantially shrunken input.
+    vars:
+      FILE: '{{.FILE | default .PRICING_DEST}}'
+    cmds:
+      - scripts/validate-pricing.sh "{{.FILE}}" "{{.PRICING_DEST}}"
+
+  mock:servers:
+    desc: Build and start the example mock MCP servers (PORT=9001)
+    summary: |
+      Builds the two mock servers under examples/_mock-servers/ and starts
+      mock-mcp-server twice, HTTP on PORT and SSE on PORT+1. Start/stop logic
+      lives in scripts/mock-servers.sh because backgrounding needs a real
+      shell. Stop with `task mock:clean`.
+    vars:
+      PORT: '{{.PORT | default "9001"}}'
+    cmds:
+      - bash scripts/mock-servers.sh start {{.PORT}}
+
+  mock:clean:
+    desc: Stop and remove the example mock MCP servers
+    cmds:
+      - bash scripts/mock-servers.sh stop

--- a/cmd/gridctl/embed.go
+++ b/cmd/gridctl/embed.go
@@ -7,7 +7,7 @@ import (
 	"io/fs"
 )
 
-// The web/dist directory is copied here during build (see Makefile).
+// The web/dist directory is copied here during build (see Taskfile.yml).
 // This file is only included when building with -tags embed_web.
 //
 //go:embed all:web/dist

--- a/docs/cost-observability.md
+++ b/docs/cost-observability.md
@@ -79,10 +79,10 @@ Per-tool cost inherits every honesty rule of the wider cost system: it is an est
 The pricing snapshot is embedded at build time via `//go:embed pkg/pricing/data/model_prices.json`. Refresh it when providers adjust rates or add new models:
 
 ```bash
-make update-pricing
+task pricing:update
 ```
 
-The target downloads the latest LiteLLM file. If the download fails, the existing snapshot is preserved (non-fatal). A weekly cadence is recommended; faster than that is rarely necessary because LiteLLM batches rate updates.
+The task downloads the latest LiteLLM file. If the download fails, the existing snapshot is preserved (non-fatal). A weekly cadence is recommended; faster than that is rarely necessary because LiteLLM batches rate updates.
 
 ## Model-ID normalization
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,11 +45,11 @@ Download the tarball for your platform from the [releases page](https://github.c
 <details>
 <summary><strong>Build from source</strong></summary>
 
-Requires Go 1.26+ and Node 20+.
+Requires Go 1.26+, Node 20+, and [Task](https://taskfile.dev/docs/installation).
 
 ```bash
 git clone https://github.com/gridctl/gridctl
-cd gridctl && make build
+cd gridctl && task build
 ./gridctl --help
 ```
 

--- a/examples/_mock-servers/README.md
+++ b/examples/_mock-servers/README.md
@@ -7,7 +7,7 @@ Test MCP servers for development purposes.
 Build and run all mock servers with a single command:
 
 ```bash
-make mock-servers
+task mock:servers
 ```
 
 This builds both servers and starts `mock-mcp-server` on ports 9001 (HTTP) and 9002 (SSE).
@@ -15,7 +15,7 @@ This builds both servers and starts `mock-mcp-server` on ports 9001 (HTTP) and 9
 To use custom ports:
 
 ```bash
-make mock-servers PORT=3000
+task mock:servers PORT=3000
 ```
 
 This starts HTTP on port 3000 and SSE on port 3001.
@@ -23,7 +23,7 @@ This starts HTTP on port 3000 and SSE on port 3001.
 To stop and clean up:
 
 ```bash
-make clean-mock-servers
+task mock:clean
 ```
 
 ## 📂 Servers

--- a/examples/registry/README.md
+++ b/examples/registry/README.md
@@ -59,7 +59,7 @@ See [`docs/config-schema.md`](../../docs/config-schema.md#skill-sources) for the
 Build the mock MCP servers:
 
 ```bash
-make mock-servers
+task mock:servers
 ```
 
 ## Quick Start

--- a/examples/registry/registry-advanced.yaml
+++ b/examples/registry/registry-advanced.yaml
@@ -5,7 +5,7 @@
 # convention, enabling workflows that span server boundaries.
 #
 # Prerequisites:
-#   Run `make mock-servers` from the project root to build the mock server.
+#   Run `task mock:servers` from the project root to build the mock server.
 #
 # Usage:
 #   gridctl apply examples/registry/registry-advanced.yaml

--- a/examples/registry/registry-basic.yaml
+++ b/examples/registry/registry-basic.yaml
@@ -6,7 +6,7 @@
 # or Web UI.
 #
 # Prerequisites:
-#   Run `make mock-servers` from the project root to build the mock server.
+#   Run `task mock:servers` from the project root to build the mock server.
 #
 # Usage:
 #   gridctl apply examples/registry/registry-basic.yaml

--- a/examples/transports/README.md
+++ b/examples/transports/README.md
@@ -17,7 +17,7 @@ Examples demonstrating different MCP transport types.
 Build and start all mock servers with one command:
 
 ```bash
-make mock-servers
+task mock:servers
 ```
 
 This builds `mock-stdio-server` and starts `mock-mcp-server` on ports 9001 (HTTP) and 9002 (SSE).

--- a/examples/transports/external-mcp.yaml
+++ b/examples/transports/external-mcp.yaml
@@ -11,7 +11,7 @@
 #   - Connecting to MCP servers managed by other orchestration systems
 #
 # Prerequisites:
-#   Run `make mock-servers` from the project root to build and start mock servers.
+#   Run `task mock:servers` from the project root to build and start mock servers.
 #   This starts mock-mcp-server on ports 9001 (HTTP) and 9002 (SSE).
 #   Or start manually:
 #     cd examples/_mock-servers/mock-mcp-server

--- a/examples/transports/local-mcp.yaml
+++ b/examples/transports/local-mcp.yaml
@@ -11,7 +11,7 @@
 #   - Lightweight deployments without container overhead
 #
 # Prerequisites:
-#   Run `make mock-servers` from the project root to build all mock servers.
+#   Run `task mock:servers` from the project root to build all mock servers.
 #   Or build manually:
 #     cd examples/_mock-servers/local-stdio-server
 #     go build -o mock-stdio-server .

--- a/pkg/config/health.go
+++ b/pkg/config/health.go
@@ -187,7 +187,7 @@ func (r *ValidationResult) addModelWarnings(s *Stack) {
 		if _, ok := pricing.Lookup(model); !ok {
 			r.Issues = append(r.Issues, ValidationIssue{
 				Field:    field,
-				Message:  fmt.Sprintf("model %q is unknown to the pricing snapshot; calls will record tokens but cost as zero (refresh with `make update-pricing` or check the ID)", model),
+				Message:  fmt.Sprintf("model %q is unknown to the pricing snapshot; calls will record tokens but cost as zero (refresh with `task pricing:update` or check the ID)", model),
 				Severity: SeverityWarning,
 			})
 			r.WarningCount++

--- a/pkg/pricing/litellm.go
+++ b/pkg/pricing/litellm.go
@@ -10,7 +10,7 @@ import (
 )
 
 // rawModelPrices is the embedded LiteLLM pricing snapshot. Refresh via
-// `make update-pricing` (see Makefile).
+// `task pricing:update` (see Taskfile.yml).
 //
 //go:embed data/model_prices.json
 var rawModelPrices []byte

--- a/scripts/mock-servers.sh
+++ b/scripts/mock-servers.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Build and run the example mock MCP servers (examples/_mock-servers/).
+# Invoked by `task mock:servers` and `task mock:clean`. The start/stop
+# lifecycle lives here rather than in Taskfile.yml because Task's embedded
+# shell has no job control: backgrounding with `&` and capturing `$!` need a
+# real bash.
+#
+# Usage:
+#   mock-servers.sh start [port]   Build both servers, start mock-mcp-server
+#                                  in HTTP mode on <port> (default 9001) and
+#                                  SSE mode on <port>+1, writing PID files.
+#   mock-servers.sh stop           Kill the started servers and remove the
+#                                  built binaries and PID files.
+set -euo pipefail
+
+# Always operate from the repo root so direct invocation from any cwd works
+# (Task already runs from the Taskfile directory; this covers everyone else).
+cd "$(dirname "$0")/.."
+
+MOCK_DIR="examples/_mock-servers"
+STDIO_DIR="$MOCK_DIR/local-stdio-server"
+MCP_DIR="$MOCK_DIR/mock-mcp-server"
+
+start() {
+  local port="${1:-9001}"
+  if ! [[ "$port" =~ ^[0-9]+$ ]]; then
+    echo "Error: port must be numeric, got '$port'" >&2
+    exit 1
+  fi
+  local sse_port=$((port + 1))
+  command -v go >/dev/null 2>&1 || { echo "Error: Go is not installed. Please install Go first: https://go.dev/dl/"; exit 1; }
+  echo "Building mock-stdio-server..."
+  (cd "$STDIO_DIR" && go build -o mock-stdio-server .)
+  echo "Building mock-mcp-server..."
+  (cd "$MCP_DIR" && go build -o mock-mcp-server .)
+  echo "Starting mock-mcp-server on port $port (HTTP mode)..."
+  "$MCP_DIR/mock-mcp-server" -port "$port" > /dev/null 2>&1 &
+  echo $! > "$MCP_DIR/.pid-http"
+  echo "Starting mock-mcp-server on port $sse_port (SSE mode)..."
+  "$MCP_DIR/mock-mcp-server" -port "$sse_port" -sse > /dev/null 2>&1 &
+  echo $! > "$MCP_DIR/.pid-sse"
+  echo ""
+  echo "Mock servers running:"
+  echo "  mock-stdio-server: built at $STDIO_DIR/mock-stdio-server"
+  echo "  mock-mcp-server:   HTTP on localhost:$port, SSE on localhost:$sse_port"
+  echo ""
+  echo "Run 'task mock:clean' to stop and remove them."
+}
+
+stop() {
+  echo "Stopping mock MCP servers..."
+  local pidfile
+  for pidfile in "$MCP_DIR/.pid-http" "$MCP_DIR/.pid-sse"; do
+    if [ -f "$pidfile" ]; then
+      kill "$(cat "$pidfile")" 2>/dev/null || true
+      rm -f "$pidfile"
+    fi
+  done
+  echo "Removing mock server binaries..."
+  rm -f "$STDIO_DIR/mock-stdio-server"
+  rm -f "$MCP_DIR/mock-mcp-server"
+  echo "Mock servers cleaned up."
+}
+
+case "${1:-}" in
+  start) start "${2:-}" ;;
+  stop) stop ;;
+  *)
+    echo "Usage: $0 {start [port]|stop}" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/validate-pricing.sh
+++ b/scripts/validate-pricing.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Validate a candidate LiteLLM pricing snapshot before it replaces the committed
-# one. Guards `make update-pricing` (and the scheduled refresh workflow) against a
+# one. Guards `task pricing:update` (and the scheduled refresh workflow) against a
 # poisoned, empty, or truncated upstream response landing silently — the failure
 # mode behind LiteLLM's 2026-01-27 model-cost-map incident, where a malformed but
 # HTTP-200 `main` shipped invalid JSON.

--- a/web/src/components/pricing/constants.ts
+++ b/web/src/components/pricing/constants.ts
@@ -16,7 +16,7 @@ export const ATTRIBUTION_HINT =
 
 // Footer copy for pickers and the pricing manager.
 export const SNAPSHOT_NOTE =
-  'Models come from the embedded LiteLLM snapshot (refreshed via make update-pricing at gateway rebuild).';
+  'Models come from the embedded LiteLLM snapshot (refreshed via task pricing:update at gateway rebuild).';
 export const UNKNOWN_MODEL_NOTE = 'Unknown model · records tokens but prices as $0';
 
 // Shown on the Cost KPI when any client/server has `mixed` provenance. The


### PR DESCRIPTION
## Description

Migrates the project task runner from make to [Task](https://taskfile.dev). The Makefile was a pure command runner whose targets had drifted from what CI actually enforces (`make test` lacked `-race`, and lint had no target at all), and its hand-maintained `help` block plus the doc tables restating it had already fallen out of sync with each other. `Taskfile.yml` is now the single source of truth: every task carries a `desc:` so `task --list` is the living catalog, and CI calls the same tasks contributors run.

Closes #1014

## Changes Made

- `Taskfile.yml` (new): all former targets, namespaced where hyphenated (`build:web`, `test:integration`, `pricing:update`, `mock:servers`), plus new `lint` / `lint:go` / `lint:web`. Global `set: [errexit, pipefail]` fixes a latent bug where a failed `npm run build` fell through and `build-web` reported success. `task test` and `task test:integration` now run with `-race` (and the integration timeout) to match Gatekeeper.
- `scripts/mock-servers.sh` (new): the mock-server start/stop lifecycle (backgrounding, PID files) moved to a real bash script, since Task's embedded shell has no job control. Mirrors the existing `scripts/validate-pricing.sh` pattern. Validates the port and works from any cwd.
- `Makefile`: replaced by a transitional shim that forwards every old target name to its task equivalent (with `PORT=` / `FILE=` and env passthrough), prints an install pointer when task is missing, and will be removed after a two-release sunset.
- CI: `gatekeeper.yaml`, `install-smoke.yaml`, and `update-pricing.yaml` install task via `go-task/setup-task@v2` and call `task build:go` / `task pricing:update`.
- Docs and references: `AGENTS.md`, `CONTRIBUTING.md`, `docs/installation.md`, `docs/cost-observability.md`, PR template, example READMEs and stack YAML comments, code comments, the runtime hint in `pkg/config/health.go`, and the pricing footer string in the web UI. `.task/` gitignored.

Out of scope: `.goreleaser.yaml`'s inline frontend-build hooks (pre-existing duplication, candidate follow-up).

## Testing

- `task build` produces `./gridctl` with embedded UI and correct `gridctl version` stamping; `task test` (full suite, `-race`), `task test:frontend` (1653 tests), and `task lint` all pass locally.
- Failure paths exercised: a failing command inside a multiline task aborts it (errexit), `task pricing:validate FILE=<bad>` exits non-zero, the fetch-failure branch of `pricing:update` warns and exits 0, and the shim exits 1 with install instructions when task is absent.
- `task mock:servers PORT=9005` / `task mock:clean` verified end to end (servers respond, PID files created and removed, processes killed), including via the `make mock-servers PORT=...` shim path.
- `shellcheck` clean on the new script; all edited workflow YAML parses.

## Checklist

- [x] Tests pass (`task test`)
- [x] Commits follow conventional format (`type: subject`)
- [x] No secrets or credentials committed
