### PR TITLE
fix: send gateway credentials from the CLI, link Cline natively

### DIFF
--- a/cmd/gridctl/activate.go
+++ b/cmd/gridctl/activate.go
@@ -116,8 +116,8 @@ func runActivate(stdout, stderr io.Writer, baseURL, name, format string, quiet b
 // caller can map non-success codes.
 func postActivate(baseURL, name string) (*registry.AgentSkill, int, []byte, error) {
 	target := fmt.Sprintf("%s/api/registry/skills/%s/activate", baseURL, url.PathEscape(name))
-	client := &http.Client{Timeout: activateHTTPTimeout}
-	resp, err := client.Post(target, "application/json", nil)
+	api := newDaemonAPIForBaseURL(baseURL, activateHTTPTimeout)
+	resp, err := api.Do(http.MethodPost, target, nil)
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf("activate: %w", err)
 	}

--- a/cmd/gridctl/apiclient.go
+++ b/cmd/gridctl/apiclient.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"strconv"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/state"
+)
+
+// daemonAPI issues authenticated requests against a running gateway's local
+// API. Every subcommand that talks to /api/* goes through here, because
+// gateway.auth is opt-in and the credentials must be attached uniformly: a
+// per-command approach leaves whichever command was missed returning 401 the
+// moment a user enables auth.
+//
+// Credentials come from the daemon state file, which already carries the
+// port these calls need. The daemon records the token there already
+// resolved, so the CLI never loads the stack or unlocks the vault.
+type daemonAPI struct {
+	port   int
+	token  string
+	header string
+	scheme string // "bearer" or an API-key style raw header value
+	client *http.Client
+}
+
+// newDaemonAPI builds a client for the daemon on the given port, adopting
+// whatever auth that daemon recorded. States are matched by port so a
+// subcommand already holding one does not have to re-read it.
+func newDaemonAPI(port int, timeout time.Duration) *daemonAPI {
+	api := &daemonAPI{port: port, client: &http.Client{Timeout: timeout}}
+	if st, ok := daemonStateForPort(port); ok {
+		api.token, api.header, api.scheme = st.AuthToken, st.AuthHeader, st.AuthType
+	}
+	return api
+}
+
+// newDaemonAPIFor builds a client from an already-loaded state, avoiding a
+// second read for callers that have one.
+func newDaemonAPIFor(st state.DaemonState, timeout time.Duration) *daemonAPI {
+	return &daemonAPI{
+		port: st.Port, token: st.AuthToken, header: st.AuthHeader, scheme: st.AuthType,
+		client: &http.Client{Timeout: timeout},
+	}
+}
+
+// daemonStateForPort finds the running daemon listening on port. Returns
+// false when no state matches, in which case requests go out unauthenticated
+// and the caller sees whatever the server decides — the same behavior as
+// before auth was recorded at all.
+func daemonStateForPort(port int) (state.DaemonState, bool) {
+	states, err := state.List()
+	if err != nil {
+		return state.DaemonState{}, false
+	}
+	for _, st := range states {
+		if st.Port == port {
+			return st, true
+		}
+	}
+	return state.DaemonState{}, false
+}
+
+// URL builds an absolute URL for a path on the daemon.
+func (a *daemonAPI) URL(path string) string {
+	return fmt.Sprintf("http://localhost:%d%s", a.port, path)
+}
+
+// Do issues a request with credentials attached.
+func (a *daemonAPI) Do(method, url string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	a.authorize(req)
+	return a.client.Do(req)
+}
+
+// Get issues an authenticated GET.
+func (a *daemonAPI) Get(url string) (*http.Response, error) {
+	return a.Do(http.MethodGet, url, nil)
+}
+
+// authorize attaches the recorded credentials. Mirrors the server's
+// authMiddleware: a bearer type gets the "Bearer " prefix, anything else is
+// sent as a raw header value, and the header name defaults to Authorization.
+func (a *daemonAPI) authorize(req *http.Request) {
+	if a.token == "" {
+		return
+	}
+	header := a.header
+	if header == "" {
+		header = "Authorization"
+	}
+	value := a.token
+	if a.scheme == "bearer" || a.scheme == "" {
+		value = "Bearer " + a.token
+	}
+	req.Header.Set(header, value)
+}
+
+// newDaemonAPIForBaseURL builds a client for a daemon addressed by base URL
+// (e.g. "http://localhost:8180"), matching the recorded state by port so
+// callers that only carry a URL still authenticate.
+func newDaemonAPIForBaseURL(baseURL string, timeout time.Duration) *daemonAPI {
+	port := 0
+	if u, err := neturl.Parse(baseURL); err == nil {
+		if p, cerr := strconv.Atoi(u.Port()); cerr == nil {
+			port = p
+		}
+	}
+	return newDaemonAPI(port, timeout)
+}

--- a/cmd/gridctl/apiclient_test.go
+++ b/cmd/gridctl/apiclient_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/pkg/state"
+)
+
+// TestDaemonAPI_AttachesRecordedCredentials is the regression case: before
+// this, no CLI subcommand sent an auth header, so enabling gateway.auth
+// returned 401 from every command that calls the local API.
+func TestDaemonAPI_AttachesRecordedCredentials(t *testing.T) {
+	tests := []struct {
+		name       string
+		st         state.DaemonState
+		wantHeader string
+		wantValue  string
+	}{
+		{
+			name:       "bearer type gets the Bearer prefix",
+			st:         state.DaemonState{AuthToken: "secret", AuthType: "bearer"},
+			wantHeader: "Authorization",
+			wantValue:  "Bearer secret",
+		},
+		{
+			name:       "empty type defaults to bearer",
+			st:         state.DaemonState{AuthToken: "secret"},
+			wantHeader: "Authorization",
+			wantValue:  "Bearer secret",
+		},
+		{
+			name:       "api-key type sends the raw value",
+			st:         state.DaemonState{AuthToken: "secret", AuthType: "api_key"},
+			wantHeader: "Authorization",
+			wantValue:  "secret",
+		},
+		{
+			name:       "custom header name is honored",
+			st:         state.DaemonState{AuthToken: "secret", AuthType: "api_key", AuthHeader: "X-Api-Key"},
+			wantHeader: "X-Api-Key",
+			wantValue:  "secret",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got http.Header
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Clone()
+			}))
+			defer srv.Close()
+
+			api := newDaemonAPIFor(tt.st, 2*time.Second)
+			resp, err := api.Get(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+
+			if v := got.Get(tt.wantHeader); v != tt.wantValue {
+				t.Errorf("%s = %q, want %q", tt.wantHeader, v, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestDaemonAPI_NoTokenSendsNoHeader(t *testing.T) {
+	// Auth is opt-in; with none configured the CLI must behave exactly as
+	// it did before, sending nothing.
+	var got http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+	}))
+	defer srv.Close()
+
+	api := newDaemonAPIFor(state.DaemonState{}, 2*time.Second)
+	resp, err := api.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if v := got.Get("Authorization"); v != "" {
+		t.Errorf("expected no Authorization header, got %q", v)
+	}
+}
+
+func TestDaemonAPI_DoAttachesOnNonGET(t *testing.T) {
+	// POST and DELETE paths build their own requests, so they need the same
+	// treatment as Get — this is the shape that would silently regress.
+	for _, method := range []string{http.MethodPost, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			var got http.Header
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Clone()
+			}))
+			defer srv.Close()
+
+			api := newDaemonAPIFor(state.DaemonState{AuthToken: "t", AuthType: "bearer"}, 2*time.Second)
+			resp, err := api.Do(method, srv.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+
+			if v := got.Get("Authorization"); v != "Bearer t" {
+				t.Errorf("%s Authorization = %q, want %q", method, v, "Bearer t")
+			}
+		})
+	}
+}
+
+func TestDaemonAPI_URL(t *testing.T) {
+	api := newDaemonAPIFor(state.DaemonState{Port: 8180}, time.Second)
+	if got := api.URL("/api/status"); got != "http://localhost:8180/api/status" {
+		t.Errorf("URL = %q", got)
+	}
+}

--- a/cmd/gridctl/auth.go
+++ b/cmd/gridctl/auth.go
@@ -204,16 +204,13 @@ func authResolveDaemon() (*state.DaemonState, error) {
 	return st, nil
 }
 
-// authAPIClient is the HTTP client for short daemon API calls.
-var authAPIClient = &http.Client{Timeout: 15 * time.Second}
-
 func authAPIURL(port int, path string) string {
 	return fmt.Sprintf("http://localhost:%d%s", port, path)
 }
 
 // fetchAuthServers pulls per-server authorization state from the daemon.
 func fetchAuthServers(port int) ([]authServerInfo, error) {
-	resp, err := authAPIClient.Get(authAPIURL(port, "/api/auth/servers"))
+	resp, err := newDaemonAPI(port, 15*time.Second).Get(authAPIURL(port, "/api/auth/servers"))
 	if err != nil {
 		return nil, fmt.Errorf("gateway unreachable: %w", err)
 	}
@@ -234,7 +231,7 @@ func fetchAuthServers(port int) ([]authServerInfo, error) {
 
 // authPostJSON posts a JSON body to a daemon auth endpoint and decodes the
 // response, mapping error payloads onto errors.
-func authPostJSON(client *http.Client, apiURL string, body, out any) error {
+func authPostJSON(api *daemonAPI, apiURL string, body, out any) error {
 	payload := []byte("{}")
 	if body != nil {
 		var err error
@@ -242,7 +239,13 @@ func authPostJSON(client *http.Client, apiURL string, body, out any) error {
 			return err
 		}
 	}
-	resp, err := client.Post(apiURL, "application/json", bytes.NewReader(payload))
+	req, rerr := http.NewRequest(http.MethodPost, apiURL, bytes.NewReader(payload))
+	if rerr != nil {
+		return rerr
+	}
+	req.Header.Set("Content-Type", "application/json")
+	api.authorize(req)
+	resp, err := api.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("gateway unreachable: %w", err)
 	}
@@ -273,7 +276,7 @@ func runAuthLogin(stdout, stderr io.Writer, server string) error {
 		AuthorizeURL string `json:"authorize_url"`
 		State        string `json:"state"`
 	}
-	err = authPostJSON(authAPIClient,
+	err = authPostJSON(newDaemonAPIFor(*st, 15*time.Second),
 		authAPIURL(st.Port, "/api/servers/"+url.PathEscape(server)+"/auth/login"),
 		map[string]int{"timeoutSeconds": int(authLoginTimeout.Seconds())}, &login)
 	if err != nil {
@@ -301,7 +304,7 @@ func runAuthLogin(stdout, stderr io.Writer, server string) error {
 		if readErr != nil && line == "" {
 			return fmt.Errorf("reading redirect URL: %w", readErr)
 		}
-		err = authPostJSON(authAPIClient,
+		err = authPostJSON(newDaemonAPIFor(*st, 15*time.Second),
 			authAPIURL(st.Port, "/api/servers/"+url.PathEscape(server)+"/auth/manual"),
 			map[string]string{"redirectUrl": strings.TrimSpace(line)}, nil)
 		if err != nil {
@@ -364,7 +367,7 @@ func runAuthAction(stdout io.Writer, server, action, successFormat string) error
 	if err != nil {
 		return err
 	}
-	err = authPostJSON(authAPIClient,
+	err = authPostJSON(newDaemonAPIFor(*st, 15*time.Second),
 		authAPIURL(st.Port, "/api/servers/"+url.PathEscape(server)+"/auth/"+action), nil, nil)
 	if err != nil {
 		return fmt.Errorf("%s for %s: %w", action, server, err)
@@ -387,7 +390,7 @@ func runAuthLogoutAll(stdout io.Writer) error {
 		return nil
 	}
 	for _, info := range infos {
-		err := authPostJSON(authAPIClient,
+		err := authPostJSON(newDaemonAPIFor(*st, 15*time.Second),
 			authAPIURL(st.Port, "/api/servers/"+url.PathEscape(info.Server)+"/auth/logout"), nil, nil)
 		if err != nil {
 			fmt.Fprintf(stdout, "Logout failed for %s: %v\n", info.Server, err)

--- a/cmd/gridctl/groups.go
+++ b/cmd/gridctl/groups.go
@@ -103,8 +103,8 @@ func resolveGroupsPort(stackName string) (int, error) {
 
 // fetchGroupsReport calls GET /api/groups on the local gateway.
 func fetchGroupsReport(port int) (mcp.GroupsReport, error) {
-	client := &http.Client{Timeout: groupsHTTPTimeout}
-	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/api/groups", port))
+	api := newDaemonAPI(port, groupsHTTPTimeout)
+	resp, err := api.Get(api.URL("/api/groups"))
 	if err != nil {
 		return mcp.GroupsReport{}, fmt.Errorf("groups: %w", err)
 	}

--- a/cmd/gridctl/limits.go
+++ b/cmd/gridctl/limits.go
@@ -108,8 +108,8 @@ func resolveLimitsPort(stackName string) (int, error) {
 
 // fetchLimitsReport calls GET /api/limits on the local gateway.
 func fetchLimitsReport(port int) (limits.StatusReport, error) {
-	client := &http.Client{Timeout: limitsHTTPTimeout}
-	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/api/limits", port))
+	api := newDaemonAPI(port, limitsHTTPTimeout)
+	resp, err := api.Get(api.URL("/api/limits"))
 	if err != nil {
 		return limits.StatusReport{}, fmt.Errorf("limits: %w", err)
 	}

--- a/cmd/gridctl/optimize.go
+++ b/cmd/gridctl/optimize.go
@@ -124,8 +124,8 @@ func fetchOptimizeReport(port int, stack string, minImpact float64, severity str
 		target += "?" + encoded
 	}
 
-	client := &http.Client{Timeout: optimizeHTTPTimeout}
-	resp, err := client.Get(target)
+	api := newDaemonAPI(port, optimizeHTTPTimeout)
+	resp, err := api.Get(target)
 	if err != nil {
 		return optimize.OptimizeReport{}, fmt.Errorf("optimize: %w", err)
 	}

--- a/cmd/gridctl/pins.go
+++ b/cmd/gridctl/pins.go
@@ -211,8 +211,8 @@ func fetchPinsRecords(st *state.DaemonState, server string) (map[string]*pins.Se
 	if server != "" {
 		url += "/" + server
 	}
-	client := &http.Client{Timeout: pinsAPITimeout}
-	resp, err := client.Get(url)
+	api := newDaemonAPIFor(*st, pinsAPITimeout)
+	resp, err := api.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("calling pins API: %w", err)
 	}
@@ -562,9 +562,9 @@ func apiErrorMessage(body []byte, fallback string) string {
 // fetchPinsDiff retrieves one server's diff from the running gateway.
 func fetchPinsDiff(st *state.DaemonState, server string) (*pinsDiffServer, error) {
 	url := fmt.Sprintf("http://localhost:%d/api/pins/%s/diff", st.Port, server)
-	client := &http.Client{Timeout: pinsAPITimeout}
+	api := newDaemonAPIFor(*st, pinsAPITimeout)
 
-	resp, err := client.Get(url)
+	resp, err := api.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("calling pins API: %w", err)
 	}
@@ -811,7 +811,6 @@ func runPinsApprove(server, expectHash string) error {
 	}
 
 	url := fmt.Sprintf("http://localhost:%d/api/pins/%s/approve", st.Port, server)
-	client := &http.Client{Timeout: pinsAPITimeout}
 
 	var reqBody io.Reader
 	if expectHash != "" {
@@ -822,7 +821,14 @@ func runPinsApprove(server, expectHash string) error {
 		reqBody = strings.NewReader(string(payload))
 	}
 
-	resp, err := client.Post(url, "application/json", reqBody)
+	api := newDaemonAPIFor(*st, pinsAPITimeout)
+	req, err := http.NewRequest(http.MethodPost, url, reqBody)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	api.authorize(req)
+	resp, err := api.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("calling pins API: %w", err)
 	}
@@ -864,14 +870,8 @@ func runPinsReset(server string) error {
 	}
 
 	url := fmt.Sprintf("http://localhost:%d/api/pins/%s", st.Port, server)
-	client := &http.Client{Timeout: pinsAPITimeout}
-
-	req, err := http.NewRequest(http.MethodDelete, url, nil)
-	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
-	}
-
-	resp, err := client.Do(req)
+	api := newDaemonAPIFor(*st, pinsAPITimeout)
+	resp, err := api.Do(http.MethodDelete, url, nil)
 	if err != nil {
 		return fmt.Errorf("calling pins API: %w", err)
 	}

--- a/cmd/gridctl/reload.go
+++ b/cmd/gridctl/reload.go
@@ -87,8 +87,8 @@ func reloadAllStacks() error {
 func callReloadAPI(st *state.DaemonState) error {
 	url := fmt.Sprintf("http://localhost:%d/api/reload", st.Port)
 
-	client := &http.Client{Timeout: reloadHTTPTimeout}
-	resp, err := client.Post(url, "application/json", nil)
+	api := newDaemonAPIFor(*st, reloadHTTPTimeout)
+	resp, err := api.Do(http.MethodPost, url, nil)
 	if err != nil {
 		return fmt.Errorf("calling reload API: %w", err)
 	}

--- a/cmd/gridctl/skill_pins.go
+++ b/cmd/gridctl/skill_pins.go
@@ -546,8 +546,14 @@ func approveSkillPinViaAPI(st *state.DaemonState, skill, expectHash, reason stri
 		return fmt.Errorf("encoding request: %w", err)
 	}
 	url := fmt.Sprintf("http://localhost:%d/api/skill-pins/%s/approve", st.Port, skill)
-	client := &http.Client{Timeout: pinsAPITimeout}
-	resp, err := client.Post(url, "application/json", strings.NewReader(string(payload)))
+	api := newDaemonAPIFor(*st, pinsAPITimeout)
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(string(payload)))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	api.authorize(req)
+	resp, err := api.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("calling skill pins API: %w", err)
 	}
@@ -594,12 +600,8 @@ func runSkillPinsReset(skill string) error {
 
 func resetSkillPinViaAPI(st *state.DaemonState, skill string) error {
 	url := fmt.Sprintf("http://localhost:%d/api/skill-pins/%s", st.Port, skill)
-	client := &http.Client{Timeout: pinsAPITimeout}
-	req, err := http.NewRequest(http.MethodDelete, url, nil)
-	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
-	}
-	resp, err := client.Do(req)
+	api := newDaemonAPIFor(*st, pinsAPITimeout)
+	resp, err := api.Do(http.MethodDelete, url, nil)
 	if err != nil {
 		return fmt.Errorf("calling skill pins API: %w", err)
 	}

--- a/cmd/gridctl/status.go
+++ b/cmd/gridctl/status.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"time"
 	"unicode/utf8"
@@ -264,8 +263,8 @@ func runStatus(stack string, showReplicas, asJSON, plain bool) error {
 // queryTraceCount queries a running gateway for the number of recorded traces.
 // Returns -1 if the gateway is unreachable or tracing is unavailable.
 func queryTraceCount(port int) int {
-	client := &http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/api/traces", port))
+	api := newDaemonAPI(port, 2*time.Second)
+	resp, err := api.Get(api.URL("/api/traces"))
 	if err != nil {
 		return -1
 	}
@@ -327,8 +326,8 @@ type mcpReplicaAPI struct {
 // gateway. Returns nil if the gateway is unreachable or the response is
 // malformed — the CLI renders whatever it can.
 func queryMCPServers(port int) []mcpServerAPI {
-	client := &http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/api/mcp-servers", port))
+	api := newDaemonAPI(port, 2*time.Second)
+	resp, err := api.Get(api.URL("/api/mcp-servers"))
 	if err != nil {
 		return nil
 	}
@@ -558,8 +557,8 @@ func formatUptime(d time.Duration) string {
 // ("on" if active, empty otherwise) and the enabled experimental flag map
 // (nil when nothing is enabled).
 func queryGatewayStatus(port int) (codeMode string, features map[string]bool) {
-	client := &http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/api/status", port))
+	api := newDaemonAPI(port, 2*time.Second)
+	resp, err := api.Get(api.URL("/api/status"))
 	if err != nil {
 		return "", nil
 	}

--- a/cmd/gridctl/traces.go
+++ b/cmd/gridctl/traces.go
@@ -135,8 +135,8 @@ func buildTracesURL(port int) string {
 // fetchTraces retrieves the trace list envelope from the gateway API.
 func fetchTraces(port int) (apiTraceList, error) {
 	var list apiTraceList
-	client := &http.Client{Timeout: tracesHTTPTimeout}
-	resp, err := client.Get(buildTracesURL(port))
+	api := newDaemonAPI(port, tracesHTTPTimeout)
+	resp, err := api.Get(buildTracesURL(port))
 	if err != nil {
 		return list, fmt.Errorf("traces: %w", err)
 	}
@@ -254,8 +254,8 @@ func runTracesFollow(port int) error {
 // runTraceDetail fetches and renders an ASCII waterfall for a single trace.
 func runTraceDetail(port int, traceID string) error {
 	detailURL := fmt.Sprintf("http://localhost:%d/api/traces/%s", port, url.PathEscape(traceID))
-	client := &http.Client{Timeout: tracesHTTPTimeout}
-	resp, err := client.Get(detailURL)
+	api := newDaemonAPI(port, tracesHTTPTimeout)
+	resp, err := api.Get(detailURL)
 	if err != nil {
 		return fmt.Errorf("traces: %w", err)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -77,18 +77,18 @@ type Config struct {
 	// what it costs, not what it enables.
 	AllowUnauthenticated bool
 	BasePort             int
-	Verbose     bool
-	Quiet       bool
-	NoCache     bool
-	NoExpand    bool
-	Foreground  bool
-	Watch       bool
-	DaemonChild bool
-	CodeMode    bool       // Enable code mode via CLI flag
-	Runtime     string     // Explicit runtime selection (docker, podman)
-	Replace     bool       // Stop a running stack before deploying (used by plan apply)
-	LogFile     string     // Path to log file (overrides stack.yaml logging.file)
-	LogLevel    slog.Level // Minimum slog level (global --log-level; zero value is info)
+	Verbose              bool
+	Quiet                bool
+	NoCache              bool
+	NoExpand             bool
+	Foreground           bool
+	Watch                bool
+	DaemonChild          bool
+	CodeMode             bool       // Enable code mode via CLI flag
+	Runtime              string     // Explicit runtime selection (docker, podman)
+	Replace              bool       // Stop a running stack before deploying (used by plan apply)
+	LogFile              string     // Path to log file (overrides stack.yaml logging.file)
+	LogLevel             slog.Level // Minimum slog level (global --log-level; zero value is info)
 
 	// OnReady fires once the gateway HTTP listener is serving and MCP server
 	// registration has run — the same readiness the daemon parent polls via
@@ -486,12 +486,16 @@ func (sc *StackController) runDaemonChild(ctx context.Context, stack *config.Sta
 		return fmt.Errorf("failed to get container info: %w", err)
 	}
 
+	token, header, authType := authStateFrom(stack)
 	st := &state.DaemonState{
-		StackName: stack.Name,
-		StackFile: sc.config.StackPath,
-		PID:       os.Getpid(),
-		Port:      sc.config.Port,
-		StartedAt: time.Now(),
+		StackName:  stack.Name,
+		StackFile:  sc.config.StackPath,
+		PID:        os.Getpid(),
+		Port:       sc.config.Port,
+		StartedAt:  time.Now(),
+		AuthToken:  token,
+		AuthHeader: header,
+		AuthType:   authType,
 	}
 	if err := state.Save(st); err != nil {
 		return fmt.Errorf("failed to save state: %w", err)
@@ -846,4 +850,16 @@ func getRunningContainers(ctx context.Context, rt *runtime.Orchestrator, stack *
 	}
 
 	return result, nil
+}
+
+// authStateFrom copies the gateway's inbound auth settings into the daemon
+// state so local subcommands can authenticate against the API. The token is
+// already resolved here: the config loader expands ${VAR} before it reaches
+// this point, so the CLI never needs the stack file or the vault.
+func authStateFrom(stack *config.Stack) (token, header, authType string) {
+	if stack == nil || stack.Gateway == nil || stack.Gateway.Auth == nil {
+		return "", "", ""
+	}
+	a := stack.Gateway.Auth
+	return a.Token, a.Header, a.Type
 }

--- a/pkg/provisioner/cline.go
+++ b/pkg/provisioner/cline.go
@@ -21,12 +21,22 @@ func newCline() *Cline {
 		"disabled":    false,
 		"alwaysAllow": []any{},
 	}
+	// Cline speaks remote HTTP natively, so it needs no npx mcp-remote
+	// bridge: a bridge would add a Node dependency, a package fetch on
+	// every start, and a process hop for nothing. Note the camelCase
+	// "streamableHttp" — Roo Code, despite the shared ancestry, spells the
+	// same transport "streamable-http", so these two must not share a
+	// serializer. Omitting type entirely makes Cline fall back to legacy
+	// SSE, so it is always written.
 	c.buildEntry = func(opts LinkOptions) map[string]any {
 		url := opts.GatewayURL
 		if opts.Port > 0 {
 			url = gatewayHTTPURLForOpts(opts)
 		}
-		return bridgeConfig(url)
+		return map[string]any{
+			"type": "streamableHttp",
+			"url":  url,
+		}
 	}
 	return c
 }

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -724,8 +724,13 @@ func TestCline_Link(t *testing.T) {
 	data := readTestJSON(t, configPath)
 	servers := data["mcpServers"].(map[string]any)
 	entry := servers["gridctl"].(map[string]any)
-	if entry["command"] != "npx" {
-		t.Errorf("expected command=npx, got %v", entry["command"])
+	// Cline speaks remote HTTP natively; the npx bridge it used to get was
+	// an unnecessary Node dependency and process hop.
+	if entry["type"] != "streamableHttp" {
+		t.Errorf("expected type=streamableHttp, got %v", entry["type"])
+	}
+	if _, ok := entry["command"]; ok {
+		t.Error("expected no npx bridge command")
 	}
 	if entry["disabled"] != false {
 		t.Errorf("expected disabled=false, got %v", entry["disabled"])
@@ -753,8 +758,9 @@ func TestClaudeDesktop_Link_UsesHTTPEndpoint(t *testing.T) {
 	data := readTestJSON(t, configPath)
 	servers := data["mcpServers"].(map[string]any)
 	entry := servers["gridctl"].(map[string]any)
+	// Claude Desktop's config format is stdio-only, so it keeps the
+	// mcp-remote bridge; only the endpoint matters here (/mcp, not /sse).
 	args := entry["args"].([]any)
-	// Should use /mcp endpoint, not /sse
 	if args[2] != "http://localhost:8180/mcp" {
 		t.Errorf("expected mcp-remote URL http://localhost:8180/mcp, got %v", args[2])
 	}
@@ -778,10 +784,13 @@ func TestCline_Link_UsesHTTPEndpoint(t *testing.T) {
 	data := readTestJSON(t, configPath)
 	servers := data["mcpServers"].(map[string]any)
 	entry := servers["gridctl"].(map[string]any)
-	args := entry["args"].([]any)
-	// Should use /mcp endpoint, not /sse
-	if args[2] != "http://localhost:8180/mcp" {
-		t.Errorf("expected mcp-remote URL http://localhost:8180/mcp, got %v", args[2])
+	// Native remote entry: the /mcp endpoint carried as a url, with no
+	// mcp-remote bridge args.
+	if entry["url"] != "http://localhost:8180/mcp" {
+		t.Errorf("expected url http://localhost:8180/mcp, got %v", entry["url"])
+	}
+	if _, ok := entry["args"]; ok {
+		t.Error("expected no bridge args")
 	}
 }
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -18,6 +18,23 @@ type DaemonState struct {
 	PID       int       `json:"pid"`
 	Port      int       `json:"port"`
 	StartedAt time.Time `json:"started_at"`
+
+	// AuthToken and AuthHeader carry the gateway's inbound credentials so
+	// local subcommands can authenticate against the API they already know
+	// the port of. Empty when gateway.auth is not configured.
+	//
+	// The daemon records the token already resolved, because the config
+	// loader expands ${VAR} references before the value reaches it. The
+	// alternative — each subcommand loading the stack and expanding it —
+	// would turn a `gridctl status` into a vault passphrase prompt.
+	//
+	// This does place a resolved secret on disk. The state file is written
+	// 0600 (see SaveDaemonState), matching the vault's own plaintext
+	// secrets.json and the machine key in pkg/mcpauth, so it is consistent
+	// with the existing posture rather than a new exposure.
+	AuthToken  string `json:"auth_token,omitempty"`
+	AuthHeader string `json:"auth_header,omitempty"`
+	AuthType   string `json:"auth_type,omitempty"`
 }
 
 // BaseDir returns the base gridctl directory (~/.gridctl/).
@@ -115,6 +132,10 @@ func Save(state *DaemonState) error {
 		return fmt.Errorf("creating state directory: %w", err)
 	}
 
+	// #nosec G117 -- AuthToken is intentionally persisted: local subcommands
+	// need the gateway credential to call the API, and the alternative (each
+	// command loading the stack and expanding ${VAR}) would prompt for the
+	// vault passphrase on every invocation. The file is written 0600 below.
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling state: %w", err)


### PR DESCRIPTION
Two independent fixes, kept as separate commits so the credential change stays reviewable on its own.

## 1. CLI sends gateway credentials (#1063)

Configuring `gateway.auth` broke gridctl's own commands. No subcommand sent an auth header — the only `Authorization` in `cmd/gridctl/` was `upgrade.go` talking to GitHub — so `status`, `traces`, `pins`, `skill-pins`, `groups`, `reload`, `optimize`, `limits`, and `auth` itself all returned 401 once authentication was on.

#1064 made this worse rather than better: refusing to start on a widened bind without auth means the users most likely to configure it are exactly the ones who hit this.

**Approach.** The daemon already holds the *resolved* token, since the config loader expands `${VAR}` before it reaches `SetAuth`, and the state file the CLI already reads for the port is already written `0600`. So the token rides along there — nothing generated, no new file format.

Credentials attach through one helper (`cmd/gridctl/apiclient.go`) rather than per command. There was no shared HTTP path before; roughly fifteen call sites each built their own request inline, which is exactly how this kind of surface ends up with one command still 401ing after the rest are fixed. Every `/api/*` call now routes through it, including the POST and DELETE paths that build their own requests.

**Rejected alternatives**, both recorded on the issue: having each subcommand load the stack and expand the token itself would turn a `gridctl status` into a vault passphrase prompt; generating a separate token would add a file format and a rotation story for something the daemon already has.

**Worth a reviewer's attention:** this places a resolved secret on disk where none was before. At `0600`, in a directory that already holds a plaintext `secrets.json` by default, that matches the existing posture rather than widening it — and the gosec suppression records the reasoning at the marshal site rather than silencing it.

## 2. Cline links natively (#1065)

Cline supports remote HTTP directly, so the `npx mcp-remote` bridge cost a Node dependency, a package fetch on every start, and a process hop for nothing.

Two details the shape depends on: omitting `type` makes Cline fall back to legacy SSE, so it is always written; and Cline spells the transport `streamableHttp` while Roo Code — despite shared ancestry — spells it `streamable-http`, so the two must not share a serializer.

Claude Desktop keeps the bridge. Its config format is stdio-only, with no field that can carry a URL.

Existing Cline users have a bridge entry recorded in the wiring lockfile; the changed shape makes those read as stale, the same as a port change, and re-linking resolves it.

## Not included

**#1066 (Continue entry shape)** is deliberately left out. On a machine with Continue installed, gridctl's entry sits at `experimental.mcpServers` in `config.json` — the block Continue's docs call legacy — while `config.yaml`, the current format, has no MCP entries. That is strong evidence the format is stale, but not proof: Continue may still read `config.json` for compatibility. Changing the written shape on evidence alone could break setups that work today, and confirming needs launching Continue and watching whether the gateway appears. The evidence is recorded on the issue, including that unlink leaves `"mcpServers": null` rather than removing the key.

## Testing

- New `apiclient_test.go` covers bearer prefixing, the api-key raw-value path, a custom header name, the no-token case (must send nothing), and the non-GET paths that build their own requests.
- Cline's two provisioner tests now assert a native entry and no bridge args; Claude Desktop's assert the bridge is retained.
- `go test -race ./...` exit 0; `go test -tags=integration -race ./tests/integration/...` exit 0 (run locally, Docker); `golangci-lint run` 0 issues.

One thing lint caught that is worth noting: the first pass hardcoded a 2s timeout at two call sites that previously used 10s constants, silently tightening them. The unused-constant warning surfaced it; both are restored.

Closes #1063
Closes #1065
