### PR TITLE
fix: deflake disk-watch router assertion

### DIFF
--- a/tests/integration/registry_disk_watch_test.go
+++ b/tests/integration/registry_disk_watch_test.go
@@ -79,11 +79,15 @@ func TestRegistryDiskWatch_PicksUpOutOfBandSkill(t *testing.T) {
 	// Write a skill directly to disk, out-of-band — the reported scenario.
 	writeSkill(t, registryDir, "node-state-snapshot", "active")
 
-	// The watcher should reconcile it within the debounce window.
+	// The watcher should reconcile it within the debounce window. The
+	// refresh callback reloads the store before registering the router
+	// client, so the skill becomes visible mid-refresh; wait for both
+	// conditions rather than asserting router state off a store-only
+	// poll, which can observe the window between the two steps.
 	deadline := time.Now().Add(5 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		if _, lastErr = srv.Store().GetSkill("node-state-snapshot"); lastErr == nil {
+		if _, lastErr = srv.Store().GetSkill("node-state-snapshot"); lastErr == nil && gw.Router().GetClient("registry") != nil {
 			break
 		}
 		time.Sleep(50 * time.Millisecond)
@@ -93,7 +97,7 @@ func TestRegistryDiskWatch_PicksUpOutOfBandSkill(t *testing.T) {
 	}
 
 	if gw.Router().GetClient("registry") == nil {
-		t.Error("expected registry client registered with the router after the skill appeared")
+		t.Error("registry client not registered with the router within deadline")
 	}
 }
 


### PR DESCRIPTION
## Description

`TestRegistryDiskWatch_PicksUpOutOfBandSkill` intermittently failed in CI: it polled the skill store with a retry loop but asserted router registration immediately afterward, racing the watcher's refresh callback, which reloads the store before calling `AddClient`. A poll tick landing in that window saw the skill present and the router client absent. Test-only race; production behavior is unchanged.

## Type of Change

- [x] Bug fix (flaky test)

## Changes Made

- The deadline loop now waits for both conditions (skill visible in the store and registry client registered with the router) before asserting
- Deadline failures name the specific unmet condition, so a genuine regression in either half stays diagnosable from CI logs

## Testing

`go test -tags=integration -race -run TestRegistryDiskWatch -count=20 ./tests/integration/` passes; both failure branches verified to fire under local inversion; `golangci-lint run` clean. No production files changed.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed

Closes #1029