### PR TITLE
fix: assert DNS resolution, not nslookup exit status

### DIFF
--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -275,6 +275,28 @@ jobs:
           GRIDCTL_RUNTIME: podman
         run: go test -tags=integration -race -timeout 5m ./tests/integration/...
 
+      - name: Podman network diagnostics
+        # This job has failed on image drift several times, and each round trip
+        # to collect basic state costs a full CI cycle. Collect it on the way
+        # out instead. Runs only on failure and never fails the job itself, so a
+        # missing tool here cannot mask the real error above.
+        if: failure()
+        run: |
+          set +e
+          echo "--- helper processes ---"
+          pgrep -a aardvark-dns || echo "aardvark-dns: not running"
+          pgrep -a netavark || echo "netavark: not running"
+          echo "--- resolved helper paths ---"
+          podman info --format json | jq -c '.host.networkBackendInfo'
+          echo "--- networks ---"
+          podman network ls
+          echo "--- aardvark-dns state ---"
+          ls -la "${XDG_RUNTIME_DIR}/containers/networks/aardvark-dns/" 2>&1 | head -20
+          head -n 40 "${XDG_RUNTIME_DIR}"/containers/networks/aardvark-dns/* 2>&1
+          echo "--- podman user service log ---"
+          journalctl --user -u podman.socket -u podman.service -n 80 --no-pager 2>&1 | tail -40
+          exit 0
+
   frontend:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -138,12 +138,19 @@ jobs:
   podman-integration:
     # Pinned to a specific Ubuntu major rather than ubuntu-latest so a future
     # label rollover cannot silently change the container stack under these
-    # tests. Note this does NOT pin the image release: the ubuntu-24.04 label
-    # serves whatever build is current, so image drift within the major still
-    # reaches this job (see #1092).
+    # tests. This does NOT pin the image release — the ubuntu-24.04 label serves
+    # whatever build is current — so the network stack is provisioned explicitly
+    # below rather than inherited from the image (#1092).
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: test
+
+    env:
+      # netavark and aardvark-dns release in lockstep and must stay on the same
+      # minor: netavark spawns aardvark-dns over a protocol that is not stable
+      # across minors. Bump these together.
+      NETAVARK_VERSION: v1.17.2
+      AARDVARK_DNS_VERSION: v1.17.1
 
     steps:
       - uses: actions/checkout@v5
@@ -157,20 +164,63 @@ jobs:
       - name: Install Podman
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq podman netavark aardvark-dns
+          sudo apt-get install -y -qq podman
           # Do NOT force the archive Podman ahead of a newer preinstalled one.
           # That was tried and reverted: on images shipping Podman 5.x, pointing
           # PATH at the archive's 4.9.3 breaks container startup outright
           # (conmon failures across every container test), which is far worse
-          # than the single rootless-DNS failure it was meant to address. The
-          # real mismatch is the other way round — Podman 5.x against the
-          # archive's netavark/aardvark-dns 1.4.0, which is too old — and fixing
-          # it needs a newer netavark from outside the Ubuntu archive (#1092).
-          # Print the resolved set so a future mismatch is diagnosable from the
-          # log alone rather than by bisecting runner images.
-          echo "podman:       $(command -v podman) — $(podman --version)"
-          echo "netavark:     $(dpkg-query -W -f='${Version}' netavark 2>/dev/null || echo absent)"
-          echo "aardvark-dns: $(dpkg-query -W -f='${Version}' aardvark-dns 2>/dev/null || echo absent)"
+          # than the single rootless-DNS failure it was meant to address (#1092).
+          #
+          # netavark and aardvark-dns are deliberately NOT installed from the
+          # archive here. The archive caps them at 1.4.0 on 24.04, and the next
+          # step provisions a matched pair from upstream instead. Printing what
+          # the image happened to ship keeps the drift visible in the log.
+          echo "podman:                  $(command -v podman) — $(podman --version)"
+          echo "netavark (from image):   $(dpkg-query -W -f='${Version}' netavark 2>/dev/null || echo absent)"
+          echo "aardvark-dns (image):    $(dpkg-query -W -f='${Version}' aardvark-dns 2>/dev/null || echo absent)"
+
+      - name: Pin Podman network stack
+        # Root cause of the recurring rootless-DNS failure: the job never
+        # controlled its own network stack. It inherited whatever netavark and
+        # aardvark-dns the runner image shipped, and that pairing changes
+        # underneath the tests whenever GitHub rolls an image. On
+        # ubuntu24/20260810.271 the image's Podman 5.8.4 resolved netavark
+        # 1.17.2 while aardvark-dns stayed at the archive's 1.4.0; a netavark
+        # that new driving an aardvark-dns that old resolves nothing and reports
+        # no error, which surfaces as a gridctl networking failure (#1092).
+        #
+        # Installing a matched pair ourselves makes the job deterministic
+        # regardless of image drift. Upstream publishes one x86_64 binary per
+        # release, which is what this runner is.
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+
+          fetch() {
+            repo="$1"; version="$2"; name="$3"
+            base="https://github.com/containers/${repo}/releases/download/${version}"
+            curl -fsSL --retry 3 --retry-delay 2 -o "${tmp}/${name}.gz" "${base}/${name}.gz"
+            curl -fsSL --retry 3 --retry-delay 2 -o "${tmp}/${name}.sha256sum" "${base}/sha256sum"
+            # The release checksum file also lists a vendor tarball this job does
+            # not download. --ignore-missing skips that entry while still failing
+            # if the binary that WAS downloaded does not match.
+            ( cd "${tmp}" && sha256sum --check --ignore-missing --status "${name}.sha256sum" )
+            gunzip -f "${tmp}/${name}.gz"
+          }
+
+          fetch netavark "${NETAVARK_VERSION}" netavark
+          fetch aardvark-dns "${AARDVARK_DNS_VERSION}" aardvark-dns
+
+          # Write to every directory Podman searches for helper binaries rather
+          # than guessing which one wins. Overwriting all of them means the
+          # resolved pair is the pinned pair no matter how the image lays itself
+          # out or which order the lookup takes. Only netavark and aardvark-dns
+          # are replaced — every other helper in these directories (rootlessport,
+          # pasta, catatonit) is left exactly as the image shipped it.
+          for dir in /usr/local/libexec/podman /usr/local/lib/podman /usr/libexec/podman /usr/lib/podman; do
+            sudo install -Dm755 "${tmp}/netavark" "${dir}/netavark"
+            sudo install -Dm755 "${tmp}/aardvark-dns" "${dir}/aardvark-dns"
+          done
 
       - name: Start Podman socket
         run: |
@@ -181,8 +231,41 @@ jobs:
 
       - name: Verify Podman
         run: |
+          set -euo pipefail
           podman info --format '{{.Version.Version}}'
           podman info --format 'network_backend={{.Host.NetworkBackend}}'
+
+          # Assert Podman actually resolved the pinned pair. Without this the pin
+          # is only a hope: if a future image moves the helper directories, the
+          # binaries land somewhere Podman never looks and the job goes back to
+          # failing four minutes later inside a test, with the same misleading
+          # "gridctl cannot resolve DNS" symptom.
+          #
+          # Versions are read with jq, not a Go template. A template naming a
+          # field that moved errors the step out with nothing useful; an absent
+          # JSON key reads as empty here and lands in the failure message with
+          # the whole document attached. The guard this job previously relied on
+          # failed silently for precisely that reason.
+          info="$(podman info --format json)"
+          backend="$(jq -c '.host.networkBackendInfo' <<<"${info}")"
+          netavark="$(jq -r '.host.networkBackendInfo.version // ""' <<<"${info}")"
+          aardvark="$(jq -r '.host.networkBackendInfo.dns.version // ""' <<<"${info}")"
+          echo "netavark:     ${netavark:-<unreported>}"
+          echo "aardvark-dns: ${aardvark:-<unreported>}"
+
+          fail() {
+            echo "::error::Podman resolved an unpinned network stack: $1"
+            echo "networkBackendInfo: ${backend}"
+            exit 1
+          }
+          case "${netavark}" in
+            *"${NETAVARK_VERSION#v}"*) ;;
+            *) fail "netavark is '${netavark:-<unreported>}', want ${NETAVARK_VERSION#v}" ;;
+          esac
+          case "${aardvark}" in
+            *"${AARDVARK_DNS_VERSION#v}"*) ;;
+            *) fail "aardvark-dns is '${aardvark:-<unreported>}', want ${AARDVARK_DNS_VERSION#v}" ;;
+          esac
 
       - name: Install Go dependencies
         run: go mod download

--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -180,18 +180,22 @@ jobs:
           echo "aardvark-dns (image):    $(dpkg-query -W -f='${Version}' aardvark-dns 2>/dev/null || echo absent)"
 
       - name: Pin Podman network stack
-        # Root cause of the recurring rootless-DNS failure: the job never
-        # controlled its own network stack. It inherited whatever netavark and
-        # aardvark-dns the runner image shipped, and that pairing changes
-        # underneath the tests whenever GitHub rolls an image. On
-        # ubuntu24/20260810.271 the image's Podman 5.8.4 resolved netavark
-        # 1.17.2 while aardvark-dns stayed at the archive's 1.4.0; a netavark
-        # that new driving an aardvark-dns that old resolves nothing and reports
-        # no error, which surfaces as a gridctl networking failure (#1092).
+        # This job had no control over its own container network stack: it
+        # inherited whatever netavark and aardvark-dns the runner image shipped,
+        # and `runs-on` cannot pin an image release, so the pairing changed
+        # underneath the tests whenever GitHub rolled an image. On
+        # ubuntu24/20260810.271 that meant Podman 5.8.4 resolving netavark
+        # 1.17.2 against the Ubuntu archive's aardvark-dns 1.4.0, a combination
+        # upstream does not support.
         #
-        # Installing a matched pair ourselves makes the job deterministic
-        # regardless of image drift. Upstream publishes one x86_64 binary per
-        # release, which is what this runner is.
+        # To be clear about what this did and did not fix: the DNS test failures
+        # that prompted it turned out to be a test bug, not a broken stack (see
+        # the lookup command in podman_test.go). This step is what makes the job
+        # deterministic rather than dependent on image contents; it is not the
+        # fix for those failures (#1092).
+        #
+        # Upstream publishes one x86_64 binary per release, which is what this
+        # runner is.
         run: |
           set -euo pipefail
           tmp="$(mktemp -d)"

--- a/tests/integration/podman_test.go
+++ b/tests/integration/podman_test.go
@@ -139,16 +139,16 @@ func incompatibleStack(podmanVersion, netavarkVersion string) bool {
 }
 
 // mismatchedHelpers reports whether netavark and aardvark-dns come from
-// different release lines. netavark spawns aardvark-dns and the two share a
-// protocol that is not stable across minors, so a mismatched pair resolves
-// nothing while reporting no error at all.
+// different release lines. netavark spawns aardvark-dns and upstream cuts the
+// two together, so a pair straddling minors is an unsupported configuration.
 //
-// This is the case that got past the guard on ubuntu24/20260810.271: Podman
-// 5.8.4 with netavark 1.17.2 is a perfectly good pairing and incompatibleStack
-// correctly cleared it, but aardvark-dns was still the archive's 1.4.0, so DNS
-// failed anyway and the suite blamed gridctl (#1092). Comparing Podman against
-// netavark alone can never catch that — the broken relationship is between the
-// two helpers.
+// Scope note, because the history here is easy to misread: the DNS failures on
+// ubuntu24/20260810.271 were NOT caused by a mismatched pair. That host ran
+// netavark 1.17.2 against aardvark-dns 1.4.0 and resolution worked; the test
+// was misreading a BusyBox nslookup exit code (see the lookup command above).
+// This check is therefore a guard against an unsupported host configuration,
+// not a reproduction of a known failure — which is why it only ever skips, and
+// only when both versions are known.
 func mismatchedHelpers(netavarkVersion, aardvarkVersion string) bool {
 	nMajor, nMinor, ok := leadingVersion(netavarkVersion)
 	if !ok {
@@ -187,8 +187,8 @@ func checkNetworkStack(podmanVersion string, s networkStack) (skip string, diags
 		diags = append(diags, "aardvark-dns version undetermined, running the test anyway: "+s.AardvarkDiag)
 	case mismatchedHelpers(s.Netavark, s.Aardvark):
 		return fmt.Sprintf("netavark %s and aardvark-dns %s are from different release "+
-			"lines; the pair resolves no names and reports no error, so the result "+
-			"would say nothing about gridctl (see #1092)", s.Netavark, s.Aardvark), diags
+			"lines, which upstream does not support; a result on this host would say "+
+			"nothing about gridctl either way (see #1092)", s.Netavark, s.Aardvark), diags
 	}
 
 	diags = append(diags, fmt.Sprintf("container stack: podman %s + netavark %s + aardvark-dns %s",
@@ -214,11 +214,10 @@ func TestPodmanRootless_MultiContainerNetworking(t *testing.T) {
 	}
 	t.Logf("Podman version=%s rootless=%v socket=%s", info.Version, info.IsRootless(), info.SocketPath)
 
-	// A mismatched host network stack fails as silent DNS non-resolution rather
-	// than a startup error, so without this check the suite reports a gridctl
-	// networking bug when the real fault is the host's container stack (#1092).
-	// The diagnostics are always logged because a guard that declines silently
-	// is indistinguishable from a guard that found nothing wrong.
+	// Report the host's container network stack, and decline to draw conclusions
+	// from a host whose stack upstream does not support. The diagnostics are
+	// always logged because a guard that declines silently is indistinguishable
+	// from a guard that found nothing wrong (#1092).
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer probeCancel()
 	skip, diags := checkNetworkStack(info.Version, readNetworkStack(probeCtx))
@@ -287,16 +286,25 @@ func TestPodmanRootless_MultiContainerNetworking(t *testing.T) {
 
 	// Start container-a — resolves container-b and exits.
 	//
-	// The exit status is BusyBox nslookup's, preserved so the assertion below is
-	// unchanged, but the command also records what the resolver actually did.
-	// An exit code on its own cannot tell "the name did not resolve" apart from
-	// "it resolved and the client objected to something else", and this test
-	// previously reported the former without ever establishing it. getent is
-	// included as a second opinion because it goes through the standard
-	// resolver and, unlike nslookup, does not care about the server's answer to
-	// queries the test is not asking about.
-	const lookupCmd = `nslookup container-b; rc=$?; echo "nslookup_exit=$rc"; ` +
-		`getent hosts container-b && echo "getent=ok" || echo "getent=fail"; ` +
+	// The exit status is getent's, NOT nslookup's. getent goes through the
+	// standard resolver and succeeds when the name resolves, which is the thing
+	// under test. BusyBox nslookup cannot express that: it queries every entry
+	// in the resolv.conf search list and exits non-zero if any of them fails,
+	// so on a host whose resolv.conf carries a search domain beyond Podman's own
+	// it reports failure having already resolved the name correctly.
+	//
+	// That is exactly what happened here. GitHub's runners are Azure VMs, and
+	// Podman copies the host search list into the container, so container-a
+	// resolved container-b.dns.podman to its address and then exited 1 over an
+	// NXDOMAIN for container-b.<azure-internal-zone> — a name nothing was ever
+	// meant to answer. The test read that exit code as "DNS is broken" and
+	// blamed the container network stack for a working lookup (#1092).
+	//
+	// nslookup output is kept for diagnostics only. Do not restore it as the
+	// signal.
+	const lookupCmd = `getent hosts container-b; rc=$?; echo "getent_exit=$rc"; ` +
+		`echo "--- nslookup (diagnostic only, exit status not asserted) ---"; ` +
+		`nslookup container-b; echo "nslookup_exit=$?"; ` +
 		`echo "--- resolv.conf ---"; cat /etc/resolv.conf; exit $rc`
 
 	statusA, err := rt.Runtime().Start(ctx, runtime.WorkloadConfig{
@@ -342,9 +350,9 @@ func TestPodmanRootless_MultiContainerNetworking(t *testing.T) {
 	t.Logf("container-a output:\n%s", containerOutput(ctx, dockerCli, string(statusA.ID)))
 
 	if result.State.ExitCode != 0 {
-		t.Errorf("inter-container DNS lookup of 'container-b' on network %q failed: "+
-			"container-a exited %d (expected 0). The output logged above shows what the "+
-			"resolver returned; check it before assuming the name did not resolve",
+		t.Errorf("inter-container DNS resolution failed: container-a could not resolve "+
+			"'container-b' by DNS alias on network %q (getent exited %d). The output "+
+			"logged above shows what the resolver returned",
 			netName, result.State.ExitCode)
 	}
 }
@@ -565,10 +573,10 @@ func TestIncompatibleStack(t *testing.T) {
 		netavark string
 		want     bool
 	}{
-		// The pairing observed on ubuntu24/20260810.271, which fails with
-		// silent DNS non-resolution (#1092).
+		// The pairing observed on ubuntu24/20260810.271 (#1092). Unsupported
+		// upstream; note this was not what made that image's DNS test fail.
 		{"podman 5 with archive netavark", "5.8.4", "1.4.0", true},
-		// The pairing on ubuntu24/20260720.247, which works.
+		// The pairing on ubuntu24/20260720.247.
 		{"podman 4 with archive netavark", "4.9.3", "1.4.0", false},
 		// Podman 5 with a netavark new enough to drive it.
 		{"podman 5 with modern netavark", "5.8.4", "1.10.3", false},

--- a/tests/integration/podman_test.go
+++ b/tests/integration/podman_test.go
@@ -32,28 +32,37 @@ func leadingVersion(s string) (major, minor int, ok bool) {
 	return major, minor, true
 }
 
-// netavarkVersion returns the netavark version Podman reports. The second
-// return is a diagnostic explaining why the version could not be determined,
-// and is empty on success.
+// networkStack is the pair of helper binaries Podman drives for rootless
+// container networking, as Podman itself reports them. Each version carries its
+// own diagnostic explaining why it could not be determined, empty on success.
 //
-// Callers MUST surface that diagnostic. An earlier version of this guard asked
+// Callers MUST surface those diagnostics. An earlier version of this guard asked
 // for a single Go-template field and swallowed any error, so when the field did
 // not resolve it silently reported "cannot determine" and the guard never fired
 // — indistinguishable from a healthy host. Parsing the whole document and
 // reporting what was actually seen makes that failure mode visible instead.
-func netavarkVersion(ctx context.Context) (string, string) {
-	out, err := exec.CommandContext(ctx, "podman", "info", "--format", "json").Output()
-	if err != nil {
-		return "", "podman info failed: " + err.Error()
-	}
-	return parseNetavarkVersion(out)
+type networkStack struct {
+	Netavark     string
+	NetavarkDiag string
+	Aardvark     string
+	AardvarkDiag string
 }
 
-// parseNetavarkVersion extracts the netavark version from `podman info --format
+// readNetworkStack returns the netavark and aardvark-dns versions Podman reports.
+func readNetworkStack(ctx context.Context) networkStack {
+	out, err := exec.CommandContext(ctx, "podman", "info", "--format", "json").Output()
+	if err != nil {
+		diag := "podman info failed: " + err.Error()
+		return networkStack{NetavarkDiag: diag, AardvarkDiag: diag}
+	}
+	return parseNetworkStack(out)
+}
+
+// parseNetworkStack extracts both helper versions from `podman info --format
 // json` output. Split from the exec so the JSON handling is testable without a
 // live Podman — the previous guard shipped its field lookup unverified and that
 // lookup is precisely what failed.
-func parseNetavarkVersion(out []byte) (string, string) {
+func parseNetworkStack(out []byte) networkStack {
 	var info struct {
 		Host struct {
 			NetworkBackend     string `json:"networkBackend"`
@@ -61,35 +70,56 @@ func parseNetavarkVersion(out []byte) (string, string) {
 				Backend string `json:"backend"`
 				Version string `json:"version"`
 				Package string `json:"package"`
+				DNS     struct {
+					Version string `json:"version"`
+					Package string `json:"package"`
+				} `json:"dns"`
 			} `json:"networkBackendInfo"`
 		} `json:"host"`
 	}
 	if err := json.Unmarshal(out, &info); err != nil {
-		return "", "podman info returned unparseable JSON: " + err.Error()
+		diag := "podman info returned unparseable JSON: " + err.Error()
+		return networkStack{NetavarkDiag: diag, AardvarkDiag: diag}
 	}
 
-	// The version may be reported bare ("1.4.0"), prefixed ("netavark 1.4.0"),
-	// or only via the package string. leadingVersion copes with all three, so
-	// take the first field that yields a version.
 	nb := info.Host.NetworkBackendInfo
-	for _, candidate := range []string{nb.Version, nb.Package} {
+	stack := networkStack{}
+
+	// A version may be reported bare ("1.4.0"), prefixed ("netavark 1.4.0"), or
+	// only via the package string. leadingVersion copes with all three, so take
+	// the first field that yields a version.
+	//
+	// Every field consulted is named in the diagnostic. networkBackend is
+	// included because it is known to populate, so if it parses while
+	// networkBackendInfo does not, the JSON key names are what changed.
+	stack.Netavark, stack.NetavarkDiag = firstVersion(
+		fmt.Sprintf("no netavark version in podman info (networkBackend=%q backend=%q version=%q package=%q)",
+			info.Host.NetworkBackend, nb.Backend, nb.Version, nb.Package),
+		nb.Version, nb.Package)
+
+	stack.Aardvark, stack.AardvarkDiag = firstVersion(
+		fmt.Sprintf("no aardvark-dns version in podman info (networkBackendInfo.dns version=%q package=%q)",
+			nb.DNS.Version, nb.DNS.Package),
+		nb.DNS.Version, nb.DNS.Package)
+
+	return stack
+}
+
+// firstVersion returns the first candidate containing a parseable version, or
+// the supplied diagnostic when none does.
+func firstVersion(diag string, candidates ...string) (string, string) {
+	for _, candidate := range candidates {
 		if _, _, ok := leadingVersion(candidate); ok {
 			return strings.TrimSpace(candidate), ""
 		}
 	}
-
-	// Report every field consulted. networkBackend is included because it is
-	// known to populate, so if it parses while networkBackendInfo does not, the
-	// JSON key names are what changed.
-	return "", fmt.Sprintf(
-		"no netavark version in podman info (networkBackend=%q backend=%q version=%q package=%q)",
-		info.Host.NetworkBackend, nb.Backend, nb.Version, nb.Package)
+	return "", diag
 }
 
-// incompatibleStack holds the version rule on its own so it is testable without
-// a live Podman. Keeping it pure matters here: CI runners draw from a mixed
-// image fleet, so the skip path above cannot be relied on to execute on any
-// given run, and the rule would otherwise ship unverified.
+// incompatibleStack reports whether Podman is too new for the netavark driving
+// it. Held apart from the test so it is testable without a live Podman: CI
+// runners draw from a mixed image fleet, so the skip path cannot be relied on to
+// execute on any given run, and the rule would otherwise ship unverified.
 func incompatibleStack(podmanVersion, netavarkVersion string) bool {
 	pMajor, _, ok := leadingVersion(podmanVersion)
 	if !ok || pMajor < 5 {
@@ -100,6 +130,64 @@ func incompatibleStack(podmanVersion, netavarkVersion string) bool {
 		return false
 	}
 	return nMajor == 1 && nMinor < 10
+}
+
+// mismatchedHelpers reports whether netavark and aardvark-dns come from
+// different release lines. netavark spawns aardvark-dns and the two share a
+// protocol that is not stable across minors, so a mismatched pair resolves
+// nothing while reporting no error at all.
+//
+// This is the case that got past the guard on ubuntu24/20260810.271: Podman
+// 5.8.4 with netavark 1.17.2 is a perfectly good pairing and incompatibleStack
+// correctly cleared it, but aardvark-dns was still the archive's 1.4.0, so DNS
+// failed anyway and the suite blamed gridctl (#1092). Comparing Podman against
+// netavark alone can never catch that — the broken relationship is between the
+// two helpers.
+func mismatchedHelpers(netavarkVersion, aardvarkVersion string) bool {
+	nMajor, nMinor, ok := leadingVersion(netavarkVersion)
+	if !ok {
+		return false
+	}
+	aMajor, aMinor, ok := leadingVersion(aardvarkVersion)
+	if !ok {
+		return false
+	}
+	return nMajor != aMajor || nMinor != aMinor
+}
+
+// checkNetworkStack reports why the host cannot support rootless inter-container
+// DNS, or an empty string when the test should run, alongside diagnostics to log
+// either way.
+//
+// It fails open on purpose: an undetermined version runs the test, so a genuine
+// gridctl regression is never masked by a probe that came back blank. Skipping
+// is reserved for stacks that are provably incapable of the thing under test,
+// where a failure would say nothing about gridctl. In CI this cannot hide drift
+// either — the workflow pins both helpers and asserts the resolved versions
+// before any test runs, so a mismatch fails the job outright rather than
+// reaching this skip.
+func checkNetworkStack(podmanVersion string, s networkStack) (skip string, diags []string) {
+	switch {
+	case s.NetavarkDiag != "":
+		diags = append(diags, "netavark version undetermined, running the test anyway: "+s.NetavarkDiag)
+	case incompatibleStack(podmanVersion, s.Netavark):
+		return fmt.Sprintf("Podman %s needs a newer netavark than this host's %s; rootless "+
+			"inter-container DNS cannot work on this stack, so the result would say "+
+			"nothing about gridctl (see #1092)", podmanVersion, s.Netavark), diags
+	}
+
+	switch {
+	case s.AardvarkDiag != "":
+		diags = append(diags, "aardvark-dns version undetermined, running the test anyway: "+s.AardvarkDiag)
+	case mismatchedHelpers(s.Netavark, s.Aardvark):
+		return fmt.Sprintf("netavark %s and aardvark-dns %s are from different release "+
+			"lines; the pair resolves no names and reports no error, so the result "+
+			"would say nothing about gridctl (see #1092)", s.Netavark, s.Aardvark), diags
+	}
+
+	diags = append(diags, fmt.Sprintf("container stack: podman %s + netavark %s + aardvark-dns %s",
+		podmanVersion, s.Netavark, s.Aardvark))
+	return "", diags
 }
 
 // TestPodmanRootless_MultiContainerNetworking is the graduation gate for stable Podman
@@ -120,27 +208,19 @@ func TestPodmanRootless_MultiContainerNetworking(t *testing.T) {
 	}
 	t.Logf("Podman version=%s rootless=%v socket=%s", info.Version, info.IsRootless(), info.SocketPath)
 
-	// Podman 5.x drives a netavark interface that 1.4.x does not implement, and
-	// the pairing fails as silent DNS non-resolution rather than a startup
-	// error. Without this check the suite reports a gridctl networking bug when
-	// the real fault is the host's container stack (#1092).
-	//
-	// Fails open on purpose: an undetermined netavark version runs the test, so
-	// a genuine regression is never masked. The diagnostic is always logged
-	// because a guard that declines silently is indistinguishable from a guard
-	// that found nothing wrong.
+	// A mismatched host network stack fails as silent DNS non-resolution rather
+	// than a startup error, so without this check the suite reports a gridctl
+	// networking bug when the real fault is the host's container stack (#1092).
+	// The diagnostics are always logged because a guard that declines silently
+	// is indistinguishable from a guard that found nothing wrong.
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer probeCancel()
-	netavark, diag := netavarkVersion(probeCtx)
-	switch {
-	case diag != "":
-		t.Logf("netavark version undetermined, running the test anyway: %s", diag)
-	case incompatibleStack(info.Version, netavark):
-		t.Skipf("skipping: Podman %s needs a newer netavark than this host's %s; "+
-			"rootless inter-container DNS cannot work on this stack, so the result "+
-			"would say nothing about gridctl (see #1092)", info.Version, netavark)
-	default:
-		t.Logf("container stack: podman %s + netavark %s", info.Version, netavark)
+	skip, diags := checkNetworkStack(info.Version, readNetworkStack(probeCtx))
+	for _, d := range diags {
+		t.Log(d)
+	}
+	if skip != "" {
+		t.Skip("skipping: " + skip)
 	}
 
 	rt, err := runtime.NewWithInfo(info)
@@ -458,7 +538,96 @@ func TestIncompatibleStack(t *testing.T) {
 	}
 }
 
-func TestParseNetavarkVersion(t *testing.T) {
+func TestMismatchedHelpers(t *testing.T) {
+	cases := []struct {
+		name               string
+		netavark, aardvark string
+		want               bool
+	}{
+		// The pairing observed on ubuntu24/20260810.271: Podman's own netavark
+		// against the Ubuntu archive's aardvark-dns. Cleared by
+		// incompatibleStack, broken in practice.
+		{"podman netavark with archive aardvark", "netavark 1.17.2", "aardvark-dns 1.4.0", true},
+		// The pinned pair this job now provisions. Patch levels differ within
+		// the minor, which is normal: upstream cuts the two projects together
+		// but does not always need the same patch on both.
+		{"pinned pair", "netavark 1.17.2", "aardvark-dns 1.17.1", false},
+		{"identical versions", "1.4.0", "1.4.0", false},
+		{"same minor across majors differs", "2.1.0", "1.1.0", true},
+		{"minor drift within a major", "1.17.2", "1.10.3", true},
+		// Unparseable input must not skip — running and failing is safer than
+		// masking a real regression.
+		{"unknown netavark", "", "aardvark-dns 1.4.0", false},
+		{"unknown aardvark", "netavark 1.17.2", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := mismatchedHelpers(c.netavark, c.aardvark); got != c.want {
+				t.Errorf("mismatchedHelpers(%q, %q) = %v, want %v",
+					c.netavark, c.aardvark, got, c.want)
+			}
+		})
+	}
+}
+
+func TestCheckNetworkStack(t *testing.T) {
+	healthy := networkStack{Netavark: "netavark 1.17.2", Aardvark: "aardvark-dns 1.17.1"}
+
+	t.Run("pinned stack runs and logs what it saw", func(t *testing.T) {
+		skip, diags := checkNetworkStack("5.8.4", healthy)
+		if skip != "" {
+			t.Fatalf("healthy stack must not skip, got %q", skip)
+		}
+		if len(diags) != 1 || !strings.Contains(diags[0], "aardvark-dns 1.17.1") {
+			t.Errorf("diags = %q, want one line naming both helpers", diags)
+		}
+	})
+
+	// The regression this guard exists for. Podman and netavark agree, so the
+	// old podman-versus-netavark rule cleared it and the suite failed inside
+	// the DNS assertion instead.
+	t.Run("skips the pairing that got past the old guard", func(t *testing.T) {
+		skip, _ := checkNetworkStack("5.8.4", networkStack{
+			Netavark: "netavark 1.17.2",
+			Aardvark: "aardvark-dns 1.4.0",
+		})
+		if skip == "" {
+			t.Fatal("netavark 1.17.2 with aardvark-dns 1.4.0 must skip")
+		}
+		if !strings.Contains(skip, "different release lines") {
+			t.Errorf("skip reason %q should name the mismatch", skip)
+		}
+	})
+
+	t.Run("skips podman 5 on archive netavark", func(t *testing.T) {
+		skip, _ := checkNetworkStack("5.8.4", networkStack{
+			Netavark: "netavark 1.4.0",
+			Aardvark: "aardvark-dns 1.4.0",
+		})
+		if !strings.Contains(skip, "needs a newer netavark") {
+			t.Errorf("skip reason %q should name the podman/netavark gap", skip)
+		}
+	})
+
+	// Failing open matters more than skipping cleanly: a blank probe must never
+	// be able to hide a real gridctl networking regression.
+	t.Run("undetermined versions run the test", func(t *testing.T) {
+		for _, s := range []networkStack{
+			{NetavarkDiag: "probe failed", Aardvark: "aardvark-dns 1.17.1"},
+			{Netavark: "netavark 1.17.2", AardvarkDiag: "probe failed"},
+		} {
+			skip, diags := checkNetworkStack("5.8.4", s)
+			if skip != "" {
+				t.Errorf("undetermined version must not skip, got %q", skip)
+			}
+			if len(diags) == 0 {
+				t.Error("an undetermined version must be logged, not swallowed")
+			}
+		}
+	})
+}
+
+func TestParseNetworkStack(t *testing.T) {
 	// Shape taken from `podman info --format json`, trimmed to the fields the
 	// guard reads.
 	const realistic = `{
@@ -468,69 +637,86 @@ func TestParseNetavarkVersion(t *testing.T) {
 	      "backend": "netavark",
 	      "version": "netavark 1.4.0",
 	      "package": "netavark-1.4.0-4",
-	      "path": "/usr/libexec/podman/netavark"
+	      "path": "/usr/libexec/podman/netavark",
+	      "dns": {
+	        "version": "aardvark-dns 1.4.0",
+	        "package": "aardvark-dns-1.4.0-5",
+	        "path": "/usr/libexec/podman/aardvark-dns"
+	      }
 	    }
 	  }
 	}`
 
-	t.Run("reads the version field", func(t *testing.T) {
-		got, diag := parseNetavarkVersion([]byte(realistic))
-		if diag != "" {
-			t.Fatalf("unexpected diagnostic: %s", diag)
+	t.Run("reads both version fields", func(t *testing.T) {
+		got := parseNetworkStack([]byte(realistic))
+		if got.NetavarkDiag != "" || got.AardvarkDiag != "" {
+			t.Fatalf("unexpected diagnostics: %q / %q", got.NetavarkDiag, got.AardvarkDiag)
 		}
-		if got != "netavark 1.4.0" {
-			t.Errorf("got %q, want %q", got, "netavark 1.4.0")
+		if got.Netavark != "netavark 1.4.0" {
+			t.Errorf("netavark = %q, want %q", got.Netavark, "netavark 1.4.0")
 		}
-		if !incompatibleStack("5.8.4", got) {
+		if got.Aardvark != "aardvark-dns 1.4.0" {
+			t.Errorf("aardvark = %q, want %q", got.Aardvark, "aardvark-dns 1.4.0")
+		}
+		if !incompatibleStack("5.8.4", got.Netavark) {
 			t.Error("podman 5.8.4 with netavark 1.4.0 must be reported incompatible")
 		}
 	})
 
-	t.Run("falls back to the package field", func(t *testing.T) {
-		const versionless = `{"host":{"networkBackend":"netavark","networkBackendInfo":{"backend":"netavark","version":"","package":"netavark-1.4.0-4"}}}`
-		got, diag := parseNetavarkVersion([]byte(versionless))
-		if diag != "" {
-			t.Fatalf("unexpected diagnostic: %s", diag)
+	t.Run("falls back to the package fields", func(t *testing.T) {
+		const versionless = `{"host":{"networkBackend":"netavark","networkBackendInfo":{"backend":"netavark","version":"","package":"netavark-1.4.0-4","dns":{"version":"","package":"aardvark-dns-1.4.0-5"}}}}`
+		got := parseNetworkStack([]byte(versionless))
+		if got.NetavarkDiag != "" || got.AardvarkDiag != "" {
+			t.Fatalf("unexpected diagnostics: %q / %q", got.NetavarkDiag, got.AardvarkDiag)
 		}
-		if got != "netavark-1.4.0-4" {
-			t.Errorf("got %q, want the package string", got)
+		if got.Netavark != "netavark-1.4.0-4" || got.Aardvark != "aardvark-dns-1.4.0-5" {
+			t.Errorf("got %q / %q, want the package strings", got.Netavark, got.Aardvark)
 		}
 	})
 
-	t.Run("bare version", func(t *testing.T) {
-		const bare = `{"host":{"networkBackendInfo":{"version":"1.10.3"}}}`
-		got, diag := parseNetavarkVersion([]byte(bare))
-		if diag != "" {
-			t.Fatalf("unexpected diagnostic: %s", diag)
+	t.Run("bare versions", func(t *testing.T) {
+		const bare = `{"host":{"networkBackendInfo":{"version":"1.17.2","dns":{"version":"1.17.1"}}}}`
+		got := parseNetworkStack([]byte(bare))
+		if got.NetavarkDiag != "" || got.AardvarkDiag != "" {
+			t.Fatalf("unexpected diagnostics: %q / %q", got.NetavarkDiag, got.AardvarkDiag)
 		}
-		if incompatibleStack("5.8.4", got) {
-			t.Error("netavark 1.10.3 is new enough for podman 5.x")
+		if incompatibleStack("5.8.4", got.Netavark) {
+			t.Error("netavark 1.17.2 is new enough for podman 5.x")
+		}
+		if mismatchedHelpers(got.Netavark, got.Aardvark) {
+			t.Error("1.17.2 and 1.17.1 are the same release line")
 		}
 	})
 
 	// This is the case that silently broke the previous guard: the fields it
 	// wanted were absent. The diagnostic must name what was actually seen so
 	// the next failure is fixable from the log alone.
-	t.Run("diagnostic names the fields consulted", func(t *testing.T) {
+	t.Run("diagnostics name the fields consulted", func(t *testing.T) {
 		const renamed = `{"host":{"networkBackend":"netavark","networkBackendInfo":{"backend":"netavark"}}}`
-		got, diag := parseNetavarkVersion([]byte(renamed))
-		if got != "" {
-			t.Errorf("got %q, want empty when no version is present", got)
+		got := parseNetworkStack([]byte(renamed))
+		if got.Netavark != "" || got.Aardvark != "" {
+			t.Errorf("got %q / %q, want empty when no version is present", got.Netavark, got.Aardvark)
 		}
-		if diag == "" {
-			t.Fatal("a missing version must produce a diagnostic, not silence")
+		if got.NetavarkDiag == "" || got.AardvarkDiag == "" {
+			t.Fatal("missing versions must produce diagnostics, not silence")
 		}
 		for _, want := range []string{"networkBackend", "version", "package"} {
-			if !strings.Contains(diag, want) {
-				t.Errorf("diagnostic %q does not mention %q", diag, want)
+			if !strings.Contains(got.NetavarkDiag, want) {
+				t.Errorf("netavark diagnostic %q does not mention %q", got.NetavarkDiag, want)
 			}
+		}
+		// The dns subtree is the field lookup this change adds, and it is the
+		// one that cannot be verified against a live Podman from a workstation.
+		// If Podman ever moves or renames it, the diagnostic has to say so.
+		if !strings.Contains(got.AardvarkDiag, "networkBackendInfo.dns") {
+			t.Errorf("aardvark diagnostic %q does not name the dns subtree", got.AardvarkDiag)
 		}
 	})
 
 	t.Run("unparseable json", func(t *testing.T) {
-		_, diag := parseNetavarkVersion([]byte("not json"))
-		if diag == "" {
-			t.Error("unparseable JSON must produce a diagnostic")
+		got := parseNetworkStack([]byte("not json"))
+		if got.NetavarkDiag == "" || got.AardvarkDiag == "" {
+			t.Error("unparseable JSON must produce diagnostics")
 		}
 	})
 }

--- a/tests/integration/podman_test.go
+++ b/tests/integration/podman_test.go
@@ -3,9 +3,11 @@
 package integration
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -14,6 +16,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/stdcopy"
+
+	"github.com/gridctl/gridctl/pkg/dockerclient"
 	"github.com/gridctl/gridctl/pkg/runtime"
 	_ "github.com/gridctl/gridctl/pkg/runtime/docker" // register factory
 )
@@ -279,14 +285,26 @@ func TestPodmanRootless_MultiContainerNetworking(t *testing.T) {
 	// Allow container-b to register with the network's DNS before container-a queries it.
 	time.Sleep(2 * time.Second)
 
-	// Start container-a — runs nslookup and exits.
-	// BusyBox nslookup (included in alpine:latest) resolves via the container network's DNS.
+	// Start container-a — resolves container-b and exits.
+	//
+	// The exit status is BusyBox nslookup's, preserved so the assertion below is
+	// unchanged, but the command also records what the resolver actually did.
+	// An exit code on its own cannot tell "the name did not resolve" apart from
+	// "it resolved and the client objected to something else", and this test
+	// previously reported the former without ever establishing it. getent is
+	// included as a second opinion because it goes through the standard
+	// resolver and, unlike nslookup, does not care about the server's answer to
+	// queries the test is not asking about.
+	const lookupCmd = `nslookup container-b; rc=$?; echo "nslookup_exit=$rc"; ` +
+		`getent hosts container-b && echo "getent=ok" || echo "getent=fail"; ` +
+		`echo "--- resolv.conf ---"; cat /etc/resolv.conf; exit $rc`
+
 	statusA, err := rt.Runtime().Start(ctx, runtime.WorkloadConfig{
 		Name:        "container-a",
 		Stack:       stackName,
 		Type:        runtime.WorkloadTypeMCPServer,
 		Image:       "alpine:latest",
-		Command:     []string{"sh", "-c", "nslookup container-b"},
+		Command:     []string{"sh", "-c", lookupCmd},
 		NetworkName: netName,
 		Labels:      managedLabels("container-a"),
 	})
@@ -319,12 +337,43 @@ func TestPodmanRootless_MultiContainerNetworking(t *testing.T) {
 	}
 	t.Logf("container-a exit_code=%d status=%s", result.State.ExitCode, result.State.Status)
 
+	// Always logged, not just on failure: a passing run that took an unexpected
+	// route through the resolver is worth seeing too.
+	t.Logf("container-a output:\n%s", containerOutput(ctx, dockerCli, string(statusA.ID)))
+
 	if result.State.ExitCode != 0 {
-		t.Errorf("inter-container DNS resolution failed: container-a exited %d (expected 0)\n"+
-			"container-a could not resolve 'container-b' by DNS alias on network %q\n"+
-			"ensure netavark and aardvark-dns are installed for rootless Podman networking",
-			result.State.ExitCode, netName)
+		t.Errorf("inter-container DNS lookup of 'container-b' on network %q failed: "+
+			"container-a exited %d (expected 0). The output logged above shows what the "+
+			"resolver returned; check it before assuming the name did not resolve",
+			netName, result.State.ExitCode)
 	}
+}
+
+// containerOutput returns a container's combined stdout and stderr, or a
+// bracketed reason it could not be read. Diagnosing a DNS failure needs what the
+// lookup printed, so this never returns an error the caller might drop — a
+// missing diagnostic is worse than an ugly one.
+func containerOutput(ctx context.Context, cli dockerclient.DockerClient, id string) string {
+	rc, err := cli.ContainerLogs(ctx, id, container.LogsOptions{ShowStdout: true, ShowStderr: true})
+	if err != nil {
+		return "<logs unavailable: " + err.Error() + ">"
+	}
+	defer func() { _ = rc.Close() }()
+
+	raw, err := io.ReadAll(rc)
+	if err != nil {
+		return "<logs unreadable: " + err.Error() + ">"
+	}
+
+	// Log streams are multiplexed for containers started without a TTY and raw
+	// otherwise. Demultiplex, falling back to the bytes as read: which shape
+	// arrives depends on how the workload was started, and guessing wrong would
+	// discard the very output this exists to capture.
+	var buf bytes.Buffer
+	if _, err := stdcopy.StdCopy(&buf, &buf, bytes.NewReader(raw)); err != nil || buf.Len() == 0 {
+		return strings.TrimSpace(string(raw))
+	}
+	return strings.TrimSpace(buf.String())
 }
 
 // TestRuntimeDetection_AutoDetect verifies auto-detection finds the available runtime.


### PR DESCRIPTION
## Description

`podman-integration` has failed repeatedly with `TestPodmanRootless_MultiContainerNetworking` reporting that a container could not be resolved by DNS alias. **Inter-container DNS was never broken.** The test was asserting on BusyBox `nslookup`'s exit status, which does not mean what the test assumed.

Fixes #1092

## Type of Change

- [x] Bug fix (test correctness + CI determinism)

## Root cause

Diagnostics added mid-PR captured what the lookup actually returned:

```
Server:    10.89.0.1
Name:      container-b.dns.podman
Address:   10.89.0.2          <- resolved correctly, first search domain
getent=ok                     <- 10.89.0.2  container-b
nslookup_exit=1               <- the only thing the test looked at

** server can't find container-b.qtqeh0lh4sgepnqtebzm4mqhhe.cx.internal.cloudapp.net: NXDOMAIN

search dns.podman qtqeh0lh4sgepnqtebzm4mqhhe.cx.internal.cloudapp.net
nameserver 10.89.0.1
```

BusyBox `nslookup` queries every entry in the resolv.conf search list and exits non-zero if any of them fails. GitHub's runners are Azure VMs, and Podman copies the host search list into the container, so the lookup succeeded on `container-b.dns.podman` and then exited 1 over an `NXDOMAIN` for `container-b.<azure-internal-zone>` — a name nothing was ever meant to answer. The suite read that exit code as a gridctl networking bug.

### This revises the version-mismatch story on #1092

That issue records a "hypothesis confirmed" that Podman 5.8.4 driving the archive's aardvark-dns 1.4.0 caused silent DNS non-resolution. That is **not** what was happening. This PR first pinned a matched netavark/aardvark-dns pair and CI verified Podman resolved it — and the test failed identically. The same host resolved names correctly with the mismatch in place; the evidence for "the mismatched pair resolves nothing" was always this same misread exit code.

## Changes Made

- **The fix:** assert on `getent hosts`, which goes through the standard resolver and reports whether the name resolved — the thing under test. `nslookup` output is retained for diagnostics only, with a comment against restoring it as the signal.
- Log container-a's actual output and `/etc/resolv.conf`. The previous assertion reported "could not resolve" from an exit code, a conclusion it had no way to reach, which is why this took several cycles to see.
- **Hardening, not the fix:** pin netavark `v1.17.2` and aardvark-dns `v1.17.1` from the upstream `containers/*` releases, checksum-verified, into every directory Podman searches for helpers, and assert in `Verify Podman` that Podman resolved that pair. `runs-on` cannot pin an image release, so without this the job's container stack changes whenever GitHub rolls an image. This makes the job deterministic; it did not fix the DNS failures.
- Extend the test guard to compare netavark against aardvark-dns rather than Podman against netavark alone, scoped explicitly as an unsupported-host-configuration check rather than a reproduction of a known failure.
- Collect Podman network state on job failure, so a future recurrence does not cost a CI cycle just to gather state.
- Comments asserting the disproven cause are corrected rather than left to mislead the next reader.

Deliberately not retried: forcing the archive's Podman 4.9.3. #1113 tried that and took the failure count from one test to 10 (`conmon failed`), reverted in #1114.

## Testing

- All five Gatekeeper checks pass, including `podman-integration` on `ubuntu24/20260810.271` — the image that was failing.
- The DNS test provably ran rather than skipping: CI asserts netavark 1.17.2 and aardvark-dns 1.17.1, and neither guard can fire on those versions.
- Pure version rules covered by unit tests; the pin script was validated end-to-end in an `amd64` `ubuntu:24.04` container.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed