### PR TITLE
docs: add LM Studio to skills channel matrix

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -36,7 +36,7 @@ Two channels, complementary and per-client.
 
 **File projection (opt-in).** `gridctl skill project sync <skill>` places selected active skills into native client skill directories, where clients that read skills from disk auto-trigger them from the frontmatter description. See [Projecting skills into clients](#projecting-skills-into-clients).
 
-Not every linked client can use both channels, and two cannot use either:
+Not every linked client can use both channels, and some cannot use either:
 
 | Client | MCP prompts | Projected files |
 |---|---|---|
@@ -46,6 +46,7 @@ Not every linked client can use both channels, and two cannot use either:
 | Antigravity | ✗ (tools-only MCP client) | ✓ (`~/.gemini/config/skills/`) |
 | Claude Desktop | partial (prompt attachments) | ✗ (skills are account-level uploads) |
 | AnythingLLM | ✗ (tools-only) | ✗ (plugin-based skills, no SKILL.md) |
+| LM Studio | unverified (no documented prompt UI in chat) | ✗ (no skills directory; system prompt is per-chat) |
 
 For Antigravity and Grok Build, projection is the only way gridctl skills reach the client at all.
 


### PR DESCRIPTION
## Description

The skills-channel matrix in docs/skills.md enumerates every linked client's access to the two skills channels (MCP prompts, projected files) and was missing LM Studio, added as the 16th link client in #1166.

## Type of Change

- [x] Documentation

## Changes Made

- Add an LM Studio row: MCP prompts marked unverified (no documented prompt UI in chat; not confirmed during live verification), projected files marked unsupported (no skills directory; system prompt is per-chat, matching the ctx unsupported reason)
- Reword the intro from "two cannot use either" to "some cannot use either", since the unverified prompts column makes a hard count wrong in either direction

## Testing

Docs-only; rendered the table locally.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Commits follow conventional format
- [x] No secrets or credentials committed