### PR TITLE
Release v0.1.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to gridctl will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.0-rc.1] - 2026-08-10
+
+First release candidate. Every shipped feature surface is now Stable (see [docs/project-status.md](docs/project-status.md)); the Experimental tier is retained only for features shipping dark behind the `experimental:` feature-flag registry, which currently holds none.
+
 ### Removed
 
 - **Breaking:** the dollar-cost layer is removed from the backend, completing the staged removal begun with the web UI entry below. The gateway sits below the LLM client and cannot observe actual spend, so its dollar figures were always estimates of a fraction of a related quantity; token and usage metrics, which the gateway does measure, stay. Gone: `pkg/pricing` and the embedded LiteLLM snapshot (with the weekly refresh workflow and `task pricing:*`), the stack.yaml attribution fields (`gateway.default_model`, per-server `model:`, `client_models:`) and dollar budgets under `limits:` (rate limits stay; existing configs still load, with the removed keys ignored by the non-strict parser), the pricing and cost API routes (`GET /api/pricing/models`, the three model PUT routes, `GET`/`DELETE /api/metrics/cost`) and the `/api/status` cost and model-attribution fields, `costUsd` on `/api/tools/usage`, the `expensive_model_on_cheap_task` heuristic, the `gen_ai.cost.usd` and `gen_ai.request.model` span attributes (token and cache attributes stay), and the budget spend ledger (leftover ledger files under the state directory are orphaned and harmless). `gridctl optimize` findings now report `impact_tokens_per_week` (projected assuming ~500 prompts/week, named in the summary) instead of `impact_usd_per_week`, and `--min-impact` is token-denominated; `gridctl limits` reports rate limits only, and its budget-exceeded exit code 1 is gone. Token counting (`pkg/token`, `tokenizer:` config) is untouched (#1089)

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -142,7 +142,7 @@ var builtin = []Flag{
 		Stage:       StageGraduated,
 		Since:       "0.1.0",
 		GraduatesBy: "0.3.0",
-		Message:     "graduated in 0.1.0-beta.16; remove the entry, the dual-stack transport is always on and per-server pinning lives in protocol_generation",
+		Message:     "graduated in 0.1.0-rc.1; remove the entry, the dual-stack transport is always on and per-server pinning lives in protocol_generation",
 	},
 }
 

--- a/pkg/project/migrate.go
+++ b/pkg/project/migrate.go
@@ -349,7 +349,7 @@ func (s *Store) writeTombstone(path, backupDir string) error {
 		Note    string `yaml:"note"`
 	}{
 		Version: legacyTombstoneVersion,
-		Note: fmt.Sprintf("projection state moved to %s; this tombstone makes older gridctl versions (before the unified project lockfile, v0.1.0-beta.16) fail loudly instead of diverging. The original file is preserved at %s.",
+		Note: fmt.Sprintf("projection state moved to %s; this tombstone makes older gridctl versions (before the unified project lockfile, v0.1.0-rc.1) fail loudly instead of diverging. The original file is preserved at %s.",
 			s.Path(), filepath.Join(backupDir, filepath.Base(path))),
 	}
 	data, err := yaml.Marshal(tombstone)


### PR DESCRIPTION
## Release v0.1.0-rc.1

First release candidate. Promotes the hand-written `[Unreleased]` section to `[0.1.0-rc.1]` and corrects two migration strings that named a release which will never exist.

## Changes

- **CHANGELOG.md**: `[Unreleased]` promoted to `## [0.1.0-rc.1] - 2026-08-10` with a lead paragraph noting that every feature surface is now Stable. A fresh empty `[Unreleased]` header sits above it.
- **`pkg/flags/flags.go`**: the `transport_dual_stack` migration message said "graduated in 0.1.0-beta.16". That release is being skipped in favor of rc.1, so a user with a stale `experimental:` entry would have been pointed at a phantom version. Now reads `0.1.0-rc.1`.
- **`pkg/project/migrate.go`**: the legacy-lockfile tombstone note named `v0.1.0-beta.16` as the release the unified project lockfile landed in. Same correction.

## Note on changelog generation

`CHANGELOG.md` was **not** regenerated with git-cliff. This project maintains it by hand under Article XV, and the entries are detailed prose keyed to PR numbers. Regenerating would have replaced every release section, back to the first, with one-line commit subjects. The release skill's git-cliff step is stale relative to how this changelog is actually maintained and should probably be dropped.

## Checklist

- [x] All checks passed (lint 0 issues, `go test -race ./...`, go build, web build)
- [x] Changelog updated for the release
- [x] No stale `beta.16` references remain in `pkg/`, `cmd/`, `internal/`, or `docs/`
- [ ] PR reviewed and approved
- [ ] After merge, run `/release-gridctl --tag` to create the release tag