### PR TITLE
docs: add daily Python source stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to gridctl will be documented in this file.
 
 ## [Unreleased]
 
+### Documentation
+
+- Python source examples now include a practical daily stack that builds the Fetch server from an exact PyPI release and the Time server from a commit-pinned project in the official MCP servers monorepo. The guide explains source pins, generated command selection, and build and runtime network behavior.
+
 ### Security
 
 - Variable names beginning with `GRIDCTL_`, plus `OP_CONNECT_TOKEN` and `OP_SERVICE_ACCOUNT_TOKEN`, are now reserved for gridctl bootstrap and control-plane credentials. New store writes reject them, imports skip them with key-only warnings, exports and variable-set injection omit legacy entries, and local MCP processes no longer inherit them from the gridctl daemon. `${var:...}` and `${vault:...}` references to reserved keys remain literal and return a distinct resolution error without falling back to the ambient environment. Ordinary environment interpolation of non-credential `GRIDCTL_*` values remains supported. This is a compatibility-sensitive security boundary for the next major release; remove legacy entries with `gridctl var delete KEY --force` after moving any downstream credential to a non-reserved name (#1186)

--- a/README.md
+++ b/README.md
@@ -221,6 +221,14 @@ mcp-servers:
       type: pypi
       package: mcp-server-fetch
       ref: 2026.8.18
+
+  - name: time
+    source:
+      type: git
+      url: https://github.com/modelcontextprotocol/servers.git
+      ref: d73f99efbfd40c3aa1b61e88728b3d49fb52608f
+      path: src/time
+      runtime: python
 ```
 
 Learn more → [Source configuration](docs/config-schema.md#source) · [Runnable example](examples/python-sources/)
@@ -391,7 +399,7 @@ Learn more → [Packs guide](docs/packs.md)
 | [`per-client-scoping.yaml`](examples/access-control/per-client-scoping.yaml) | Restrict which servers and tools each linked client may touch |
 | [`declarative-link/stack.yaml`](examples/declarative-link/stack.yaml) | Auto-link LLM clients on apply with a `link:` block |
 | [`autoscale-basic.yaml`](examples/autoscale/autoscale-basic.yaml) | Reactive replica autoscaling for a stdio server |
-| [`pypi.yaml`](examples/python-sources/pypi.yaml) | Generate a non-root Python container from an exact PyPI release |
+| [`python-sources/`](examples/python-sources/) | Generate non-root Python containers from exact PyPI and Git sources |
 | [`otlp-jaeger.yaml`](examples/tracing/otlp-jaeger.yaml) | Export traces to Jaeger via OTLP |
 | [`portable-pack/`](examples/portable-pack) | Team pack: skills, agents, and wiring from one manifest |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,7 +36,7 @@ gridctl apply examples/getting-started/mcp-basic.yaml
 2. **Real MCP servers**: `transports/local-mcp.yaml` - actual MCP server logic via stdio transport
 3. **Platforms**: `platforms/github-mcp.yaml` - third-party MCP servers
 4. **OpenAPI**: `openapi/openapi-basic.yaml` - turn any REST API into MCP tools
-5. **Python sources**: `python-sources/pypi.yaml` - build an exact package into a container
+5. **Python sources**: `python-sources/pypi.yaml` - start with one exact package, then try `daily.yaml` for PyPI and Git together
 6. **Registry**: `registry/registry-basic.yaml` - Skills as MCP prompts (imports also discover agents)
 7. **Packs**: `portable-pack/` - one manifest importing skills, agents, and rules as a unit
 8. **Scaling**: `autoscale/autoscale-basic.yaml` - reactive autoscaling of MCP replicas
@@ -59,6 +59,7 @@ gridctl apply examples/getting-started/mcp-basic.yaml
 | context7-mcp | stdio (host process) | Library docs via npx |
 | github-mcp | stdio (container) | Official containerized platform server |
 | pypi | stdio (generated container) | Exact public PyPI release, automatic console command, pinned Python/uv bases |
+| daily | stdio (generated containers) | Exact PyPI release and commit-pinned Git project in one stack |
 | zapier-mcp | http (remote URL) | Hosted platform server with OAuth brokering |
 | openapi-basic | openapi | REST API as MCP tools, operation filtering |
 | openapi-auth | openapi | Bearer, header, query, OAuth2, basic auth, and mTLS |

--- a/examples/python-sources/README.md
+++ b/examples/python-sources/README.md
@@ -1,8 +1,13 @@
 # Python source containers
 
 Gridctl can generate a container image for an exact public PyPI release or a
-packaged Python project in a git or local source. Docker or Podman performs the
+packaged Python project in a Git or local source. Docker or Podman performs the
 build; host Python and uv are not required.
+
+| Example | Use it to |
+|---------|-----------|
+| [`pypi.yaml`](pypi.yaml) | Try one generated server with the smallest useful stack |
+| [`daily.yaml`](daily.yaml) | Run pinned PyPI and Git sources together |
 
 ## PyPI example
 
@@ -24,9 +29,34 @@ Later unchanged applies reuse the image when its build-input label matches.
 The plan resolves the exact artifact, previews the generated Dockerfile, and
 reports whether the resulting image is already cached.
 
+## Daily topology
+
+`daily.yaml` is a practical agent setup with two credential-free tools:
+
+| Server | Source | Pin | Runtime behavior |
+|--------|--------|-----|------------------|
+| `fetch` | Public `mcp-server-fetch` release on PyPI | Exact package version | Fetches web content over the network |
+| `time` | `src/time` in the official MCP servers Git repository | Full commit SHA | Answers time and timezone queries locally |
+
+Both packages expose one console script, so neither server needs an explicit
+`command`. Gridctl builds both as non-root stdio containers and publishes no
+host ports.
+
+```bash
+gridctl validate examples/python-sources/daily.yaml
+gridctl plan examples/python-sources/daily.yaml --show-dockerfile
+gridctl apply examples/python-sources/daily.yaml
+gridctl logs --server fetch
+gridctl logs --server time
+gridctl destroy examples/python-sources/daily.yaml
+```
+
+The first plan or apply needs network access to PyPI, GitHub, and the configured
+container registry; later unchanged operations can reuse verified local images.
+
 ## Packaged git and local projects
 
-For a packaged project in git, set `runtime: python` and use `path` for a clean
+For a packaged project in Git, set `runtime: python` and use `path` for a clean
 subdirectory below the checkout:
 
 ```yaml

--- a/examples/python-sources/daily.yaml
+++ b/examples/python-sources/daily.yaml
@@ -1,0 +1,37 @@
+# Build two useful stdio MCP servers from pinned Python sources.
+#
+# Prerequisites:
+#   - Docker or Podman
+#   - Network access to PyPI, GitHub, and container registries for the first build
+#
+# Usage:
+#   gridctl validate examples/python-sources/daily.yaml
+#   gridctl plan examples/python-sources/daily.yaml --show-dockerfile
+#   gridctl apply examples/python-sources/daily.yaml
+#   gridctl destroy examples/python-sources/daily.yaml
+
+version: "1"
+name: daily
+
+network:
+  name: daily-net
+  driver: bridge
+
+mcp-servers:
+  # Exact public PyPI release. PyPI implies runtime: python, and the package's
+  # single console script is selected automatically.
+  - name: fetch
+    source:
+      type: pypi
+      package: mcp-server-fetch
+      ref: 2026.8.18
+
+  # Commit-pinned Python project inside the official MCP servers monorepo.
+  # runtime: python selects Dockerfile generation instead of Dockerfile lookup.
+  - name: time
+    source:
+      type: git
+      url: https://github.com/modelcontextprotocol/servers.git
+      ref: d73f99efbfd40c3aa1b61e88728b3d49fb52608f
+      path: src/time
+      runtime: python


### PR DESCRIPTION
## Description

Add a practical Python source topology that combines an exact PyPI release with a commit-pinned Git project, and update the documentation indexes and feature overview to explain the workflow.

## Type of Change

- [x] Documentation

## Changes Made

- Add a runnable Fetch and Time generated-container stack
- Document source pins, command selection, network requirements, and cache reuse
- Update the README, examples index, and changelog

## Testing

- `task build`
- `./gridctl validate examples/python-sources/pypi.yaml`
- `./gridctl validate examples/python-sources/daily.yaml`
- `./gridctl plan examples/python-sources/daily.yaml --show-dockerfile --format json`
- `git diff --check`

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review has been performed
- [x] Commits follow conventional format and are signed
- [x] No secrets or credentials are committed