### PR TITLE
feat: add experimental feature flags in stack.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to gridctl will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Experimental feature flags: a new optional top-level `experimental:` block in stack.yaml enables registered experimental flags by name, backed by a typed registry (`pkg/flags`) with lifecycle stages (experimental, graduated, removed) and a graduation-deadline test so flags cannot rot silently. Everything defaults to off, so an unchanged stack.yaml behaves identically. Unknown flag names warn at `gridctl apply` and `gridctl validate` listing the valid names, and graduated or removed names warn with a specific migration message — never an error, so a stack written against a newer gridctl still deploys. Each flag can be overridden per process with `GRIDCTL_EXPERIMENTAL_<NAME>` (strconv.ParseBool vocabulary; unset defers to YAML, unparseable warns). Enabled flags surface in `GET /api/status` (`features` plus `feature_details`), `gridctl status --json`, and the web UI as a read-only "N experimental" status-bar chip with per-flag rows in the spec pane; flags are configured in stack.yaml only and cannot be toggled from the UI. Edits to the block hot-reload without container restarts. The first registered flag, `transport_dual_stack`, is reserved for the MCP transport work and currently has no effect. The flag lifecycle is documented in CONTRIBUTING.md, and `GRIDCTL_NO_SKILL_UPDATE_CHECK` now accepts the same boolean vocabulary (previously only `"1"`) (#1021)
+
 ### Changed
+
+- Code mode is now a stable feature: the `gateway.code_mode` and `gateway.code_mode_timeout` settings and the `--code-mode` flag are no longer labeled experimental. Behavior is unchanged (#1021)
 
 - The project task runner is now Task (https://taskfile.dev): `task build`, `task test`, `task lint`, and friends replace the Makefile targets, with namespaced names for grouped work (`build:web`, `test:integration`, `pricing:update`, `mock:servers`). Run `task --list` for the catalog. A transitional Makefile shim keeps every old `make <target>` name working while muscle memory catches up. `task test` and `task test:integration` now run with the race detector to match CI, `task lint` covers both golangci-lint and the frontend lint, a failed frontend build now fails `task build:web` instead of silently staging stale assets, and the `gridctl validate` hint for unknown pricing models points at `task pricing:update` (#1014)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,40 @@ task test                  # Unit tests
 task test:integration      # Integration tests (requires Docker)
 ```
 
+### Experimental Feature Flags
+
+Risky or unfinished features ship dark behind a flag in the `pkg/flags`
+registry, enabled per stack via the `experimental:` block in stack.yaml.
+The registry is the single source of truth for what is experimental; the
+user-facing flag table lives in `docs/config-schema.md` and must be updated
+in the same PR as any registry change.
+
+Lifecycle:
+
+1. **Born experimental, off by default.** Register the flag with a
+   `Description`, `Since` (the release introducing it), and `GraduatesBy`
+   (the release by which a decision is forced). Name the flag in snake_case,
+   spelled identically to the stable config key it will graduate to, so
+   graduation is a promotion rather than a rename. Everything the flag
+   gates must default to off (Article IX).
+2. **Graduation.** Promote the behavior to a real config block (or make it
+   unconditional), flip the registry entry's stage to graduated, and add a
+   `Message` telling users what to do with the stale entry, naming the
+   release the change shipped in (e.g. "graduated in 0.2.0; remove the
+   entry, the feature is now always on"). A stack.yaml still setting the
+   flag keeps working and warns with that message — never an error.
+3. **Removal.** Two minor releases after graduation (or when an experiment
+   is abandoned), flip the stage to removed. The entry stays in the
+   registry forever: one map entry is the price of a specific migration
+   message instead of a generic unknown-key warning.
+4. **The graduation clock.** `TestNoBuiltinFlagOverdue` in `pkg/flags`
+   fails when a flag's `GraduatesBy` is at or before the most recent
+   release in CHANGELOG.md. Fix it by graduating the flag or by extending
+   the deadline deliberately in a reviewed diff — flags never rot silently.
+
+Every flag addition, graduation, and removal gets a CHANGELOG entry
+(Article XV).
+
 ## 📋 Commit Guidelines
 
 ### Commit Message Format

--- a/cmd/gridctl/apply.go
+++ b/cmd/gridctl/apply.go
@@ -79,7 +79,7 @@ func init() {
 	applyCmd.Flags().BoolVar(&applyNoExpand, "no-expand", false, "Disable environment variable expansion in OpenAPI spec files")
 	applyCmd.Flags().BoolVarP(&applyWatch, "watch", "w", false, "Watch stack file for changes and hot reload")
 	applyCmd.Flags().BoolVar(&applyFlash, "flash", false, "Auto-link detected LLM clients after apply")
-	applyCmd.Flags().BoolVar(&applyCodeMode, "code-mode", false, "Enable gateway code mode (replaces tools with search + execute meta-tools) (experimental)")
+	applyCmd.Flags().BoolVar(&applyCodeMode, "code-mode", false, "Enable gateway code mode (replaces tools with search + execute meta-tools)")
 	applyCmd.Flags().StringVar(&applyLogFile, "log-file", "", "Path to log file for structured JSON output with automatic rotation")
 }
 

--- a/cmd/gridctl/status.go
+++ b/cmd/gridctl/status.go
@@ -35,6 +35,9 @@ type statusGatewayJSON struct {
 	Status    string    `json:"status"`
 	StartedAt time.Time `json:"started_at"`
 	CodeMode  string    `json:"code_mode,omitempty"`
+	// Features mirrors /api/status features: each enabled experimental
+	// flag mapped to true. Omitted when nothing is enabled.
+	Features map[string]bool `json:"features,omitempty"`
 }
 
 // statusContainerJSON is one container entry of `gridctl status --json`.
@@ -130,9 +133,10 @@ func runStatus(stack string, showReplicas, asJSON, plain bool) error {
 			Status:  status,
 			Started: formatDuration(time.Since(s.StartedAt)),
 		}
-		// Query the running gateway for code mode status
+		// Query the running gateway for code mode and experimental flag status
+		var features map[string]bool
 		if status == "running" {
-			gw.CodeMode = queryCodeMode(s.Port)
+			gw.CodeMode, features = queryGatewayStatus(s.Port)
 		}
 		gateways = append(gateways, gw)
 		gatewaysJSON = append(gatewaysJSON, statusGatewayJSON{
@@ -142,6 +146,7 @@ func runStatus(stack string, showReplicas, asJSON, plain bool) error {
 			Status:    status,
 			StartedAt: s.StartedAt,
 			CodeMode:  gw.CodeMode,
+			Features:  features,
 		})
 	}
 
@@ -546,23 +551,25 @@ func formatUptime(d time.Duration) string {
 	}
 }
 
-// queryCodeMode queries a running gateway's API for code mode status.
-// Returns "on" if active, empty string otherwise.
-func queryCodeMode(port int) string {
+// queryGatewayStatus queries a running gateway's API for code mode status
+// ("on" if active, empty otherwise) and the enabled experimental flag map
+// (nil when nothing is enabled).
+func queryGatewayStatus(port int) (codeMode string, features map[string]bool) {
 	client := &http.Client{Timeout: 2 * time.Second}
 	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/api/status", port))
 	if err != nil {
-		return ""
+		return "", nil
 	}
 	defer resp.Body.Close()
 
 	var status struct {
-		CodeMode string `json:"code_mode"`
+		CodeMode string          `json:"code_mode"`
+		Features map[string]bool `json:"features"`
 	}
 	if json.NewDecoder(resp.Body).Decode(&status) == nil {
-		return status.CodeMode
+		return status.CodeMode, status.Features
 	}
-	return ""
+	return "", nil
 }
 
 // loadPinLabels loads pin status for all provided stacks and returns a map

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -180,6 +180,13 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8180/api/status
 | `effective_server_models` | map | Server -> `{model, provenance, share, models}` reporting which model priced each server's cost (`provenance` is `declared`, `mixed`, or `none`) |
 | `effective_client_models` | map | Client -> effective-model object, same shape as above |
 
+**Experimental flag fields** appear at the top level when any experimental flag is enabled (via the stack's `experimental:` block or a `GRIDCTL_EXPERIMENTAL_*` env override), and are omitted otherwise:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `features` | map | Each enabled flag name mapped to `true` — the capability-bit view for UI gating |
+| `feature_details` | array | `{name, stage, description}` display metadata for the same flags, sorted by name. Read-only: flags are configured in `stack.yaml`, never toggled over the API |
+
 #### `GET /api/sessions`
 
 Returns the active Streamable HTTP MCP session count and the list of session IDs.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -66,8 +66,8 @@ gateway:
 |-------|------|----------|---------|-------------|
 | `allowed_origins` | []string | No | `["*"]` | CORS allowed origins. Empty or unset allows all |
 | `auth` | object | No | - | Authentication configuration |
-| `code_mode` | string | No | `"off"` | Enable code mode: `"on"` or `"off"` *(experimental)* |
-| `code_mode_timeout` | int | No | `30` | Code mode execution timeout in seconds. Must be >= 0 *(experimental)* |
+| `code_mode` | string | No | `"off"` | Enable code mode: `"on"` or `"off"` |
+| `code_mode_timeout` | int | No | `30` | Code mode execution timeout in seconds. Must be >= 0 |
 | `default_model` | string | No | - | Model ID used to price tool calls for servers without their own `model` field (e.g. `"claude-opus-4-7"`). Enables cost observability; figures are estimates from the embedded LiteLLM rates, not billing truth. Empty disables cost attribution for servers without a per-server `model` |
 | `output_format` | string | No | `"json"` | Default output format for tool call results: `"json"`, `"toon"`, `"csv"`, or `"text"`. Per-server `output_format` overrides this value |
 | `maxToolResultBytes` | int | No | `65536` | Maximum size of a tool result in bytes before truncation. Results over the limit are truncated with a suffix noting the original size. `0` uses the default (64 KB) |
@@ -1099,6 +1099,50 @@ Reconcile semantics:
   `limits:`).
 - With a `link:` block present, `apply --flash` is ignored with a notice
   (the block owns the linking decision).
+
+## Experimental (feature flags)
+
+The optional top-level `experimental:` block enables registered experimental
+feature flags by name. Omitting the block preserves legacy behavior — every
+flag defaults to off, and an unchanged stack.yaml behaves identically across
+upgrades.
+
+```yaml
+experimental:
+  transport_dual_stack: true
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `<flag name>` | bool | No | `false` | Enables the named experimental flag. Keys are snake_case and spelled identically to the stable config key the feature graduates to |
+
+Registered flags:
+
+| Flag | Stage | Since | Description |
+|------|-------|-------|-------------|
+| `transport_dual_stack` | experimental | 0.1.0 | Reserved for the MCP 2026-07-28 transport dual-stack work; currently has no effect |
+
+Semantics:
+
+- **Warnings, never errors.** An unknown flag name warns at `gridctl apply`
+  and `gridctl validate` (listing the valid names) and is ignored; a
+  graduated or removed flag name warns with a specific migration message.
+  A stack.yaml written against a newer gridctl still deploys on this one.
+- **Env override.** Each flag can be overridden per process with
+  `GRIDCTL_EXPERIMENTAL_<NAME>` (upper snake_case), accepting the
+  `strconv.ParseBool` vocabulary: `1`, `t`, `T`, `TRUE`, `true`, `True`,
+  `0`, `f`, `F`, `FALSE`, `false`, `False`. The env value beats the YAML
+  value; an unset variable defers to YAML; an unparseable value warns and
+  is ignored.
+- **Visibility.** Enabled flags appear in `GET /api/status` as `features`
+  (with display metadata in `feature_details`), in `gridctl status --json`,
+  and as a read-only chip plus per-flag rows in the web UI. Flags cannot be
+  toggled from the UI; stack.yaml stays user-owned.
+- **Hot reload.** Editing the block on a running stack re-resolves flags
+  without restarting any containers.
+- **Lifecycle.** Flags graduate by promotion to a real config block; the
+  full lifecycle (stages, deadlines, and the graduation clock) is
+  documented in [CONTRIBUTING.md](../CONTRIBUTING.md#experimental-feature-flags).
 
 ## Skill Sources
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -79,6 +79,12 @@ type Server struct {
 	// or "" when none is configured. Must be safe for concurrent calls.
 	defaultModel func() string
 
+	// features returns the enabled experimental flags (stack.yaml
+	// `experimental:` plus env overrides), for the /api/status features
+	// payload. Nil means no flag support is wired. Must be safe for
+	// concurrent calls and must reflect hot-reload swaps.
+	features func() []FeatureStatus
+
 	// limitsStatus returns the budgets/rate-limits consumption snapshot for
 	// GET /api/limits. Nil means the builder wired no limits support (the
 	// endpoint then reports configured: false). Must be safe for concurrent
@@ -243,6 +249,31 @@ func (s *Server) SetTokenizerName(name string) {
 // /api/status cost_attribution flag.
 func (s *Server) SetModelAttribution(get func() map[string]string) {
 	s.modelAttribution = get
+}
+
+// FeatureStatus is one enabled experimental flag as exposed on /api/status.
+// Read-only display metadata: the UI never toggles flags (they are configured
+// in stack.yaml and cannot be changed from the browser).
+type FeatureStatus struct {
+	Name        string `json:"name"`
+	Stage       string `json:"stage"`
+	Description string `json:"description"`
+}
+
+// SetFeatures sets a getter for the enabled experimental flag list. The
+// getter (rather than a static slice) lets hot reloads of `experimental:`
+// reach /api/status without re-wiring; it must be safe for concurrent calls.
+func (s *Server) SetFeatures(get func() []FeatureStatus) {
+	s.features = get
+}
+
+// featureList returns the enabled experimental flags, or nil when no getter
+// is wired or nothing is enabled.
+func (s *Server) featureList() []FeatureStatus {
+	if s.features == nil {
+		return nil
+	}
+	return s.features()
 }
 
 // SetClientModelAttribution sets a getter for the client ID -> model mapping
@@ -603,6 +634,13 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		EffectiveClientModels map[string]EffectiveModel `json:"effective_client_models,omitempty"`
 		EffectiveServerModels map[string]EffectiveModel `json:"effective_server_models,omitempty"`
 		StackName             string                    `json:"stack_name,omitempty"`
+		// Features maps each ENABLED experimental flag name to true —
+		// the capability-bit view for UI gating. Omitted when nothing is
+		// enabled so the no-flags payload is byte-identical to before.
+		Features map[string]bool `json:"features,omitempty"`
+		// FeatureDetails carries the display metadata (stage, description)
+		// for the same enabled flags, for the read-only spec panel rows.
+		FeatureDetails []FeatureStatus `json:"feature_details,omitempty"`
 	}{
 		Gateway: ServerInfo{
 			Name:      s.gateway.ServerInfo().Name,
@@ -640,6 +678,13 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	status.ServerModels = s.modelAttributionMap()
 	status.DefaultModel = s.defaultModelValue()
 	status.CostAttribution = len(status.ServerModels) > 0 || len(status.ClientModels) > 0
+	if features := s.featureList(); len(features) > 0 {
+		status.FeatureDetails = features
+		status.Features = make(map[string]bool, len(features))
+		for _, f := range features {
+			status.Features[f.Name] = true
+		}
+	}
 
 	writeJSON(w, status)
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1909,3 +1909,59 @@ func TestGetResourceStatuses_ListErrorLogsWarning(t *testing.T) {
 		t.Errorf("expected underlying error in log, got: %q", out)
 	}
 }
+
+func TestHandleStatus_IncludesFeatures(t *testing.T) {
+	srv := newTestServer(t)
+	srv.SetFeatures(func() []FeatureStatus {
+		return []FeatureStatus{
+			{Name: "transport_dual_stack", Stage: "experimental", Description: "test"},
+		}
+	})
+
+	handler := srv.Handler()
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var result struct {
+		Features       map[string]bool `json:"features"`
+		FeatureDetails []FeatureStatus `json:"feature_details"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if !result.Features["transport_dual_stack"] {
+		t.Errorf("features = %v, want transport_dual_stack true", result.Features)
+	}
+	if len(result.FeatureDetails) != 1 || result.FeatureDetails[0].Stage != "experimental" {
+		t.Errorf("feature_details = %+v", result.FeatureDetails)
+	}
+}
+
+func TestHandleStatus_OmitsFeaturesWhenEmpty(t *testing.T) {
+	// No getter wired at all, and a wired getter returning nothing, must both
+	// omit the fields so the no-flags payload is unchanged.
+	for name, srv := range map[string]*Server{
+		"no getter":    newTestServer(t),
+		"empty getter": newTestServer(t),
+	} {
+		if name == "empty getter" {
+			srv.SetFeatures(func() []FeatureStatus { return nil })
+		}
+		handler := srv.Handler()
+		req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		var result map[string]json.RawMessage
+		if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+			t.Fatalf("%s: failed to unmarshal: %v", name, err)
+		}
+		if _, ok := result["features"]; ok {
+			t.Errorf("%s: expected features to be omitted", name)
+		}
+		if _, ok := result["feature_details"]; ok {
+			t.Errorf("%s: expected feature_details to be omitted", name)
+		}
+	}
+}

--- a/pkg/config/health.go
+++ b/pkg/config/health.go
@@ -3,9 +3,11 @@ package config
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/gridctl/gridctl/pkg/flags"
 	"github.com/gridctl/gridctl/pkg/pricing"
 )
 
@@ -171,6 +173,42 @@ func (r *ValidationResult) addWarnings(s *Stack) {
 	}
 
 	r.addModelWarnings(s)
+	r.addExperimentalIssues(s)
+}
+
+// addExperimentalIssues reports on the `experimental:` map: unknown flag
+// names and concluded (graduated/removed) names surface as warnings with the
+// registry's migration text, and each enabled valid flag surfaces as an
+// info-level line so `gridctl validate` and the UI panel show active
+// experiments. Warnings only — an unrecognized name never blocks a deploy
+// (Article IX: a stack written against a newer gridctl must still start).
+func (r *ValidationResult) addExperimentalIssues(s *Stack) {
+	reg := flags.Default()
+	for _, w := range flags.CheckNames(reg, s.Experimental) {
+		r.Issues = append(r.Issues, ValidationIssue{
+			Field:    "experimental." + w.Name,
+			Message:  w.Message,
+			Severity: SeverityWarning,
+		})
+		r.WarningCount++
+	}
+	names := make([]string, 0, len(s.Experimental))
+	for name, on := range s.Experimental {
+		if !on {
+			continue
+		}
+		if f, ok := reg.Lookup(name); ok && f.Stage == flags.StageExperimental {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		r.Issues = append(r.Issues, ValidationIssue{
+			Field:    "experimental." + name,
+			Message:  "experimental flag enabled",
+			Severity: SeverityInfo,
+		})
+	}
 }
 
 // addModelWarnings flags cost-attribution declarations that would silently

--- a/pkg/config/health_test.go
+++ b/pkg/config/health_test.go
@@ -273,3 +273,68 @@ func TestValidateWithIssues_ModelWarnings(t *testing.T) {
 		t.Error("model warnings must not invalidate the stack")
 	}
 }
+
+func TestValidateWithIssues_ExperimentalIssues(t *testing.T) {
+	base := func() *Stack {
+		return &Stack{
+			Name:    "test",
+			Network: Network{Name: "test-net"},
+			Gateway: &GatewayConfig{Auth: &AuthConfig{Type: "bearer", Token: "secret"}},
+			MCPServers: []MCPServer{
+				{Name: "s1", Image: "alpine", Port: 3000},
+			},
+		}
+	}
+
+	t.Run("omitted block adds nothing (back-compat)", func(t *testing.T) {
+		result := ValidateWithIssues(base())
+		for _, issue := range result.Issues {
+			if strings.HasPrefix(issue.Field, "experimental.") {
+				t.Fatalf("unexpected experimental issue: %+v", issue)
+			}
+		}
+	})
+
+	t.Run("unknown flag name warns without invalidating", func(t *testing.T) {
+		stack := base()
+		stack.Experimental = map[string]bool{"tpyo_flag": true}
+		result := ValidateWithIssues(stack)
+		require.True(t, result.Valid)
+		var found bool
+		for _, issue := range result.Issues {
+			if issue.Field == "experimental.tpyo_flag" {
+				found = true
+				assert.Equal(t, SeverityWarning, issue.Severity)
+				assert.Contains(t, issue.Message, "unknown experimental flag")
+			}
+		}
+		require.True(t, found, "expected a warning for the unknown flag name")
+		assert.Greater(t, result.WarningCount, 0)
+	})
+
+	t.Run("enabled known flag reports as info", func(t *testing.T) {
+		stack := base()
+		stack.Experimental = map[string]bool{"transport_dual_stack": true}
+		result := ValidateWithIssues(stack)
+		require.True(t, result.Valid)
+		var found bool
+		for _, issue := range result.Issues {
+			if issue.Field == "experimental.transport_dual_stack" {
+				found = true
+				assert.Equal(t, SeverityInfo, issue.Severity)
+			}
+		}
+		require.True(t, found, "expected an info line for the enabled flag")
+	})
+
+	t.Run("disabled known flag stays silent", func(t *testing.T) {
+		stack := base()
+		stack.Experimental = map[string]bool{"transport_dual_stack": false}
+		result := ValidateWithIssues(stack)
+		for _, issue := range result.Issues {
+			if strings.HasPrefix(issue.Field, "experimental.") {
+				t.Fatalf("unexpected experimental issue: %+v", issue)
+			}
+		}
+	})
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -29,6 +29,14 @@ type Stack struct {
 	// `extends` (matching clients/groups/limits).
 	Link []LinkEntry `yaml:"link,omitempty" json:"link,omitempty"`
 
+	// Experimental enables registered experimental feature flags by name
+	// (see pkg/flags for the registry and lifecycle). Omitted (the default)
+	// enables nothing — Article IX by construction. Unknown, graduated, and
+	// removed names warn at validate and apply time but never block a
+	// deploy. Deliberately typed map[string]bool so YAML 1.1 boolean
+	// spellings (on/yes) decode as booleans.
+	Experimental map[string]bool `yaml:"experimental,omitempty" json:"experimental,omitempty"`
+
 	// ClientModels declares which model each connecting client runs, purely
 	// for cost attribution: tool calls from a declared client are priced at
 	// that model's rates ahead of any per-server model or gateway
@@ -334,10 +342,8 @@ type GatewayConfig struct {
 
 	// CodeMode controls whether the gateway replaces individual tool definitions
 	// with two meta-tools (search + execute). Values: "off" (default), "on".
-	// Experimental: may change without notice.
 	CodeMode string `yaml:"code_mode,omitempty"`
 	// CodeModeTimeout is the execution timeout in seconds (default: 30).
-	// Experimental: may change without notice.
 	CodeModeTimeout int `yaml:"code_mode_timeout,omitempty"`
 
 	// OutputFormat sets the default output format for tool call results.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/flags"
 	"github.com/gridctl/gridctl/pkg/logging"
 	"github.com/gridctl/gridctl/pkg/output"
 	"github.com/gridctl/gridctl/pkg/pins"
@@ -283,6 +284,18 @@ func (sc *StackController) Deploy(ctx context.Context) error {
 	// Create output printer and phase reporter
 	printer := sc.createPrinter(stack)
 	reporter := sc.createReporter()
+
+	// Surface experimental flag issues (unknown names, concluded flags,
+	// malformed env overrides) at apply time. Warnings only — a stack.yaml
+	// written against a newer gridctl must still deploy on this one.
+	// Foreground mode skips this pass: the gateway builder logs the same
+	// warnings via slog, which reaches the terminal directly there, and
+	// printing both would duplicate every line.
+	if printer != nil && !cfg.Foreground {
+		for _, w := range flags.Resolve(flags.Default(), stack.Experimental).Warnings {
+			printer.Warn(w.Message)
+		}
+	}
 
 	// Start containers
 	rt, err := sc.createRuntime()

--- a/pkg/controller/experimental_flags_test.go
+++ b/pkg/controller/experimental_flags_test.go
@@ -1,0 +1,78 @@
+package controller
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/config"
+)
+
+// TestRefreshExperimentalFlags exercises the resolve-and-store path the
+// /api/status features closure reads through, including the hot-reload swap.
+func TestRefreshExperimentalFlags(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("omitted block resolves to no features (back-compat)", func(t *testing.T) {
+		b := &GatewayBuilder{}
+		b.refreshExperimentalFlags(&config.Stack{}, logger)
+		state := b.experimentalFlags.Load()
+		if state == nil {
+			t.Fatal("refresh must always store a state")
+		}
+		if len(state.features) != 0 {
+			t.Fatalf("features = %+v, want none", state.features)
+		}
+	})
+
+	t.Run("enabled registered flag surfaces with metadata", func(t *testing.T) {
+		b := &GatewayBuilder{}
+		b.refreshExperimentalFlags(&config.Stack{
+			Experimental: map[string]bool{"transport_dual_stack": true},
+		}, logger)
+		features := b.experimentalFlags.Load().features
+		if len(features) != 1 {
+			t.Fatalf("features = %+v, want exactly one", features)
+		}
+		f := features[0]
+		if f.Name != "transport_dual_stack" || f.Stage != "experimental" || f.Description == "" {
+			t.Fatalf("feature = %+v", f)
+		}
+	})
+
+	t.Run("disabled and unknown flags do not surface", func(t *testing.T) {
+		b := &GatewayBuilder{}
+		b.refreshExperimentalFlags(&config.Stack{
+			Experimental: map[string]bool{
+				"transport_dual_stack": false,
+				"not_a_real_flag":      true,
+			},
+		}, logger)
+		if features := b.experimentalFlags.Load().features; len(features) != 0 {
+			t.Fatalf("features = %+v, want none", features)
+		}
+	})
+
+	t.Run("hot reload swaps the stored set", func(t *testing.T) {
+		b := &GatewayBuilder{}
+		b.refreshExperimentalFlags(&config.Stack{
+			Experimental: map[string]bool{"transport_dual_stack": true},
+		}, logger)
+		if len(b.experimentalFlags.Load().features) != 1 {
+			t.Fatal("setup: expected one feature before reload")
+		}
+		b.refreshExperimentalFlags(&config.Stack{}, logger)
+		if features := b.experimentalFlags.Load().features; len(features) != 0 {
+			t.Fatalf("features after reload = %+v, want none", features)
+		}
+	})
+
+	t.Run("env override enables without yaml", func(t *testing.T) {
+		t.Setenv("GRIDCTL_EXPERIMENTAL_TRANSPORT_DUAL_STACK", "true")
+		b := &GatewayBuilder{}
+		b.refreshExperimentalFlags(&config.Stack{}, logger)
+		features := b.experimentalFlags.Load().features
+		if len(features) != 1 || features[0].Name != "transport_dual_stack" {
+			t.Fatalf("features = %+v, want transport_dual_stack via env", features)
+		}
+	})
+}

--- a/pkg/controller/gateway_builder.go
+++ b/pkg/controller/gateway_builder.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -19,6 +20,7 @@ import (
 	"github.com/gridctl/gridctl/internal/api"
 	"github.com/gridctl/gridctl/internal/probe"
 	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/flags"
 	"github.com/gridctl/gridctl/pkg/limits"
 	"github.com/gridctl/gridctl/pkg/logging"
 	"github.com/gridctl/gridctl/pkg/mcp"
@@ -96,6 +98,18 @@ type GatewayBuilder struct {
 	// observations; the observer's resolver closure reads through it on
 	// every call.
 	modelAttribution atomic.Pointer[modelAttribution]
+
+	// experimentalFlags holds the resolved experimental flag display list
+	// (enabled flags only, sorted). Stored behind an atomic pointer so the
+	// hot-reload hook can swap it without racing the /api/status features
+	// closure.
+	experimentalFlags atomic.Pointer[experimentalState]
+}
+
+// experimentalState is the resolved experimental flag set derived from a
+// stack's `experimental:` map plus GRIDCTL_EXPERIMENTAL_* env overrides.
+type experimentalState struct {
+	features []api.FeatureStatus
 }
 
 // modelAttribution is the resolved cost-attribution state derived from a
@@ -621,6 +635,7 @@ func (b *GatewayBuilder) buildAPIServer(gateway *mcp.Gateway, logBuffer *logging
 	accumulator := metrics.NewAccumulator(10000)
 	observer := metrics.NewObserver(counter, accumulator)
 	b.wireModelAttribution(observer, server)
+	b.wireExperimentalFlags(server, handler)
 	gateway.SetToolCallObserver(observer)
 	gateway.SetPromptGetObserver(observer)
 	gateway.SetTokenCounter(counter)
@@ -1086,6 +1101,57 @@ func (b *GatewayBuilder) wireModelAttribution(observer *metrics.Observer, apiSer
 	})
 }
 
+// wireExperimentalFlags resolves the stack's experimental flag map and
+// exposes the enabled set to /api/status as the features payload. The getter
+// closure reads through an atomic pointer so hot reloads of `experimental:`
+// (via refreshExperimentalFlags in the onConfigApplied hook) are reflected
+// without re-wiring.
+func (b *GatewayBuilder) wireExperimentalFlags(apiServer *api.Server, handler slog.Handler) {
+	logger := slog.Default()
+	if handler != nil {
+		logger = slog.New(handler)
+	}
+	b.refreshExperimentalFlags(b.stack, logger)
+	apiServer.SetFeatures(func() []api.FeatureStatus {
+		state := b.experimentalFlags.Load()
+		if state == nil {
+			return nil
+		}
+		return state.features
+	})
+}
+
+// refreshExperimentalFlags re-resolves the experimental flag set from the
+// given stack (YAML map plus env overrides). Called at build time and from
+// the hot-reload hook so `experimental:` edits take effect without restart.
+// Resolution warnings (unknown names, concluded flags, malformed env
+// overrides) are logged; they never block anything.
+func (b *GatewayBuilder) refreshExperimentalFlags(cfg *config.Stack, logger *slog.Logger) {
+	reg := flags.Default()
+	res := flags.Resolve(reg, cfg.Experimental)
+	for _, w := range res.Warnings {
+		logger.Warn("experimental flag issue", "flag", w.Name, "detail", w.Message)
+	}
+	names := make([]string, 0, len(res.Enabled))
+	for name := range res.Enabled {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	features := make([]api.FeatureStatus, 0, len(names))
+	for _, name := range names {
+		f, ok := reg.Lookup(name)
+		if !ok {
+			continue
+		}
+		features = append(features, api.FeatureStatus{
+			Name:        f.Name,
+			Stage:       string(f.Stage),
+			Description: f.Description,
+		})
+	}
+	b.experimentalFlags.Store(&experimentalState{features: features})
+}
+
 // refreshModelAttribution re-resolves the client and server model mappings
 // from the given stack. Called at build time and from the hot-reload hook so
 // `client_models:`, `model:`, and `default_model:` edits take effect on the
@@ -1186,6 +1252,9 @@ func (b *GatewayBuilder) setupHotReload(ctx context.Context, inst *GatewayInstan
 		// Re-resolve cost attribution so `client_models:`, `model:`, and
 		// `default_model:` edits price subsequent calls without a restart.
 		b.refreshModelAttribution(newCfg)
+		// Re-resolve experimental flags so `experimental:` edits reach
+		// /api/status (and everything gated on a flag) without restart.
+		b.refreshExperimentalFlags(newCfg, slog.New(handler))
 		// Rebuild the limits policy so `limits:` edits enforce on the next
 		// call. Current-window spend carries over for unchanged entries;
 		// raising a cap mid-window never refills spent budget.

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,31 @@
+// Package env provides the one boolean environment-variable parsing rule
+// used across gridctl. Boolean env vars (kill switches, experimental flag
+// overrides) accept exactly the strconv.ParseBool vocabulary: 1, t, T, TRUE,
+// true, True, 0, f, F, FALSE, false, False. Anything else is a parse error
+// the caller surfaces as a warning; it never silently means false.
+package env
+
+import (
+	"os"
+	"strconv"
+)
+
+// Bool reads a boolean environment variable. The three outcomes are
+// distinct on purpose:
+//
+//   - unset or empty: (nil, nil) — the variable expresses no opinion and the
+//     caller falls back to its config-derived value
+//   - parseable: (&value, nil)
+//   - anything else: (nil, error) — the caller should warn and fall back,
+//     never treat the malformed value as false
+func Bool(name string) (*bool, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return nil, nil
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -1,0 +1,54 @@
+package env
+
+import "testing"
+
+func TestBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		set     bool
+		want    *bool
+		wantErr bool
+	}{
+		{name: "unset defers", set: false, want: nil},
+		{name: "empty defers", value: "", set: true, want: nil},
+		{name: "one is true", value: "1", set: true, want: boolPtr(true)},
+		{name: "zero is false", value: "0", set: true, want: boolPtr(false)},
+		{name: "true lowercase", value: "true", set: true, want: boolPtr(true)},
+		{name: "TRUE uppercase", value: "TRUE", set: true, want: boolPtr(true)},
+		{name: "False mixed", value: "False", set: true, want: boolPtr(false)},
+		{name: "t shorthand", value: "t", set: true, want: boolPtr(true)},
+		{name: "yes is an error, not false", value: "yes", set: true, wantErr: true},
+		{name: "garbage is an error", value: "banana", set: true, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const key = "GRIDCTL_TEST_ENV_BOOL"
+			if tt.set {
+				t.Setenv(key, tt.value)
+			}
+			got, err := Bool(key)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Bool(%q)=%v, want error", tt.value, got)
+				}
+				if got != nil {
+					t.Fatalf("Bool(%q) returned a value alongside the error", tt.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Bool(%q) unexpected error: %v", tt.value, err)
+			}
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("Bool(%q)=%v, want %v", tt.value, got, tt.want)
+			}
+			if got != nil && *got != *tt.want {
+				t.Fatalf("Bool(%q)=%v, want %v", tt.value, *got, *tt.want)
+			}
+		})
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -1,0 +1,341 @@
+// Package flags is gridctl's experimental feature-flag registry. A flag is
+// born experimental and off by default, is enabled per stack through the
+// top-level `experimental:` map in stack.yaml (or per process through a
+// GRIDCTL_EXPERIMENTAL_<NAME> environment variable), and graduates by having
+// its behavior promoted to a real config block. Registry entries are never
+// deleted: a graduated or removed flag keeps its entry so a stale stack.yaml
+// gets a specific migration message instead of a generic unknown-key warning.
+//
+// Stage semantics follow the OpenTelemetry Collector featuregate model.
+// Setting an unknown or concluded flag name is always a warning, never an
+// error: a stack.yaml written against a newer gridctl must still start on an
+// older one (Article IX).
+package flags
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/gridctl/gridctl/pkg/env"
+)
+
+// Stage is a flag's lifecycle position.
+type Stage string
+
+const (
+	// StageExperimental flags are off by default and settable via the
+	// `experimental:` map or env override.
+	StageExperimental Stage = "experimental"
+	// StageGraduated flags have been promoted to a real config block.
+	// Setting one warns with its migration message; the value is ignored.
+	StageGraduated Stage = "graduated"
+	// StageRemoved flags no longer exist in any form. Setting one warns
+	// with its migration message; the value is ignored.
+	StageRemoved Stage = "removed"
+)
+
+// Flag is one registry entry.
+type Flag struct {
+	// Name is the snake_case flag key, spelled identically to the stable
+	// config key the feature will graduate to.
+	Name string
+	// Description is the one-line summary shown in docs and the UI.
+	Description string
+	// Stage is the lifecycle position.
+	Stage Stage
+	// Since is the release that introduced the flag (bare semver, e.g. "0.1.0").
+	Since string
+	// GraduatesBy is the release by which an experimental flag must
+	// graduate or have its deadline deliberately extended. Required for
+	// experimental flags; the enforcement test fails past it.
+	GraduatesBy string
+	// Message is the migration text for graduated and removed flags, e.g.
+	// "graduated in 0.2.0; remove the entry, the feature is now always on".
+	Message string
+}
+
+// EnvVar returns the environment variable that overrides this flag.
+func (f Flag) EnvVar() string {
+	return "GRIDCTL_EXPERIMENTAL_" + strings.ToUpper(f.Name)
+}
+
+// Registry is an ordered, indexed set of flags.
+type Registry struct {
+	ordered []Flag
+	index   map[string]Flag
+}
+
+// NewRegistry validates and indexes a set of flags. It returns an error for
+// duplicate or empty names, a missing Since, an experimental flag without a
+// GraduatesBy, or a concluded flag without a migration Message.
+func NewRegistry(entries ...Flag) (*Registry, error) {
+	r := &Registry{index: make(map[string]Flag, len(entries))}
+	for _, f := range entries {
+		if f.Name == "" {
+			return nil, fmt.Errorf("flag with empty name")
+		}
+		if strings.ToLower(f.Name) != f.Name || strings.ContainsAny(f.Name, " -") {
+			return nil, fmt.Errorf("flag %q: name must be snake_case", f.Name)
+		}
+		if _, dup := r.index[f.Name]; dup {
+			return nil, fmt.Errorf("flag %q registered twice", f.Name)
+		}
+		if f.Since == "" {
+			return nil, fmt.Errorf("flag %q: Since is required", f.Name)
+		}
+		switch f.Stage {
+		case StageExperimental:
+			if f.GraduatesBy == "" {
+				return nil, fmt.Errorf("flag %q: GraduatesBy is required for experimental flags", f.Name)
+			}
+		case StageGraduated, StageRemoved:
+			if f.Message == "" {
+				return nil, fmt.Errorf("flag %q: Message is required for %s flags", f.Name, f.Stage)
+			}
+		default:
+			return nil, fmt.Errorf("flag %q: unknown stage %q", f.Name, f.Stage)
+		}
+		r.index[f.Name] = f
+		r.ordered = append(r.ordered, f)
+	}
+	return r, nil
+}
+
+// Lookup returns the flag with the given name.
+func (r *Registry) Lookup(name string) (Flag, bool) {
+	f, ok := r.index[name]
+	return f, ok
+}
+
+// All returns every entry in registration order.
+func (r *Registry) All() []Flag {
+	out := make([]Flag, len(r.ordered))
+	copy(out, r.ordered)
+	return out
+}
+
+// experimentalNames returns the sorted names of settable (experimental)
+// flags, for "valid names are:" warning text.
+func (r *Registry) experimentalNames() []string {
+	var names []string
+	for _, f := range r.ordered {
+		if f.Stage == StageExperimental {
+			names = append(names, f.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// builtin is gridctl's flag registry. Entries are append-only: graduation
+// flips Stage and adds a Message, removal flips Stage again; names are never
+// deleted. The lifecycle rules live in CONTRIBUTING.md.
+var builtin = []Flag{
+	{
+		Name:        "transport_dual_stack",
+		Description: "Reserved for the MCP 2026-07-28 transport dual-stack work; currently has no effect.",
+		Stage:       StageExperimental,
+		Since:       "0.1.0",
+		GraduatesBy: "0.3.0",
+	},
+}
+
+var defaultRegistry = sync.OnceValues(func() (*Registry, error) {
+	return NewRegistry(builtin...)
+})
+
+// Default returns the built-in registry. The entries are compile-time
+// constants validated by TestBuiltinRegistryValid; if construction ever
+// fails at runtime an empty registry is returned so no flag resolves on.
+func Default() *Registry {
+	r, err := defaultRegistry()
+	if err != nil {
+		return &Registry{index: map[string]Flag{}}
+	}
+	return r
+}
+
+// Warning is one advisory finding from resolution or name validation.
+// Warnings never block an apply.
+type Warning struct {
+	// Name is the flag key the warning is about ("" for none).
+	Name string
+	// Message is the full human-readable warning text.
+	Message string
+}
+
+// Resolved is the outcome of resolving a stack's experimental map against a
+// registry and the process environment.
+type Resolved struct {
+	// Enabled maps every known experimental flag name that resolved to true.
+	// Flags resolving to false are absent. Nil when nothing is enabled.
+	Enabled map[string]bool
+	// Warnings lists unknown names, concluded names, and malformed env
+	// overrides encountered during resolution.
+	Warnings []Warning
+}
+
+// Resolve computes the effective flag set from the stack.yaml `experimental:`
+// map and per-flag GRIDCTL_EXPERIMENTAL_<NAME> env overrides. An env override
+// beats the YAML value; an unset env var defers to YAML; a malformed env
+// value warns and defers to YAML (never silently false). Unknown YAML names
+// warn listing the valid flags; graduated and removed names warn with their
+// migration message and contribute nothing.
+func Resolve(reg *Registry, experimental map[string]bool) Resolved {
+	res := Resolved{}
+	res.Warnings = append(res.Warnings, CheckNames(reg, experimental)...)
+
+	values := map[string]bool{}
+	for name, value := range experimental {
+		if f, ok := reg.Lookup(name); ok && f.Stage == StageExperimental {
+			values[name] = value
+		}
+	}
+	for _, f := range reg.All() {
+		if f.Stage != StageExperimental {
+			continue
+		}
+		override, err := env.Bool(f.EnvVar())
+		if err != nil {
+			res.Warnings = append(res.Warnings, Warning{
+				Name: f.Name,
+				Message: fmt.Sprintf("%s=%q is not a boolean (accepted: 1, 0, true, false); ignoring the override",
+					f.EnvVar(), os.Getenv(f.EnvVar())),
+			})
+			continue
+		}
+		if override != nil {
+			values[f.Name] = *override
+		}
+	}
+
+	for name, on := range values {
+		if !on {
+			continue
+		}
+		if res.Enabled == nil {
+			res.Enabled = map[string]bool{}
+		}
+		res.Enabled[name] = true
+	}
+	return res
+}
+
+// CheckNames validates the names of a stack's experimental map against a
+// registry without consulting the environment. It backs both apply-time
+// console warnings and the design-time ValidateWithIssues channel.
+func CheckNames(reg *Registry, experimental map[string]bool) []Warning {
+	if len(experimental) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(experimental))
+	for name := range experimental {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var warnings []Warning
+	for _, name := range names {
+		f, ok := reg.Lookup(name)
+		if !ok {
+			valid := reg.experimentalNames()
+			hint := "no experimental flags are registered in this build"
+			if len(valid) > 0 {
+				hint = "valid flags: " + strings.Join(valid, ", ")
+			}
+			warnings = append(warnings, Warning{
+				Name:    name,
+				Message: fmt.Sprintf("unknown experimental flag %q ignored (%s)", name, hint),
+			})
+			continue
+		}
+		switch f.Stage {
+		case StageGraduated, StageRemoved:
+			warnings = append(warnings, Warning{
+				Name:    name,
+				Message: fmt.Sprintf("experimental flag %q %s: %s", name, concludedVerb(f.Stage), f.Message),
+			})
+		case StageExperimental:
+			// Settable; nothing to report.
+		}
+	}
+	return warnings
+}
+
+// Overdue returns the experimental flags whose GraduatesBy deadline is at or
+// before currentVersion. An empty, "dev", or unparseable currentVersion
+// returns nil: development builds never enforce the graduation clock.
+// Pre-release suffixes are ignored — the clock compares major.minor.patch
+// only, so 0.3.0-beta.1 already counts as 0.3.0.
+func Overdue(reg *Registry, currentVersion string) []Flag {
+	current, ok := parseVersion(currentVersion)
+	if !ok {
+		return nil
+	}
+	var overdue []Flag
+	for _, f := range reg.All() {
+		if f.Stage != StageExperimental {
+			continue
+		}
+		deadline, ok := parseVersion(f.GraduatesBy)
+		if !ok {
+			continue
+		}
+		if compareVersions(current, deadline) >= 0 {
+			overdue = append(overdue, f)
+		}
+	}
+	return overdue
+}
+
+// concludedVerb labels a concluded flag's warning. The Message is expected
+// to name the release the conclusion landed in (see CONTRIBUTING.md) — the
+// registry cannot derive it, since GraduatesBy is a deadline, not the
+// release the decision actually shipped in.
+func concludedVerb(s Stage) string {
+	if s == StageGraduated {
+		return "graduated"
+	}
+	return "was removed"
+}
+
+type version struct{ major, minor, patch uint64 }
+
+// parseVersion parses "1.2.3", "v1.2.3", or "1.2.3-beta.4" into a numeric
+// triple, deliberately dropping any pre-release suffix: the graduation clock
+// treats 0.3.0-beta.1 as 0.3.0 so a decision is forced by the first build of
+// the deadline release.
+func parseVersion(s string) (version, bool) {
+	v, err := semver.NewVersion(strings.TrimSpace(s))
+	if err != nil {
+		return version{}, false
+	}
+	return version{major: v.Major(), minor: v.Minor(), patch: v.Patch()}, true
+}
+
+func compareVersions(a, b version) int {
+	switch {
+	case a.major != b.major:
+		return cmpUint64(a.major, b.major)
+	case a.minor != b.minor:
+		return cmpUint64(a.minor, b.minor)
+	default:
+		return cmpUint64(a.patch, b.patch)
+	}
+}
+
+func cmpUint64(a, b uint64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -1,0 +1,365 @@
+package flags
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func experimentalFlag(name string) Flag {
+	return Flag{
+		Name:        name,
+		Description: "test flag",
+		Stage:       StageExperimental,
+		Since:       "0.1.0",
+		GraduatesBy: "0.3.0",
+	}
+}
+
+func mustRegistry(t *testing.T, entries ...Flag) *Registry {
+	t.Helper()
+	r, err := NewRegistry(entries...)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	return r
+}
+
+func TestNewRegistry(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []Flag
+		wantErr string
+	}{
+		{name: "empty registry is valid"},
+		{name: "valid experimental flag", entries: []Flag{experimentalFlag("foo_bar")}},
+		{
+			name: "valid graduated flag",
+			entries: []Flag{{
+				Name: "old_flag", Description: "d", Stage: StageGraduated,
+				Since: "0.1.0", GraduatesBy: "0.2.0",
+				Message: "remove the entry, the feature is now always on",
+			}},
+		},
+		{
+			name:    "duplicate names rejected",
+			entries: []Flag{experimentalFlag("dup"), experimentalFlag("dup")},
+			wantErr: "registered twice",
+		},
+		{
+			name:    "empty name rejected",
+			entries: []Flag{{Stage: StageExperimental, Since: "0.1.0", GraduatesBy: "0.2.0"}},
+			wantErr: "empty name",
+		},
+		{
+			name:    "kebab-case rejected",
+			entries: []Flag{experimentalFlag("foo-bar")},
+			wantErr: "snake_case",
+		},
+		{
+			name: "experimental without GraduatesBy rejected",
+			entries: []Flag{{
+				Name: "no_deadline", Stage: StageExperimental, Since: "0.1.0",
+			}},
+			wantErr: "GraduatesBy is required",
+		},
+		{
+			name: "graduated without Message rejected",
+			entries: []Flag{{
+				Name: "no_message", Stage: StageGraduated, Since: "0.1.0",
+			}},
+			wantErr: "Message is required",
+		},
+		{
+			name:    "missing Since rejected",
+			entries: []Flag{{Name: "no_since", Stage: StageExperimental, GraduatesBy: "0.2.0"}},
+			wantErr: "Since is required",
+		},
+		{
+			name:    "unknown stage rejected",
+			entries: []Flag{{Name: "bad_stage", Stage: Stage("beta"), Since: "0.1.0"}},
+			wantErr: "unknown stage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewRegistry(tt.entries...)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("NewRegistry: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("NewRegistry error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuiltinRegistryValid(t *testing.T) {
+	if _, err := NewRegistry(builtin...); err != nil {
+		t.Fatalf("built-in registry invalid: %v", err)
+	}
+	if len(Default().All()) != len(builtin) {
+		t.Fatal("Default() lost entries")
+	}
+}
+
+func TestLookupAndAll(t *testing.T) {
+	r := mustRegistry(t, experimentalFlag("aaa"), experimentalFlag("bbb"))
+	if _, ok := r.Lookup("aaa"); !ok {
+		t.Fatal("Lookup(aaa) not found")
+	}
+	if _, ok := r.Lookup("missing"); ok {
+		t.Fatal("Lookup(missing) unexpectedly found")
+	}
+	all := r.All()
+	if len(all) != 2 || all[0].Name != "aaa" || all[1].Name != "bbb" {
+		t.Fatalf("All() = %v, want registration order aaa, bbb", all)
+	}
+	// All returns a copy: mutating it must not corrupt the registry.
+	all[0].Name = "mutated"
+	if _, ok := r.Lookup("aaa"); !ok {
+		t.Fatal("registry mutated through All() result")
+	}
+}
+
+func TestEnvVar(t *testing.T) {
+	f := experimentalFlag("transport_dual_stack")
+	if got := f.EnvVar(); got != "GRIDCTL_EXPERIMENTAL_TRANSPORT_DUAL_STACK" {
+		t.Fatalf("EnvVar() = %q", got)
+	}
+}
+
+func TestResolve(t *testing.T) {
+	// Article IX back-compat first: an absent map resolves to nothing.
+	t.Run("nil map resolves empty", func(t *testing.T) {
+		r := mustRegistry(t, experimentalFlag("foo"))
+		res := Resolve(r, nil)
+		if res.Enabled != nil || len(res.Warnings) != 0 {
+			t.Fatalf("Resolve(nil) = %+v, want empty", res)
+		}
+	})
+
+	t.Run("yaml true enables", func(t *testing.T) {
+		r := mustRegistry(t, experimentalFlag("foo"))
+		res := Resolve(r, map[string]bool{"foo": true})
+		if !res.Enabled["foo"] || len(res.Warnings) != 0 {
+			t.Fatalf("Resolve = %+v", res)
+		}
+	})
+
+	t.Run("yaml false stays off and out of Enabled", func(t *testing.T) {
+		r := mustRegistry(t, experimentalFlag("foo"))
+		res := Resolve(r, map[string]bool{"foo": false})
+		if res.Enabled != nil {
+			t.Fatalf("Enabled = %v, want nil", res.Enabled)
+		}
+	})
+
+	t.Run("unknown name warns and lists valid flags", func(t *testing.T) {
+		r := mustRegistry(t, experimentalFlag("foo"))
+		res := Resolve(r, map[string]bool{"tpyo": true})
+		if res.Enabled != nil {
+			t.Fatalf("Enabled = %v, want nil", res.Enabled)
+		}
+		if len(res.Warnings) != 1 ||
+			!strings.Contains(res.Warnings[0].Message, `unknown experimental flag "tpyo"`) ||
+			!strings.Contains(res.Warnings[0].Message, "valid flags: foo") {
+			t.Fatalf("Warnings = %+v", res.Warnings)
+		}
+	})
+
+	t.Run("graduated name warns with migration message and is ignored", func(t *testing.T) {
+		r := mustRegistry(t, Flag{
+			Name: "grown_up", Description: "d", Stage: StageGraduated,
+			Since: "0.1.0", GraduatesBy: "0.2.0",
+			Message: "graduated in 0.2.0; remove the entry, the feature is now always on",
+		})
+		res := Resolve(r, map[string]bool{"grown_up": true})
+		if res.Enabled != nil {
+			t.Fatalf("Enabled = %v, want nil", res.Enabled)
+		}
+		if len(res.Warnings) != 1 ||
+			!strings.Contains(res.Warnings[0].Message, `"grown_up" graduated:`) ||
+			!strings.Contains(res.Warnings[0].Message, "always on") {
+			t.Fatalf("Warnings = %+v", res.Warnings)
+		}
+	})
+
+	t.Run("removed name warns with migration message", func(t *testing.T) {
+		r := mustRegistry(t, Flag{
+			Name: "gone", Description: "d", Stage: StageRemoved,
+			Since: "0.1.0", GraduatesBy: "0.2.0", Message: "the experiment was abandoned in 0.3.0",
+		})
+		res := Resolve(r, map[string]bool{"gone": true})
+		if res.Enabled != nil || len(res.Warnings) != 1 ||
+			!strings.Contains(res.Warnings[0].Message, `"gone" was removed: the experiment was abandoned in 0.3.0`) {
+			t.Fatalf("res = %+v", res)
+		}
+	})
+
+	t.Run("env override beats yaml true", func(t *testing.T) {
+		r := mustRegistry(t, experimentalFlag("foo"))
+		t.Setenv("GRIDCTL_EXPERIMENTAL_FOO", "false")
+		res := Resolve(r, map[string]bool{"foo": true})
+		if res.Enabled != nil {
+			t.Fatalf("Enabled = %v, want nil (env false wins)", res.Enabled)
+		}
+	})
+
+	t.Run("env override enables without yaml", func(t *testing.T) {
+		r := mustRegistry(t, experimentalFlag("foo"))
+		t.Setenv("GRIDCTL_EXPERIMENTAL_FOO", "1")
+		res := Resolve(r, nil)
+		if !res.Enabled["foo"] {
+			t.Fatalf("Enabled = %v, want foo on", res.Enabled)
+		}
+	})
+
+	t.Run("malformed env warns and defers to yaml", func(t *testing.T) {
+		r := mustRegistry(t, experimentalFlag("foo"))
+		t.Setenv("GRIDCTL_EXPERIMENTAL_FOO", "banana")
+		res := Resolve(r, map[string]bool{"foo": true})
+		if !res.Enabled["foo"] {
+			t.Fatal("yaml true must survive a malformed env override")
+		}
+		if len(res.Warnings) != 1 ||
+			!strings.Contains(res.Warnings[0].Message, `GRIDCTL_EXPERIMENTAL_FOO="banana"`) {
+			t.Fatalf("Warnings = %+v", res.Warnings)
+		}
+	})
+}
+
+func TestCheckNames_EmptyMap(t *testing.T) {
+	r := mustRegistry(t, experimentalFlag("foo"))
+	if w := CheckNames(r, nil); w != nil {
+		t.Fatalf("CheckNames(nil) = %v, want nil", w)
+	}
+	if w := CheckNames(r, map[string]bool{}); w != nil {
+		t.Fatalf("CheckNames(empty) = %v, want nil", w)
+	}
+}
+
+func TestCheckNames_DeterministicOrder(t *testing.T) {
+	r := mustRegistry(t)
+	w := CheckNames(r, map[string]bool{"zzz": true, "aaa": true})
+	if len(w) != 2 || w[0].Name != "aaa" || w[1].Name != "zzz" {
+		t.Fatalf("warnings not sorted by name: %+v", w)
+	}
+}
+
+func TestOverdue(t *testing.T) {
+	deadline := Flag{
+		Name: "late", Description: "d", Stage: StageExperimental,
+		Since: "0.1.0", GraduatesBy: "0.2.0",
+	}
+	fresh := Flag{
+		Name: "fresh", Description: "d", Stage: StageExperimental,
+		Since: "0.1.0", GraduatesBy: "9.9.9",
+	}
+	r := mustRegistry(t, deadline, fresh)
+
+	tests := []struct {
+		name    string
+		version string
+		want    []string
+	}{
+		{name: "before deadline", version: "0.1.9", want: nil},
+		{name: "at deadline is overdue", version: "0.2.0", want: []string{"late"}},
+		{name: "past deadline", version: "1.0.0", want: []string{"late"}},
+		{name: "prerelease of deadline counts", version: "0.2.0-beta.1", want: []string{"late"}},
+		{name: "v prefix accepted", version: "v0.2.0", want: []string{"late"}},
+		{name: "dev build never enforces", version: "dev", want: nil},
+		{name: "empty version never enforces", version: "", want: nil},
+		{name: "unparseable version never enforces", version: "nightly", want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Overdue(r, tt.version)
+			var names []string
+			for _, f := range got {
+				names = append(names, f.Name)
+			}
+			if len(names) != len(tt.want) {
+				t.Fatalf("Overdue(%q) = %v, want %v", tt.version, names, tt.want)
+			}
+			for i := range names {
+				if names[i] != tt.want[i] {
+					t.Fatalf("Overdue(%q) = %v, want %v", tt.version, names, tt.want)
+				}
+			}
+		})
+	}
+
+	// Graduated flags are never overdue: the decision was made.
+	t.Run("graduated flags exempt", func(t *testing.T) {
+		r := mustRegistry(t, Flag{
+			Name: "done", Description: "d", Stage: StageGraduated,
+			Since: "0.1.0", GraduatesBy: "0.2.0", Message: "always on",
+		})
+		if got := Overdue(r, "9.9.9"); got != nil {
+			t.Fatalf("Overdue = %v, want nil", got)
+		}
+	})
+}
+
+// TestNoBuiltinFlagOverdue is the graduation clock: it fails when a built-in
+// experimental flag's GraduatesBy is at or before the most recent release in
+// CHANGELOG.md. Fix it by graduating the flag (promote the config, flip the
+// Stage, add a Message) or by deliberately extending GraduatesBy in a
+// reviewed diff.
+func TestNoBuiltinFlagOverdue(t *testing.T) {
+	version := latestReleaseVersion(t)
+	if version == "" {
+		t.Skip("no release heading found in CHANGELOG.md")
+	}
+	overdue := Overdue(Default(), version)
+	for _, f := range overdue {
+		t.Errorf("flag %q passed its GraduatesBy deadline (%s, current release %s): graduate it or extend the deadline deliberately",
+			f.Name, f.GraduatesBy, version)
+	}
+}
+
+// latestReleaseVersion parses the newest "## [x.y.z...]" heading out of the
+// repo's CHANGELOG.md, skipping [Unreleased].
+func latestReleaseVersion(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "CHANGELOG.md"))
+	if err != nil {
+		t.Skipf("CHANGELOG.md unreadable: %v", err)
+	}
+	re := regexp.MustCompile(`(?m)^## \[(\d+\.\d+\.\d+[^\]]*)\]`)
+	m := re.FindSubmatch(data)
+	if m == nil {
+		return ""
+	}
+	return string(m[1])
+}
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		ok   bool
+		want version
+	}{
+		{"1.2.3", true, version{1, 2, 3}},
+		{"v1.2.3", true, version{1, 2, 3}},
+		{"0.1.0-beta.15", true, version{0, 1, 0}},
+		{"1.2.3+build.4", true, version{1, 2, 3}},
+		{"dev", false, version{}},
+		{"", false, version{}},
+		{"1.2", true, version{1, 2, 0}}, // semver coerces a missing patch to 0
+		{"a.b.c", false, version{}},
+	}
+	for _, tt := range tests {
+		got, ok := parseVersion(tt.in)
+		if ok != tt.ok || got != tt.want {
+			t.Errorf("parseVersion(%q) = %v, %v; want %v, %v", tt.in, got, ok, tt.want, tt.ok)
+		}
+	}
+}

--- a/pkg/reload/diff.go
+++ b/pkg/reload/diff.go
@@ -33,6 +33,10 @@ type ConfigDiff struct {
 	// Like ClientsChanged it needs only an in-memory policy rebuild via the
 	// onConfigApplied hook but must still mark the diff non-empty.
 	GroupsChanged bool
+	// ExperimentalChanged indicates the `experimental:` flag map changed.
+	// Like ClientsChanged it needs only an in-memory flag re-resolution via
+	// the onConfigApplied hook but must still mark the diff non-empty.
+	ExperimentalChanged bool
 }
 
 // MCPServerDiff contains changes to MCP servers.
@@ -80,7 +84,8 @@ func (d *ConfigDiff) IsEmpty() bool {
 		!d.ClientsChanged &&
 		!d.ModelAttributionChanged &&
 		!d.LimitsChanged &&
-		!d.GroupsChanged
+		!d.GroupsChanged &&
+		!d.ExperimentalChanged
 }
 
 // ComputeDiff computes the differences between two stack configurations.
@@ -108,7 +113,18 @@ func ComputeDiff(old, new *config.Stack) *ConfigDiff {
 	// Detect tool-group (`groups:`) changes
 	diff.GroupsChanged = groupsChanged(old, new)
 
+	// Detect experimental flag (`experimental:`) changes
+	diff.ExperimentalChanged = experimentalChanged(old, new)
+
 	return diff
+}
+
+// experimentalChanged reports whether the `experimental:` flag map differs
+// between two stacks. A change needs only the resolved flag set rebuilt (via
+// the reload's onConfigApplied hook); no containers are touched. maps.Equal
+// handles the nil-to-set transitions directly.
+func experimentalChanged(old, new *config.Stack) bool {
+	return !maps.Equal(old.Experimental, new.Experimental)
 }
 
 // groupsChanged reports whether the `groups:` block differs between two

--- a/pkg/reload/diff_experimental_test.go
+++ b/pkg/reload/diff_experimental_test.go
@@ -1,0 +1,62 @@
+package reload
+
+import (
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/config"
+)
+
+func experimentalTestStack(experimental map[string]bool) *config.Stack {
+	return &config.Stack{
+		Name:         "test",
+		Network:      config.Network{Name: "test-net", Driver: "bridge"},
+		MCPServers:   []config.MCPServer{{Name: "github", Image: "image1", Port: 3000}},
+		Experimental: experimental,
+	}
+}
+
+func TestComputeDiff_ExperimentalOnlyChange(t *testing.T) {
+	old := experimentalTestStack(nil)
+	new := experimentalTestStack(map[string]bool{"transport_dual_stack": true})
+
+	diff := ComputeDiff(old, new)
+	if !diff.ExperimentalChanged {
+		t.Error("expected ExperimentalChanged to be true")
+	}
+	if diff.IsEmpty() {
+		t.Error("expected non-empty diff for an experimental-only change so onConfigApplied fires")
+	}
+	if len(diff.MCPServers.Added) != 0 || len(diff.MCPServers.Modified) != 0 ||
+		diff.NetworkChanged || diff.ClientsChanged || diff.LimitsChanged || diff.GroupsChanged {
+		t.Error("experimental-only change flagged unrelated diffs")
+	}
+}
+
+func TestComputeDiff_ExperimentalIdentical(t *testing.T) {
+	mk := func() map[string]bool {
+		return map[string]bool{"transport_dual_stack": true, "other": false}
+	}
+	diff := ComputeDiff(experimentalTestStack(mk()), experimentalTestStack(mk()))
+	if diff.ExperimentalChanged {
+		t.Error("expected ExperimentalChanged to be false for identical maps")
+	}
+	if !diff.IsEmpty() {
+		t.Error("expected empty diff for stacks with identical experimental maps")
+	}
+}
+
+func TestComputeDiff_ExperimentalValueFlip(t *testing.T) {
+	old := experimentalTestStack(map[string]bool{"transport_dual_stack": true})
+	new := experimentalTestStack(map[string]bool{"transport_dual_stack": false})
+	if diff := ComputeDiff(old, new); !diff.ExperimentalChanged {
+		t.Error("expected a true-to-false flip to mark ExperimentalChanged")
+	}
+}
+
+func TestComputeDiff_ExperimentalSetToNil(t *testing.T) {
+	old := experimentalTestStack(map[string]bool{"transport_dual_stack": true})
+	new := experimentalTestStack(nil)
+	if diff := ComputeDiff(old, new); !diff.ExperimentalChanged {
+		t.Error("expected removing the block to mark ExperimentalChanged")
+	}
+}

--- a/pkg/skills/updater.go
+++ b/pkg/skills/updater.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/gridctl/gridctl/pkg/env"
 )
 
 // UpdateStatus records the result of a background update check.
@@ -74,8 +76,10 @@ func WriteUpdateCacheAt(path string, status *UpdateStatus) error {
 }
 
 // ShouldCheckUpdates returns false if update checks are disabled.
+// GRIDCTL_NO_SKILL_UPDATE_CHECK accepts the shared boolean vocabulary
+// (env.Bool); a malformed value is ignored and checks proceed.
 func ShouldCheckUpdates() bool {
-	if os.Getenv("GRIDCTL_NO_SKILL_UPDATE_CHECK") == "1" {
+	if disabled, err := env.Bool("GRIDCTL_NO_SKILL_UPDATE_CHECK"); err == nil && disabled != nil && *disabled {
 		return false
 	}
 	if os.Getenv("CI") == "true" {

--- a/web/src/__tests__/StatusBar.test.tsx
+++ b/web/src/__tests__/StatusBar.test.tsx
@@ -37,6 +37,7 @@ beforeEach(() => {
     codeMode: 'off',
     tokenUsage: null,
     costUsage: null,
+    featureDetails: [],
     connectionStatus: 'connected',
     lastUpdated: null,
     error: null,
@@ -64,5 +65,23 @@ describe('StatusBar', () => {
     renderBar();
     expect(screen.getByText('MCP')).toBeInTheDocument();
     expect(screen.queryByText('err')).not.toBeInTheDocument();
+  });
+
+  it('shows an aggregate experimental chip when flags are enabled', () => {
+    useStackStore.setState({
+      featureDetails: [
+        { name: 'transport_dual_stack', stage: 'experimental', description: 'd' },
+        { name: 'other_flag', stage: 'experimental', description: 'd' },
+      ],
+    });
+    renderBar();
+    const chip = screen.getByRole('button', { name: /2 experimental flags enabled/i });
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent('experimental');
+  });
+
+  it('hides the experimental chip when no flags are enabled', () => {
+    renderBar();
+    expect(screen.queryByText('experimental')).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { Wifi, WifiOff, Clock, Server, Box, Radio, Code, Gauge, ArrowDown, DollarSign } from 'lucide-react';
+import { Wifi, WifiOff, Clock, Server, Box, Radio, Code, FlaskConical, Gauge, ArrowDown, DollarSign } from 'lucide-react';
 import { useNavigate } from 'react-router';
 import { cn } from '../../lib/cn';
 import { useStackStore } from '../../stores/useStackStore';
@@ -16,6 +16,7 @@ export function StatusBar() {
   const resources = useStackStore((s) => s.resources);
   const sessions = useStackStore((s) => s.sessions);
   const codeMode = useStackStore((s) => s.codeMode);
+  const featureDetails = useStackStore((s) => s.featureDetails);
   const tokenUsage = useStackStore((s) => s.tokenUsage);
   const costUsage = useStackStore((s) => s.costUsage);
   const tokenizerName = useStackStore((s) => s.gatewayInfo?.tokenizer);
@@ -102,6 +103,26 @@ export function StatusBar() {
             <Code size={11} className="text-primary" />
             <span className="text-primary font-semibold">Code Mode</span>
           </div>
+        )}
+
+        {/* Experimental flags — an aggregate count, deliberately neutral (an
+            enabled experiment is not "good" or "bad"). Read-only: flags are
+            configured in stack.yaml and cannot be toggled from the UI; the
+            click deep-links to the spec pane where each flag is listed. */}
+        {featureDetails.length > 0 && (
+          <button
+            type="button"
+            onClick={() => navigate('/stack?spec=1')}
+            aria-label={`${featureDetails.length} experimental ${featureDetails.length === 1 ? 'flag' : 'flags'} enabled. Open spec pane`}
+            title={featureDetails.map((f) => f.name).join(', ')}
+            className="flex items-center gap-2 text-text-muted rounded px-1 -mx-1 hover:bg-surface-highlight/50 hover:text-text-secondary transition-colors"
+          >
+            <FlaskConical size={11} />
+            <span>
+              <span className="font-semibold">{featureDetails.length}</span>
+              <span className="ml-1">experimental</span>
+            </span>
+          </button>
         )}
 
         {/* Token counter — opens the Metrics workspace */}

--- a/web/src/components/spec/SpecTab.tsx
+++ b/web/src/components/spec/SpecTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useRef } from 'react';
-import { GitCompareArrows, AlertCircle, CheckCircle2, AlertTriangle, RefreshCw } from 'lucide-react';
+import { GitCompareArrows, AlertCircle, CheckCircle2, AlertTriangle, FlaskConical, RefreshCw } from 'lucide-react';
 import { useSpecStore } from '../../stores/useSpecStore';
+import { useStackStore } from '../../stores/useStackStore';
 import { fetchStackSpec, fetchStackHealth, validateStackSpec } from '../../lib/api';
 import type { ValidationIssue, IssueSeverity } from '../../types';
 
@@ -86,6 +87,7 @@ function getLineIssues(lineNum: number, issues: ValidationIssue[]): ValidationIs
 }
 
 export function SpecTab() {
+  const featureDetails = useStackStore((s) => s.featureDetails);
   const spec = useSpecStore((s) => s.spec);
   const specLoading = useSpecStore((s) => s.specLoading);
   const specError = useSpecStore((s) => s.specError);
@@ -191,6 +193,25 @@ export function SpecTab() {
           Compare to running
         </button>
       </div>
+
+      {/* Enabled experimental flags — read-only rows (flags are configured
+          in stack.yaml, or via GRIDCTL_EXPERIMENTAL_* env vars, and cannot
+          be toggled here). Stage is conveyed as text plus the flask icon,
+          never color alone. */}
+      {featureDetails.length > 0 && (
+        <div role="status" aria-label="Enabled experimental flags" className="px-4 py-2 border-b border-border/30 flex-shrink-0 space-y-1">
+          {featureDetails.map((f) => (
+            <div key={f.name} className="flex items-start gap-2 text-xs">
+              <FlaskConical size={11} className="text-text-muted mt-0.5 flex-shrink-0" />
+              <span className="font-mono text-text-secondary">{f.name}</span>
+              <span className="px-1.5 rounded-full border border-border/50 text-text-muted uppercase tracking-wide text-[10px]">
+                {f.stage}
+              </span>
+              {f.description && <span className="text-text-muted">{f.description}</span>}
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Spec content */}
       <div className="flex-1 overflow-auto scrollbar-dark font-mono text-xs leading-relaxed">

--- a/web/src/stores/useStackStore.ts
+++ b/web/src/stores/useStackStore.ts
@@ -12,6 +12,7 @@ import type {
   TokenUsage,
   CostUsage,
   EffectiveModel,
+  FeatureDetail,
   ConnectionStatus,
   AutoscaleDecisionKind,
 } from '../types';
@@ -71,6 +72,8 @@ interface StackState {
   effectiveClientModels: Record<string, EffectiveModel>;
   effectiveServerModels: Record<string, EffectiveModel>;
   stackName: string;        // Active stack name; empty string in stackless mode
+  features: Record<string, boolean>;  // Enabled experimental flags, name -> true
+  featureDetails: FeatureDetail[];    // Display metadata for the same flags (read-only)
 
   // === React Flow State ===
   nodes: Node[];
@@ -149,6 +152,8 @@ export const useStackStore = create<StackState>()(
     effectiveServerModels: {},
     defaultModel: '',
     stackName: '',
+    features: {},
+    featureDetails: [],
     nodes: [],
     edges: [],
     draggedPositions: new Map(),
@@ -210,6 +215,8 @@ export const useStackStore = create<StackState>()(
         effectiveServerModels: status.effective_server_models ?? {},
         defaultModel: status.default_model ?? '',
         stackName: status.stack_name || '',
+        features: status.features ?? {},
+        featureDetails: status.feature_details ?? [],
         autoscaleHistory: folded.history,
         autoscaleDecisions: folded.decisions,
         autoscaleLastSeen: folded.lastSeen,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -276,6 +276,15 @@ export interface EffectiveModel {
   models?: ModelShare[];      // full breakdown, descending by cost
 }
 
+// One enabled experimental flag from /api/status feature_details.
+// Read-only display metadata: flags are configured in stack.yaml (or via
+// GRIDCTL_EXPERIMENTAL_* env vars) and cannot be toggled from the UI.
+export interface FeatureDetail {
+  name: string;        // snake_case flag key, e.g. "transport_dual_stack"
+  stage: string;       // lifecycle stage, e.g. "experimental"
+  description: string; // one-line summary from the flag registry
+}
+
 // Gateway status response from GET /api/status
 export interface GatewayStatus {
   gateway: ServerInfo;
@@ -294,6 +303,8 @@ export interface GatewayStatus {
   effective_client_models?: Record<string, EffectiveModel>;
   effective_server_models?: Record<string, EffectiveModel>;
   stack_name?: string;     // Active stack name; omitted in stackless mode
+  features?: Record<string, boolean>; // Enabled experimental flags, name -> true (omitted when none)
+  feature_details?: FeatureDetail[];  // Display metadata for the same flags (omitted when none)
 }
 
 // Response from GET /api/pricing/models


### PR DESCRIPTION
## Summary

Adds lightweight feature-flag scaffolding so risky work can ship dark and graduate once proven. Everything defaults to off: an unchanged stack.yaml behaves identically.

- **`pkg/flags`**: typed registry (name, description, stage, since, graduates-by) with OTel-style lifecycle stages (experimental / graduated / removed). Registry entries are never deleted, so concluded flags produce specific migration messages instead of generic unknown-key warnings. `TestNoBuiltinFlagOverdue` fails when a flag outlives its graduation deadline (parsed from the latest CHANGELOG release), forcing graduate-or-extend each release.
- **`experimental:` block in stack.yaml**: enables registered flags by name. Unknown names warn at `gridctl apply` (console) and `gridctl validate` / UI validate panel (listing valid names); never an error, so a stack written against a newer gridctl still deploys.
- **Env overrides**: `GRIDCTL_EXPERIMENTAL_<NAME>` per flag, `strconv.ParseBool` vocabulary via a new shared `pkg/env` helper. Unset defers to YAML; unparseable warns and is ignored. `GRIDCTL_NO_SKILL_UPDATE_CHECK` is retrofitted onto the helper (`"1"` still works, `true` now also accepted).
- **Visibility**: enabled flags appear in `GET /api/status` (`features` capability bits + `feature_details` display metadata), `gridctl status --json`, and the web UI as a read-only "N experimental" status-bar chip with per-flag rows in the spec pane. Flags are configured in stack.yaml only; no UI toggle.
- **Hot reload**: `experimental:` edits re-resolve via a new `ExperimentalChanged` diff flag and the existing `onConfigApplied` hook; no container restarts.
- **code_mode graduates to stable**: experimental labels removed from code comments, CLI help, and docs. Behavior unchanged.
- **Docs**: new `## Experimental` section in config-schema.md, /api/status fields in api-reference.md, and the flag lifecycle (stages, deadlines, graduation clock) in CONTRIBUTING.md.

The first registered flag, `transport_dual_stack`, is reserved for the MCP transport dual-stack work and currently has no effect.

## Testing

- `go test -race ./...` passes; new table-driven tests cover the registry, resolution, env parsing, health warnings, reload diff, builder wiring, and /api/status present/omitted shapes
- `cd web && npm test` passes (1655 tests), with new StatusBar chip coverage
- `golangci-lint run` clean; `task build` (embedded UI) verified, plus a manual `gridctl validate` smoke test of unknown-name warning, info line, exit code 2, and `--format json` output

Closes #1021