### PR TITLE
feat: Python MCP Containers (1/9)

### DIFF
--- a/pkg/controller/source_lifecycle_test.go
+++ b/pkg/controller/source_lifecycle_test.go
@@ -1,0 +1,39 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/runtime"
+)
+
+func TestServerRegistrar_AutoscaledSourceUsesResolvedImage(t *testing.T) {
+	t.Skip("pending resolved source image plumbing for autoscaled servers")
+
+	rt := &stubContainerRuntime{startStatus: runtime.WorkloadStatus{ID: "source-1"}}
+	registrar := NewServerRegistrar(mcp.NewGateway(), false)
+	registrar.SetRuntime(rt)
+	server := config.MCPServer{
+		Name:      "source",
+		Image:     "gridctl-source:commit-a",
+		Source:    &config.Source{Type: "git", URL: "https://example.com/source.git", Ref: "commit-a"},
+		Transport: "stdio",
+		Autoscale: &config.AutoscaleConfig{Min: 1, Max: 1, TargetInFlight: 1},
+	}
+	stack := &config.Stack{Name: "demo", Network: config.Network{Name: "demo-net"}}
+
+	if err := registrar.registerAutoscaled(context.Background(), server, stack, "stack.yaml", 9000); err != nil {
+		t.Fatalf("registerAutoscaled: %v", err)
+	}
+	if len(rt.startCalls) != 1 {
+		t.Fatalf("Start calls = %d, want 1 initial replica", len(rt.startCalls))
+	}
+	if rt.startCalls[0].Image != server.Image {
+		t.Fatalf("Start image = %q, want resolved image %q", rt.startCalls[0].Image, server.Image)
+	}
+	if rt.startCalls[0].Image == "gridctl-demo-source:latest" {
+		t.Fatalf("Start reconstructed mutable source image %q", rt.startCalls[0].Image)
+	}
+}

--- a/pkg/reload/source_lifecycle_test.go
+++ b/pkg/reload/source_lifecycle_test.go
@@ -1,0 +1,59 @@
+package reload
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/config"
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/runtime"
+)
+
+type recordingReloadBuilder struct {
+	calls []runtime.BuildOptions
+}
+
+func (b *recordingReloadBuilder) Build(_ context.Context, opts runtime.BuildOptions) (*runtime.BuildResult, error) {
+	b.calls = append(b.calls, opts)
+	return &runtime.BuildResult{ImageTag: "gridctl-source:" + opts.Ref}, nil
+}
+
+func TestComputeDiff_SourceRefChangeRestartsServer(t *testing.T) {
+	oldServer := config.MCPServer{
+		Name:   "source",
+		Source: &config.Source{Type: "git", URL: "https://example.com/source.git", Ref: "commit-a"},
+	}
+	newServer := oldServer
+	newServer.Source = &config.Source{Type: "git", URL: "https://example.com/source.git", Ref: "commit-b"}
+
+	diff := ComputeDiff(
+		&config.Stack{MCPServers: []config.MCPServer{oldServer}},
+		&config.Stack{MCPServers: []config.MCPServer{newServer}},
+	)
+
+	if len(diff.MCPServers.Modified) != 1 {
+		t.Fatalf("Modified = %d, want 1 for source ref change", len(diff.MCPServers.Modified))
+	}
+}
+
+func TestHandler_StartMCPServer_BuildsChangedSourceBeforeReplacement(t *testing.T) {
+	t.Skip("pending source lifecycle reconciliation during reload")
+
+	rt := newMockWorkloadRuntime()
+	builder := &recordingReloadBuilder{}
+	orch := runtime.NewOrchestrator(rt, builder)
+	handler := NewHandler("stack.yaml", &config.Stack{Name: "demo"}, mcp.NewGateway(), orch, 8180, 9000, nil, nil)
+	server := config.MCPServer{
+		Name:   "source",
+		Source: &config.Source{Type: "git", URL: "https://example.com/source.git", Ref: "commit-b"},
+		Port:   3000,
+	}
+	stack := &config.Stack{Name: "demo", Network: config.Network{Name: "demo-net"}}
+
+	if err := handler.startMCPServer(context.Background(), server, stack); err != nil {
+		t.Fatalf("startMCPServer: %v", err)
+	}
+	if len(builder.calls) != 1 {
+		t.Fatalf("Build calls = %d, want 1 before replacement start", len(builder.calls))
+	}
+}

--- a/pkg/reload/source_lifecycle_test.go
+++ b/pkg/reload/source_lifecycle_test.go
@@ -18,6 +18,75 @@ func (b *recordingReloadBuilder) Build(_ context.Context, opts runtime.BuildOpti
 	return &runtime.BuildResult{ImageTag: "gridctl-source:" + opts.Ref}, nil
 }
 
+type recordingReloadRuntime struct {
+	*mockWorkloadRuntime
+	ensured []string
+	started []runtime.WorkloadConfig
+	stopped []runtime.WorkloadID
+	removed []runtime.WorkloadID
+}
+
+func newRecordingReloadRuntime() *recordingReloadRuntime {
+	return &recordingReloadRuntime{mockWorkloadRuntime: newMockWorkloadRuntime()}
+}
+
+func (r *recordingReloadRuntime) EnsureImage(_ context.Context, image string) error {
+	r.ensured = append(r.ensured, image)
+	return nil
+}
+
+func (r *recordingReloadRuntime) Start(ctx context.Context, cfg runtime.WorkloadConfig) (*runtime.WorkloadStatus, error) {
+	r.started = append(r.started, cfg)
+	return r.mockWorkloadRuntime.Start(ctx, cfg)
+}
+
+func (r *recordingReloadRuntime) Stop(_ context.Context, id runtime.WorkloadID) error {
+	r.stopped = append(r.stopped, id)
+	return nil
+}
+
+func (r *recordingReloadRuntime) Remove(_ context.Context, id runtime.WorkloadID) error {
+	r.removed = append(r.removed, id)
+	return nil
+}
+
+func sourceRefChange() (config.MCPServer, config.MCPServer) {
+	oldServer := config.MCPServer{
+		Name:   "source",
+		Source: &config.Source{Type: "git", URL: "https://example.com/source.git", Ref: "commit-a"},
+		Port:   3000,
+	}
+	newServer := oldServer
+	newServer.Source = &config.Source{Type: "git", URL: "https://example.com/source.git", Ref: "commit-b"}
+	return oldServer, newServer
+}
+
+func runSourceRefReload(t *testing.T) (*recordingReloadRuntime, *recordingReloadBuilder) {
+	t.Helper()
+
+	oldServer, newServer := sourceRefChange()
+	rt := newRecordingReloadRuntime()
+	rt.existsFn = func(context.Context, string) (bool, runtime.WorkloadID, error) {
+		return true, "existing-source", nil
+	}
+	builder := &recordingReloadBuilder{}
+	orch := runtime.NewOrchestrator(rt, builder)
+	oldStack := &config.Stack{Name: "demo", Network: config.Network{Name: "demo-net"}, MCPServers: []config.MCPServer{oldServer}}
+	newStack := &config.Stack{Name: "demo", Network: config.Network{Name: "demo-net"}, MCPServers: []config.MCPServer{newServer}}
+	handler := NewHandler("stack.yaml", oldStack, mcp.NewGateway(), orch, 8180, 9000, nil, nil)
+	handler.SetRegisterServerFunc(func(context.Context, config.MCPServer, []ReplicaRuntime, string) error { return nil })
+	diff := ComputeDiff(oldStack, newStack)
+	result := &ReloadResult{}
+
+	if err := handler.applyMCPServerChanges(context.Background(), diff.MCPServers, newStack, result); err != nil {
+		t.Fatalf("applyMCPServerChanges: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("reload errors: %v", result.Errors)
+	}
+	return rt, builder
+}
+
 func TestComputeDiff_SourceRefChangeRestartsServer(t *testing.T) {
 	oldServer := config.MCPServer{
 		Name:   "source",
@@ -36,24 +105,43 @@ func TestComputeDiff_SourceRefChangeRestartsServer(t *testing.T) {
 	}
 }
 
-func TestHandler_StartMCPServer_BuildsChangedSourceBeforeReplacement(t *testing.T) {
+func TestHandler_ReloadBuildsChangedSourceBeforeReplacement(t *testing.T) {
 	t.Skip("pending source lifecycle reconciliation during reload")
 
-	rt := newMockWorkloadRuntime()
-	builder := &recordingReloadBuilder{}
-	orch := runtime.NewOrchestrator(rt, builder)
-	handler := NewHandler("stack.yaml", &config.Stack{Name: "demo"}, mcp.NewGateway(), orch, 8180, 9000, nil, nil)
-	server := config.MCPServer{
-		Name:   "source",
-		Source: &config.Source{Type: "git", URL: "https://example.com/source.git", Ref: "commit-b"},
-		Port:   3000,
-	}
-	stack := &config.Stack{Name: "demo", Network: config.Network{Name: "demo-net"}}
-
-	if err := handler.startMCPServer(context.Background(), server, stack); err != nil {
-		t.Fatalf("startMCPServer: %v", err)
-	}
+	rt, builder := runSourceRefReload(t)
 	if len(builder.calls) != 1 {
 		t.Fatalf("Build calls = %d, want 1 before replacement start", len(builder.calls))
+	}
+	if builder.calls[0].Ref != "commit-b" {
+		t.Fatalf("Build ref = %q, want commit-b", builder.calls[0].Ref)
+	}
+	if len(rt.started) != 1 {
+		t.Fatalf("Start calls = %d, want 1 replacement", len(rt.started))
+	}
+	if rt.started[0].Image != "gridctl-source:commit-b" {
+		t.Fatalf("Start image = %q, want build result", rt.started[0].Image)
+	}
+	if rt.started[0].Image == "gridctl-demo-source:latest" {
+		t.Fatalf("Start used mutable source image %q", rt.started[0].Image)
+	}
+	if len(rt.ensured) != 0 {
+		t.Fatalf("EnsureImage calls = %v, want none for source build", rt.ensured)
+	}
+	if len(rt.stopped) != 1 || len(rt.removed) != 1 {
+		t.Fatalf("replacement did not stop and remove existing container: stopped=%v removed=%v", rt.stopped, rt.removed)
+	}
+}
+
+func TestHandler_CurrentReloadReusesMutableSourceImage(t *testing.T) {
+	rt, builder := runSourceRefReload(t)
+
+	if len(builder.calls) != 0 {
+		t.Fatalf("Build calls = %d, want current stale count 0", len(builder.calls))
+	}
+	if len(rt.ensured) != 1 || rt.ensured[0] != "gridctl-demo-source:latest" {
+		t.Fatalf("EnsureImage calls = %v, want current mutable source image", rt.ensured)
+	}
+	if len(rt.started) != 1 || rt.started[0].Image != "gridctl-demo-source:latest" {
+		t.Fatalf("Start calls = %+v, want current mutable source image", rt.started)
 	}
 }

--- a/pkg/runtime/source_lifecycle_test.go
+++ b/pkg/runtime/source_lifecycle_test.go
@@ -23,11 +23,11 @@ func (b *recordingSourceBuilder) Build(_ context.Context, opts BuildOptions) (*B
 }
 
 type sourceLifecycleRuntime struct {
-	WorkloadRuntime
-	statuses map[string]*WorkloadStatus
-	started  []WorkloadConfig
-	stopped  []WorkloadID
-	removed  []WorkloadID
+	statuses      map[string]*WorkloadStatus
+	started       []WorkloadConfig
+	stopped       []WorkloadID
+	removed       []WorkloadID
+	ensuredImages []string
 }
 
 func newSourceLifecycleRuntime() *sourceLifecycleRuntime {
@@ -36,7 +36,24 @@ func newSourceLifecycleRuntime() *sourceLifecycleRuntime {
 
 func (r *sourceLifecycleRuntime) Ping(context.Context) error { return nil }
 
+func (r *sourceLifecycleRuntime) Close() error { return nil }
+
 func (r *sourceLifecycleRuntime) EnsureNetwork(context.Context, string, NetworkOptions) error {
+	return nil
+}
+
+func (r *sourceLifecycleRuntime) List(context.Context, WorkloadFilter) ([]WorkloadStatus, error) {
+	return nil, nil
+}
+
+func (r *sourceLifecycleRuntime) ListNetworks(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func (r *sourceLifecycleRuntime) RemoveNetwork(context.Context, string) error { return nil }
+
+func (r *sourceLifecycleRuntime) EnsureImage(_ context.Context, image string) error {
+	r.ensuredImages = append(r.ensuredImages, image)
 	return nil
 }
 
@@ -110,6 +127,87 @@ func sourceLifecycleStack(ref string, replicas int, autoscale *config.AutoscaleC
 	}
 }
 
+func TestOrchestrator_Up_CurrentSourceRefChangeReusesStaleContainer(t *testing.T) {
+	rt := newSourceLifecycleRuntime()
+	builder := &recordingSourceBuilder{}
+	orch := NewOrchestrator(rt, builder)
+
+	stack := sourceLifecycleStack("commit-a", 0, nil)
+	if _, err := orch.Up(context.Background(), stack, UpOptions{BasePort: 9000}); err != nil {
+		t.Fatalf("first Up: %v", err)
+	}
+	stack.MCPServers[0].Source.Ref = "commit-b"
+	if _, err := orch.Up(context.Background(), stack, UpOptions{BasePort: 9000}); err != nil {
+		t.Fatalf("second Up: %v", err)
+	}
+
+	if len(builder.calls) != 1 {
+		t.Fatalf("Build calls = %d, want current stale count 1", len(builder.calls))
+	}
+	if len(rt.started) != 1 {
+		t.Fatalf("Start calls = %d, want current stale count 1", len(rt.started))
+	}
+	if len(rt.removed) != 0 {
+		t.Fatalf("Remove calls = %d, want current stale count 0", len(rt.removed))
+	}
+}
+
+func TestOrchestrator_Up_CurrentExistingSourceSkipsBuild(t *testing.T) {
+	rt := newSourceLifecycleRuntime()
+	rt.statuses["gridctl-demo-source"] = &WorkloadStatus{
+		ID:       "existing-source",
+		State:    WorkloadStateRunning,
+		HostPort: 9000,
+		Image:    "gridctl-source:commit-a",
+	}
+	builder := &recordingSourceBuilder{}
+	orch := NewOrchestrator(rt, builder)
+
+	if _, err := orch.Up(context.Background(), sourceLifecycleStack("commit-a", 0, nil), UpOptions{BasePort: 9000}); err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	if len(builder.calls) != 0 {
+		t.Fatalf("Build calls = %d, want current stale count 0", len(builder.calls))
+	}
+}
+
+func TestOrchestrator_Up_CurrentSourceReplicasBuildPerReplica(t *testing.T) {
+	rt := newSourceLifecycleRuntime()
+	builder := &recordingSourceBuilder{}
+	orch := NewOrchestrator(rt, builder)
+
+	if _, err := orch.Up(context.Background(), sourceLifecycleStack("commit-a", 2, nil), UpOptions{BasePort: 9000}); err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	if len(builder.calls) != 2 {
+		t.Fatalf("Build calls = %d, want current stale count 2", len(builder.calls))
+	}
+	if len(rt.started) != 2 {
+		t.Fatalf("Start calls = %d, want 2 replicas", len(rt.started))
+	}
+}
+
+func TestOrchestrator_Up_CurrentAutoscaledSourceSkipsBuild(t *testing.T) {
+	rt := newSourceLifecycleRuntime()
+	builder := &recordingSourceBuilder{}
+	orch := NewOrchestrator(rt, builder)
+	stack := sourceLifecycleStack("commit-a", 0, &config.AutoscaleConfig{
+		Min:            0,
+		Max:            2,
+		TargetInFlight: 1,
+	})
+
+	if _, err := orch.Up(context.Background(), stack, UpOptions{BasePort: 9000}); err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	if len(builder.calls) != 0 {
+		t.Fatalf("Build calls = %d, want current stale count 0", len(builder.calls))
+	}
+}
+
 func TestOrchestrator_Up_SourceRefChangeReplacesStaleContainer(t *testing.T) {
 	t.Skip(pendingSourceLifecycle)
 
@@ -132,8 +230,14 @@ func TestOrchestrator_Up_SourceRefChangeReplacesStaleContainer(t *testing.T) {
 	if len(rt.started) != 2 {
 		t.Fatalf("Start calls = %d, want 2", len(rt.started))
 	}
-	if rt.started[0].Image == rt.started[1].Image {
-		t.Fatalf("ref change reused image %q", rt.started[0].Image)
+	if builder.calls[1].Ref != "commit-b" {
+		t.Fatalf("second Build ref = %q, want commit-b", builder.calls[1].Ref)
+	}
+	if rt.started[1].Image != "gridctl-source:commit-b" {
+		t.Fatalf("second Start image = %q, want second build result", rt.started[1].Image)
+	}
+	if rt.started[1].Image == generateTag("demo", "source") {
+		t.Fatalf("second Start reused mutable image %q", rt.started[1].Image)
 	}
 	if len(rt.removed) != 1 {
 		t.Errorf("Remove calls = %d, want 1 stale container", len(rt.removed))

--- a/pkg/runtime/source_lifecycle_test.go
+++ b/pkg/runtime/source_lifecycle_test.go
@@ -1,0 +1,215 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gridctl/gridctl/pkg/config"
+)
+
+const pendingSourceLifecycle = "pending source lifecycle reconciliation"
+
+type recordingSourceBuilder struct {
+	calls []BuildOptions
+}
+
+func (b *recordingSourceBuilder) Build(_ context.Context, opts BuildOptions) (*BuildResult, error) {
+	b.calls = append(b.calls, opts)
+	ref := opts.Ref
+	if ref == "" {
+		ref = "resolved"
+	}
+	return &BuildResult{ImageTag: "gridctl-source:" + ref}, nil
+}
+
+type sourceLifecycleRuntime struct {
+	WorkloadRuntime
+	statuses map[string]*WorkloadStatus
+	started  []WorkloadConfig
+	stopped  []WorkloadID
+	removed  []WorkloadID
+}
+
+func newSourceLifecycleRuntime() *sourceLifecycleRuntime {
+	return &sourceLifecycleRuntime{statuses: make(map[string]*WorkloadStatus)}
+}
+
+func (r *sourceLifecycleRuntime) Ping(context.Context) error { return nil }
+
+func (r *sourceLifecycleRuntime) EnsureNetwork(context.Context, string, NetworkOptions) error {
+	return nil
+}
+
+func (r *sourceLifecycleRuntime) Exists(_ context.Context, name string) (bool, WorkloadID, error) {
+	status, ok := r.statuses[name]
+	if !ok {
+		return false, "", nil
+	}
+	return true, status.ID, nil
+}
+
+func (r *sourceLifecycleRuntime) Status(_ context.Context, id WorkloadID) (*WorkloadStatus, error) {
+	for _, status := range r.statuses {
+		if status.ID == id {
+			return status, nil
+		}
+	}
+	return nil, ErrWorkloadNotFound
+}
+
+func (r *sourceLifecycleRuntime) GetHostPort(ctx context.Context, id WorkloadID, _ int) (int, error) {
+	status, err := r.Status(ctx, id)
+	if err != nil {
+		return 0, err
+	}
+	return status.HostPort, nil
+}
+
+func (r *sourceLifecycleRuntime) Start(_ context.Context, cfg WorkloadConfig) (*WorkloadStatus, error) {
+	r.started = append(r.started, cfg)
+	name := "gridctl-" + cfg.Stack + "-" + cfg.Name
+	status := &WorkloadStatus{
+		ID:       WorkloadID("id-" + cfg.Name),
+		Name:     cfg.Name,
+		Stack:    cfg.Stack,
+		Type:     cfg.Type,
+		State:    WorkloadStateRunning,
+		HostPort: cfg.HostPort,
+		Image:    cfg.Image,
+	}
+	r.statuses[name] = status
+	return status, nil
+}
+
+func (r *sourceLifecycleRuntime) Stop(_ context.Context, id WorkloadID) error {
+	r.stopped = append(r.stopped, id)
+	return nil
+}
+
+func (r *sourceLifecycleRuntime) Remove(_ context.Context, id WorkloadID) error {
+	r.removed = append(r.removed, id)
+	for name, status := range r.statuses {
+		if status.ID == id {
+			delete(r.statuses, name)
+		}
+	}
+	return nil
+}
+
+func sourceLifecycleStack(ref string, replicas int, autoscale *config.AutoscaleConfig) *config.Stack {
+	return &config.Stack{
+		Name:    "demo",
+		Network: config.Network{Name: "demo-net", Driver: "bridge"},
+		MCPServers: []config.MCPServer{{
+			Name:      "source",
+			Source:    &config.Source{Type: "git", URL: "https://example.com/source.git", Ref: ref},
+			Port:      3000,
+			Replicas:  replicas,
+			Autoscale: autoscale,
+		}},
+	}
+}
+
+func TestOrchestrator_Up_SourceRefChangeReplacesStaleContainer(t *testing.T) {
+	t.Skip(pendingSourceLifecycle)
+
+	rt := newSourceLifecycleRuntime()
+	builder := &recordingSourceBuilder{}
+	orch := NewOrchestrator(rt, builder)
+
+	stack := sourceLifecycleStack("commit-a", 0, nil)
+	if _, err := orch.Up(context.Background(), stack, UpOptions{BasePort: 9000}); err != nil {
+		t.Fatalf("first Up: %v", err)
+	}
+	stack.MCPServers[0].Source.Ref = "commit-b"
+	if _, err := orch.Up(context.Background(), stack, UpOptions{BasePort: 9000}); err != nil {
+		t.Fatalf("second Up: %v", err)
+	}
+
+	if len(builder.calls) != 2 {
+		t.Fatalf("Build calls = %d, want 2", len(builder.calls))
+	}
+	if len(rt.started) != 2 {
+		t.Fatalf("Start calls = %d, want 2", len(rt.started))
+	}
+	if rt.started[0].Image == rt.started[1].Image {
+		t.Fatalf("ref change reused image %q", rt.started[0].Image)
+	}
+	if len(rt.removed) != 1 {
+		t.Errorf("Remove calls = %d, want 1 stale container", len(rt.removed))
+	}
+}
+
+func TestOrchestrator_Up_ResolvesSourceBeforeExistingContainerReuse(t *testing.T) {
+	t.Skip(pendingSourceLifecycle)
+
+	rt := newSourceLifecycleRuntime()
+	rt.statuses["gridctl-demo-source"] = &WorkloadStatus{
+		ID:       "existing-source",
+		State:    WorkloadStateRunning,
+		HostPort: 9000,
+		Image:    "gridctl-source:commit-a",
+	}
+	builder := &recordingSourceBuilder{}
+	orch := NewOrchestrator(rt, builder)
+
+	if _, err := orch.Up(context.Background(), sourceLifecycleStack("commit-a", 0, nil), UpOptions{BasePort: 9000}); err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	if len(builder.calls) != 1 {
+		t.Fatalf("Build calls = %d, want 1 before reuse check", len(builder.calls))
+	}
+	if len(rt.started) != 0 {
+		t.Errorf("matching existing container was replaced: %d Start calls", len(rt.started))
+	}
+}
+
+func TestOrchestrator_Up_TwoSourceReplicasBuildOnce(t *testing.T) {
+	t.Skip(pendingSourceLifecycle)
+
+	rt := newSourceLifecycleRuntime()
+	builder := &recordingSourceBuilder{}
+	orch := NewOrchestrator(rt, builder)
+
+	if _, err := orch.Up(context.Background(), sourceLifecycleStack("commit-a", 2, nil), UpOptions{BasePort: 9000}); err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	if len(builder.calls) != 1 {
+		t.Fatalf("Build calls = %d, want 1 per logical server", len(builder.calls))
+	}
+	if len(rt.started) != 2 {
+		t.Fatalf("Start calls = %d, want 2 replicas", len(rt.started))
+	}
+	if rt.started[0].Image != rt.started[1].Image {
+		t.Errorf("replica images differ: %q and %q", rt.started[0].Image, rt.started[1].Image)
+	}
+}
+
+func TestOrchestrator_Up_AutoscaledSourceBuildsBeforeRegistration(t *testing.T) {
+	t.Skip(pendingSourceLifecycle)
+
+	rt := newSourceLifecycleRuntime()
+	builder := &recordingSourceBuilder{}
+	orch := NewOrchestrator(rt, builder)
+	stack := sourceLifecycleStack("commit-a", 0, &config.AutoscaleConfig{
+		Min:            0,
+		Max:            2,
+		TargetInFlight: 1,
+	})
+
+	result, err := orch.Up(context.Background(), stack, UpOptions{BasePort: 9000})
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+	if len(builder.calls) != 1 {
+		t.Fatalf("Build calls = %d, want 1 before autoscaler registration", len(builder.calls))
+	}
+	if len(rt.started) != 0 {
+		t.Errorf("orchestrator started %d autoscaled replicas", len(rt.started))
+	}
+	if len(result.MCPServers) != 1 {
+		t.Fatalf("result servers = %d, want 1", len(result.MCPServers))
+	}
+}


### PR DESCRIPTION
## Summary

- Add desired lifecycle contracts for source ref changes and existing-container reconciliation.
- Keep current stale build counts and mutable reload image behavior visible through enabled characterization tests.
- Cover build-once behavior and exact image wiring for static replicas, autoscaled spawners, and hot reload.

## Testing

- `task test`

## Review Notes

Desired lifecycle specifications are skipped so the test-only change preserves the green baseline. Enabled characterization tests pin the current stale behavior and should be removed when the corresponding contracts are enabled during reconciliation. The reload contract drives a modified existing server, and the autoscaler contract covers registrar-to-spawner image wiring.

Part of #1201
