### PR TITLE
fix: guard Homebrew xattr hook

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -145,5 +145,7 @@ homebrew_casks:
     hooks:
       post:
         install: |
-          system_command "/usr/bin/xattr",
-                         args: ["-dr", "com.apple.quarantine", "#{staged_path}/gridctl"]
+          if OS.mac?
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/gridctl"]
+          end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to gridctl will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- Limit the Homebrew cask's quarantine removal to macOS so Linuxbrew installations no longer fail by invoking the unavailable `/usr/bin/xattr`.
+
 ### Maintenance
 
 - Add a manually triggered, read-only Homebrew authentication diagnostic that compares the release Python helper with GitHub CLI and reports sanitized results without exposing credentials.

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -41,6 +41,19 @@ class ReleasePolicyTests(unittest.TestCase):
                          set(publisher["publish"]["needs"]))
         self.assertEqual("publish", publisher["homebrew"]["needs"])
 
+    def test_homebrew_xattr_hook_is_macos_only(self):
+        import yaml
+
+        cask = yaml.safe_load(Path(".goreleaser.yaml").read_text())["homebrew_casks"][0]
+        self.assertEqual(
+            'if OS.mac?\n'
+            '  system_command "/usr/bin/xattr",\n'
+            '                 args: ["-dr", "com.apple.quarantine", "#{staged_path}/gridctl"]\n'
+            'end\n',
+            cask["hooks"]["post"]["install"],
+        )
+        self.assertNotIn("custom_block", cask)
+
     def test_prepare_requires_complete_inventories(self):
         import jsonschema
 


### PR DESCRIPTION
## Description

Guard the Homebrew cask quarantine cleanup so Linuxbrew does not invoke the
macOS-only `/usr/bin/xattr`. Keep the current legacy hook until stable
GoReleaser v2.19 supports structured install steps.

## Changes Made

- Wrap the generated xattr hook with `if OS.mac?`.
- Add a release-policy regression for the platform guard.
- Document the restored Linuxbrew installation path.

## Testing

- `mise exec goreleaser@2.14.3 -- goreleaser check`
- GoReleaser snapshot generation with the guarded cask output
- All 19 Python release-policy tests
- `task build` and `./gridctl version`
- Linux Homebrew installs on AMD64 and ARM64 using the guarded cask
- macOS Homebrew reinstall and quarantine attribute verification

Closes #1249
