### PR TITLE
fix: enforce grouped MCP authentication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Task (https://taskfile.dev) is the entry point for everything; tasks live in `Ta
 | `task build:web` | Frontend only (`cd web && npm run build`). |
 | `task dev` | Runs the Vite dev server (`web/`) against a separately-running backend. |
 | `task test` | `go test -race ./...` (unit tests only, same race detector CI runs). |
-| `task test:integration` | `go test -tags=integration -race -timeout 15m ./tests/integration/...`. Requires Docker (or Podman). These tests hit real container runtimes per Article IV of `CONSTITUTION.md`; mocks are disallowed in `tests/integration/`. |
+| `task test:integration` | `go test -tags=integration -race -timeout 15m ./tests/integration/...`. The full suite requires Docker (or Podman); selected HTTP/subprocess suites need no container runtime. All use real dependencies per Article IV of `CONSTITUTION.md`; mocks are disallowed in `tests/integration/`. |
 | `task test:frontend` | `cd web && npm test` (Vitest). |
 | `task lint` | `golangci-lint run` plus `npm run lint` in `web/` (both CI-gated). |
 | `task generate` | Regenerates `go.uber.org/mock` mocks under `pkg/mcp/` and `pkg/runtime/`. Required after touching the interfaces they're generated from. |
@@ -31,7 +31,7 @@ Run a single Go test:
 
 ```bash
 go test -v -run TestFunctionName ./pkg/runtime/...
-go test -v -race -tags=integration -run TestGatewayLifecycle ./tests/integration/...
+go test -v -race -tags=integration -run TestToolGroups_Authentication ./tests/integration/...
 ```
 
 Lint:
@@ -51,6 +51,9 @@ cmd/gridctl/        Cobra CLI entry points, one file per subcommand (apply, serv
 internal/api/       REST handlers backing the web UI (one file per resource: stack, skills, vault, pins, telemetry, traces, …).
                     Python source validation, resolution previews, generated files, and status provenance live in
                     python_sources.go. The Server struct in api.go wires together every pkg/* subsystem the UI needs.
+                    Server.Handler assembles HTTP routes and CORS/Host/auth middleware; auth.go protects operational
+                    namespaces, including grouped MCP/SSE. UI files, probes, terminal preflight, and the exact
+                    state-validated downstream OAuth callback do not require the gateway token.
 internal/probe/     Ephemeral MCP tool-list probe for the "add server" wizard (not registered with the gateway).
 pkg/catalog/        MCP server catalog behind `gridctl search` / `gridctl add`: curated embedded entries plus the
                     official MCP Registry, with install-shape mapping into stack.yaml server blocks.
@@ -104,7 +107,7 @@ web/                React 19 + Vite + TypeScript. Tailwind v4 (postcss plugin). 
 
 tests/integration/  Real-runtime suites (build tag `integration`). Cover gateway lifecycle, hot reload, autoscaler,
                     replicas, transports (incl. Podman), private git auth, generated Python source builds, and
-                    optimize heuristics.
+                    optimize heuristics. Grouped auth tests use real HTTP and a subprocess MCP backend.
 examples/           Example stack YAMLs grouped by surface (getting-started, transports, openapi, registry, secrets-vault,
                     code-mode, platforms, tracing, access-control, autoscale, declarative-link, gateways, portable-stack,
                     portable-pack, model-policy, python-sources). examples/_mock-servers/ is the source for `task mock:servers`.
@@ -112,7 +115,7 @@ docs/               User-facing documentation (cli-reference, config-schema, api
                     global-context, model-policy, scaling, usage-observability, installation, project-status, troubleshooting).
 ```
 
-End-to-end request flow for an upstream MCP tool call: client → HTTP listener built by `pkg/controller` (gateway_builder.go) → `pkg/mcp` transport (SSE/streamable/stdio) → `mcp.Gateway` router → per-server `mcp.Client` (process/SSE/HTTP/OpenAPI) → response, with telemetry, tracing, schema pinning, and (optional) output-format conversion attached on the way back.
+End-to-end request flow for an upstream HTTP MCP tool call: client → HTTP listener built by `pkg/controller` (gateway_builder.go) → `internal/api.Server.Handler` (CORS, Host validation, configured auth, and route/group selection) → `pkg/mcp` Streamable HTTP transport (Host/Origin checks and protocol handling) → `mcp.Gateway` router → per-server `mcp.Client` (process/stdio/SSE/HTTP/OpenAPI) → response, with telemetry, tracing, schema pinning, and (optional) output-format conversion attached on the way back. Legacy SSE routes return a negotiation hint rather than dispatching tools.
 
 End-to-end for the web UI: React store action → `/api/...` handler in `internal/api/` → method on `Server` → call into the relevant `pkg/*` subsystem → JSON response → store update → component re-render.
 
@@ -121,7 +124,7 @@ End-to-end for the web UI: React store action → `/api/...` handler in `interna
 `CONSTITUTION.md` is binding for every change. Articles that most often catch a refactor by surprise:
 
 - **III (Test-first):** every exported function gets a test before merge; bug fixes need a regression test.
-- **IV (Integration tests use real dependencies):** anything under `tests/integration/` runs against real Docker/Podman and must pass `-race`. Mocks are unit-test only.
+- **IV (Integration tests use real dependencies):** anything under `tests/integration/` uses real dependencies (containers, network connections, or subprocesses as applicable) and must pass `-race`. Mocks are unit-test only.
 - **V (No panics in `pkg/` or `internal/`):** return errors. CLI init in `cmd/` is the only place panic is allowed.
 - **VI (Context propagation):** any I/O, blocking, or external call takes `context.Context` as the first arg and respects cancellation.
 - **IX (Stack YAML back-compat):** new `stack.yaml` fields are optional with a default that preserves existing behavior. Renames and removals are breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to gridctl will be documented in this file.
 
 ### Security
 
+- Configured gateway authentication now covers grouped MCP and SSE routes, including initialization, discovery, calls, stream replay, and session deletion. Grouped clients that omitted credentials must send the same bearer token or API-key header required by `/mcp` on every request. Public UI files, probes, terminal CORS preflight, and the exact state-validated downstream OAuth callback remain public; no-auth loopback, valid credential formats, and all supported MCP protocol generations remain unchanged (#1223)
 - Variable names beginning with `GRIDCTL_`, plus `OP_CONNECT_TOKEN` and `OP_SERVICE_ACCOUNT_TOKEN`, are now reserved for gridctl bootstrap and control-plane credentials. New store writes reject them, imports skip them with key-only warnings, exports and variable-set injection omit legacy entries, and local MCP processes no longer inherit them from the gridctl daemon. `${var:...}` and `${vault:...}` references to reserved keys remain literal and return a distinct resolution error without falling back to the ambient environment. Ordinary environment interpolation of non-credential `GRIDCTL_*` values remains supported. This is a compatibility-sensitive security boundary for the next major release; remove legacy entries with `gridctl var delete KEY --force` after moving any downstream credential to a non-reserved name (#1186)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to gridctl will be documented in this file.
 
 ### Documentation
 
+- Correct the API reference's grouped-auth exemptions and remote gateway setup guidance, and clarify credential requirements in group and client-linking documentation (#1223).
 - Python source examples now include a practical daily stack that builds the Fetch server from an exact PyPI release and the Time server from a commit-pinned project in the official MCP servers monorepo. The guide explains source pins, generated command selection, and build and runtime network behavior.
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ gridctl groups                     # Groups, member counts, and endpoints
 gridctl link cursor --group release
 ```
 
+With `gateway.auth` configured, grouped endpoints require the same bearer token or API-key header as `/mcp` on every request. Linking selects an endpoint but does not provision credentials; supply them through your client's authentication settings. Groups and self-declared client selectors are not authenticated identities. See [gateway authentication](docs/config-schema.md#auth), including HTTPS or encrypted-tunnel requirements for remote access.
+
 Learn more → [Tools Workspace](docs/tools-workspace.md)
 
 ### Rate Limits

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,19 +4,23 @@ The gridctl gateway exposes a REST API for managing stacks, secrets, skills, pac
 
 ## Authentication
 
-When `gateway.auth` is configured, authentication is required for `/api/*`, `/mcp`, `/sse`, `/message`, and `/.well-known/*` paths. Exempt: `/health`, `/ready`, CORS preflight (`OPTIONS`) requests, the static web UI (`GET /`), `/oauth/callback`, and the group MCP endpoints (`/groups/{name}/mcp`, `/groups/{name}/sse`).
+When `gateway.auth` is configured, authentication is required for `/api/`, `/groups/`, `/a2a/`, and `/.well-known/` namespaces, plus `/mcp`, `/sse`, and `/message`. This includes `/groups/{name}/mcp` and `/groups/{name}/sse`, as well as unknown paths within protected namespaces. Missing or incorrect credentials return HTTP `401` with a plain-text `Unauthorized` body before operational handling.
+
+The UI shell, assets, and deep links, `/health`, and `/ready` do not require the gateway token. `OPTIONS` terminates in the CORS layer without dispatching an operation. When downstream OAuth brokering is enabled, the exact `GET /oauth/callback` route validates single-use OAuth state instead of the gateway token; `/api/auth/` and `/api/servers/{name}/auth/` remain protected. Host checks and MCP Origin checks apply independently of authentication; native clients may omit Origin.
+
+Send the credential on every operational request, including initialization, discovery, stream reconnection or replay, and session deletion. Group names, client selectors, `Mcp-Session-Id`, and `Last-Event-ID` do not authenticate callers. Shared-token mode does not implement the full MCP OAuth authorization profile. Use HTTPS or an encrypted tunnel for remote access; see [gateway authentication](config-schema.md#auth) for configuration and transport requirements. Without configured auth, loopback use remains unchanged.
 
 **Bearer token:**
 ```bash
-curl -H "Authorization: Bearer <token>" http://localhost:8180/api/status
+curl -H "Authorization: Bearer ${GATEWAY_TOKEN}" http://localhost:8180/api/status
 ```
 
-**API key:**
+**API key** (with `gateway.auth.type: api_key` and `gateway.auth.header: X-API-Key`):
 ```bash
-curl -H "X-API-Key: <token>" http://localhost:8180/api/status
+curl -H "X-API-Key: ${GATEWAY_TOKEN}" http://localhost:8180/api/status
 ```
 
-Token comparison uses constant-time equality to prevent timing attacks.
+Supply `GATEWAY_TOKEN` in the shell environment. API-key mode sends the raw token, without a `Bearer ` prefix; its default header is `Authorization` when no custom header is set. Token comparison uses constant-time equality to prevent timing attacks. Throughout this reference, **Auth: Yes** means required when `gateway.auth` is configured.
 
 ---
 
@@ -664,7 +668,7 @@ curl -H "Authorization: Bearer $TOKEN" "http://localhost:8180/api/optimize?min_i
 
 #### `GET /api/groups`
 
-Returns every tool group declared under `groups:` in stack.yaml, resolved against the live tool surface. Backs `gridctl groups`. Always `200`: with no groups configured the payload carries `configured: false` and an empty array. Each group also serves MCP at `GET|POST|DELETE /groups/{name}/mcp` (and a negotiation hint at `GET /groups/{name}/sse`); unknown group names return `404` before any session is created.
+Returns every tool group declared under `groups:` in stack.yaml, resolved against the live tool surface. Backs `gridctl groups`. An authenticated request returns `200`: with no groups configured the payload carries `configured: false` and an empty array. Each group also serves MCP at `GET|POST|DELETE /groups/{name}/mcp` (and a negotiation hint at `GET /groups/{name}/sse`). These routes require the same configured credential as `/mcp` on every request. After authentication, unknown group names return `404` before any session is created.
 
 **Auth:** Yes
 
@@ -3389,19 +3393,21 @@ session-based SSE message endpoint was retired with the legacy transport.
 
 #### `GET /`
 
-Serves the embedded web UI. All unmatched paths fall back to `index.html` for SPA routing. Static assets are served with appropriate content types.
+Serves the embedded web UI. Unmatched paths fall back to `index.html` for SPA routing, but paths within protected namespaces still pass through authentication first. Static assets are served with appropriate content types.
 
-**Auth:** Yes
+**Auth:** No (UI shell, assets, and deep links outside protected namespaces)
 
 ---
 
 ## Error Responses
 
-All API errors return JSON:
+REST handlers generally return errors as JSON:
 
 ```json
 {"error": "error message"}
 ```
+
+HTTP middleware and routing errors can be plain text, including `401 Unauthorized` from gateway authentication and `403 Forbidden` from Host or MCP Origin checks.
 
 **Status codes:**
 
@@ -3412,6 +3418,7 @@ All API errors return JSON:
 | `204` | Success, no content |
 | `400` | Invalid input or request |
 | `401` | Missing or invalid authentication |
+| `403` | Host, MCP Origin, or endpoint-specific access check rejected the request |
 | `404` | Resource not found |
 | `405` | HTTP method not allowed |
 | `409` | Resource conflict (e.g., duplicate name) |
@@ -3429,4 +3436,4 @@ Access-Control-Allow-Headers: Content-Type, Authorization
 Vary: Origin
 ```
 
-`OPTIONS` preflight requests return `200 OK` with CORS headers without authentication.
+`OPTIONS` requests return `200 OK` without authentication and never dispatch an operation. CORS response headers are present only when the request supplies an allowed Origin; a custom `gateway.auth.header` is also included in `Access-Control-Allow-Headers`. Preflight success does not authenticate the subsequent request.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -120,6 +120,8 @@ Install MCP servers by name instead of hand-writing `command`/`args`/`env`. The 
 
 Named cross-server tool bundles declared under `groups:` in stack.yaml (see the [config schema](config-schema.md#groups-tool-bundles)), each served at `/groups/{name}/mcp`. Exit codes: `0` success (including no groups configured), `2` infrastructure error.
 
+When `gateway.auth` is configured, grouped MCP clients must send the same credential as `/mcp` on every request. `gridctl link --group` selects the endpoint but does not provision credentials into client files; configure authentication in the client separately. Local CLI API requests continue to use the credential recorded in daemon state. See [gateway authentication](config-schema.md#auth).
+
 | Command | Purpose |
 |---|---|
 | `gridctl groups` | Table of groups with member counts (resolved against the live tool surface), override counts, and endpoints. `-s` / `--stack <name>` picks the stack (auto-detected when only one is running). Prints a sample `groups:` block when none is configured. |

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -79,7 +79,7 @@ gateway:
 | `bind` | string | No | `127.0.0.1` | Address the HTTP listener binds. Loopback by default, so the API, web UI, and gateway are unreachable from other hosts and from containers. Set `0.0.0.0` to listen on every interface. The `--bind` and `--bind-all` flags override this. **A non-loopback bind requires `auth`** — gridctl refuses to start otherwise |
 | `insecure_allow_unauthenticated` | bool | No | `false` | Permit a non-loopback bind with no `auth` configured. Without it gridctl refuses to start in that combination. Exists as a config field as well as the `--insecure-allow-unauthenticated` flag, because a flag can be dropped by whatever wraps the process (launchd, a Homebrew service, a Dockerfile `CMD`). Warns loudly on every start |
 | `allowed_origins` | []string | No | `["*"]` | CORS allowed origins. Empty or unset allows all |
-| `allowed_hosts` | []string | No | `[]` | Extra `Host` header values accepted on the MCP endpoint (DNS rebinding protection). Loopback hosts are always accepted, so unset means loopback-only. Set only when a reverse proxy or container hostname fronts the gateway. Unlike `allowed_origins`, `"*"` is **not** a wildcard here and matches nothing |
+| `allowed_hosts` | []string | No | `[]` | Extra `Host` header values accepted for loopback-arriving connections across the HTTP surface, including MCP, REST, the UI, and the OAuth callback (DNS rebinding protection). Probes and terminal CORS preflight are exempt. Unset accepts only loopback hosts on those connections; non-loopback-arriving connections skip this check. Set when a reverse proxy forwards a non-loopback hostname. Unlike `allowed_origins`, `"*"` is **not** a wildcard here and matches nothing |
 | `auth` | object | No | - | Authentication configuration |
 | `code_mode` | string | No | `"off"` | Enable code mode: `"on"` or `"off"` |
 | `code_mode_timeout` | int | No | `30` | Code mode execution timeout in seconds. Must be >= 0 |
@@ -1105,6 +1105,8 @@ per-server `tools:` whitelist narrows what exists, groups curate what an
 endpoint shows, client scoping restricts what a client may touch, and all
 three intersect. Omitting the block changes nothing; the default `/mcp`
 endpoint always serves the full surface.
+
+With `gateway.auth` configured, `/groups/{name}/mcp` and the legacy negotiation hint at `/groups/{name}/sse` require the same credential as `/mcp` on every request. Authentication precedes the group lookup: missing or incorrect credentials return HTTP 401 even for unknown groups; authenticated requests to unknown groups return 404. Group selection is not credential-bound authorization. See [Auth](#auth).
 
 ```yaml
 groups:

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -93,7 +93,13 @@ gateway:
 
 ### Auth
 
-When configured, all requests (except `/health` and `/ready`) require a valid token.
+When configured, authentication covers `/mcp`, `/sse`, `/message`, `/groups/{name}/mcp`, `/groups/{name}/sse`, and the `/api/` namespace. The `/groups/`, `/a2a/`, and `/.well-known/` namespaces are classified as protected, including unknown paths. Missing or incorrect credentials receive HTTP 401 before operational handling, including initialization, discovery, tool calls, stream establishment or replay, and session deletion.
+
+The UI shell, assets, and UI deep links remain public so the browser can load. `/health` and `/ready` do not require the gateway token (readiness can still return 503). CORS preflight terminates without dispatching an operation. When downstream OAuth brokering is enabled, the exact `GET /oauth/callback` route uses single-use OAuth state instead of the gateway token; this does not exempt `/api/auth/` or `/api/servers/{name}/auth/`. Host checks and the MCP transport's Origin checks remain independent of authentication; native clients do not need an Origin header.
+
+Send `Authorization: Bearer <token>` for bearer auth, or the raw token in the configured header for API-key auth. Group names, client selectors, `Mcp-Session-Id`, and `Last-Event-ID` are not credentials or credential-bound identities. Shared-token mode does not implement the full MCP OAuth authorization profile.
+
+Remote access requires HTTPS through a TLS-terminating reverse proxy or an encrypted tunnel. A shared token sent over unencrypted remote HTTP can be intercepted; authentication alone does not encrypt traffic. Keep the backend listener private to the proxy or tunnel. Loopback without configured auth remains supported, and a non-loopback listener still requires auth unless the explicit insecure override is set.
 
 ```yaml
 gateway:

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -19,7 +19,7 @@ Current as of **v0.1.0-rc.3 plus `[Unreleased]`** (see [CHANGELOG.md](../CHANGEL
 | Container orchestration (Docker) | Stable | Backward compatible in 0.x |
 | Generated Python source containers (PyPI, git, local) | Stable | Opt-in through `source.runtime: python` or `source.type: pypi`; existing Dockerfile sources are unchanged |
 | Config schema (servers, resources) | Stable | Backward compatible in 0.x |
-| Auth middleware (bearer, API key) | Stable | Backward compatible in 0.x |
+| Auth middleware (bearer, API key) | Stable | Credential formats unchanged; grouped MCP/SSE now require configured auth on every request (see [migration guidance](troubleshooting.md#grouped-mcp-requests-return-401)) |
 | Hot reload | Stable | Backward compatible in 0.x |
 | Vault secrets | Stable | Backward compatible in 0.x |
 | Web UI | Stable | No API guarantee (internal) |
@@ -59,7 +59,7 @@ Current as of **v0.1.0-rc.3 plus `[Unreleased]`** (see [CHANGELOG.md](../CHANGEL
 | Downstream OAuth brokering (auth) | Stable | Backward compatible in 0.x |
 | TOFU schema pinning (pins) | Stable | Backward compatible in 0.x |
 | Tool-poisoning scan | Stable | Backward compatible in 0.x |
-| Tool groups | Stable | Backward compatible in 0.x |
+| Tool groups | Stable | YAML unchanged; clients must send configured gateway credentials on grouped endpoints |
 | Per-client access scoping | Stable | Backward compatible in 0.x |
 | Rate limits | Stable | Backward compatible in 0.x |
 | Dollar-cost layer (pricing, model attribution, budgets) | Removed in v0.1.x | The gateway cannot observe actual spend; token metrics remain (see [Usage Observability](usage-observability.md)) |

--- a/docs/tools-workspace.md
+++ b/docs/tools-workspace.md
@@ -57,6 +57,8 @@ Treat these as claims, not guarantees: they are reported by the server and not v
 
 Where they overlap: whitelists (this workspace) decide what the gateway exposes at all; Access decides which client sees which servers and tools; Groups publish named subsets at separate endpoints. A tool must survive all applicable layers for a client to call it.
 
+These filters are separate from [gateway authentication](config-schema.md#auth). When configured, the gateway credential is required on every grouped MCP request, just as on `/mcp`. Client selectors are self-declared, and group names are not authenticated identities; the filters are guardrails for cooperating clients.
+
 ## Related
 
 - [Configuration Reference](config-schema.md) - `tools:`, `clients:`, and `groups:` blocks

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -652,6 +652,14 @@ Browser shows a blank page or connection refused when accessing the gateway URL.
 
 3. The web UI requires a modern browser - Chrome, Firefox, Safari, or Edge.
 
+### Grouped MCP requests return 401
+
+With `gateway.auth` configured, grouped endpoints now require the same credential as `/mcp` and `/api/`. Clients that previously reached `/groups/{name}/mcp` or `/groups/{name}/sse` without a credential must attach it to every request, including SSE negotiation, stream reconnection, and DELETE. Use `Authorization: Bearer <token>` for `type: bearer`, or the raw token in the configured header for `type: api_key` (default: `Authorization`). A session ID or replay ID does not replace the credential.
+
+The UI shell and assets, `/health`, `/ready`, terminal CORS preflight, and the exact state-validated downstream OAuth callback remain accessible without the gateway token. A working health probe therefore does not prove that an MCP client's authentication is configured correctly. A valid token also does not override Host or MCP Origin rejection (HTTP 403); native clients may omit Origin.
+
+Use HTTPS or an encrypted tunnel for remote connections. Do not troubleshoot by sending the credential over plain remote HTTP, disabling auth, or widening CORS. See [gateway authentication](config-schema.md#auth) for the route boundary and [the remote gateway example](../examples/gateways/gateway-remote.yaml) for transport guidance.
+
 ### Authentication prompt loop
 
 **Symptoms:**

--- a/examples/README.md
+++ b/examples/README.md
@@ -67,7 +67,7 @@ gridctl apply examples/getting-started/mcp-basic.yaml
 | per-client-scoping | http (containers) | `clients:` blocks restricting servers and tools per client |
 | code-mode-basic | http (containers) | Search + execute meta-tools |
 | gateway-basic | http | Gateway to an existing MCP server, tokenizer config |
-| gateway-remote | http | Gateway to a remote MCP deployment |
+| gateway-remote | http | Authenticated remote gateway access through HTTPS or an encrypted tunnel |
 | var-basic | stdio, http | `${var:KEY}` references and value-free `variables:` declarations |
 | var-sets | http (containers) | Variable sets fanning out to all workloads |
 | var-sets-scoped | stdio | Variable sets scoped to named servers and resources |

--- a/examples/access-control/README.md
+++ b/examples/access-control/README.md
@@ -46,6 +46,8 @@ The scope is enforced on `tools/list`, `tools/call`, and the code-mode search/ex
 gridctl link cursor --client-id cursor
 ```
 
+Client identifiers are self-declared, so scoping is a guardrail for cooperating clients, not authentication against a hostile client. Configured `gateway.auth` separately requires the shared credential on every operational request, including grouped MCP endpoints. See [gateway authentication](../../docs/config-schema.md#auth).
+
 See [docs/config-schema.md](../../docs/config-schema.md#clients-per-client-access-scoping) for the full reference, including client-identity reconciliation and reload semantics.
 
 ## 💻 Usage

--- a/examples/declarative-link/README.md
+++ b/examples/declarative-link/README.md
@@ -13,6 +13,8 @@ Once the gateway is healthy, apply links each declared client exactly as
 endpoint, and Cursor gets the `dev` group's endpoint under the entry name
 `gridctl-dev`, bound to a `clients:` access profile via `client_id`.
 
+This example uses the default loopback listener without gateway auth. If you add `gateway.auth`, clients must send its credential on every request, including grouped requests. Linking does not provision credentials into client files; configure authentication in each client separately. `client_id` is a self-declared selector, not an authenticated identity. See [gateway authentication](../../docs/config-schema.md#auth).
+
 Reconcile is additive and idempotent. Already-linked clients are silent
 no-ops; clients not installed on this machine warn and skip, so the same
 committed file works for every teammate. Removing an entry never unlinks

--- a/examples/gateways/README.md
+++ b/examples/gateways/README.md
@@ -39,37 +39,46 @@ gridctl apply examples/gateways/gateway-basic.yaml
 
 ## 🖥️ gateway-remote.yaml
 
-Exposes Gridctl's gateway on all interfaces for remote MCP clients.
+Exposes Gridctl's gateway on all interfaces for remote MCP clients through HTTPS or an encrypted tunnel. Authentication does not encrypt traffic: do not expose plain HTTP port 8180 to remote clients.
 
 ### Prerequisites
 
 1. An MCP server running (e.g., Qdrant MCP, Itential dev-stack)
-2. Port 8180 accessible from the remote machine (check firewall)
+2. A gateway token stored on the server with `gridctl var set GATEWAY_TOKEN`
+3. A TLS-terminating reverse proxy forwarding to port 8180, with the backend firewalled so only the proxy can reach it, or an SSH tunnel
+
+If the proxy forwards the public hostname in the `Host` header, add that exact hostname to `gateway.allowed_hosts`. Loopback hosts are accepted by default; valid credentials do not bypass Host validation. See [gateway configuration](../../docs/config-schema.md#gateway).
 
 ### Usage
 
 ```bash
 # Deploy on the server
 gridctl apply examples/gateways/gateway-remote.yaml
-
-# Find server IP
-ip addr show | grep "inet " | grep -v 127.0.0.1
 ```
+
+For SSH-only access, change `gateway.bind` in the example to `127.0.0.1` before applying it, and run `ssh -N -L 8180:localhost:8180 <host>` on the client machine. Connect the client to `http://localhost:8180/mcp` through that tunnel, retaining the configured authentication.
 
 ### Client Configuration
 
-On the remote machine, configure Claude Desktop:
+Configure your MCP client's Streamable HTTP connection using the following values (replace `gateway.example.com` with your proxy's HTTPS hostname):
 
-```json
-{
-  "mcpServers": {
-    "gridctl": {
-      "command": "npx",
-      "args": ["mcp-remote", "http://<SERVER_IP>:8180/sse", "--allow-http", "--transport", "sse-only"]
-    }
-  }
-}
+| Setting | Value |
+|---------|-------|
+| Endpoint | `https://gateway.example.com/mcp` |
+| Header | `Authorization: Bearer <token>` |
+
+Supply the token through the client's secure credential or environment settings, not a literal value in version-controlled configuration. The YAML example includes an `mcp-remote` bridge configuration for clients that require stdio. `/sse` only returns a legacy negotiation hint; it is not a persistent MCP transport.
+
+Grouped endpoints at `/groups/{name}/mcp` require the same header on every request, including stream reconnection and session deletion. Neither a group name nor a session ID authenticates the caller. `gridctl link --group` selects an endpoint but does not provision credentials into managed client files.
+
+Check the public probe and authenticated API separately, with `GATEWAY_TOKEN` supplied securely in the local shell environment:
+
+```bash
+curl https://gateway.example.com/health
+curl -H "Authorization: Bearer ${GATEWAY_TOKEN}" https://gateway.example.com/api/status
 ```
+
+The probe does not verify credentials. With auth configured, a missing or incorrect token on `/api/status` or a grouped endpoint returns HTTP 401. Native MCP clients may omit Origin; valid credentials do not bypass MCP Origin checks.
 
 ### 📂 Config File Locations
 

--- a/examples/gateways/gateway-remote.yaml
+++ b/examples/gateways/gateway-remote.yaml
@@ -24,6 +24,9 @@
 #   2. The MCP server must be accessible at http://localhost:8000/mcp
 #   3. An HTTPS reverse proxy forwarding to port 8180, or an encrypted tunnel
 #      For SSH-only access, change gateway.bind below to 127.0.0.1.
+#      If the proxy preserves the public Host header, add that exact hostname
+#      to gateway.allowed_hosts; authentication does not bypass Host checks.
+#   4. Store the gateway token on the server: gridctl var set GATEWAY_TOKEN
 #
 # Usage:
 #   1. Deploy this stack:
@@ -51,8 +54,9 @@
 #
 # Testing connectivity:
 #   From remote machine:
-#     curl https://<GATEWAY_HOST>/health
-#     curl -H "Authorization: Bearer ${GATEWAY_TOKEN}" https://<GATEWAY_HOST>/api/status
+#     curl https://gateway.example.com/health
+#     curl -H "Authorization: Bearer ${GATEWAY_TOKEN}" https://gateway.example.com/api/status
+#   Replace gateway.example.com with your proxy's HTTPS hostname.
 #   /health is public; an authenticated /api/status verifies the credential.
 #
 # Claude Desktop config locations:
@@ -67,7 +71,7 @@ name: gateway-remote
 
 gateway:
   # Opt in to all interfaces. Without this the gateway binds 127.0.0.1 and
-  # the remote steps above will not reach it.
+  # a proxy on another machine cannot reach it directly. SSH needs only loopback.
   bind: "0.0.0.0"
   # Required whenever bind is not loopback: gridctl refuses to start with a
   # network-reachable listener and no authentication. Store the token in the

--- a/examples/gateways/gateway-remote.yaml
+++ b/examples/gateways/gateway-remote.yaml
@@ -1,18 +1,20 @@
 # Remote Gateway Access
 #
 # Enables remote access to Gridctl from MCP clients (e.g., Claude Desktop)
-# running on another machine on the same network.
+# running on another machine through HTTPS or an encrypted tunnel.
 #
 # Gridctl Gateway:
 #   - Listens on loopback by default; this example opts in to all interfaces
 #     via `gateway.bind` below (equivalently: `gridctl apply --bind-all`)
-#   - Exposes SSE endpoint at /sse for MCP clients
+#   - Serves Streamable HTTP at /mcp; /sse is a legacy negotiation hint
 #   - Aggregates tools from connected MCP servers with prefixes
 #
 # SECURITY: widening the bind puts the gateway API — including variable
 # endpoints — on your local network. gridctl refuses to start with a
 # non-loopback bind and no `gateway.auth` configured, so the auth block
-# below is required, not optional. Prefer SSH forwarding
+# below is required, not optional. A token does not encrypt remote HTTP:
+# use a TLS-terminating proxy or an encrypted tunnel, and firewall port 8180
+# so it is reachable only by that proxy or tunnel. Prefer SSH forwarding
 # (`ssh -L 8180:localhost:8180 <host>`) when you only need access from one
 # machine — it needs no widened bind at all.
 #
@@ -20,32 +22,38 @@
 #   1. An MCP server running locally (this example uses itential-dev-stack)
 #      See: https://github.com/itential/itential-dev-stack
 #   2. The MCP server must be accessible at http://localhost:8000/mcp
-#   3. Port 8180 must be accessible from the remote machine (check firewall)
+#   3. An HTTPS reverse proxy forwarding to port 8180, or an encrypted tunnel
+#      For SSH-only access, change gateway.bind below to 127.0.0.1.
 #
 # Usage:
 #   1. Deploy this stack:
 #      gridctl apply examples/gateways/gateway-remote.yaml
 #
-#   2. Find this machine's IP address:
-#      ip addr show | grep "inet " | grep -v 127.0.0.1
-#      # or: hostname -I
+#   2. Configure an HTTPS hostname on your reverse proxy, or open the SSH
+#      tunnel above. Do not expose plain HTTP port 8180 to remote clients.
 #
-#   3. On the remote machine, configure Claude Desktop with:
+#   3. On the remote machine, configure an MCP client with:
 #      {
 #        "mcpServers": {
 #          "gridctl": {
 #            "command": "npx",
-#            "args": ["mcp-remote", "http://<THIS_MACHINE_IP>:8180/sse", "--allow-http", "--transport", "sse-only"]
+#            "args": ["mcp-remote", "https://<GATEWAY_HOST>/mcp", "--header", "Authorization: Bearer ${GATEWAY_TOKEN}"]
 #          }
 #        }
 #      }
+#      Supply GATEWAY_TOKEN securely in the client process environment;
+#      the placeholder is expanded by mcp-remote, not stored as a literal
+#      credential in this file. gridctl does not project credentials into
+#      managed client files. Grouped /groups/<name>/mcp endpoints require
+#      the same header on every request; group and session IDs are not auth.
 #
 #   4. Restart Claude Desktop on the remote machine
 #
 # Testing connectivity:
 #   From remote machine:
-#     curl http://<THIS_MACHINE_IP>:8180/api/status
-#     curl http://<THIS_MACHINE_IP>:8180/api/tools
+#     curl https://<GATEWAY_HOST>/health
+#     curl -H "Authorization: Bearer ${GATEWAY_TOKEN}" https://<GATEWAY_HOST>/api/status
+#   /health is public; an authenticated /api/status verifies the credential.
 #
 # Claude Desktop config locations:
 #   Linux:   ~/.config/Claude/claude_desktop_config.json

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -242,7 +242,8 @@ func (s *Server) SetAllowedHosts(hosts []string) {
 }
 
 // SetAuth configures authentication for the server.
-// When configured, all requests (except /health and /ready) must include a valid token.
+// When configured, operational routes require a valid token; the UI, probes,
+// terminal CORS preflight, and state-validated OAuth callback remain public.
 func (s *Server) SetAuth(authType, token, header string) {
 	s.authType = authType
 	s.authToken = token

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/subtle"
 	"net/http"
+	"path"
 	"strings"
 )
 
@@ -18,8 +19,10 @@ func authMiddleware(authType, token, header string, next http.Handler) http.Hand
 		header = "Authorization"
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Skip auth for health/ready, CORS preflight, and static web UI files
-		if r.URL.Path == "/health" || r.URL.Path == "/ready" || r.Method == http.MethodOptions || !isProtectedPath(r.URL.Path) {
+		// Check the decoded path and its redirect target. Keep the original
+		// check too: ServeMux treats escaped dot segments as literal segments.
+		// CORS preflight terminates in the outer CORS layer, never here.
+		if !isProtectedPath(r.URL.Path) && !isProtectedPath(path.Clean(r.URL.Path)) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -47,10 +50,12 @@ func authMiddleware(authType, token, header string, next http.Handler) http.Hand
 }
 
 // isProtectedPath returns true for paths that require authentication:
-// API, MCP, SSE, A2A, and well-known endpoints.
+// API, MCP (including groups), SSE, A2A, and well-known endpoints.
 func isProtectedPath(path string) bool {
 	switch {
 	case strings.HasPrefix(path, "/api/"):
+		return true
+	case strings.HasPrefix(path, "/groups/"):
 		return true
 	case path == "/mcp":
 		return true

--- a/internal/api/auth_routes_test.go
+++ b/internal/api/auth_routes_test.go
@@ -1,0 +1,373 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/fstest"
+
+	"github.com/gridctl/gridctl/pkg/mcp"
+	"github.com/gridctl/gridctl/pkg/mcpauth"
+	"github.com/stretchr/testify/require"
+)
+
+// Walk the production registrations rather than keep a second route inventory.
+// Unknown registration expressions fail closed until the test can exercise them.
+func TestAuthHandler_RegisteredRoutes(t *testing.T) {
+	f, err := parser.ParseFile(token.NewFileSet(), "api.go", nil, 0)
+	require.NoError(t, err)
+	var patterns []string
+	var patternStrings func(ast.Expr, string) string
+	patternStrings = func(expr ast.Expr, prefix string) string {
+		switch e := expr.(type) {
+		case *ast.BasicLit:
+			s, err := strconv.Unquote(e.Value)
+			require.NoError(t, err)
+			return s
+		case *ast.BinaryExpr:
+			require.Equal(t, token.ADD, e.Op)
+			return patternStrings(e.X, prefix) + patternStrings(e.Y, prefix)
+		case *ast.Ident:
+			require.Equal(t, "prefix", e.Name)
+			return prefix
+		case *ast.SelectorExpr:
+			require.Equal(t, "mcpauth", e.X.(*ast.Ident).Name)
+			require.Equal(t, "CallbackPath", e.Sel.Name)
+			return mcpauth.CallbackPath
+		default:
+			t.Fatalf("unhandled route expression %T", expr)
+			return ""
+		}
+	}
+	var prefixes []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if ok {
+			if name, ok := call.Fun.(*ast.Ident); ok && name.Name == "registerVarRoutes" {
+				prefixes = append(prefixes, patternStrings(call.Args[0], ""))
+			}
+		}
+		return true
+	})
+	require.NotEmpty(t, prefixes)
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || (sel.Sel.Name != "Handle" && sel.Sel.Name != "HandleFunc") {
+			return true
+		}
+		for _, prefix := range prefixes {
+			patterns = append(patterns, patternStrings(call.Args[0], prefix))
+		}
+		return true
+	})
+	require.NotEmpty(t, patterns)
+	s := NewServer(groupsGateway(), nil)
+	t.Cleanup(s.Close)
+	s.SetAuth("bearer", rand.Text(), "")
+	handler := s.Handler()
+	for _, pattern := range patterns {
+		method, path, found := strings.Cut(pattern, " ")
+		if !found {
+			method, path = http.MethodGet, pattern
+		}
+		switch path {
+		case "/", "/health", "/ready", "/oauth/callback":
+			continue // Public contracts are exercised separately below.
+		}
+		for strings.Contains(path, "{") {
+			start, end := strings.Index(path, "{"), strings.Index(path, "}")
+			path = path[:start] + "release" + path[end+1:]
+		}
+		t.Run(pattern, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, loopbackRequest(method, path, nil))
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+	}
+}
+
+func TestAuthHandler_RouteMatrix(t *testing.T) {
+	for _, mode := range []struct{ name, kind, header string }{
+		{"bearer", "bearer", ""},
+		{"api-key", "api_key", ""},
+		{"custom-header", "api_key", "X-Gateway-Key"},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			s := NewServer(groupsGateway(), fstest.MapFS{
+				"index.html":    {Data: []byte("public shell")},
+				"assets/app.js": {Data: []byte("public asset")},
+			})
+			t.Cleanup(s.Close)
+			credential := rand.Text()
+			s.SetAuth(mode.kind, credential, mode.header)
+			h := s.Handler()
+			header := mode.header
+			if header == "" {
+				header = "Authorization"
+			}
+			for _, path := range []string{
+				"/mcp", "/sse", "/message", "/api/status",
+				"/groups/release/mcp", "/groups/release/sse", "/groups/unknown/mcp",
+				"/groups/unknown/sse", "/groups/release/mcp/", "/groups/release/sse/",
+				"/groups/release/%6dcp", "/%67roups/release/sse", "/groups/%72elease/mcp",
+				"/groups/release%2Fother/mcp", "/groups/%2e%2e/mcp", "/groups%2Frelease/mcp",
+				"//groups/release/mcp", "/x/../groups/release/mcp", "/%6dcp", "/api%2fstatus",
+				"/api/var/%2e%2e", "/groups/%2e%2e/health", "/x/../mcp", "/%2fmcp",
+			} {
+				for _, method := range []string{http.MethodPost, http.MethodGet, http.MethodDelete, http.MethodHead, http.MethodPut, http.MethodPatch} {
+					for _, value := range []string{"", rand.Text()} {
+						t.Run(method+path, func(t *testing.T) {
+							r := loopbackRequest(method, path, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+							if value != "" {
+								if mode.kind == "bearer" {
+									value = "Bearer " + value
+								}
+								r.Header.Set(header, value)
+							}
+							w := httptest.NewRecorder()
+							h.ServeHTTP(w, r)
+							require.Equal(t, http.StatusUnauthorized, w.Code)
+							require.Empty(t, w.Header().Get("Location"))
+							require.Empty(t, w.Header().Get("Mcp-Session-Id"))
+						})
+					}
+				}
+			}
+			require.Zero(t, s.streamableServer.SessionCount())
+			for _, path := range []string{"/", "/assets/app.js", "/tools", "/groups-lookalike/release/mcp", "/mcpx", "/apiary/status", "/health", "/ready"} {
+				w := httptest.NewRecorder()
+				h.ServeHTTP(w, loopbackRequest(http.MethodGet, path, nil))
+				want := http.StatusOK
+				if path == "/ready" {
+					want = http.StatusServiceUnavailable // No stack is loaded.
+				}
+				require.Equal(t, want, w.Code, path)
+			}
+			for _, path := range []string{"/mcp", "/groups/release/mcp", "/groups/release/sse", "/api/status"} {
+				r := loopbackRequest(http.MethodOptions, path, strings.NewReader(`{"method":"initialize"}`))
+				r.Header.Set("Origin", "https://untrusted.invalid")
+				r.Header.Set("Access-Control-Request-Method", http.MethodPost)
+				w := httptest.NewRecorder()
+				h.ServeHTTP(w, r)
+				require.Equal(t, http.StatusOK, w.Code)
+				require.Empty(t, w.Body.String())
+				require.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+				require.Empty(t, w.Header().Get("Content-Type"))
+			}
+			require.Zero(t, s.streamableServer.SessionCount())
+			for _, route := range []struct {
+				method, path, body string
+				status             int
+			}{
+				{http.MethodGet, "/sse", "POST /mcp", http.StatusOK},
+				{http.MethodGet, "/groups/release/sse", "POST /groups/release/mcp", http.StatusOK},
+				{http.MethodHead, "/groups/release/sse", "", http.StatusOK},
+				{http.MethodPost, "/message", "legacy SSE", http.StatusGone},
+				{http.MethodGet, "/api/status", `"gateway"`, http.StatusOK},
+				{http.MethodPost, "/groups/unknown/mcp", "", http.StatusNotFound},
+				{http.MethodGet, "/groups/unknown/sse", "", http.StatusNotFound},
+				{http.MethodPost, "/groups/release/%6dcp", "Invalid JSON", http.StatusOK},
+				{http.MethodGet, "/%67roups/release/sse", "POST /groups/release/mcp", http.StatusOK},
+			} {
+				r := loopbackRequest(route.method, route.path, nil)
+				value := credential
+				if mode.kind == "bearer" {
+					value = "Bearer " + value
+				}
+				r.Header.Set(header, value)
+				w := httptest.NewRecorder()
+				h.ServeHTTP(w, r)
+				require.Equal(t, route.status, w.Code, route.path)
+				require.Contains(t, w.Body.String(), route.body)
+			}
+			for _, path := range []string{"/mcp", "/groups/release/mcp"} {
+				for _, defense := range []string{"Host", "Origin"} {
+					r := loopbackRequest(http.MethodPost, path, strings.NewReader(`{"method":"initialize"}`))
+					value := credential
+					if mode.kind == "bearer" {
+						value = "Bearer " + value
+					}
+					r.Header.Set(header, value)
+					if defense == "Host" {
+						r.Host = "untrusted.invalid"
+					} else {
+						r.Header.Set("Origin", "https://untrusted.invalid")
+					}
+					w := httptest.NewRecorder()
+					h.ServeHTTP(w, r)
+					require.Equal(t, http.StatusForbidden, w.Code, defense)
+				}
+			}
+		})
+	}
+}
+
+func TestAuthHandler_ProtocolEras(t *testing.T) {
+	for _, mode := range []struct{ kind, header string }{{"bearer", ""}, {"api_key", ""}, {"api_key", "X-Gateway-Key"}, {"", ""}} {
+		for _, path := range []string{"/mcp", "/groups/release/mcp"} {
+			for _, version := range mcp.SupportedProtocolVersions {
+				t.Run(mode.kind+mode.header+path+version, func(t *testing.T) {
+					s := NewServer(groupsGateway(), nil)
+					t.Cleanup(s.Close)
+					client := &authCountingClient{mockAgentClient: newMockAgentClient("github", []mcp.Tool{{Name: "create_issue"}})}
+					s.gateway.Router().AddClient(client)
+					toolName := "github__create_issue"
+					if path != "/mcp" {
+						toolName = "create_issue"
+					}
+					credential := rand.Text()
+					if mode.kind != "" {
+						s.SetAuth(mode.kind, credential, mode.header)
+					}
+					h := s.Handler()
+					session := ""
+					do := func(method, rpc, value string) *httptest.ResponseRecorder {
+						params := fmt.Sprintf(`{"protocolVersion":%q,"clientInfo":{"name":"test","version":"1"},"capabilities":{}}`, version)
+						if mcp.EraOfVersion(version) == mcp.EraStateless {
+							params = fmt.Sprintf(`{"_meta":{"io.modelcontextprotocol/protocolVersion":%q,"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1"},"io.modelcontextprotocol/clientCapabilities":{}}}`, version)
+						}
+						if rpc == "tools/call" {
+							params = strings.TrimSuffix(params, "}") + fmt.Sprintf(`,"name":%q,"arguments":{}}`, toolName)
+						}
+						r := loopbackRequest(method, path, strings.NewReader(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":%q,"params":%s}`, rpc, params)))
+						r.Header.Set("Content-Type", "application/json")
+						r.Header.Set("MCP-Protocol-Version", version)
+						r.Header.Set("Mcp-Method", rpc)
+						if rpc == "tools/call" {
+							r.Header.Set("Mcp-Name", toolName)
+						}
+						r.Header.Set("Mcp-Session-Id", session)
+						r.Header.Set("Last-Event-ID", "0")
+						if value != "" && mode.kind != "" {
+							header := mode.header
+							if header == "" {
+								header = "Authorization"
+							}
+							if mode.kind == "bearer" {
+								value = "Bearer " + value
+							}
+							r.Header.Set(header, value)
+						}
+						// A canceled context bounds valid GET streams without hiding stream setup.
+						ctx, cancel := context.WithCancel(r.Context())
+						defer cancel()
+						if method == http.MethodGet {
+							cancel()
+						}
+						w := httptest.NewRecorder()
+						h.ServeHTTP(w, r.WithContext(ctx))
+						return w
+					}
+					initial := "initialize"
+					modern := mcp.EraOfVersion(version) == mcp.EraStateless
+					if modern {
+						initial = "server/discover"
+					}
+					if mode.kind != "" {
+						for _, value := range []string{"", rand.Text()} {
+							require.Equal(t, http.StatusUnauthorized, do(http.MethodPost, initial, value).Code)
+						}
+						require.Zero(t, s.streamableServer.SessionCount())
+					}
+					w := do(http.MethodPost, initial, credential)
+					require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+					require.NotContains(t, w.Body.String(), `"error"`)
+					session = w.Header().Get("Mcp-Session-Id")
+					if modern {
+						require.Empty(t, session)
+					} else {
+						require.NotEmpty(t, session)
+					}
+					if mode.kind != "" {
+						for _, value := range []string{"", rand.Text()} {
+							for _, rpc := range []string{"tools/list", "tools/call", "notifications/initialized", "server/discover"} {
+								require.Equal(t, http.StatusUnauthorized, do(http.MethodPost, rpc, value).Code)
+							}
+							for _, method := range []string{http.MethodGet, http.MethodDelete} {
+								w := do(method, "", value)
+								require.Equal(t, http.StatusUnauthorized, w.Code)
+								require.NotEqual(t, "text/event-stream", w.Header().Get("Content-Type"))
+							}
+						}
+					}
+					w = do(http.MethodPost, "tools/list", credential)
+					require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+					require.NotContains(t, w.Body.String(), `"error"`)
+					require.Zero(t, client.calls.Load(), "unauthorized requests reached tool dispatch")
+					w = do(http.MethodPost, "tools/call", credential)
+					require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+					require.NotContains(t, w.Body.String(), `"error"`)
+					require.Equal(t, int64(1), client.calls.Load())
+					want := http.StatusOK
+					if modern {
+						want = http.StatusMethodNotAllowed
+					}
+					w = do(http.MethodGet, "", credential)
+					require.Equal(t, want, w.Code)
+					if !modern {
+						require.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+					}
+					require.Equal(t, want, do(http.MethodDelete, "", credential).Code)
+					require.Zero(t, s.streamableServer.SessionCount())
+				})
+			}
+		}
+	}
+}
+
+type authCountingClient struct {
+	*mockAgentClient
+	calls atomic.Int64
+}
+
+func (c *authCountingClient) CallTool(context.Context, string, map[string]any) (*mcp.ToolCallResult, error) {
+	c.calls.Add(1)
+	return &mcp.ToolCallResult{Content: []mcp.Content{mcp.NewTextContent("called")}}, nil
+}
+
+func TestAuthHandler_CallbackBoundary(t *testing.T) {
+	store, err := mcpauth.NewTokenStore(t.TempDir())
+	require.NoError(t, err)
+	s := NewServer(groupsGateway(), nil)
+	t.Cleanup(s.Close)
+	s.SetAuth("bearer", rand.Text(), "")
+	s.SetOAuthBroker(mcpauth.NewBroker(store, "http://localhost:8180"+mcpauth.CallbackPath, nil))
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	for _, route := range []struct {
+		method, path string
+		status       int
+	}{
+		{http.MethodGet, "/oauth/callback?code=x&state=unknown", http.StatusBadRequest},
+		{http.MethodGet, "/oauth/callback/extra?code=x&state=unknown", http.StatusNotFound},
+		{http.MethodGet, "/oauth/callback-lookalike?code=x&state=unknown", http.StatusNotFound},
+		{http.MethodPost, "/oauth/callback?code=x&state=unknown", http.StatusNotFound},
+		{http.MethodGet, "/api/auth/servers", http.StatusUnauthorized},
+		{http.MethodPost, "/api/servers/release/auth/login", http.StatusUnauthorized},
+		{http.MethodGet, "/oauth/callback/../../groups/release/sse", http.StatusUnauthorized},
+		{http.MethodPost, "/x/../groups/release/mcp", http.StatusUnauthorized},
+		{http.MethodGet, "//groups/release/sse", http.StatusUnauthorized},
+		{http.MethodGet, "/groups/release/%73se", http.StatusUnauthorized},
+	} {
+		r, err := http.NewRequestWithContext(t.Context(), route.method, ts.URL+route.path, nil)
+		require.NoError(t, err)
+		resp, err := ts.Client().Do(r) // Follow any outer mux normalization redirects.
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, route.status, resp.StatusCode, route.path)
+	}
+	require.Zero(t, s.streamableServer.SessionCount())
+}

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -157,15 +157,15 @@ func TestAuthMiddleware_ProtectedPaths(t *testing.T) {
 	}
 }
 
-func TestAuthMiddleware_OptionsPassthrough(t *testing.T) {
+func TestAuthMiddleware_OptionsRequiresAuth(t *testing.T) {
 	handler := authMiddleware("bearer", "mysecret", "", okHandler())
 
 	req := loopbackRequest(http.MethodOptions, "/api/status", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Errorf("expected 200 for OPTIONS without auth, got %d", rec.Code)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 outside the terminal CORS layer, got %d", rec.Code)
 	}
 }
 
@@ -220,14 +220,14 @@ func TestAuthMiddleware_TimingSafe(t *testing.T) {
 }
 
 func TestIsProtectedPath(t *testing.T) {
-	protected := []string{"/api/status", "/api/tools", "/api/mcp-servers", "/mcp", "/sse", "/message", "/a2a/agent1", "/.well-known/agent.json"}
+	protected := []string{"/api/status", "/api/tools", "/api/mcp-servers", "/mcp", "/sse", "/message", "/groups/release/mcp", "/groups/release/sse", "/groups/unknown/mcp", "/a2a/agent1", "/.well-known/agent.json"}
 	for _, path := range protected {
 		if !isProtectedPath(path) {
 			t.Errorf("expected %s to be protected", path)
 		}
 	}
 
-	unprotected := []string{"/", "/index.html", "/assets/main.js", "/favicon.png", "/health", "/ready"}
+	unprotected := []string{"/", "/index.html", "/assets/main.js", "/favicon.png", "/health", "/ready", "/groups-lookalike/release/mcp", "/mcpx", "/apiary/status"}
 	for _, path := range unprotected {
 		if isProtectedPath(path) {
 			t.Errorf("expected %s to be unprotected", path)

--- a/internal/api/groups.go
+++ b/internal/api/groups.go
@@ -23,8 +23,8 @@ func (s *Server) handleGroupMCP(w http.ResponseWriter, r *http.Request) {
 // endpoints, pointing clients at the group's streamable path.
 func (s *Server) handleGroupSSE(w http.ResponseWriter, r *http.Request) {
 	// Echo only the configured group name, never the raw path input: the
-	// exact-match lookup against the policy's name list both authorizes the
-	// endpoint and yields a config-originated string for the response.
+	// exact-match lookup against the policy's name list validates the group
+	// and yields a config-originated string for the response, not caller identity.
 	name := s.configuredGroupName(r.PathValue("name"))
 	if name == "" {
 		http.NotFound(w, r)

--- a/tests/integration/groups_auth_test.go
+++ b/tests/integration/groups_auth_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gridctl/gridctl/internal/api"
+	"github.com/gridctl/gridctl/pkg/mcp"
+)
+
+func TestToolGroups_Authentication(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+	port := freePort(t)
+	startMockServer(t, mockHTTPServerBin, "-port", fmt.Sprint(port))
+	waitForPort(t, ctx, port)
+
+	for _, mode := range []struct{ kind, header string }{{"bearer", "Authorization"}, {"api_key", "Authorization"}, {"api_key", "X-Gateway-Key"}} {
+		t.Run(mode.kind+mode.header, func(t *testing.T) {
+			gw := mcp.NewGateway()
+			if err := gw.RegisterMCPServer(ctx, mcp.MCPServerConfig{
+				Name: "alpha", Transport: mcp.TransportHTTP,
+				Endpoint: fmt.Sprintf("http://127.0.0.1:%d/mcp", port),
+			}); err != nil {
+				gw.Close()
+				t.Fatal(err)
+			}
+			gw.SetGroupPolicy(groupsTestPolicy())
+			s := api.NewServer(gw, nil)
+			t.Cleanup(s.Close)
+			credential := rand.Text()
+			s.SetAuth(mode.kind, credential, mode.header)
+			ts := httptest.NewServer(s.Handler())
+			t.Cleanup(ts.Close)
+			session := ""
+			do := func(method, path, body, value string, want int) (http.Header, string) {
+				t.Helper()
+				r, err := http.NewRequestWithContext(ctx, method, ts.URL+path, strings.NewReader(body))
+				if err != nil {
+					t.Fatal(err)
+				}
+				r.Header.Set("Content-Type", "application/json")
+				r.Header.Set("Mcp-Session-Id", session)
+				r.Header.Set("Last-Event-ID", "0")
+				if value != "" {
+					if mode.kind == "bearer" {
+						value = "Bearer " + value
+					}
+					r.Header.Set(mode.header, value)
+				}
+				resp, err := ts.Client().Do(r)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != want {
+					t.Fatalf("%s %s: status %d, want %d", method, path, resp.StatusCode, want)
+				}
+				data, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return resp.Header, string(data)
+			}
+			initialize := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"test","version":"1"}}}`
+			for _, value := range []string{"", rand.Text()} {
+				headers, _ := do(http.MethodPost, "/groups/release/mcp", initialize, value, http.StatusUnauthorized)
+				if headers.Get("Mcp-Session-Id") != "" {
+					t.Fatal("unauthorized initialization created a session")
+				}
+			}
+			headers, _ := do(http.MethodPost, "/groups/release/mcp", initialize, credential, http.StatusOK)
+			session = headers.Get("Mcp-Session-Id")
+			if session == "" {
+				t.Fatal("authenticated initialize returned no session")
+			}
+			call := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"shout","arguments":{"message":"authenticated"}}}`
+			for _, value := range []string{"", rand.Text()} {
+				for _, path := range []string{"/mcp", "/groups/release/mcp", "/groups/release/%6dcp"} {
+					do(http.MethodPost, path, call, value, http.StatusUnauthorized)
+					do(http.MethodGet, path, "", value, http.StatusUnauthorized)
+					do(http.MethodDelete, path, "", value, http.StatusUnauthorized)
+				}
+				do(http.MethodGet, "/groups/release/sse", "", value, http.StatusUnauthorized)
+			}
+			_, body := do(http.MethodPost, "/groups/release/mcp", call, credential, http.StatusOK)
+			if !strings.Contains(body, "Echo: authenticated") {
+				t.Fatalf("authenticated call did not reach real backend: %s", body)
+			}
+			_, body = do(http.MethodGet, "/api/sessions", "", credential, http.StatusOK)
+			var sessions struct {
+				Count int `json:"count"`
+			}
+			if err := json.Unmarshal([]byte(body), &sessions); err != nil {
+				t.Fatal(err)
+			}
+			if sessions.Count != 1 {
+				t.Fatalf("session count = %d, want 1", sessions.Count)
+			}
+			do(http.MethodDelete, "/groups/release/mcp", "", credential, http.StatusOK)
+			do(http.MethodPost, "/groups/release/mcp", call, credential, http.StatusNotFound)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Enforce configured gateway authentication on grouped MCP and SSE routes before initialization, discovery, dispatch, stream replay, or session deletion. Grouped clients must send the same bearer token or API-key header used for `/mcp` on every request.

## Changes Made

- Add segment-aware grouped route coverage and check decoded paths and normalization targets. Leave constant-time credential validation unchanged.
- Keep OPTIONS terminal in CORS rather than allowing it through auth to operational handlers.
- Preserve public UI files, probes, the exact state-validated OAuth callback, no-auth loopback behavior, and independent Host/Origin checks.
- Add registration-coupled mux tests, every supported protocol version, dispatch counters, and real-backend HTTP regressions.
- Document public exceptions and credential requirements; update remote examples to require HTTPS or an encrypted tunnel.

## Testing

- `task build` and the resulting `./gridctl version` passed.
- `task test && task test:frontend` passed, including the Go race detector and 1,940 frontend tests.
- Grouped real-backend suites, all gateway lifecycle tests, and the isolated daemon shutdown test passed with `-race`.
- CI-pinned golangci-lint v2.11.3 passed via `go run` because the executable was absent from PATH. Frontend lint passed with one existing React Compiler warning.
- Browser automation and the full Docker/Podman platform matrix were not run locally.

## Checklist

- [x] Tests pass (`task test`)
- [x] No secrets or credentials committed

Closes #1223
