### PR TITLE
chore: ignore typescript major bumps until TS 7 lints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,14 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+    ignore:
+      # typescript-eslint caps its typescript peer at <6.1.0, so a TS 7 bump
+      # fails npm ci with ERESOLVE (see PR #1124). Forcing the install past it
+      # does not help: typescript-eslint hard-errors on load under TS 7.0 with
+      # "typescript-eslint does not support TS 7.0", and upstream is targeting
+      # TS >=7.1 only (typescript-eslint#10940). The compiler itself is fine,
+      # tsc -b passes clean on 7.0.2. Drop this ignore once typescript-eslint
+      # ships TS 7 support and TS >=7.1 is released.
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Stops Dependabot from re-opening TypeScript major bumps that cannot pass CI, and records why in the config.

## Why

PR #1124 (typescript 6.0.3 to 7.0.2) fails the `frontend` job at `npm ci`:

```
npm error While resolving: typescript-eslint@8.65.0
npm error Found: typescript@7.0.2
npm error peer typescript@">=4.8.4 <6.1.0" from typescript-eslint@8.65.0
```

No published typescript-eslint accepts TS 7. Both `latest` (8.67.0) and `canary` (8.67.1-alpha.4) still cap the peer at `<6.1.0`.

Forcing the install past the peer conflict does not help. With `--legacy-peer-deps`, the failure just moves from `npm ci` to `eslint .`:

```
typescript-eslint does not support TS 7.0.
See https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking
typescript-eslint's support for TS >=7.1
```

Upstream is targeting TS >=7.1, so 7.0.x will never be supported.

The compiler side is ready: `tsc --noEmit` on 7.0.2 passes clean across all 4,703 files for both `tsconfig.app.json` and `tsconfig.node.json`. Only the lint toolchain blocks the bump, so the ignore is temporary.

## What changed

An `ignore` entry for `typescript` major-version updates in the npm ecosystem block, with a comment covering the peer cap, the runtime guard, and the tracking issue. This follows the existing react/react-dom grouping comment, which documents the same class of trap.

Minor bumps still flow, and TS stays on `~6.0.3`, already the newest 6.x. Remove the ignore once typescript-eslint ships TS 7 support and TS >=7.1 is released.

Closes #1124 via `@dependabot ignore this major version`.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses, and the ignore entry reads back as expected.
- TS 7 type-check verified in an isolated copy of `web/`, with the checker confirmed live by injecting a deliberate type error (TS2322).
