### PR TITLE
docs: prepare v1.0.0-rc.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to gridctl will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.0-rc.1] - 2026-09-09
+
 ### Documentation
 
 - Link external release verification from installation and CLI guidance, clarify verifier diagnostics and immutable-mode prerequisites, and document separate release-policy tests (#1220).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,7 +56,7 @@ Export is semantic, not byte-for-byte: comments and formatting are not preserved
 
 `-o <dir>` writes `stack.yaml` or `stack.json`, leaving stdout empty and reporting written filenames on stderr. YAML directory exports also write `skills.yaml` when the local skills lockfile records sources; that sidecar contains only each source's name, repository, and ref, not its authentication settings or installed skill content. JSON, stdout, and REST exports have no sidecar. Every artifact is prepared and checked before creating the output directory. Unreadable skills metadata and explicit URL userinfo in sidecar repository metadata block the directory export. Output cannot overwrite the source stack or a parsed ancestor, including symlink and hard-link aliases. These checks apply to `-o`, not shell redirection: never redirect stdout onto a source file, because the shell truncates it before gridctl runs. Other existing destination files can be overwritten. Filesystem writes are not a multi-file transaction: failures report completed artifacts and identify an attempted file that may be incomplete.
 
-This is a breaking security correction under Article VIII and must not ship in a patch or minor release. No version is assigned here, and no resolved-export fallback is provided. Verbose apply diagnostics now show counts and transport/auth configuration summaries rather than resolved JSON.
+This breaking security correction is included in v1.0.0-rc.1, with a major-version increment under Article VIII. No resolved-export fallback is provided. Verbose apply diagnostics now show counts and transport/auth configuration summaries rather than resolved JSON.
 
 ## Catalog
 

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -1,15 +1,15 @@
 # Project Status
 
-Gridctl is pre-1.0 software. This page tracks the stability tier of each feature surface and lists currently known limitations.
+Gridctl is preparing its 1.0 release. This page tracks the stability tier of each feature surface and lists currently known limitations.
 
 **Stability tiers**:
 
-- **Stable** - production-ready. Backward-compatible changes only within the `0.x` line; breaking changes ride a clearly-labeled release.
+- **Stable** - production-ready. Breaking public CLI, stack YAML, and MCP protocol changes require a major-version increment under Constitution Article VIII. The compatibility table records the prior `0.x` baseline; see the release notes for the 1.0 migration.
 - **Experimental** - usable but the API, CLI surface, or output shape may change without notice. Pin a version if you build automation on top of it.
 
 Nearly every shipped feature surface is Stable as of the release candidate; the table below marks the exceptions. The Experimental tier also covers features that ship dark behind the `experimental:` feature-flag registry (see [Config Schema](config-schema.md#experimental-feature-flags)), though a surface can be Experimental for stability reasons without being flag-gated (the model routing policy is: its CLI is on by default, but the upstream LiteLLM schema it renders is still evolving).
 
-Current as of **v0.1.0-rc.3 plus `[Unreleased]`** (see [CHANGELOG.md](../CHANGELOG.md) for release-by-release detail).
+Current as of **v1.0.0-rc.1** (see [CHANGELOG.md](../CHANGELOG.md) for release-by-release detail).
 
 ## Feature stability
 
@@ -33,7 +33,7 @@ Current as of **v0.1.0-rc.3 plus `[Unreleased]`** (see [CHANGELOG.md](../CHANGEL
 | Podman runtime | Stable | Backward compatible in 0.x |
 | Skills registry (prompt-only) | Stable | Backward compatible in 0.x |
 | Library workspace (UI) | Stable | No API guarantee (internal) |
-| Stack export (export) | Stable | Breaking security correction in `[Unreleased]`: references stay unresolved, and recognized inline credentials reject export. Requires a major release under Article VIII; see [migration guidance](cli-reference.md#export-semantics) |
+| Stack export (export) | Stable | Breaking security correction in v1.0.0-rc.1: references stay unresolved, and recognized inline credentials reject export. See [migration guidance](cli-reference.md#export-semantics) |
 | Spec drift detection | Stable | No API guarantee (internal) |
 | Visual spec builder | Stable | No API guarantee (internal) |
 | Skills import (skill add) | Stable | Backward compatible in 0.x |

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
-go = "1.25.8"
-node = "20"
-goreleaser = "2.13"
+go = "1.26.6"
+node = "22"
+golangci-lint = "2.11.3"
+goreleaser = "2.14.3"


### PR DESCRIPTION
## Summary
Prepare v1.0.0-rc.1 by promoting the hand-written Unreleased entries verbatim under the 2026-09-09 release header. Preserve all older sections and leave Unreleased empty. Update release references and align mise with the existing reviewed toolchain.

The major-version increment satisfies Constitution Article VIII for changed stack export output and reserved-variable restrictions. Grouped MCP/SSE clients must supply configured gateway credentials.

## Validation
Passed with Go 1.26.6 and Node.js 22 through mise:
- `npm ci --prefix web`
- `task build` and `./gridctl version`
- `task test` (race-enabled)
- `task test:frontend` (1,946 tests)
- `task lint` (one existing frontend warning, zero errors)
- `task test:integration` (Docker, race-enabled)
- `go test ./pkg/flags/...`
- Python policy regressions (11 tests), using UV with jsonschema 4.23.0 and PyYAML 6.0.3
- `goreleaser check`, using the digest-pinned 2.14.3 executable
- `git diff --check`

The initial Go environment mismatch was resolved with mise. Integration was rerun successfully with a sufficient command timeout.

## Release sequence
Actions is enabled; RELEASE_MODE is unset and defaults to mutable. Publication requires the signed tag workflow and its exact-commit gates, draft verification, public asset verification, and Homebrew update.

- [ ] Review
- [ ] Merge
- [ ] Confirm publication and push the signed annotated tag
- [ ] Verify production assets and Homebrew update